### PR TITLE
Messy binary

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -440,12 +440,15 @@ public final class ImageConverter {
       new Object[] {reader.getFormat(), out, format});
     long mid = System.currentTimeMillis();
 
+    // if the writer type supports stacks setup the variables for
+    //    the first and last series in the file
     int total = 0;
     int num = writer.canDoStacks() ? reader.getSeriesCount() : 1;
     long read = 0, write = 0;
     int first = series == -1 ? 0 : series;
     int last = series == -1 ? num : series + 1;
     long timeLastLogged = System.currentTimeMillis();
+    // for each series in the current file
     for (int q=first; q<last; q++) {
       reader.setSeries(q);
 
@@ -477,16 +480,24 @@ public final class ImageConverter {
       total += numImages;
 
       int count = 0;
+
       HashMap<String, Integer> nextOutputIndex = new HashMap<String, Integer>();
+
+      // loop through each of the planes in the current series
       for (int i=startPlane; i<endPlane; i++) {
+          // for each plane get the ZCT location
         int[] coords = reader.getZCTCoords(i);
 
+        //
         if ((zSection >= 0 && coords[0] != zSection) || (channel >= 0 &&
           coords[1] != channel) || (timepoint >= 0 && coords[2] != timepoint))
         {
+            // Skip the rest of this loop
           continue;
         }
 
+        // Set the current filename that the writer should use for the
+        //    current plane and sceries
         String outputName = FormatTools.getFilename(q, i, reader, out);
         writer.setId(outputName);
         if (compression != null) writer.setCompression(compression);
@@ -497,6 +508,9 @@ public final class ImageConverter {
         }
 
         long s = System.currentTimeMillis();
+
+        // convertPlane actualy does the work,
+        //    the other lines are handeling the logging and timekeeping
         long m = convertPlane(writer, i, outputIndex);
         long e = System.currentTimeMillis();
         read += m - s;

--- a/components/formats-bsd/src/loci/formats/out/OMEBinaryOnlyTiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEBinaryOnlyTiffWriter.java
@@ -95,7 +95,7 @@ public class OMEBinaryOnlyTiffWriter extends OMETiffWriter {
   // -- Constructor --
 
   public OMEBinaryOnlyTiffWriter() {
-    super();
+    super("COME-TIFF", new String[] {"come.tif", "come.tiff"});
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-bsd/src/loci/formats/out/OMEBinaryOnlyTiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEBinaryOnlyTiffWriter.java
@@ -1,0 +1,242 @@
+/*
+ * #%L
+ * OME Bio-Formats package for BSD-licensed readers and writers.
+ * %%
+ * Copyright (C) 2005 - 2013 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
+import loci.common.Location;
+import loci.common.RandomAccessInputStream;
+import loci.common.RandomAccessOutputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.ome.OMEXMLMetadataImpl;
+import loci.formats.services.OMEXMLService;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.TiffSaver;
+
+/**
+ * OMETiffWriter is the file format writer for OME-TIFF files.
+ *
+ * <dl><dt><b>Source code:</b></dt>
+ * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/out/OMETiffWriter.java">Trac</a>,
+ * <a href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/src/loci/formats/out/OMETiffWriter.java;hb=HEAD">Gitweb</a></dd></dl>
+ */
+public class OMEBinaryOnlyTiffWriter extends OMETiffWriter {
+
+  // -- Constants --
+
+	private static final String BINARY_ONLY_WARNING_COMMENT =
+		    "<!-- Warning: this comment is an OME-XML binary only metadata block, " +
+		    "points to other important metadata. " +
+		    "Please edit cautiously (if at all), and back up the original data " +
+		    "before doing so. For more information, see the OME-TIFF web site: " +
+		    FormatTools.URL_OME_TIFF + ". -->";
+
+	private static final String COMPANION_WARNING_COMMENT =
+		    "<!-- Warning: this is an OME-XML companion metadata file, " +
+		    "and points to pixel data in other files. " +
+		    "Please edit cautiously (if at all), and back up the original data " +
+		    "before doing so. For more information, see the OME-TIFF web site: " +
+		    FormatTools.URL_OME_TIFF + ". -->";
+
+	private String companionFilename;
+	private String companionUUID;
+
+  // -- Constructor --
+
+  public OMEBinaryOnlyTiffWriter() {
+    super();
+	companionFilename = "companion.ome";
+	companionUUID = "urn:uuid:" + getUUID(companionFilename);
+  }
+
+  // -- IFormatHandler API methods --
+
+  /* @see loci.formats.IFormatHandler#close() */
+  public void close() throws IOException {
+    try {
+      if (currentId != null) {
+        setupServiceAndMetadata();
+
+        // remove any BinData elements from the OME-XML
+        service.removeBinData(omeMeta);
+
+        for (int series=0; series<omeMeta.getImageCount(); series++) {
+          setSeries(series);
+          populateImage(omeMeta, series);
+        }
+
+        List<String> files = new ArrayList<String>();
+        for (String[] s : imageLocations) {
+          for (String f : s) {
+            if (!files.contains(f) && f != null) {
+              files.add(f);
+
+              String xml = getBinaryOnlyOMEXML(f);
+
+              // write OME-XML to the first IFD's comment
+              saveComment(f, xml);
+            }
+          }
+        }
+      }
+    }
+    catch (DependencyException de) {
+      throw new RuntimeException(de);
+    }
+    catch (ServiceException se) {
+      throw new RuntimeException(se);
+    }
+    catch (FormatException fe) {
+      throw new RuntimeException(fe);
+    }
+    catch (IllegalArgumentException iae) {
+      throw new RuntimeException(iae);
+    }
+    finally {
+      super.closeParentWorkaroundToFix();
+
+      boolean canReallyClose =
+        omeMeta == null || ifdCounts.size() == omeMeta.getImageCount();
+
+      if (omeMeta != null && canReallyClose) {
+        int omePlaneCount = 0;
+        for (int i=0; i<omeMeta.getImageCount(); i++) {
+          int sizeZ = omeMeta.getPixelsSizeZ(i).getValue();
+          int sizeC = omeMeta.getPixelsSizeC(i).getValue();
+          int sizeT = omeMeta.getPixelsSizeT(i).getValue();
+
+          omePlaneCount += sizeZ * sizeC * sizeT;
+        }
+
+        int ifdCount = 0;
+        for (String key : ifdCounts.keySet()) {
+          ifdCount += ifdCounts.get(key);
+        }
+
+        canReallyClose = omePlaneCount == ifdCount;
+      }
+
+      if (canReallyClose) {
+        imageLocations = null;
+        omeMeta = null;
+        service = null;
+        ifdCounts.clear();
+      }
+      else {
+        for(String k : ifdCounts.keySet())
+        ifdCounts.put(k, 0);
+      }
+    }
+  }
+
+  // -- Helper methods --
+
+  @Override
+  protected void setupServiceAndMetadata()
+    throws DependencyException, ServiceException
+  {
+    // extract OME-XML string from metadata object
+    MetadataRetrieve retrieve = getMetadataRetrieve();
+
+    ServiceFactory factory = new ServiceFactory();
+    service = factory.getInstance(OMEXMLService.class);
+    OMEXMLMetadata originalOMEMeta = service.getOMEMetadata(retrieve);
+    originalOMEMeta.resolveReferences();
+
+    String omexml = service.getOMEXML(originalOMEMeta);
+    omeMeta = service.createOMEXMLMetadata(omexml);
+  }
+
+  @Override
+  protected String getOMEXML(String file) throws FormatException, IOException {
+    // generate UUID and add to OME element
+    String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
+    omeMeta.setUUID(uuid);
+
+    String xml;
+    try {
+      xml = service.getOMEXML(omeMeta);
+    }
+    catch (ServiceException se) {
+      throw new FormatException(se);
+    }
+
+    // insert warning comment
+    String prefix = xml.substring(0, xml.indexOf(">") + 1);
+    String suffix = xml.substring(xml.indexOf(">") + 1);
+    return prefix + COMPANION_WARNING_COMMENT + suffix;
+  }
+
+  protected String getBinaryOnlyOMEXML(String file) throws FormatException, IOException, DependencyException, ServiceException {
+	    // generate UUID and add to OME element
+	    String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
+	    ServiceFactory factory = new ServiceFactory();
+	    service = factory.getInstance(OMEXMLService.class);
+	    OMEXMLMetadata omeBinaryMeta = service.createOMEXMLMetadata();
+		omeBinaryMeta.setUUID(uuid);
+	    omeBinaryMeta.setBinaryOnlyMetadataFile(companionFilename);
+	    omeBinaryMeta.setBinaryOnlyUUID(companionUUID);
+	    
+	    String xml;
+	    try {
+	      xml = service.getOMEXML(omeBinaryMeta);
+	    }
+	    catch (ServiceException se) {
+	      throw new FormatException(se);
+	    }
+
+	    // insert warning comment
+	    String prefix = xml.substring(0, xml.indexOf(">") + 1);
+	    String suffix = xml.substring(xml.indexOf(">") + 1);
+	    return prefix + BINARY_ONLY_WARNING_COMMENT + suffix;
+	  }
+
+  
+}

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -74,10 +74,10 @@ public class OMETiffWriter extends TiffWriter {
   // -- Fields --
 
   private List<Integer> seriesMap;
-  private String[][] imageLocations;
-  private OMEXMLMetadata omeMeta;
-  private OMEXMLService service;
-  private Map<String, Integer> ifdCounts = new HashMap<String, Integer>();
+  protected String[][] imageLocations;
+  protected OMEXMLMetadata omeMeta;
+  protected OMEXMLService service;
+  protected Map<String, Integer> ifdCounts = new HashMap<String, Integer>();
 
   private Map<String, String> uuids = new HashMap<String, String>();
 
@@ -228,7 +228,7 @@ public class OMETiffWriter extends TiffWriter {
   // -- Helper methods --
 
   /** Gets the UUID corresponding to the given filename. */
-  private String getUUID(String filename) {
+  protected String getUUID(String filename) {
     String uuid = uuids.get(filename);
     if (uuid == null) {
       uuid = UUID.randomUUID().toString();
@@ -237,7 +237,7 @@ public class OMETiffWriter extends TiffWriter {
     return uuid;
   }
 
-  private void setupServiceAndMetadata()
+  protected void setupServiceAndMetadata()
     throws DependencyException, ServiceException
   {
     // extract OME-XML string from metadata object
@@ -252,7 +252,7 @@ public class OMETiffWriter extends TiffWriter {
     omeMeta = service.createOMEXMLMetadata(omexml);
   }
 
-  private String getOMEXML(String file) throws FormatException, IOException {
+  protected String getOMEXML(String file) throws FormatException, IOException {
     // generate UUID and add to OME element
     String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
     omeMeta.setUUID(uuid);
@@ -271,7 +271,7 @@ public class OMETiffWriter extends TiffWriter {
     return prefix + WARNING_COMMENT + suffix;
   }
 
-  private void saveComment(String file, String xml) throws IOException {
+  protected void saveComment(String file, String xml) throws IOException {
     if (out != null) out.close();
     out = new RandomAccessOutputStream(file);
     RandomAccessInputStream in = null;
@@ -304,7 +304,7 @@ public class OMETiffWriter extends TiffWriter {
     omeMeta.setTiffDataPlaneCount(new NonNegativeInteger(1), series, plane);
   }
 
-  private void populateImage(OMEXMLMetadata omeMeta, int series) {
+  protected void populateImage(OMEXMLMetadata omeMeta, int series) {
     String dimensionOrder = omeMeta.getPixelsDimensionOrder(series).toString();
     int sizeZ = omeMeta.getPixelsSizeZ(series).getValue().intValue();
     int sizeC = omeMeta.getPixelsSizeC(series).getValue().intValue();
@@ -369,4 +369,9 @@ public class OMETiffWriter extends TiffWriter {
     return z * c * t;
   }
 
+  public void closeParentWorkaroundToFix() throws IOException {
+	  super.close();
+  }
+
+  
 }

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -41,7 +41,6 @@ import java.util.UUID;
 
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveInteger;
-
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
@@ -88,6 +87,10 @@ public class OMETiffWriter extends TiffWriter {
   }
 
   // -- IFormatHandler API methods --
+
+  public OMETiffWriter(String readerName, String[] extensions) {
+      super(readerName, extensions);
+  }
 
   /* @see loci.formats.IFormatHandler#close() */
   @Override

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -25,73 +25,27 @@
 
 package loci.formats.utests;
 
-import ome.xml.meta.OMEXMLMetadataRoot;
-import ome.xml.model.Arc;
-import ome.xml.model.BinaryFile;
-import ome.xml.model.BooleanAnnotation;
-import ome.xml.model.Channel;
-import ome.xml.model.CommentAnnotation;
-import ome.xml.model.Detector;
-import ome.xml.model.Dichroic;
-import ome.xml.model.DoubleAnnotation;
-import ome.xml.model.External;
-import ome.xml.model.Filament;
-import ome.xml.model.Filter;
-import ome.xml.model.FilterSet;
-import ome.xml.model.Image;
-import ome.xml.model.Instrument;
-import ome.xml.model.Laser;
-import ome.xml.model.LightEmittingDiode;
-import ome.xml.model.ListAnnotation;
-import ome.xml.model.LongAnnotation;
-import ome.xml.model.Objective;
-import ome.xml.model.ObjectiveSettings;
-import ome.xml.model.Pixels;
-import ome.xml.model.Plate;
-import ome.xml.model.ROI;
-import ome.xml.model.Rectangle;
-import ome.xml.model.StructuredAnnotations;
-import ome.xml.model.TiffData;
-import ome.xml.model.TimestampAnnotation;
-import ome.xml.model.UUID;
-import ome.xml.model.Union;
-import ome.xml.model.Well;
-import ome.xml.model.WellSample;
-import ome.xml.model.XMLAnnotation;
-import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.PositiveInteger;
-import ome.xml.model.primitives.Timestamp;
-
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
-import loci.formats.Modulo;
 import loci.formats.gui.BufferedImageWriter;
 import loci.formats.meta.IMetadata;
 import loci.formats.out.OMEBinaryOnlyTiffWriter;
-import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
+
 import ome.xml.model.enums.EnumerationException;
 
 
@@ -129,15 +83,28 @@ public class SampleBinaryOMETiff {
 		}
 
 		final String id;
-		if (filename.toLowerCase().endsWith(OME_TIFF_EXTENSION)) id = filename;
-		else id = filename + OME_TIFF_EXTENSION;
-		filename = filename.replaceAll(FormatTools.Z_NUM, "#");
-		filename = filename.replaceAll(FormatTools.T_NUM, "#");
-		filename = filename.replaceAll(FormatTools.CHANNEL_NUM, "#");
+		String justFilename;
+		String metaFilename;
+		if (filename.toLowerCase().endsWith(OME_TIFF_EXTENSION)) {
+			id = filename;
+			justFilename = new String(filename);
+			justFilename = justFilename.substring(0, justFilename.length() - OME_TIFF_EXTENSION.length());
+
+		}
+		else {
+			id = filename + OME_TIFF_EXTENSION;
+			justFilename = new String(filename);
+		}
+
+		metaFilename = new String(justFilename);
+
+		metaFilename = metaFilename.replaceAll(FormatTools.Z_NUM, "#");
+		metaFilename = metaFilename.replaceAll(FormatTools.T_NUM, "#");
+		metaFilename = metaFilename.replaceAll(FormatTools.CHANNEL_NUM, "#");
 
 		final OMEBinaryOnlyTiffWriter out = new OMEBinaryOnlyTiffWriter();
 		try {
-			out.setMetadataRetrieve(createMetadata(filename, coreInfo));
+			out.setMetadataRetrieve(createMetadata(id, coreInfo));
 		}
 		catch (final DependencyException e) {
 			out.close();
@@ -159,7 +126,7 @@ public class SampleBinaryOMETiff {
 	        out.setId(planeFilenameBuilder.toString());
 			out.saveBytes(i, BufferedImageWriter.toBytes(plane, out));
 		}
-		out.setId(id);
+		out.setId(metaFilename);
 		out.close();
 
 	}
@@ -234,8 +201,8 @@ public class SampleBinaryOMETiff {
 		
 		String planeFilename = new String(name);
 	    planeFilename = planeFilename.replaceAll(FormatTools.Z_NUM, String.valueOf(zct[0] + 1));
-	    planeFilename = planeFilename.replaceAll(FormatTools.T_NUM, String.valueOf(zct[1] + 1));
-	    planeFilename = planeFilename.replaceAll(FormatTools.CHANNEL_NUM, String.valueOf(zct[2] + 1));
+	    planeFilename = planeFilename.replaceAll(FormatTools.CHANNEL_NUM, String.valueOf(zct[1] + 1));
+	    planeFilename = planeFilename.replaceAll(FormatTools.T_NUM, String.valueOf(zct[2] + 1));
 		if (info.sizeZ > 1) {
 			lines.add(new TextLine(
 					"Focal plane = " + (zct[0] + 1) + "/" + info.sizeZ, font, 20, space));

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -130,8 +130,8 @@ public class SampleBinaryOMETiff {
 		}
 
 		final String id;
-		if (filename.toLowerCase().endsWith(".ome.tif")) id = filename;
-		else id = filename + ".ome.tif";
+		if (filename.toLowerCase().endsWith(".come.tif")) id = filename;
+		else id = filename + ".come.tif";
 
 		final OMEBinaryOnlyTiffWriter out = new OMEBinaryOnlyTiffWriter();
 		try {
@@ -332,6 +332,7 @@ public class SampleBinaryOMETiff {
 		makeBinaryOmeTiff("multi-channel", 439, 167, 1, 3, 1, "XYZCT");
 		makeBinaryOmeTiff("z-series", 439, 167, 5, 1, 1, "XYZCT");
 		makeBinaryOmeTiff("multi-channel-z-series", 439, 167, 5, 3, 1, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-z-series-Z%z", 439, 167, 5, 3, 1, "XYZCT");
 		makeBinaryOmeTiff("time-series", 439, 167, 1, 1, 7, "XYZCT");
 		makeBinaryOmeTiff("multi-channel-time-series", 439, 167, 1, 3, 7, "XYZCT");
 		makeBinaryOmeTiff("4D-series", 439, 167, 5, 1, 7, "XYZCT");

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -102,8 +102,6 @@ import ome.xml.model.enums.EnumerationException;
  */
 public class SampleBinaryOMETiff {
 
-	private OMEXMLMetadataRoot ome;
-
 	public int sizeZsub;
 	public int sizeTsub;
 	public int sizeCsub;
@@ -342,7 +340,7 @@ public class SampleBinaryOMETiff {
 	private static void makeBinaryOmeTiff(String filename, int x,
 			int y, int z, int c, int t,
 			String order) throws FormatException, IOException {
-		final String name = "multi-channel-4D-series";
+		final String name = filename;
 		final CoreMetadata info = new CoreMetadata();
 		info.sizeX = x;
 		info.sizeY = y;

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -100,18 +100,16 @@ import ome.xml.model.enums.EnumerationException;
  * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/test/loci/formats/utests/SampleTiffOMEModelMock.java">Trac</a>,
  * <a href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/test/loci/formats/utests/SampleTiffOMEModelMock.java;hb=HEAD">Gitweb</a></dd></dl>
  */
-public class SampleTiffOMEModelMock implements OMEModelMock {
+public class SampleBinaryOMETiff {
 
 	private OMEXMLMetadataRoot ome;
-
-	private StructuredAnnotations annotations;
 
 	public int sizeZsub;
 	public int sizeTsub;
 	public int sizeCsub;
 	public boolean isModulo;
 
-	public SampleTiffOMEModelMock(String filename, CoreMetadata coreInfo) throws FormatException, IOException {
+	public SampleBinaryOMETiff(String filename, CoreMetadata coreInfo) throws FormatException, IOException {
 
 		//TODO: Move to using Modulo directly from core data
 		isModulo = false;
@@ -160,10 +158,6 @@ public class SampleTiffOMEModelMock implements OMEModelMock {
 		}
 		out.close();
 
-	}
-
-	public OMEXMLMetadataRoot getRoot() {
-		return ome;
 	}
 
 	private IMetadata createMetadata(final String name, final CoreMetadata info)
@@ -333,50 +327,46 @@ public class SampleTiffOMEModelMock implements OMEModelMock {
 
 	}
 
-	@SuppressWarnings("unused")
-	public static void main(String[] args) throws Exception {
+	public static void makeSamples() throws FormatException, IOException {
+		makeBinaryOmeTiff("single-channel", 439, 167, 1, 1, 1, "XYZCT");
+		makeBinaryOmeTiff("multi-channel", 439, 167, 1, 3, 1, "XYZCT");
+		makeBinaryOmeTiff("z-series", 439, 167, 5, 1, 1, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-z-series", 439, 167, 5, 3, 1, "XYZCT");
+		makeBinaryOmeTiff("time-series", 439, 167, 1, 1, 7, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-time-series", 439, 167, 1, 3, 7, "XYZCT");
+		makeBinaryOmeTiff("4D-series", 439, 167, 5, 1, 7, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-4D-series", 439, 167, 5, 3, 7, "XYZCT");
+	}
+	
+	private static void makeBinaryOmeTiff(String filename, int x,
+			int y, int z, int c, int t,
+			String order) throws FormatException, IOException {
 		final String name = "multi-channel-4D-series";
 		final CoreMetadata info = new CoreMetadata();
-		info.sizeX = 439;
-		info.sizeY = 167;
-		info.sizeZ = 5;
-		info.sizeC = 3;
-		info.sizeT = 7;
+		info.sizeX = x;
+		info.sizeY = y;
+		info.sizeZ = z;
+		info.sizeC = c;
+		info.sizeT = t;
 		info.imageCount = info.sizeZ * info.sizeC * info.sizeT;
-		info.dimensionOrder = "XYZCT";
-		if (false) {
-			info.moduloZ.start = 0;
-			info.moduloZ.step = 1;
-			info.moduloZ.end = 3;
-			info.moduloC.start = 4;
-			info.moduloC.step = 0.5;
-			info.moduloC.end = 6;
-			info.moduloT.start = 100;
-			info.moduloT.step = 10;
-			info.moduloT.end = 150;
-		}
-		SampleTiffOMEModelMock mock = new SampleTiffOMEModelMock(name, info);
-		
-//		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-//		DocumentBuilder parser = factory.newDocumentBuilder();
-//		Document document = parser.newDocument();
-//		// Produce a valid OME DOM element hierarchy
-//		Element root = mock.ome.asXMLElement(document);
-//		SampleTiffOMEModelMock.postProcess(root, document, true);
-		// Produce string XML
-//		OutputStream outputStream = new FileOutputStream(args[0]);
-//		outputStream.write(SampleTiffOMEModelMock.asString(document).getBytes());
-//		outputStream.close();
+		info.dimensionOrder = order;
+
+		new SampleBinaryOMETiff(name, info);
 	}
 
-	private static String asString(Document document) {
-		// TODO Auto-generated method stub
-		return null;
+/*
+	info.moduloZ.start = 0;
+	info.moduloZ.step = 1;
+	info.moduloZ.end = 3;
+	info.moduloC.start = 4;
+	info.moduloC.step = 0.5;
+	info.moduloC.end = 6;
+	info.moduloT.start = 100;
+	info.moduloT.step = 10;
+	info.moduloT.end = 150;
+*/
+	
+	public static void main(String[] args) throws Exception {
+		makeSamples();
 	}
-
-	private static void postProcess(Element root, Document document, boolean b) {
-		// TODO Auto-generated method stub
-		
-	}
-
 }

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -330,7 +330,7 @@ public class SampleBinaryOMETiff {
 		makeBinaryOmeTiff("multi-channel", 439, 167, 1, 3, 1, "XYZCT");
 		makeBinaryOmeTiff("z-series", 439, 167, 5, 1, 1, "XYZCT");
 		makeBinaryOmeTiff("multi-channel-z-series", 439, 167, 5, 3, 1, "XYZCT");
-		makeBinaryOmeTiff("multi-channel-z-series-Z%z", 439, 167, 5, 3, 1, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-z-series-Z%z", 460, 167, 5, 3, 1, "XYZCT");
 		makeBinaryOmeTiff("time-series", 439, 167, 1, 1, 7, "XYZCT");
 		makeBinaryOmeTiff("multi-channel-time-series", 439, 167, 1, 3, 7, "XYZCT");
 		makeBinaryOmeTiff("4D-series", 439, 167, 5, 1, 7, "XYZCT");

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -102,6 +102,7 @@ import ome.xml.model.enums.EnumerationException;
  */
 public class SampleBinaryOMETiff {
 
+	private static final String OME_TIFF_EXTENSION = ".ome.tif";
 	public int sizeZsub;
 	public int sizeTsub;
 	public int sizeCsub;
@@ -128,8 +129,11 @@ public class SampleBinaryOMETiff {
 		}
 
 		final String id;
-		if (filename.toLowerCase().endsWith(".come.tif")) id = filename;
-		else id = filename + ".come.tif";
+		if (filename.toLowerCase().endsWith(OME_TIFF_EXTENSION)) id = filename;
+		else id = filename + OME_TIFF_EXTENSION;
+		filename = filename.replaceAll(FormatTools.Z_NUM, "#");
+		filename = filename.replaceAll(FormatTools.T_NUM, "#");
+		filename = filename.replaceAll(FormatTools.CHANNEL_NUM, "#");
 
 		final OMEBinaryOnlyTiffWriter out = new OMEBinaryOnlyTiffWriter();
 		try {
@@ -148,8 +152,6 @@ public class SampleBinaryOMETiff {
 			throw new FormatException(e);
 		}
 
-		out.setId(id);
-
 		for (int i = 0; i < coreInfo.imageCount; i++) {
 	          // for each plane get the ZCT location
 	        StringBuilder planeFilenameBuilder = new StringBuilder();
@@ -157,6 +159,7 @@ public class SampleBinaryOMETiff {
 	        out.setId(planeFilenameBuilder.toString());
 			out.saveBytes(i, BufferedImageWriter.toBytes(plane, out));
 		}
+		out.setId(id);
 		out.close();
 
 	}
@@ -295,7 +298,9 @@ public class SampleBinaryOMETiff {
 		g.dispose();
 
 		// Fill the "out" parameter with the new filename
-		planeFilenameBuilder.append(planeFilename); 
+		planeFilenameBuilder.append(planeFilename);
+		planeFilenameBuilder.append(OME_TIFF_EXTENSION);
+		
 		return plane;
 	}
 
@@ -339,12 +344,13 @@ public class SampleBinaryOMETiff {
 		makeBinaryOmeTiff("single-channel", 439, 167, 1, 1, 1, "XYZCT");
 		makeBinaryOmeTiff("multi-channel", 439, 167, 1, 3, 1, "XYZCT");
 		makeBinaryOmeTiff("z-series", 439, 167, 5, 1, 1, "XYZCT");
-		makeBinaryOmeTiff("multi-channel-z-series", 439, 167, 5, 3, 1, "XYZCT");
-		makeBinaryOmeTiff("multi-channel-z-series-Z%z", 460, 167, 5, 3, 1, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-z-series-single", 700, 167, 5, 3, 1, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-z-series-Z%z", 700, 167, 5, 3, 1, "XYZCT");
 		makeBinaryOmeTiff("time-series", 439, 167, 1, 1, 7, "XYZCT");
 		makeBinaryOmeTiff("multi-channel-time-series", 439, 167, 1, 3, 7, "XYZCT");
 		makeBinaryOmeTiff("4D-series", 439, 167, 5, 1, 7, "XYZCT");
-		makeBinaryOmeTiff("multi-channel-4D-series", 439, 167, 5, 3, 7, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-4D-series-single", 700, 167, 5, 3, 7, "XYZCT");
+		makeBinaryOmeTiff("multi-channel-4D-series-Z%z-C%c-T%t", 700, 167, 5, 3, 7, "XYZCT");
 	}
 	
 	private static void makeBinaryOmeTiff(String filename, int x,

--- a/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleBinaryOMETiff.java
@@ -151,7 +151,10 @@ public class SampleBinaryOMETiff {
 		out.setId(id);
 
 		for (int i = 0; i < coreInfo.imageCount; i++) {
-			final BufferedImage plane = createPlane(filename, coreInfo, i);
+	          // for each plane get the ZCT location
+	        StringBuilder planeFilenameBuilder = new StringBuilder();
+			final BufferedImage plane = createPlane(filename, coreInfo, i, planeFilenameBuilder);
+	        out.setId(planeFilenameBuilder.toString());
 			out.saveBytes(i, BufferedImageWriter.toBytes(plane, out));
 		}
 		out.close();
@@ -198,7 +201,7 @@ public class SampleBinaryOMETiff {
 	}
 
 
-	private BufferedImage createPlane(final String name, final CoreMetadata info, final int no)
+	private BufferedImage createPlane(final String name, final CoreMetadata info, final int no, StringBuilder planeFilenameBuilder)
 	{
 		final int[] zct =
 				FormatTools.getZCTCoords(info.dimensionOrder, info.sizeZ, info.sizeC,
@@ -225,6 +228,11 @@ public class SampleBinaryOMETiff {
 		lines.add(new TextLine(info.dimensionOrder, font.deriveFont(Font.ITALIC,
 				14f), 30, 5));
 		int space = 5;
+		
+		String planeFilename = new String(name);
+	    planeFilename = planeFilename.replaceAll(FormatTools.Z_NUM, String.valueOf(zct[0] + 1));
+	    planeFilename = planeFilename.replaceAll(FormatTools.T_NUM, String.valueOf(zct[1] + 1));
+	    planeFilename = planeFilename.replaceAll(FormatTools.CHANNEL_NUM, String.valueOf(zct[2] + 1));
 		if (info.sizeZ > 1) {
 			lines.add(new TextLine(
 					"Focal plane = " + (zct[0] + 1) + "/" + info.sizeZ, font, 20, space));
@@ -286,6 +294,8 @@ public class SampleBinaryOMETiff {
 		}
 		g.dispose();
 
+		// Fill the "out" parameter with the new filename
+		planeFilenameBuilder.append(planeFilename); 
 		return plane;
 	}
 

--- a/components/formats-gpl/test/loci/formats/utests/SampleTiffOMEModelMock.java
+++ b/components/formats-gpl/test/loci/formats/utests/SampleTiffOMEModelMock.java
@@ -1,0 +1,382 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import ome.xml.meta.OMEXMLMetadataRoot;
+import ome.xml.model.Arc;
+import ome.xml.model.BinaryFile;
+import ome.xml.model.BooleanAnnotation;
+import ome.xml.model.Channel;
+import ome.xml.model.CommentAnnotation;
+import ome.xml.model.Detector;
+import ome.xml.model.Dichroic;
+import ome.xml.model.DoubleAnnotation;
+import ome.xml.model.External;
+import ome.xml.model.Filament;
+import ome.xml.model.Filter;
+import ome.xml.model.FilterSet;
+import ome.xml.model.Image;
+import ome.xml.model.Instrument;
+import ome.xml.model.Laser;
+import ome.xml.model.LightEmittingDiode;
+import ome.xml.model.ListAnnotation;
+import ome.xml.model.LongAnnotation;
+import ome.xml.model.Objective;
+import ome.xml.model.ObjectiveSettings;
+import ome.xml.model.Pixels;
+import ome.xml.model.Plate;
+import ome.xml.model.ROI;
+import ome.xml.model.Rectangle;
+import ome.xml.model.StructuredAnnotations;
+import ome.xml.model.TiffData;
+import ome.xml.model.TimestampAnnotation;
+import ome.xml.model.UUID;
+import ome.xml.model.Union;
+import ome.xml.model.Well;
+import ome.xml.model.WellSample;
+import ome.xml.model.XMLAnnotation;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.Modulo;
+import loci.formats.gui.BufferedImageWriter;
+import loci.formats.meta.IMetadata;
+import loci.formats.out.OMEBinaryOnlyTiffWriter;
+import loci.formats.out.OMETiffWriter;
+import loci.formats.services.OMEXMLService;
+import ome.xml.model.enums.EnumerationException;
+
+
+/**
+ * <dl><dt><b>Source code:</b></dt>
+ * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/test/loci/formats/utests/SampleTiffOMEModelMock.java">Trac</a>,
+ * <a href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/test/loci/formats/utests/SampleTiffOMEModelMock.java;hb=HEAD">Gitweb</a></dd></dl>
+ */
+public class SampleTiffOMEModelMock implements OMEModelMock {
+
+	private OMEXMLMetadataRoot ome;
+
+	private StructuredAnnotations annotations;
+
+	public int sizeZsub;
+	public int sizeTsub;
+	public int sizeCsub;
+	public boolean isModulo;
+
+	public SampleTiffOMEModelMock(String filename, CoreMetadata coreInfo) throws FormatException, IOException {
+
+		//TODO: Move to using Modulo directly from core data
+		isModulo = false;
+		if (coreInfo.moduloC.start == coreInfo.moduloC.end) {
+			sizeCsub = 1;
+		} else {
+			sizeCsub = 3;
+		}
+		if (coreInfo.moduloZ.start == coreInfo.moduloZ.end) {
+			sizeZsub = 1;
+		} else {
+			sizeZsub = 2;
+		}
+		if (coreInfo.moduloT.start == coreInfo.moduloT.end) {
+			sizeTsub = 1;
+		} else {
+			sizeTsub = 4;
+		}
+
+		final String id;
+		if (filename.toLowerCase().endsWith(".ome.tif")) id = filename;
+		else id = filename + ".ome.tif";
+
+		final OMEBinaryOnlyTiffWriter out = new OMEBinaryOnlyTiffWriter();
+		try {
+			out.setMetadataRetrieve(createMetadata(filename, coreInfo));
+		}
+		catch (final DependencyException e) {
+			out.close();
+			throw new FormatException(e);
+		}
+		catch (final ServiceException e) {
+			out.close();
+			throw new FormatException(e);
+		}
+		catch (final EnumerationException e) {
+			out.close();
+			throw new FormatException(e);
+		}
+
+		out.setId(id);
+
+		for (int i = 0; i < coreInfo.imageCount; i++) {
+			final BufferedImage plane = createPlane(filename, coreInfo, i);
+			out.saveBytes(i, BufferedImageWriter.toBytes(plane, out));
+		}
+		out.close();
+
+	}
+
+	public OMEXMLMetadataRoot getRoot() {
+		return ome;
+	}
+
+	private IMetadata createMetadata(final String name, final CoreMetadata info)
+			throws DependencyException, ServiceException, EnumerationException {
+		final ServiceFactory serviceFactory = new ServiceFactory();
+		final OMEXMLService omexmlService =
+				serviceFactory.getInstance(OMEXMLService.class);
+		final IMetadata meta = omexmlService.createOMEXMLMetadata();
+		MetadataTools.populateMetadata(meta, 0, name, info);
+
+		if (isModulo) {
+			meta.setXMLAnnotationID("Annotation:Modulo:0", 0);
+			meta.setXMLAnnotationNamespace("openmicroscopy.org/omero/dimension/modulo", 0);
+			meta.setXMLAnnotationDescription("For a description of how 6D, 7D, and 8D data is stored using the Modulo extension see http://www.openmicroscopy.org/site/support/ome-model/developers/6d-7d-and-8d-storage.html", 0);
+			StringBuilder moduloBlock = new StringBuilder();
+
+			moduloBlock.append("<Modulo namespace=\"http://www.openmicroscopy.org/Schemas/Additions/2011-09\">");
+			if (sizeZsub != 1) {
+				moduloBlock.append("<ModuloAlongZ Type=\"other\" TypeDescription=\"Example Data Over Z-Plane\" Start=\"0\" Step=\"1\" End=\"");
+				moduloBlock.append(sizeZsub);
+				moduloBlock.append("\"/>");
+			}
+			if (sizeTsub != 1) {
+				moduloBlock.append("<ModuloAlongT Type=\"other\" TypeDescription=\"Example Data Over Time \" Start=\"0\" Step=\"1\" End=\"");
+				moduloBlock.append(sizeTsub);
+				moduloBlock.append("\"/>");
+			}
+			if (sizeCsub != 1) {
+				moduloBlock.append("<ModuloAlongC Type=\"other\" TypeDescription=\"Example Data Over Channel\" Start=\"0\" Step=\"1\" End=\"");
+				moduloBlock.append(sizeCsub);
+				moduloBlock.append("\"/>");
+			}
+			moduloBlock.append("</Modulo>");
+
+			meta.setXMLAnnotationValue(moduloBlock.toString(), 0);
+
+			meta.setImageAnnotationRef("Annotation:Modulo:0", 0, 0);
+		}
+		return meta;
+	}
+
+
+	private BufferedImage createPlane(final String name, final CoreMetadata info, final int no)
+	{
+		final int[] zct =
+				FormatTools.getZCTCoords(info.dimensionOrder, info.sizeZ, info.sizeC,
+						info.sizeT, info.imageCount, no);
+
+		final BufferedImage plane =
+				new BufferedImage(info.sizeX, info.sizeY, BufferedImage.TYPE_BYTE_GRAY);
+		final Graphics2D g = plane.createGraphics();
+
+		// draw gradient
+		final int type = 0;
+		for (int y = 0; y < info.sizeY; y++) {
+			final int v = gradient(type, y, info.sizeY);
+			g.setColor(new Color(v, v, v));
+			g.drawLine(0, y, info.sizeX, y);
+		}
+
+		// build list of text lines from planar information
+		final ArrayList<TextLine> lines = new ArrayList<TextLine>();
+		final Font font = g.getFont();
+		lines.add(new TextLine(name, font.deriveFont(32f), 5, -5));
+		lines.add(new TextLine(info.sizeX + " x " + info.sizeY, font.deriveFont(
+				Font.ITALIC, 16f), 20, 10));
+		lines.add(new TextLine(info.dimensionOrder, font.deriveFont(Font.ITALIC,
+				14f), 30, 5));
+		int space = 5;
+		if (info.sizeZ > 1) {
+			lines.add(new TextLine(
+					"Focal plane = " + (zct[0] + 1) + "/" + info.sizeZ, font, 20, space));
+			space = 2;
+		}
+		if (info.sizeC > 1) {
+			lines.add(new TextLine("Channel = " + (zct[1] + 1) + "/" + info.sizeC,
+					font, 20, space));
+			space = 2;
+		}
+		if (info.sizeT > 1) {
+			lines.add(new TextLine("Time point = " + (zct[2] + 1) + "/" + info.sizeT,
+					font, 20, space));
+			space = 2;
+		}
+
+		if (isModulo) {
+			if (sizeZsub > 1) {
+				lines.add(new TextLine("True-Z point = " + ((zct[0]/sizeZsub) + 1) + "/" + info.sizeZ/sizeZsub,
+						font, 20, space));
+				space = 2;
+			}
+			if (sizeZsub > 1) {
+				lines.add(new TextLine("Sub-Z = " + ((zct[0]%sizeZsub) + 1) + "/" + sizeZsub,
+						font, 20, space));
+				space = 2;
+			}
+			if (sizeCsub > 1) {
+				lines.add(new TextLine("True Channel = " + ((zct[1]/sizeCsub) + 1) + "/" + info.sizeC/sizeCsub,
+						font, 20, space));
+				space = 2;
+			}
+			if (sizeCsub > 1) {
+				lines.add(new TextLine("Sub Channel = " + ((zct[1]%sizeCsub) + 1) + "/" + sizeCsub,
+						font, 20, space));
+				space = 2;
+			}
+			if (sizeTsub > 1) {
+				lines.add(new TextLine("True-T point = " + ((zct[2]/sizeTsub) + 1) + "/" + info.sizeT/sizeTsub,
+						font, 20, space));
+				space = 2;
+			}
+			if (sizeTsub > 1) {
+				lines.add(new TextLine("Sub-T = " + ((zct[2]%sizeTsub) + 1) + "/" + sizeTsub,
+						font, 20, space));
+				space = 2;
+			}
+		}
+		// draw text lines to image
+		g.setColor(Color.white);
+		int yoff = 0;
+		for (int l = 0; l < lines.size(); l++) {
+			final TextLine text = lines.get(l);
+			g.setFont(text.font);
+			final Rectangle2D r =
+					g.getFont().getStringBounds(text.line, g.getFontRenderContext());
+			yoff += r.getHeight() + text.ypad;
+			g.drawString(text.line, text.xoff, yoff);
+		}
+		g.dispose();
+
+		return plane;
+	}
+
+	private int gradient(final int type, final int num, final int total) {
+		final int max = 96;
+		final int split = type / 2 + 1;
+		final boolean reverse = type % 2 == 0;
+		int v = max;
+		final int splitTotal = total / split;
+		for (int i = 1; i <= split + 1; i++) {
+			if (num < i * splitTotal) {
+				if (i % 2 == 0) v = max * (num % splitTotal) / splitTotal;
+				else v = max * (splitTotal - num % splitTotal) / splitTotal;
+				break;
+			}
+		}
+		if (reverse) v = max - v;
+		return v;
+	}
+
+	// -- Helper classes --
+
+	private static class TextLine {
+
+		final String line;
+		final Font font;
+		final int xoff;
+		final int ypad;
+
+		TextLine(final String line, final Font font, final int xoff, final int ypad)
+		{
+			this.line = line;
+			this.font = font;
+			this.xoff = xoff;
+			this.ypad = ypad;
+		}
+
+	}
+
+	@SuppressWarnings("unused")
+	public static void main(String[] args) throws Exception {
+		final String name = "multi-channel-4D-series";
+		final CoreMetadata info = new CoreMetadata();
+		info.sizeX = 439;
+		info.sizeY = 167;
+		info.sizeZ = 5;
+		info.sizeC = 3;
+		info.sizeT = 7;
+		info.imageCount = info.sizeZ * info.sizeC * info.sizeT;
+		info.dimensionOrder = "XYZCT";
+		if (false) {
+			info.moduloZ.start = 0;
+			info.moduloZ.step = 1;
+			info.moduloZ.end = 3;
+			info.moduloC.start = 4;
+			info.moduloC.step = 0.5;
+			info.moduloC.end = 6;
+			info.moduloT.start = 100;
+			info.moduloT.step = 10;
+			info.moduloT.end = 150;
+		}
+		SampleTiffOMEModelMock mock = new SampleTiffOMEModelMock(name, info);
+		
+//		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+//		DocumentBuilder parser = factory.newDocumentBuilder();
+//		Document document = parser.newDocument();
+//		// Produce a valid OME DOM element hierarchy
+//		Element root = mock.ome.asXMLElement(document);
+//		SampleTiffOMEModelMock.postProcess(root, document, true);
+		// Produce string XML
+//		OutputStream outputStream = new FileOutputStream(args[0]);
+//		outputStream.write(SampleTiffOMEModelMock.asString(document).getBytes());
+//		outputStream.close();
+	}
+
+	private static String asString(Document document) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	private static void postProcess(Element root, Document document, boolean b) {
+		// TODO Auto-generated method stub
+		
+	}
+
+}


### PR DESCRIPTION
Is this an ok approach?

I think it would need OMETiffWriter.java and OMEBinaryOnlyTiffWriter.java defined from a common code (OMECoreTiffWriter.java?) that has almost all of the functions from OMETiffWriter.java. The current approach is a bit messy. (e.g. a function called closeParentWorkaroundToFix)

The other approach is putting a lot of conditionals into OMETiffWriter.java and having a function to set a flag, something like setSaveBinaryOnly(true).

Also at the moment is is saving 1 companion and 1 tiff with all the planes in it. Working on that bit now. The %z in the filename is currently being ignored.

--exclude

@melissalinkert @joshmoore