### PR TITLE
specification: Add metadata for HDF5 embedding

### DIFF
--- a/ant/xsd-fu.xml
+++ b/ant/xsd-fu.xml
@@ -13,6 +13,7 @@ Include this in components generating sources using xsd-fu.
   <property name="xsdfu.schema.ome" value="${xsdfu.schemapath}/ome.xsd"/>
   <property name="xsdfu.schema.binaryfile" value="${xsdfu.schemapath}/BinaryFile.xsd"/>
   <property name="xsdfu.schema.hdf5file" value="${xsdfu.schemapath}/HDF5File.xsd"/>
+  <property name="xsdfu.schema.tifffile" value="${xsdfu.schemapath}/TIFFFile.xsd"/>
   <property name="xsdfu.schema.roi" value="${xsdfu.schemapath}/ROI.xsd"/>
   <property name="xsdfu.schema.sa" value="${xsdfu.schemapath}/SA.xsd"/>
   <property name="xsdfu.schema.spw" value="${xsdfu.schemapath}/SPW.xsd"/>
@@ -42,6 +43,7 @@ Include this in components generating sources using xsd-fu.
 	<arg value="${xsdfu.schema.ome}"/>
 	<arg value="${xsdfu.schema.binaryfile}"/>
         <arg value="${xsdfu.schema.hdf5file}"/>
+        <arg value="${xsdfu.schema.tifffile}"/>
 	<arg value="${xsdfu.schema.roi}"/>
 	<arg value="${xsdfu.schema.sa}"/>
 	<arg value="${xsdfu.schema.spw}"/>

--- a/ant/xsd-fu.xml
+++ b/ant/xsd-fu.xml
@@ -12,6 +12,7 @@ Include this in components generating sources using xsd-fu.
   <property name="xsdfu.templatepath" value="${root.dir}/components/xsd-fu"/>
   <property name="xsdfu.schema.ome" value="${xsdfu.schemapath}/ome.xsd"/>
   <property name="xsdfu.schema.binaryfile" value="${xsdfu.schemapath}/BinaryFile.xsd"/>
+  <property name="xsdfu.schema.hdf5file" value="${xsdfu.schemapath}/HDF5File.xsd"/>
   <property name="xsdfu.schema.roi" value="${xsdfu.schemapath}/ROI.xsd"/>
   <property name="xsdfu.schema.sa" value="${xsdfu.schemapath}/SA.xsd"/>
   <property name="xsdfu.schema.spw" value="${xsdfu.schemapath}/SPW.xsd"/>
@@ -40,6 +41,7 @@ Include this in components generating sources using xsd-fu.
 	<arg value="--print-generated"/>
 	<arg value="${xsdfu.schema.ome}"/>
 	<arg value="${xsdfu.schema.binaryfile}"/>
+        <arg value="${xsdfu.schema.hdf5file}"/>
 	<arg value="${xsdfu.schema.roi}"/>
 	<arg value="${xsdfu.schema.sa}"/>
 	<arg value="${xsdfu.schema.spw}"/>

--- a/components/specification/released-schema/2013-10-dev-2/HDF5File.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/HDF5File.xsd
@@ -1,0 +1,60 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!--
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #
+    # Copyright (C) 2003 - 2014 Open Microscopy Environment
+    #       Massachusetts Institute of Technology,
+    #       National Institutes of Health,
+    #       University of Dundee,
+    #       University of Wisconsin at Madison
+    #
+    # This work is licensed under the
+    #       Creative Commons Attribution 3.0 Unported License.
+    # To view a copy of this license, visit
+    #       http://creativecommons.org/licenses/by/3.0/
+    # or send a letter to
+    #       Creative Commons, 444 Castro Street, Suite 900,
+    #       Mountain View, California, 94041, USA.
+    # For attribution instructions, visit
+    #       http://www.openmicroscopy.org/info/attribution
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+<!--
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Written by:  Josiah Johnston <siah@nih.gov>, Andrew J Patterson
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+<xsd:schema
+	xmlns:xsd = "http://www.w3.org/2001/XMLSchema"
+	targetNamespace = "http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
+	xmlns:HDF = "http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
+	xmlns:OME = "http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	version = "1"
+	elementFormDefault = "qualified">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
+		schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2/ome.xsd"/>
+	<xsd:annotation>
+		<xsd:documentation>
+			The elements in this file are not yet represented by classes in the EA diagrams - ajp
+		</xsd:documentation>
+	</xsd:annotation>
+	<xsd:element name="Hdf5Data"> <!-- top level definition -->
+		<xsd:annotation>
+			<xsd:appinfo><xsdfu><plural>Hdf5DataBlock</plural></xsdfu></xsd:appinfo>
+			<xsd:documentation>
+				This describes the location of the pixel data in a HDF5 file.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="Path" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Path to the pixel hypervolume in the HDF5 file.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/components/specification/released-schema/2013-10-dev-2/ROI.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/ROI.xsd
@@ -28,6 +28,7 @@
 	targetNamespace = "http://www.openmicroscopy.org/Schemas/ROI/2013-10-dev-2"
 	xmlns:OME = "http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
 	xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2"
+	xmlns:HDF="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
 	xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
 	xmlns:xsd = "http://www.w3.org/2001/XMLSchema"
 	version = "1"
@@ -320,15 +321,19 @@
 		<xsd:annotation>
 			<xsd:appinfo><xsdfu><plural>Masks</plural></xsdfu></xsd:appinfo>
 			<xsd:documentation>
-				The Mask ROI shape is a link to a BIN:BinData object that is
-				a BIT mask drawn on top of the image as an ROI. It is applied
-				at the same scale, pixel to pixel, as the Image the ROI is
-				applied to, unless a transform is applied at the shape level.
+				The Mask ROI shape is a link to a BIN:BinData or HDF:HDF5Data
+				object that is a BIT mask drawn on top of the image as an ROI.
+				It is applied at the same scale, pixel to pixel, as the Image
+				the ROI is applied to, unless a transform is applied at the
+				shape level.
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
-				<xsd:element ref="BIN:BinData" minOccurs="1" maxOccurs="unbounded"/>
+				<xsd:choice minOccurs="1" maxOccurs="1">
+					<xsd:element ref="BIN:BinData" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element ref="HDF:Hdf5Data" minOccurs="1" maxOccurs="1"/>
+				</xsd:choice>
 			</xsd:sequence>
 			<xsd:attribute name="X" use="required" type="xsd:float">
 				<xsd:annotation>

--- a/components/specification/released-schema/2013-10-dev-2/ROI.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/ROI.xsd
@@ -29,6 +29,7 @@
 	xmlns:OME = "http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
 	xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2"
 	xmlns:HDF="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
+	xmlns:TIFF="http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2"
 	xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
 	xmlns:xsd = "http://www.w3.org/2001/XMLSchema"
 	version = "1"
@@ -37,6 +38,8 @@
 		schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2/ome.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2/BinaryFile.xsd"/>
+	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2"
+		schemaLocation="http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2/TIFFFile.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2/SA.xsd"/>
 

--- a/components/specification/released-schema/2013-10-dev-2/ROI.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/ROI.xsd
@@ -333,6 +333,7 @@
 				<xsd:choice minOccurs="1" maxOccurs="1">
 					<xsd:element ref="BIN:BinData" minOccurs="1" maxOccurs="unbounded"/>
 					<xsd:element ref="HDF:Hdf5Data" minOccurs="1" maxOccurs="1"/>
+					<xsd:element ref="TIFF:TiffData" minOccurs="1" maxOccurs="unbounded"/>
 				</xsd:choice>
 			</xsd:sequence>
 			<xsd:attribute name="X" use="required" type="xsd:float">

--- a/components/specification/released-schema/2013-10-dev-2/TIFFFile.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/TIFFFile.xsd
@@ -1,0 +1,122 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!--
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #
+    # Copyright (C) 2003 - 2014 Open Microscopy Environment
+    #       Massachusetts Institute of Technology,
+    #       National Institutes of Health,
+    #       University of Dundee,
+    #       University of Wisconsin at Madison
+    #
+    # This work is licensed under the
+    #       Creative Commons Attribution 3.0 Unported License.
+    # To view a copy of this license, visit
+    #       http://creativecommons.org/licenses/by/3.0/
+    # or send a letter to
+    #       Creative Commons, 444 Castro Street, Suite 900,
+    #       Mountain View, California, 94041, USA.
+    # For attribution instructions, visit
+    #       http://www.openmicroscopy.org/info/attribution
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+<!--
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Written by:  Josiah Johnston <siah@nih.gov>, Andrew J Patterson
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+<xsd:schema
+	xmlns:xsd = "http://www.w3.org/2001/XMLSchema"
+	targetNamespace = "http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2"
+	xmlns:TIFF = "http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2"
+	xmlns:OME = "http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	version = "1"
+	elementFormDefault = "qualified">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
+		schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2/ome.xsd"/>
+	<xsd:annotation>
+		<xsd:documentation>
+			The elements in this file are not yet represented by classes in the EA diagrams - ajp
+		</xsd:documentation>
+	</xsd:annotation>
+	<xsd:element name="TiffData"> <!-- top level definition -->
+		<xsd:annotation>
+			<xsd:appinfo><xsdfu><plural>TiffDataBlocks</plural></xsdfu></xsd:appinfo>
+			<xsd:documentation>
+				This described the location of the pixel data in a tiff file.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="UUID" minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							This must be used when the IFDs are located in another file.
+							Note: It is permissible for this to be self referential.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:simpleContent>
+							<xsd:extension base = "UniversallyUniqueIdentifier">
+								<xsd:attribute name="FileName" use="optional" type="xsd:string">
+									<xsd:annotation>
+										<xsd:documentation>
+											This can be used when the IFDs are located in another file.
+											The / (forward slash) is used as the path separator.
+											A relative path is recommended. However an absolute path can be specified.
+											Default is to use the file the ome-xml data has been pulled from.
+											Note: It is permissible for this to be self referential. The file image1.tiff
+											may contain ome-xml data that has FilePath="image1.tiff" or "./image1.tiff"
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+							</xsd:extension>
+						</xsd:simpleContent>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="IFD" type="NonNegativeInt" default="0" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Gives the IFD(s) for which this element is applicable. Indexed from 0.
+						Default is 0 (the first IFD). [units:none]
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="FirstZ" type="NonNegativeInt" default="0" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Gives the Z position of the image plane at the specified IFD. Indexed from 0.
+						Default is 0 (the first Z position). [units:none]
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="FirstT" type="NonNegativeInt" default="0" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Gives the T position of the image plane at the specified IFD. Indexed from 0.
+						Default is 0 (the first T position). [units:none]
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="FirstC" type="NonNegativeInt" default="0" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Gives the C position of the image plane at the specified IFD. Indexed from 0.
+						Default is 0 (the first C position). [units:none]
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="PlaneCount" use="optional" type="NonNegativeInt">
+				<xsd:annotation>
+					<xsd:documentation>
+						Gives the number of IFDs affected. Dimension order of IFDs is given by the enclosing
+						Pixels element's DimensionOrder attribute. Default is the number of IFDs in the TIFF
+						file, unless an IFD is specified, in which case the default is 1. [units:none]
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/components/specification/released-schema/2013-10-dev-2/ome.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/ome.xsd
@@ -29,6 +29,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
 	xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2"
+	xmlns:HDF="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
 	xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2013-10-dev-2"
 	xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
 	xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2013-10-dev-2"
@@ -37,6 +38,8 @@
 	elementFormDefault="qualified">
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2/BinaryFile.xsd"/>
+	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
+		schemaLocation="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2/HDF5File.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/SPW/2013-10-dev-2"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/SPW/2013-10-dev-2/SPW.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
@@ -353,9 +356,10 @@
 					<xsd:annotation>
 						<xsd:appinfo><xsdfu><ordered/></xsdfu></xsd:appinfo>
 					</xsd:annotation>
-                </xsd:element>
+				</xsd:element>
 				<xsd:choice minOccurs="1" maxOccurs="1">
 					<xsd:element ref="BIN:BinData" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element ref="HDF:Hdf5Data" minOccurs="1" maxOccurs="1"/>
 					<xsd:element ref="TiffData" minOccurs="1" maxOccurs="unbounded"/>
 					<xsd:element ref="MetadataOnly" minOccurs="1" maxOccurs="1"/>
 				</xsd:choice>
@@ -415,10 +419,10 @@
 					<xsd:documentation>
 						This is true if the pixels data was written in BigEndian order.
 
-						If this value is present it should match the value used in BinData
-						or TiffData. If it does not a reader should honour the value used
-						in the BinData or TiffData. This values is useful for MetadataOnly
-						files and is to allow for future storage solutions.
+						If this value is present it should match the value used in BinData,
+						Hdf5Data or TiffData. If it does not a reader should honour the value
+						used in BinData, Hdf5Data or TiffData. This value is useful for
+						MetadataOnly files and is to allow for future storage solutions.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/components/specification/released-schema/2013-10-dev-2/ome.xsd
+++ b/components/specification/released-schema/2013-10-dev-2/ome.xsd
@@ -30,6 +30,7 @@
 	xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2013-10-dev-2"
 	xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2"
 	xmlns:HDF="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
+	xmlns:TIFF="http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2"
 	xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2013-10-dev-2"
 	xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
 	xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2013-10-dev-2"
@@ -40,6 +41,8 @@
 		schemaLocation="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-10-dev-2/BinaryFile.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/HDF5File/2013-10-dev-2/HDF5File.xsd"/>
+	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2"
+		schemaLocation="http://www.openmicroscopy.org/Schemas/TIFFFile/2013-10-dev-2/TIFFFile.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/SPW/2013-10-dev-2"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/SPW/2013-10-dev-2/SPW.xsd"/>
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/SA/2013-10-dev-2"
@@ -360,7 +363,7 @@
 				<xsd:choice minOccurs="1" maxOccurs="1">
 					<xsd:element ref="BIN:BinData" minOccurs="1" maxOccurs="unbounded"/>
 					<xsd:element ref="HDF:Hdf5Data" minOccurs="1" maxOccurs="1"/>
-					<xsd:element ref="TiffData" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element ref="TIFF:TiffData" minOccurs="1" maxOccurs="unbounded"/>
 					<xsd:element ref="MetadataOnly" minOccurs="1" maxOccurs="1"/>
 				</xsd:choice>
 				<xsd:element ref="Plane" minOccurs="0" maxOccurs="unbounded"/>
@@ -738,85 +741,6 @@
 				This place holder means there is on pixel data in this file.
 			</xsd:documentation>
 		</xsd:annotation>
-	</xsd:element>
-	<xsd:element name="TiffData"> <!-- top level definition -->
-		<xsd:annotation>
-			<xsd:appinfo><xsdfu><plural>TiffDataBlocks</plural></xsdfu></xsd:appinfo>
-			<xsd:documentation>
-				This described the location of the pixel data in a tiff file.
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element name="UUID" minOccurs="0" maxOccurs="1">
-					<xsd:annotation>
-						<xsd:documentation>
-							This must be used when the IFDs are located in another file.
-							Note: It is permissible for this to be self referential.
-						</xsd:documentation>
-					</xsd:annotation>
-					<xsd:complexType>
-						<xsd:simpleContent>
-							<xsd:extension base = "UniversallyUniqueIdentifier">
-								<xsd:attribute name="FileName" use="optional" type="xsd:string">
-									<xsd:annotation>
-										<xsd:documentation>
-											This can be used when the IFDs are located in another file.
-											The / (forward slash) is used as the path separator.
-											A relative path is recommended. However an absolute path can be specified.
-											Default is to use the file the ome-xml data has been pulled from.
-											Note: It is permissible for this to be self referential. The file image1.tiff
-											may contain ome-xml data that has FilePath="image1.tiff" or "./image1.tiff"
-										</xsd:documentation>
-									</xsd:annotation>
-								</xsd:attribute>
-							</xsd:extension>
-						</xsd:simpleContent>
-					</xsd:complexType>
-				</xsd:element>
-			</xsd:sequence>
-			<xsd:attribute name="IFD" type="NonNegativeInt" default="0" use="optional">
-				<xsd:annotation>
-					<xsd:documentation>
-						Gives the IFD(s) for which this element is applicable. Indexed from 0.
-						Default is 0 (the first IFD). [units:none]
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="FirstZ" type="NonNegativeInt" default="0" use="optional">
-				<xsd:annotation>
-					<xsd:documentation>
-						Gives the Z position of the image plane at the specified IFD. Indexed from 0.
-						Default is 0 (the first Z position). [units:none]
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="FirstT" type="NonNegativeInt" default="0" use="optional">
-				<xsd:annotation>
-					<xsd:documentation>
-						Gives the T position of the image plane at the specified IFD. Indexed from 0.
-						Default is 0 (the first T position). [units:none]
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="FirstC" type="NonNegativeInt" default="0" use="optional">
-				<xsd:annotation>
-					<xsd:documentation>
-						Gives the C position of the image plane at the specified IFD. Indexed from 0.
-						Default is 0 (the first C position). [units:none]
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="PlaneCount" use="optional" type="NonNegativeInt">
-				<xsd:annotation>
-					<xsd:documentation>
-						Gives the number of IFDs affected. Dimension order of IFDs is given by the enclosing
-						Pixels element's DimensionOrder attribute. Default is the number of IFDs in the TIFF
-						file, unless an IFD is specified, in which case the default is 1. [units:none]
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-		</xsd:complexType>
 	</xsd:element>
 	<xsd:element name="StageLabel"> <!-- top level definition -->
 		<xsd:annotation>


### PR DESCRIPTION
- add Hdf5Data element for use in Pixels and Mask
- split TiffData out of ome.xsd and allow use in Mask

This is intended for comments, not merging at this time.  The intent isn't to get OME-HDF5 working or fully specified at this point, but to add the necessary bits to the schema to allow OME-XML to reference datasets (pixel data hypervolumes) in an HDF5 file.

--exclude