### PR TITLE
Allow tile-based access of large JPEG-2000 images

### DIFF
--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -146,12 +146,21 @@ public class JAIIIOServiceImpl extends AbstractService
   {
     J2KImageReader reader = getReader();
     MemoryCacheImageInputStream mciis = new MemoryCacheImageInputStream(in);
-    reader.setInput(mciis, false, true);
-    J2KImageReadParam param = (J2KImageReadParam) reader.getDefaultReadParam();
-    if (options.resolution != null) {
-      param.setResolution(options.resolution.intValue());
+    try {
+      reader.setInput(mciis, false, true);
+      J2KImageReadParam param = (J2KImageReadParam) reader.getDefaultReadParam();
+      if (options.resolution != null) {
+        param.setResolution(options.resolution.intValue());
+      }
+      if (options.tileWidth > 0 && options.tileHeight > 0) {
+        param.setSourceRegion(new Rectangle(options.tileGridXOffset,
+          options.tileGridYOffset, options.tileWidth, options.tileHeight));
+      }
+      return reader.read(0, param);
     }
-    return reader.read(0, param);
+    finally {
+      mciis.close();
+    }
   }
 
   /* @see JAIIIOService#readImage(InputStream) */
@@ -167,16 +176,21 @@ public class JAIIIOServiceImpl extends AbstractService
   {
     J2KImageReader reader = getReader();
     MemoryCacheImageInputStream mciis = new MemoryCacheImageInputStream(in);
-    reader.setInput(mciis, false, true);
-    J2KImageReadParam param = (J2KImageReadParam) reader.getDefaultReadParam();
-    if (options.resolution != null) {
-      param.setResolution(options.resolution.intValue());
+    try {
+      reader.setInput(mciis, false, true);
+      J2KImageReadParam param = (J2KImageReadParam) reader.getDefaultReadParam();
+      if (options.resolution != null) {
+        param.setResolution(options.resolution.intValue());
+      }
+      if (options.tileWidth > 0 && options.tileHeight > 0) {
+        param.setSourceRegion(new Rectangle(options.tileGridXOffset,
+          options.tileGridYOffset, options.tileWidth, options.tileHeight));
+      }
+      return reader.readRaster(0, param);
     }
-    if (options.tileWidth > 0 && options.tileHeight > 0) {
-      param.setSourceRegion(new Rectangle(options.tileGridXOffset,
-        options.tileGridYOffset, options.tileWidth, options.tileHeight));
+    finally {
+      mciis.close();
     }
-    return reader.readRaster(0, param);
   }
 
   /* @see JAIIIOService#readRaster(InputStream) */

--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -32,6 +32,7 @@
 
 package loci.formats.services;
 
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.awt.image.Raster;
 import java.io.IOException;
@@ -171,6 +172,8 @@ public class JAIIIOServiceImpl extends AbstractService
     if (options.resolution != null) {
       param.setResolution(options.resolution.intValue());
     }
+    param.setSourceRegion(new Rectangle(options.tileGridXOffset,
+      options.tileGridYOffset, options.tileWidth, options.tileHeight));
     return reader.readRaster(0, param);
   }
 

--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -172,8 +172,10 @@ public class JAIIIOServiceImpl extends AbstractService
     if (options.resolution != null) {
       param.setResolution(options.resolution.intValue());
     }
-    param.setSourceRegion(new Rectangle(options.tileGridXOffset,
-      options.tileGridYOffset, options.tileWidth, options.tileHeight));
+    if (options.tileWidth > 0 && options.tileHeight > 0) {
+      param.setSourceRegion(new Rectangle(options.tileGridXOffset,
+        options.tileGridYOffset, options.tileWidth, options.tileHeight));
+    }
     return reader.readRaster(0, param);
   }
 


### PR DESCRIPTION
--exclude

See QA 9464 and https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7568.  Tile based access largely works now without requiring an inordinate amount of memory, but this needs further work to fix tile reading beyond the coordinate (9216, 4096).