### PR TITLE
Parse physical pixel sizes from CellSens .vsi datasets

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -370,41 +370,33 @@ public abstract class FormatReader extends FormatHandler
     return metadata.get(key);
   }
 
-  protected void addGlobalMetaList(String key, Object value) {
-    Vector list = (Vector) metadata.get(key);
-    metadata.remove(key);
-    addGlobalMeta(key, value);
-    Object newValue = metadata.get(key);
-    metadata.remove(key);
+  protected void addMetaList(String key, Object value,
+    Hashtable<String, Object> meta)
+  {
+    Vector list = (Vector) meta.get(key);
+    meta.remove(key);
+    addMeta(key, value, meta);
+    Object newValue = meta.get(key);
+    meta.remove(key);
     if (newValue != null) {
       if (list == null) {
         list = new Vector();
       }
 
       list.add(newValue);
-      metadata.put(key, list);
+      meta.put(key, list);
     }
     else if (list != null) {
-      metadata.put(key, list);
+      meta.put(key, list);
     }
   }
 
-  protected void addSeriesMetaList(String key, Object value) {
-    Vector list = (Vector) core.get(getCoreIndex()).seriesMetadata.get(key);
-    core.get(getCoreIndex()).seriesMetadata.remove(key);
-    addSeriesMeta(key, value);
-    Object newValue = core.get(getCoreIndex()).seriesMetadata.get(key);
-    if (newValue != null) {
-      if (list == null) {
-        list = new Vector();
-      }
+  protected void addGlobalMetaList(String key, Object value) {
+    addMetaList(key, value, metadata);
+  }
 
-      list.add(newValue);
-      core.get(getCoreIndex()).seriesMetadata.put(key, list);
-    }
-    else if (list != null) {
-      core.get(getCoreIndex()).seriesMetadata.put(key, list);
-    }
+  protected void addSeriesMetaList(String key, Object value) {
+    addMetaList(key, value, core.get(getCoreIndex()).seriesMetadata);
   }
 
   protected void flattenHashtables() {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -826,6 +826,9 @@ public class CellSensReader extends FormatReader {
         if (!imageName.equals("Overview") && !imageName.equals("Label") && duplicate) {
           imageName += " #" + ii;
         }
+        if (imageName.equals("Overview") || imageName.equals("Label")) {
+          imageName = imageName.toLowerCase();
+        }
         store.setImageName(imageName, ii);
         store.setObjectiveSettingsID(MetadataTools.createLSID("Objective", 0, nextPyramid - 1), ii);
         store.setObjectiveSettingsRefractiveIndex(pyramid.refractiveIndex, ii);
@@ -844,7 +847,7 @@ public class CellSensReader extends FormatReader {
         }
       }
       else {
-        store.setImageName("Macro Image", ii);
+        store.setImageName("macro image", ii);
       }
 
       i += core.get(i).resolutionCount;

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -577,7 +577,7 @@ public class CellSensReader extends FormatReader {
     RandomAccessInputStream vsi = new RandomAccessInputStream(id);
     vsi.order(parser.getStream().isLittleEndian());
     vsi.seek(8);
-    readTags(vsi);
+    readTags(vsi, false);
     vsi.seek(parser.getStream().getFilePointer());
 
     vsi.skipBytes(273);
@@ -1126,7 +1126,7 @@ public class CellSensReader extends FormatReader {
     }
   }
 
-  private void readTags(RandomAccessInputStream vsi) {
+  private void readTags(RandomAccessInputStream vsi, boolean populateMetadata) {
     try {
       // read the VSI header
       long fp = vsi.getFilePointer();
@@ -1207,7 +1207,7 @@ public class CellSensReader extends FormatReader {
             vsi.getFilePointer() < vsi.length())
           {
             long start = vsi.getFilePointer();
-            readTags(vsi);
+            readTags(vsi, populateMetadata);
             long end = vsi.getFilePointer();
             if (start == end) {
               break;
@@ -1224,7 +1224,7 @@ public class CellSensReader extends FormatReader {
             vsi.getFilePointer() < vsi.length())
           {
             long start = vsi.getFilePointer();
-            readTags(vsi);
+            readTags(vsi, tag != 2037);
             long end = vsi.getFilePointer();
             if (start == end) {
               break;
@@ -1376,8 +1376,9 @@ public class CellSensReader extends FormatReader {
             acquisitionTimes.add(new Long(value));
           }
 
-          addGlobalMetaList(tagName, value);
-
+          if (populateMetadata) {
+            addGlobalMetaList(tagName, value);
+          }
         }
 
         if (inDimensionProperties) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -998,8 +998,11 @@ public class CellSensReader extends FormatReader {
       }
     }
 
-    ms.sizeX = imageWidths.get(s * (maxC[0] + 1) * (maxZ[0] + 1) * (maxT[0] + 1));
-    ms.sizeY = imageHeights.get(s * (maxC[0] + 1) * (maxZ[0] + 1) * (maxT[0] + 1));
+    int mult = imageWidths.size() / (usedFiles.length - 1);
+    int dimensionIndex = s * mult + 1;
+
+    ms.sizeX = imageWidths.get(dimensionIndex);
+    ms.sizeY = imageHeights.get(dimensionIndex);
     ms.sizeZ = maxZ[0] + 1;
     if (maxC[0] > 0) {
       ms.sizeC *= (maxC[0] + 1);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -703,16 +703,18 @@ public class CellSensReader extends FormatReader {
         }
       }
 
-      String imageType = imageTypes.get(nextSize);
-      while (!imageType.equals("Macro image") &&
-        !imageType.equals("Overview image") &&
-        !imageType.equals("Default image"))
-      {
-        nextSize++;
-        if (nextSize < imageTypes.size()) {
-          imageType = imageTypes.get(nextSize);
+      if (nextSize < imageTypes.size()) {
+        String imageType = imageTypes.get(nextSize);
+        while (!imageType.equals("Macro image") &&
+          !imageType.equals("Overview image") &&
+          !imageType.equals("Default image"))
+        {
+          nextSize++;
+          if (nextSize < imageTypes.size()) {
+            imageType = imageTypes.get(nextSize);
+          }
+          else break;
         }
-        else break;
       }
 
       if (nextSize < imageNames.size()) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -846,7 +846,7 @@ public class CellSensReader extends FormatReader {
 
     ms.pixelType = convertPixelType(pixelType);
     if (usePyramid) {
-      int finalResolution = 0;
+      int finalResolution = 1;
       double aspectRatio = (double) ms.sizeX / ms.sizeY;
       for (int i=1; i<maxResolution; i++) {
         CoreMetadata newResolution = new CoreMetadata(ms);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -737,9 +737,15 @@ public class CellSensReader extends FormatReader {
 
       for (int q=0; q<pyramid.deviceTypes.size(); q++) {
         if (pyramid.deviceTypes.get(q).equals("Camera")) {
-          store.setDetectorModel(pyramid.deviceNames.get(q), 0, i);
-          store.setDetectorSerialNumber(pyramid.deviceIDs.get(q), 0, i);
-          store.setDetectorManufacturer(pyramid.deviceManufacturers.get(q), 0, i);
+          if (q < pyramid.deviceNames.size()) {
+            store.setDetectorModel(pyramid.deviceNames.get(q), 0, i);
+          }
+          if (q < pyramid.deviceIDs.size()) {
+            store.setDetectorSerialNumber(pyramid.deviceIDs.get(q), 0, i);
+          }
+          if (q < pyramid.deviceManufacturers.size()) {
+            store.setDetectorManufacturer(pyramid.deviceManufacturers.get(q), 0, i);
+          }
           store.setDetectorType(getDetectorType("CCD"), 0, i);
           break;
         }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -891,19 +891,15 @@ public class CellSensReader extends FormatReader {
 
         if (maxX[i] >= 1) {
           newResolution.sizeX = tileX.get(tileX.size() - 1) * (maxX[i] + 1);
-          cols.add(maxX[i] + 1);
         }
         else {
           newResolution.sizeX = tileX.get(tileX.size() - 1);
-          cols.add(1);
         }
         if (maxY[i] >= 1) {
           newResolution.sizeY = tileY.get(tileY.size() - 1) * (maxY[i] + 1);
-          rows.add(maxY[i] + 1);
         }
         else {
           newResolution.sizeY = tileY.get(tileY.size() - 1);
-          rows.add(1);
         }
         newResolution.sizeZ = maxZ[i] + 1;
         if (maxC[i] > 0 && newResolution.sizeC != (maxC[i] + 1)) {
@@ -924,6 +920,10 @@ public class CellSensReader extends FormatReader {
         double newAspect = (double) newResolution.sizeX / newResolution.sizeY;
         if (Math.abs(newAspect - aspectRatio) < Constants.EPSILON) {
           core.add(newResolution);
+
+          rows.add(maxY[i] >= 1 ? maxY[i] + 1 : 1);
+          cols.add(maxX[i] >= 1 ? maxX[i] + 1 : 1);
+
           fileMap.put(core.size() - 1, file);
           finalResolution = core.size() - initialCoreSize + 1;
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -500,6 +500,9 @@ public class CellSensReader extends FormatReader {
         int magIndex = xDims.get(keys[i]);
         magnifications.set(magIndex, newMags[i]);
       }
+      for (Double magnification : magnifications) {
+        addGlobalMetaList("Magnification", magnification);
+      }
     }
 
     if (physicalSizeX > 0 && physicalSizeY > 0) {
@@ -1057,7 +1060,6 @@ public class CellSensReader extends FormatReader {
                 else if (tag == MAGNIFICATION) {
                   magnifications.add(
                     new Double(value.substring(0, value.length() - 1)));
-                  addGlobalMetaList("Magnification", value);
                 }
                 else {
                   addGlobalMetaList(String.valueOf(tag), value);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -802,6 +802,8 @@ public class CellSensReader extends FormatReader {
           }
           for (int z=0; z<core.get(i).sizeZ; z++) {
             for (int t=0; t<core.get(i).sizeT; t++) {
+              nextPlane = getIndex(z, c, t);
+
               Long exp = pyramid.defaultExposureTime;
               if (c < pyramid.exposureTimes.size()) {
                 exp = pyramid.exposureTimes.get(c);
@@ -814,7 +816,6 @@ public class CellSensReader extends FormatReader {
                 FormatTools.createLength(pyramid.originX, UNITS.MICROM), ii, nextPlane);
               store.setPlanePositionY(
                 FormatTools.createLength(pyramid.originY, UNITS.MICROM), ii, nextPlane);
-              nextPlane++;
             }
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -863,13 +863,6 @@ public class CellSensReader extends FormatReader {
       for (int i=1; i<maxResolution; i++) {
         CoreMetadata newResolution = new CoreMetadata(ms);
 
-        tileX.add(tileX.get(tileX.size() - 1));
-        tileY.add(tileY.get(tileY.size() - 1));
-        compressionType.add(compressionType.get(compressionType.size() - 1));
-        tileMap.add(map);
-        nDimensions.add(nDimensions.get(nDimensions.size() - 1));
-        tileOffsets.add(tileOffsets.get(tileOffsets.size() - 1));
-
         if (maxX[i] >= 1) {
           newResolution.sizeX = tileX.get(tileX.size() - 1) * (maxX[i] + 1);
           cols.add(maxX[i] + 1);
@@ -907,6 +900,13 @@ public class CellSensReader extends FormatReader {
           core.add(newResolution);
           fileMap.put(core.size() - 1, file);
           finalResolution = core.size() - initialCoreSize + 1;
+
+          tileX.add(tileX.get(tileX.size() - 1));
+          tileY.add(tileY.get(tileY.size() - 1));
+          compressionType.add(compressionType.get(compressionType.size() - 1));
+          tileMap.add(map);
+          nDimensions.add(nDimensions.get(nDimensions.size() - 1));
+          tileOffsets.add(tileOffsets.get(tileOffsets.size() - 1));
         }
       }
 
@@ -969,6 +969,10 @@ public class CellSensReader extends FormatReader {
 
       LOGGER.debug("parsing {} tags from {}", tagCount, vsi.getFilePointer());
 
+      if (tagCount > vsi.length()) {
+        return;
+      }
+
       for (int i=0; i<tagCount; i++) {
         if (vsi.getFilePointer() + 16 >= vsi.length()) {
           break;
@@ -1001,6 +1005,13 @@ public class CellSensReader extends FormatReader {
         LOGGER.debug("  extraTag = {}", extraTag);
         LOGGER.debug("  extendedField = {}", extendedField);
         LOGGER.debug("  realType = {}", realType);
+
+        if (tag < 0) {
+          if (!inlineData) {
+            vsi.skipBytes(dataSize);
+          }
+          return;
+        }
 
         if (extendedField && realType == NEW_VOLUME_HEADER) {
           if (tag == 2007) {
@@ -1101,7 +1112,7 @@ public class CellSensReader extends FormatReader {
           }
         }
 
-        if (nextField == 0) {
+        if (nextField == 0 || tag == -494804095) {
           return;
         }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -359,6 +359,7 @@ public class CellSensReader extends FormatReader {
   private static final int DEVICE_NAME = 120116;
   private static final int DEVICE_ID = 120129;
   private static final int DEVICE_SUBTYPE = 120130;
+  private static final int DEVICE_MANUFACTURER = 120133;
   private static final int VALUE = 268435458;
 
   // -- Fields --
@@ -738,6 +739,8 @@ public class CellSensReader extends FormatReader {
         if (pyramid.deviceTypes.get(q).equals("Camera")) {
           store.setDetectorModel(pyramid.deviceNames.get(q), 0, i);
           store.setDetectorSerialNumber(pyramid.deviceIDs.get(q), 0, i);
+          store.setDetectorManufacturer(pyramid.deviceManufacturers.get(q), 0, i);
+          store.setDetectorType(getDetectorType("CCD"), 0, i);
           break;
         }
       }
@@ -1532,6 +1535,9 @@ public class CellSensReader extends FormatReader {
               else if (tag == DEVICE_NAME) {
                 pyramid.deviceNames.add(value);
               }
+              else if (tag == DEVICE_MANUFACTURER) {
+                pyramid.deviceManufacturers.add(value);
+              }
               else if (tag == EXPOSURE_TIME) {
                 pyramid.exposureTimes.add(new Long(value));
               }
@@ -1982,7 +1988,7 @@ public class CellSensReader extends FormatReader {
         return "Device Subtype";
       case 120132:
         return "Device Model";
-      case 120133:
+      case DEVICE_MANUFACTURER:
         return "Device Manufacturer";
       case 121102:
         return "Stage Insert Position";
@@ -2241,6 +2247,7 @@ public class CellSensReader extends FormatReader {
     public ArrayList<String> deviceNames = new ArrayList<String>();
     public ArrayList<String> deviceTypes = new ArrayList<String>();
     public ArrayList<String> deviceIDs = new ArrayList<String>();
+    public ArrayList<String> deviceManufacturers = new ArrayList<String>();
 
     public Hashtable<String, Object> originalMetadata =
       new Hashtable<String, Object>();

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -125,9 +125,190 @@ public class CellSensReader extends FormatReader {
   private static final int VECTOR_DATA = 11;
 
   // Tag values
-  private static final int PHYSICAL_SIZE = 20007;
-  private static final int ORIGIN = 20006;
+
+  private static final int COLLECTION_VOLUME = 2000;
+  private static final int MULTIDIM_IMAGE_VOLUME = 2001;
+  private static final int IMAGE_FRAME_VOLUME = 2002;
+  private static final int DIMENSION_SIZE = 2003;
+  private static final int IMAGE_COLLECTION_PROPERTIES = 2004;
+  private static final int MULTIDIM_STACK_PROPERTIES = 2005;
+  private static final int FRAME_PROPERTIES = 2006;
+  private static final int DIMENSION_DESCRIPTION_VOLUME = 2007;
+  private static final int CHANNEL_PROPERTIES = 2008;
+  private static final int DISPLAY_MAPPING_VOLUME = 2011;
+  private static final int LAYER_INFO_PROPERTIES = 2012;
+  private static final int CHANNEL_INFO_PROPERTIES = 2013;
+  private static final int DEFAULT_SAMPLE_IFD = 2016;
+  private static final int VECTOR_LAYER_VOLUME = 2017;
+  private static final int EXTERNAL_FILE_PROPERTIES = 2018;
+  private static final int COARSE_FRAME_IFD = 2019;
+  private static final int COARSE_PYRAMID_LEVEL = 2022;
+  private static final int SERIALIZED_MASK = 2023;
+  private static final int UNKNOWN_BLOBS_VOLUME = 2024;
+  private static final int SAMPLE_ID_LIST = 2027;
+  private static final int EXTRA_SAMPLES = 2028;
+  private static final int EXTRA_SAMPLES_PROPERTIES = 2029;
+  private static final int SAMPLE_FLAGS_LIST = 2030;
+  private static final int FRAME_TYPE = 2031;
+  private static final int DEFAULT_BACKGROUND_COLOR = 2034;
+  private static final int VERSION_NUMBER = 2035;
+
+  private static final int DOCUMENT_PROPERTIES = 2109;
+  private static final int DOCUMENT_NAME = 11;
+  private static final int DOCUMENT_NOTE = 13;
+  private static final int DOCUMENT_TIME = 14;
+  private static final int DOCUMENT_AUTHOR = 15;
+  private static final int DOCUMENT_COMPANY = 16;
+  private static final int DOCUMENT_CREATOR_NAME = 17;
+  private static final int DOCUMENT_CREATOR_MAJOR_VERSION = 18;
+  private static final int DOCUMENT_CREATOR_MINOR_VERSION = 19;
+  private static final int DOCUMENT_CREATOR_SUB_VERSION = 20;
+  private static final int DOCUMENT_CREATOR_BUILD_NUMBER = 21;
+  private static final int DOCUMENT_CREATOR_PACKAGE = 22;
+  private static final int DOCUMENT_PRODUCT = 23;
+  private static final int DOCUMENT_PRODUCT_NAME = 24;
+  private static final int DOCUMENT_PRODUCT_VERSION = 25;
+  private static final int DOCUMENT_TYPE_HINT = 27;
+  private static final int DOCUMENT_THUMB = 28;
+
+  private static final int SLIDE_PROPERTIES = 2062;
+  private static final int SLIDE_SPECIMEN = 2055;
+  private static final int SLIDE_TISSUE = 2057;
+  private static final int SLIDE_PREPARATION = 2058;
+  private static final int SLIDE_STAINING = 2059;
+  private static final int SLIDE_INFO = 2060;
+  private static final int SLIDE_NAME = 2061;
+
+  private static final int DYNAMIC_PROPERTIES = 27300;
+
   private static final int MAGNIFICATION = 1073741824;
+
+  // External Raw Data properties (stored under EXTERNAL_FILE_PROPERTIES)
+  private static final int IMAGE_BOUNDARY = 2053;
+  private static final int TILE_SYSTEM = 20004;
+  private static final int HAS_EXTERNAL_FILE = 20005;
+  private static final int EXTERNAL_DATA_VOLUME = 20025;
+  private static final int TILE_ORIGIN = 2410;
+
+  // Camera property tags
+  private static final int EXPOSURE_TIME = 100002;
+  private static final int CAMERA_GAIN = 100003;
+  private static final int CAMERA_OFFSET = 100004;
+  private static final int CAMERA_GAMMA = 100005;
+  private static final int SHARPNESS = 100006;
+  private static final int RED_GAIN = 100007;
+  private static final int GREEN_GAIN = 100008;
+  private static final int BLUE_GAIN = 100009;
+  private static final int RED_OFFSET = 100010;
+  private static final int GREEN_OFFSET = 100011;
+  private static final int BLUE_OFFSET = 100012;
+  private static final int SHADING_SUB = 100013;
+  private static final int SHADING_MUL = 100014;
+  private static final int X_BINNING = 100015;
+  private static final int Y_BINNING = 100016;
+  private static final int CLIPPING = 100017;
+  private static final int MIRROR_H = 100023;
+  private static final int MIRROR_V = 100024;
+  private static final int CLIPPING_STATE = 100025;
+  private static final int ICC_ENABLED = 100030;
+  private static final int BRIGHTNESS = 100031;
+  private static final int CONTRAST = 100032;
+  private static final int CONTRAST_TARGET = 100033;
+  private static final int ACCUMULATION = 100034;
+  private static final int AVERAGING = 100035;
+  private static final int ISO_SENSITIVITY = 100038;
+  private static final int ACCUMULATION_MODE = 100039;
+  private static final int AUTOEXPOSURE = 100043;
+  private static final int EXPOSURE_METERING_MODE = 100044;
+
+  // Dimension properties
+  private static final int Z_START = 2012;
+  private static final int Z_INCREMENT = 2013;
+  private static final int Z_VALUE = 2014;
+  private static final int TIME_START = 2100;
+  private static final int TIME_INCREMENT = 2016;
+  private static final int TIME_VALUE = 2017;
+  private static final int LAMBDA_START = 2039;
+  private static final int LAMBDA_INCREMENT = 2040;
+  private static final int LAMBDA_VALUE = 2041;
+  private static final int DIMENSION_NAME = 2021;
+  private static final int DIMENSION_MEANING = 2023;
+  private static final int DIMENSION_START_ID = 2025;
+  private static final int DIMENSION_INCREMENT_ID = 2026;
+  private static final int DIMENSION_VALUE_ID = 2027;
+
+  private static final int CHANNEL_NAME = 2419;
+
+  // Stack properties
+  private static final int DISPLAY_LIMITS = 2003;
+  private static final int STACK_DISPLAY_LUT = 2004;
+  private static final int GAMMA_CORRECTION = 2005;
+  private static final int FRAME_ORIGIN = 2006;
+  private static final int FRAME_SCALE = 2007;
+  private static final int DISPLAY_COLOR = 2008;
+  private static final int CREATION_TIME = 2015;
+  private static final int RWC_FRAME_ORIGIN = 2018;
+  private static final int RWC_FRAME_SCALE = 2019;
+  private static final int RWC_FRAME_UNIT = 2020;
+  private static final int STACK_NAME = 2030;
+  private static final int CHANNEL_DIM = 2031;
+  private static final int OPTICAL_PATH = 2043;
+  private static final int STACK_TYPE = 2074;
+  private static final int LIVE_OVERFLOW = 2076;
+  private static final int IS_TRANSMISSION = 20035;
+  private static final int CONTRAST_BRIGHTNESS = 10047;
+  private static final int ACQUISITION_PROPERTIES = 10048;
+  private static final int GRADIENT_LUT = 10065;
+
+  // Stack types
+  private static final int DEFAULT_IMAGE = 0;
+  private static final int OVERVIEW_IMAGE = 1;
+  private static final int SAMPLE_MASK = 2;
+  private static final int FOCUS_IMAGE = 4;
+  private static final int EFI_SHARPNESS_MAP = 8;
+  private static final int EFI_HEIGHT_MAP = 16;
+  private static final int EFI_TEXTURE_MAP = 32;
+  private static final int EFI_STACK = 64;
+  private static final int MACRO_IMAGE = 256;
+
+  // Display mapping tags
+  private static final int DISPLAY_PROCESSOR_TYPE = 10000;
+  private static final int RENDER_OPERATION_ID = 10001;
+  private static final int DISPLAY_STACK_ID = 10005;
+  private static final int TRANSPARENCY_ID = 10006;
+  private static final int THIRD_ID = 10007;
+  private static final int DISPLAY_VISIBLE = 10008;
+  private static final int TRANSPARENCY_VALUE = 10009;
+  private static final int DISPLAY_LUT = 10013;
+  private static final int DISPLAY_STACK_INDEX = 10014;
+  private static final int CHANNEL_TRANSPARENCY_VALUE = 10018;
+  private static final int CHANNEL_VISIBLE = 10025;
+  private static final int SELECTED_CHANNELS = 10028;
+  private static final int DISPLAY_GAMMA_CORRECTION = 10032;
+  private static final int CHANNEL_GAMMA_CORRECTION = 10033;
+  private static final int DISPLAY_CONTRAST_BRIGHTNESS = 10045;
+  private static final int CHANNEL_CONTRAST_BRIGHTNESS = 10046;
+  private static final int ACTIVE_STACK_DIMENSION = 10049;
+  private static final int SELECTED_FRAMES = 10050;
+  private static final int DISPLAYED_LUT_ID = 10054;
+  private static final int HIDDEN_LAYER = 10056;
+  private static final int LAYER_XY_FIXED = 10057;
+  private static final int ACTIVE_LAYER_VECTOR = 10060;
+  private static final int ACTIVE_LAYER_INDEX_VECTOR = 10061;
+  private static final int CHAINED_LAYERS = 10062;
+  private static final int LAYER_SELECTION = 10063;
+  private static final int LAYER_SELECTION_INDEX = 10064;
+  private static final int CANVAS_COLOR_1 = 10066;
+  private static final int CANVAS_COLOR_2 = 10067;
+  private static final int ORIGINAL_FRAME_RATE = 10069;
+  private static final int USE_ORIGINAL_FRAME_RATE = 10070;
+  private static final int ACTIVE_CHANNEL = 10071;
+  private static final int PLANE_UNIT = 2011;
+  private static final int Y_PLANE_DIMENSION_UNIT = 2063;
+  private static final int Y_DIMENSION_UNIT = 2064;
+  private static final int PLANE_ORIGIN_RWC = 20006;
+  private static final int PLANE_SCALE_RWC = 20007;
+  private static final int CHANNEL_OVERFLOW = 2073;
 
   // -- Fields --
 
@@ -159,6 +340,8 @@ public class CellSensReader extends FormatReader {
   private double physicalSizeX, physicalSizeY;
   private double originX, originY;
   private ArrayList<Double> magnifications = new ArrayList<Double>();
+  private ArrayList<Integer> imageWidths = new ArrayList<Integer>();
+  private ArrayList<Integer> imageHeights = new ArrayList<Integer>();
 
   // -- Constructor --
 
@@ -198,10 +381,10 @@ public class CellSensReader extends FormatReader {
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
-    if (getCoreIndex() < core.size() - ifds.size()) {
+    if (getCoreIndex() < core.size() - 1) {
       return tileX.get(getCoreIndex());
     }
-    int ifdIndex = ifds.size() - (core.size() - getCoreIndex());
+    int ifdIndex = 1 - (core.size() - getCoreIndex());
     try {
       return (int) ifds.get(ifdIndex).getTileWidth();
     }
@@ -215,10 +398,10 @@ public class CellSensReader extends FormatReader {
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
-    if (getCoreIndex() < core.size() - ifds.size()) {
+    if (getCoreIndex() < core.size() - 1) {
       return tileY.get(getCoreIndex());
     }
-    int ifdIndex = ifds.size() - (core.size() - getCoreIndex());
+    int ifdIndex = 1 - (core.size() - getCoreIndex());
     try {
       return (int) ifds.get(ifdIndex).getTileLength();
     }
@@ -259,7 +442,7 @@ public class CellSensReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    if (getCoreIndex() < core.size() - ifds.size()) {
+    if (getCoreIndex() < core.size() - 1) {
       int tileRows = rows.get(getCoreIndex());
       int tileCols = cols.get(getCoreIndex());
 
@@ -312,7 +495,7 @@ public class CellSensReader extends FormatReader {
       return buf;
     }
     else {
-      int ifdIndex = ifds.size() - (core.size() - getCoreIndex());
+      int ifdIndex = 1 - (core.size() - getCoreIndex());
       return parser.getSamples(ifds.get(ifdIndex), buf, x, y, w, h);
     }
   }
@@ -836,18 +1019,8 @@ public class CellSensReader extends FormatReader {
       }
     }
 
-    if (maxX[0] > 1) {
-      ms.sizeX = tileX.get(tileX.size() - 1) * (maxX[0] + 1);
-    }
-    else {
-      ms.sizeX = tileX.get(tileX.size() - 1);
-    }
-    if (maxY[0] > 1) {
-      ms.sizeY = tileY.get(tileY.size() - 1) * (maxY[0] + 1);
-    }
-    else {
-      ms.sizeY = tileY.get(tileY.size() - 1);
-    }
+    ms.sizeX = imageWidths.get(s * (maxC[0] + 1) * (maxZ[0] + 1) * (maxT[0] + 1));
+    ms.sizeY = imageHeights.get(s * (maxC[0] + 1) * (maxZ[0] + 1) * (maxT[0] + 1));
     ms.sizeZ = maxZ[0] + 1;
     if (maxC[0] > 0) {
       ms.sizeC *= (maxC[0] + 1);
@@ -884,22 +1057,28 @@ public class CellSensReader extends FormatReader {
     ms.pixelType = convertPixelType(pixelType);
     if (usePyramid) {
       int finalResolution = 1;
-      double aspectRatio = (double) ms.sizeX / ms.sizeY;
       int initialCoreSize = core.size();
       for (int i=1; i<maxResolution; i++) {
         CoreMetadata newResolution = new CoreMetadata(ms);
 
-        if (maxX[i] >= 1) {
-          newResolution.sizeX = tileX.get(tileX.size() - 1) * (maxX[i] + 1);
+        int previousX = core.get(core.size() - 1).sizeX;
+        int previousY = core.get(core.size() - 1).sizeY;
+        int maxSizeX = tileX.get(tileX.size() - 1) * (maxX[i] <= 1 ? 1 : maxX[i] + 1);
+        int maxSizeY = tileY.get(tileY.size() - 1) * (maxY[i] <= 1 ? 1 : maxY[i] + 1);
+
+        newResolution.sizeX = previousX / 2;
+        if (previousX % 2 == 1 && newResolution.sizeX < maxSizeX) {
+          newResolution.sizeX++;
         }
-        else {
-          newResolution.sizeX = tileX.get(tileX.size() - 1);
+        else if (newResolution.sizeX > maxSizeX) {
+          newResolution.sizeX = maxSizeX;
         }
-        if (maxY[i] >= 1) {
-          newResolution.sizeY = tileY.get(tileY.size() - 1) * (maxY[i] + 1);
+        newResolution.sizeY = previousY / 2;
+        if (previousY % 2 == 1 && newResolution.sizeY < maxSizeY) {
+          newResolution.sizeY++;
         }
-        else {
-          newResolution.sizeY = tileY.get(tileY.size() - 1);
+        else if (newResolution.sizeY > maxSizeY) {
+          newResolution.sizeY = maxSizeY;
         }
         newResolution.sizeZ = maxZ[i] + 1;
         if (maxC[i] > 0 && newResolution.sizeC != (maxC[i] + 1)) {
@@ -917,23 +1096,20 @@ public class CellSensReader extends FormatReader {
         newResolution.metadataComplete = true;
         newResolution.dimensionOrder = "XYCZT";
 
-        double newAspect = (double) newResolution.sizeX / newResolution.sizeY;
-        if (Math.abs(newAspect - aspectRatio) < Constants.EPSILON) {
-          core.add(newResolution);
+        core.add(newResolution);
 
-          rows.add(maxY[i] >= 1 ? maxY[i] + 1 : 1);
-          cols.add(maxX[i] >= 1 ? maxX[i] + 1 : 1);
+        rows.add(maxY[i] >= 1 ? maxY[i] + 1 : 1);
+        cols.add(maxX[i] >= 1 ? maxX[i] + 1 : 1);
 
-          fileMap.put(core.size() - 1, file);
-          finalResolution = core.size() - initialCoreSize + 1;
+        fileMap.put(core.size() - 1, file);
+        finalResolution = core.size() - initialCoreSize + 1;
 
-          tileX.add(tileX.get(tileX.size() - 1));
-          tileY.add(tileY.get(tileY.size() - 1));
-          compressionType.add(compressionType.get(compressionType.size() - 1));
-          tileMap.add(map);
-          nDimensions.add(nDimensions.get(nDimensions.size() - 1));
-          tileOffsets.add(tileOffsets.get(tileOffsets.size() - 1));
-        }
+        tileX.add(tileX.get(tileX.size() - 1));
+        tileY.add(tileY.get(tileY.size() - 1));
+        compressionType.add(compressionType.get(compressionType.size() - 1));
+        tileMap.add(map);
+        nDimensions.add(nDimensions.get(nDimensions.size() - 1));
+        tileOffsets.add(tileOffsets.get(tileOffsets.size() - 1));
       }
 
       ms.resolutionCount = finalResolution;
@@ -1040,7 +1216,7 @@ public class CellSensReader extends FormatReader {
         }
 
         if (extendedField && realType == NEW_VOLUME_HEADER) {
-          if (tag == 2007) {
+          if (tag == DIMENSION_DESCRIPTION_VOLUME) {
             dimensionTag = secondTag;
             inDimensionProperties = true;
           }
@@ -1055,40 +1231,63 @@ public class CellSensReader extends FormatReader {
               break;
             }
           }
-          if (tag == 2007) {
+          if (tag == DIMENSION_DESCRIPTION_VOLUME) {
             inDimensionProperties = false;
             foundChannelTag = false;
           }
         }
-        else {
-          if (inlineData) {
-            addGlobalMetaList(String.valueOf(tag), dataSize);
+        else if (extendedField && realType == PROPERTY_SET_VOLUME) {
+          long endPointer = vsi.getFilePointer() + nextField;
+          while (vsi.getFilePointer() < endPointer &&
+            vsi.getFilePointer() < vsi.length())
+          {
+            long start = vsi.getFilePointer();
+            readTags(vsi);
+            long end = vsi.getFilePointer();
+            if (start == end) {
+              break;
+            }
           }
-          else {
+        }
+        else {
+          String tagName = getTagName(tag);
+          String value = inlineData ? String.valueOf(dataSize) : null;
+          if (!inlineData && dataSize > 0) {
             switch (realType) {
-              case DOUBLE_2:
-                double first = vsi.readDouble();
-                double second = vsi.readDouble();
-
-                String tagName = null;
-                if (tag == PHYSICAL_SIZE) {
-                  physicalSizeX = first;
-                  physicalSizeY = second;
-                  tagName = "Physical pixel size";
-                }
-                else if (tag == ORIGIN) {
-                  originX = first;
-                  originY = second;
-                  tagName = "Origin";
-                }
-
-                if (tagName != null) {
-                  addGlobalMetaList(tagName, first + ", " + second);
-                }
+              case CHAR:
+              case UCHAR:
+                value = String.valueOf(vsi.read());
+                break;
+              case SHORT:
+              case USHORT:
+                value = String.valueOf(vsi.readShort());
+                break;
+              case INT:
+              case UINT:
+              case DWORD:
+              case FIELD_TYPE:
+              case MEM_MODEL:
+              case COLOR_SPACE:
+                value = String.valueOf(vsi.readInt());
+                break;
+              case LONG:
+              case ULONG:
+              case TIMESTAMP:
+                value = String.valueOf(vsi.readLong());
+                break;
+              case FLOAT:
+                value = String.valueOf(vsi.readFloat());
+                break;
+              case DOUBLE:
+              case DATE:
+                value = String.valueOf(vsi.readDouble());
+                break;
+              case BOOLEAN:
+                value = new Boolean(vsi.readBoolean()).toString();
                 break;
               case TCHAR:
               case UNICODE_TCHAR:
-                String value = vsi.readString(dataSize);
+                value = vsi.readString(dataSize);
                 value = DataTools.stripString(value);
 
                 if (tag == 2011) {
@@ -1107,19 +1306,101 @@ public class CellSensReader extends FormatReader {
                   magnifications.add(
                     new Double(value.substring(0, value.length() - 1)));
                 }
-                else {
-                  addGlobalMetaList(String.valueOf(tag), value);
+                break;
+              case INT_2:
+              case INT_INTERVAL:
+              case INT_ARRAY_2:
+              case INT_3:
+              case INT_ARRAY_3:
+              case INT_4:
+              case INT_RECT:
+              case INT_ARRAY_4:
+              case INT_ARRAY_5:
+              case DIM_INDEX_1:
+              case DIM_INDEX_2:
+              case VOLUME_INDEX:
+              case PIXEL_INFO_TYPE:
+                int nIntValues = dataSize / 4;
+                int[] intValues = new int[nIntValues];
+                value = nIntValues > 1 ? "(" : "";
+                for (int v=0; v<nIntValues; v++) {
+                  intValues[v] = vsi.readInt();
+                  value += intValues[v];
+                  if (v < nIntValues - 1) {
+                    value += ", ";
+                  }
                 }
+                if (nIntValues > 1) {
+                  value += ")";
+                }
+
+                if (tag == IMAGE_BOUNDARY) {
+                  imageWidths.add(intValues[2]);
+                  imageHeights.add(intValues[3]);
+                }
+                break;
+              case COMPLEX:
+              case DOUBLE_2:
+              case DOUBLE_INTERVAL:
+              case DOUBLE_ARRAY_2:
+              case DOUBLE_3:
+              case DOUBLE_ARRAY_3:
+              case DOUBLE_4:
+              case DOUBLE_RECT:
+              case DOUBLE_2_2:
+              case DOUBLE_3_3:
+              case DOUBLE_4_4:
+                int nDoubleValues = dataSize / 8;
+                double[] doubleValues = new double[nDoubleValues];
+                value = nDoubleValues > 1 ? "(" : "";
+                for (int v=0; v<nDoubleValues; v++) {
+                  doubleValues[v] = vsi.readDouble();
+                  value += doubleValues[v];
+                  if (v < nDoubleValues - 1) {
+                    value += ", ";
+                  }
+                }
+                if (nDoubleValues > 1) {
+                  value += ")";
+                }
+
+                if (tag == PLANE_SCALE_RWC) {
+                  physicalSizeX = doubleValues[0];
+                  physicalSizeY = doubleValues[1];
+                }
+                else if (tag == PLANE_ORIGIN_RWC) {
+                  originX = doubleValues[0];
+                  originY = doubleValues[1];
+                }
+                break;
+              case RGB:
+                int red = vsi.read();
+                int green = vsi.read();
+                int blue = vsi.read();
+                value = "red = " + red + ", green = " + green + ", blue = " + blue;
+                break;
+              case BGR:
+                blue = vsi.read();
+                green = vsi.read();
+                red = vsi.read();
+                value = "red = " + red + ", green = " + green + ", blue = " + blue;
                 break;
             }
           }
+
+          if (tag == STACK_TYPE) {
+            value = getStackType(value);
+          }
+
+          addGlobalMetaList(tagName, value);
+
         }
 
         if (inDimensionProperties) {
           if (tag == 2012 && !dimensionOrdering.containsValue(dimensionTag)) {
             dimensionOrdering.put("Z", dimensionTag);
           }
-          else if ((tag == 2100 || tag == 2027) &&
+          else if ((tag == 2100 || tag == DIMENSION_VALUE_ID) &&
             !dimensionOrdering.containsValue(dimensionTag))
           {
             dimensionOrdering.put("T", dimensionTag);
@@ -1151,6 +1432,301 @@ public class CellSensReader extends FormatReader {
     catch (Exception e) {
       LOGGER.debug("Failed to read all tags", e);
     }
+  }
+
+  private String getTagName(int tag) {
+    switch (tag) {
+      case Y_PLANE_DIMENSION_UNIT:
+        return "Image plane rectangle unit (Y dimension)";
+      case Y_DIMENSION_UNIT:
+        return "Y dimension unit";
+      case CHANNEL_OVERFLOW:
+        return "Channel under/overflow";
+      case SLIDE_SPECIMEN:
+        return "Specimen";
+      case SLIDE_TISSUE:
+        return "Tissue";
+      case SLIDE_PREPARATION:
+        return "Preparation";
+      case SLIDE_STAINING:
+        return "Staining";
+      case SLIDE_INFO:
+        return "Slide Info";
+      case SLIDE_NAME:
+        return "Slide Name";
+      case EXPOSURE_TIME:
+        return "Exposure time (ms)";
+      case CAMERA_GAIN:
+        return "Camera gain";
+      case CAMERA_OFFSET:
+        return "Camera offset";
+      case CAMERA_GAMMA:
+        return "Camera gamma";
+      case SHARPNESS:
+        return "Sharpness";
+      case RED_GAIN:
+        return "Red channel gain";
+      case GREEN_GAIN:
+        return "Green channel gain";
+      case BLUE_GAIN:
+        return "Blue channel gain";
+      case RED_OFFSET:
+        return "Red channel offset";
+      case GREEN_OFFSET:
+        return "Green channel offset";
+      case BLUE_OFFSET:
+        return "Blue channel offset";
+      case SHADING_SUB:
+        return "Shading sub";
+      case SHADING_MUL:
+        return "Shading mul";
+      case X_BINNING:
+        return "Binning (X)";
+      case Y_BINNING:
+        return "Binning (Y)";
+      case CLIPPING:
+        return "Clipping";
+      case MIRROR_H:
+        return "Horizontally mirrored";
+      case MIRROR_V:
+        return "Vertically mirrored";
+      case CLIPPING_STATE:
+        return "Clipping state";
+      case ICC_ENABLED:
+        return "ICC enabled";
+      case BRIGHTNESS:
+        return "Brightness";
+      case CONTRAST:
+        return "Contrast";
+      case CONTRAST_TARGET:
+        return "Contrast reference";
+      case ACCUMULATION:
+        return "Camera accumulation";
+      case AVERAGING:
+        return "Camera averaging";
+      case ISO_SENSITIVITY:
+        return "ISO sensitivity";
+      case ACCUMULATION_MODE:
+        return "Camera accumulation mode";
+      case AUTOEXPOSURE:
+        return "Autoexposure enabled";
+      case EXPOSURE_METERING_MODE:
+        return "Autoexposure metering mode";
+      case Z_START:
+        return "Z stack start";
+      case Z_INCREMENT:
+        return "Z stack increment";
+      case Z_VALUE:
+        return "Z position";
+      case TIME_START:
+        return "Timelapse start";
+      case TIME_INCREMENT:
+        return "Timelapse increment";
+      case TIME_VALUE:
+        return "Timestamp";
+      case LAMBDA_START:
+        return "Lambda start";
+      case LAMBDA_INCREMENT:
+        return "Lambda increment";
+      case LAMBDA_VALUE:
+        return "Lambda value";
+      case DIMENSION_NAME:
+        return "Dimension name";
+      case DIMENSION_MEANING:
+        return "Dimension description";
+      case DIMENSION_START_ID:
+        return "Dimension start ID";
+      case DIMENSION_INCREMENT_ID:
+        return "Dimension increment ID";
+      case DIMENSION_VALUE_ID:
+        return "Dimension value ID";
+      case IMAGE_BOUNDARY:
+        return "Image size";
+      case TILE_SYSTEM:
+        return "Tile system";
+      case HAS_EXTERNAL_FILE:
+        return "External file present";
+      case EXTERNAL_DATA_VOLUME:
+        return "External file volume";
+      case TILE_ORIGIN:
+        return "Origin of tile coordinate system";
+      case DISPLAY_LIMITS:
+        return "Display limits";
+      case STACK_DISPLAY_LUT:
+        return "Stack display LUT";
+      case GAMMA_CORRECTION:
+        return "Gamma correction";
+      case FRAME_ORIGIN:
+        return "Frame origin (plane coordinates)";
+      case FRAME_SCALE:
+        return "Frame scale (plane coordinates)";
+      case DISPLAY_COLOR:
+        return "Display color";
+      case CREATION_TIME:
+        return "Creation time (UTC)";
+      case RWC_FRAME_ORIGIN:
+        return "Frame origin (real-world coordinates)";
+      case RWC_FRAME_SCALE:
+        return "Frame scale (real-world coordinates)";
+      case RWC_FRAME_UNIT:
+        return "Frame units (real-world coordinates)";
+      case STACK_NAME:
+        return "Stack name";
+      case CHANNEL_DIM:
+        return "Channel dimension";
+      case OPTICAL_PATH:
+        return "Optical path";
+      case STACK_TYPE:
+        return "Stack type";
+      case LIVE_OVERFLOW:
+        return "Live overflow";
+      case IS_TRANSMISSION:
+        return "IS transmission mask";
+      case CONTRAST_BRIGHTNESS:
+        return "Contrast and brightness";
+      case ACQUISITION_PROPERTIES:
+        return "Acquisition properties";
+      case GRADIENT_LUT:
+        return "Gradient LUT";
+      case DISPLAY_PROCESSOR_TYPE:
+        return "Display processor type";
+      case RENDER_OPERATION_ID:
+        return "Render operation ID";
+      case DISPLAY_STACK_ID:
+        return "Displayed stack ID";
+      case TRANSPARENCY_ID:
+        return "Transparency ID";
+      case THIRD_ID:
+        return "Display third ID";
+      case DISPLAY_VISIBLE:
+        return "Display visible";
+      case TRANSPARENCY_VALUE:
+        return "Transparency value";
+      case DISPLAY_LUT:
+        return "Display LUT";
+      case DISPLAY_STACK_INDEX:
+        return "Display stack index";
+      case CHANNEL_TRANSPARENCY_VALUE:
+        return "Channel transparency value";
+      case CHANNEL_VISIBLE:
+        return "Channel visible";
+      case SELECTED_CHANNELS:
+        return "List of selected channels";
+      case DISPLAY_GAMMA_CORRECTION:
+        return "Display gamma correction";
+      case CHANNEL_GAMMA_CORRECTION:
+        return "Channel gamma correction";
+      case DISPLAY_CONTRAST_BRIGHTNESS:
+        return "Display contrast and brightness";
+      case CHANNEL_CONTRAST_BRIGHTNESS:
+        return "Channel contrast and brightness";
+      case ACTIVE_STACK_DIMENSION:
+        return "Active stack dimension";
+      case SELECTED_FRAMES:
+        return "Selected frames";
+      case DISPLAYED_LUT_ID:
+        return "Displayed LUT ID";
+      case HIDDEN_LAYER:
+        return "Hidden layer";
+      case LAYER_XY_FIXED:
+        return "Layer fixed in XY";
+      case ACTIVE_LAYER_VECTOR:
+        return "Active layer vector";
+      case ACTIVE_LAYER_INDEX_VECTOR:
+        return "Active layer index vector";
+      case CHAINED_LAYERS:
+        return "Chained layers";
+      case LAYER_SELECTION:
+        return "Layer selection";
+      case LAYER_SELECTION_INDEX:
+        return "Layer selection index";
+      case CANVAS_COLOR_1:
+        return "Canvas background color 1";
+      case CANVAS_COLOR_2:
+        return "Canvas background color 2";
+      case ORIGINAL_FRAME_RATE:
+        return "Original frame rate (ms)";
+      case USE_ORIGINAL_FRAME_RATE:
+        return "Use original frame rate";
+      case ACTIVE_CHANNEL:
+        return "Active channel";
+      case PLANE_UNIT:
+        return "Plane unit";
+      case PLANE_ORIGIN_RWC:
+        return "Origin";
+      case PLANE_SCALE_RWC:
+        return "Physical pixel size";
+      case MAGNIFICATION:
+        return "Original magnification";
+      case DOCUMENT_NAME:
+        return "Document name";
+      case DOCUMENT_NOTE:
+        return "Document note";
+      case DOCUMENT_TIME:
+        return "Document creation time";
+      case DOCUMENT_AUTHOR:
+        return "Document author";
+      case DOCUMENT_COMPANY:
+        return "Document company";
+      case DOCUMENT_CREATOR_NAME:
+        return "Document creator name";
+      case DOCUMENT_CREATOR_MAJOR_VERSION:
+        return "Document creator major version";
+      case DOCUMENT_CREATOR_MINOR_VERSION:
+        return "Document creator minor version";
+      case DOCUMENT_CREATOR_SUB_VERSION:
+        return "Document creator sub version";
+      case DOCUMENT_CREATOR_BUILD_NUMBER:
+        return "Document creator build number";
+      case DOCUMENT_CREATOR_PACKAGE:
+        return "Document creator package";
+      case DOCUMENT_PRODUCT:
+        return "Document product";
+      case DOCUMENT_PRODUCT_NAME:
+        return "Document product name";
+      case DOCUMENT_PRODUCT_VERSION:
+        return "Document product version";
+      case DOCUMENT_TYPE_HINT:
+        return "Document type hint";
+      case DOCUMENT_THUMB:
+        return "Document thumbnail";
+      case COARSE_PYRAMID_LEVEL:
+        return "Coarse pyramid level";
+      case EXTRA_SAMPLES:
+        return "Extra samples";
+      case DEFAULT_BACKGROUND_COLOR:
+        return "Default background color";
+      case VERSION_NUMBER:
+        return "Version number";
+      case CHANNEL_NAME:
+        return "Channel name";
+    }
+    return "tag " + tag;
+  }
+
+  private String getStackType(String type) {
+    int stackType = Integer.parseInt(type);
+    switch (stackType) {
+      case DEFAULT_IMAGE:
+        return "Default image";
+      case OVERVIEW_IMAGE:
+        return "Overview image";
+      case SAMPLE_MASK:
+        return "Sample mask";
+      case FOCUS_IMAGE:
+        return "Focus image";
+      case EFI_SHARPNESS_MAP:
+        return "EFI sharpness map";
+      case EFI_HEIGHT_MAP:
+        return "EFI height map";
+      case EFI_TEXTURE_MAP:
+        return "EFI texture map";
+      case EFI_STACK:
+        return "EFI stack";
+      case MACRO_IMAGE:
+        return "Macro image";
+    }
+    return type;
   }
 
   // -- Helper class --

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1042,8 +1042,8 @@ public class CellSensReader extends FormatReader {
 
         int previousX = core.get(core.size() - 1).sizeX;
         int previousY = core.get(core.size() - 1).sizeY;
-        int maxSizeX = tileX.get(tileX.size() - 1) * (maxX[i] <= 1 ? 1 : maxX[i] + 1);
-        int maxSizeY = tileY.get(tileY.size() - 1) * (maxY[i] <= 1 ? 1 : maxY[i] + 1);
+        int maxSizeX = tileX.get(tileX.size() - 1) * (maxX[i] < 1 ? 1 : maxX[i] + 1);
+        int maxSizeY = tileY.get(tileY.size() - 1) * (maxY[i] < 1 ? 1 : maxY[i] + 1);
 
         newResolution.sizeX = previousX / 2;
         if (previousX % 2 == 1 && newResolution.sizeX < maxSizeX) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -481,7 +481,7 @@ public class CellSensReader extends FormatReader {
 
     // make sure magnification order matches resolution order
 
-    Double maxMag = 0d;
+    Double maxMag = magnifications.get(0);
     if (magnifications.size() > 1) {
       HashMap<Integer, Integer> xDims = new HashMap<Integer, Integer>();
       for (int i=0; i<core.size();) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1327,7 +1327,7 @@ public class CellSensReader extends FormatReader {
         if (tag == EXTERNAL_FILE_PROPERTIES && previousTag == IMAGE_FRAME_VOLUME) {
           metadataIndex++;
         }
-        else if (tag == DOCUMENT_PROPERTIES) {
+        else if (tag == DOCUMENT_PROPERTIES || tag == SLIDE_PROPERTIES) {
           metadataIndex = -1;
         }
 
@@ -1601,7 +1601,7 @@ public class CellSensReader extends FormatReader {
               addMetaList(tagPrefix + tagName, value,
                 pyramids.get(metadataIndex).originalMetadata);
             }
-            else {
+            else if (tag != VALUE || tagPrefix.length() > 0) {
               addGlobalMetaList(tagPrefix + tagName, value);
             }
           }
@@ -2116,6 +2116,8 @@ public class CellSensReader extends FormatReader {
         return "Slide Loader";
       case 40000:
         return "Manual Control";
+      case 40500:
+        return "Microscope Frame";
     }
     return type;
   }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -190,7 +190,8 @@ public class CellSensReader extends FormatReader {
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
 
-    return usedFiles;
+    // all files contain pixels
+    return noPixels ? null : usedFiles;
   }
 
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -554,6 +554,12 @@ public class CellSensReader extends FormatReader {
     }
   }
 
+  /* @see loci.formats.IFormatReader#reopenFile() */
+  public void reopenFile() throws IOException {
+    super.reopenFile();
+    parser = new TiffParser(currentId);
+  }
+
   /* @see loci.formats.IFormatReader#close(boolean) */
   @Override
   public void close(boolean fileOnly) throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -763,6 +763,19 @@ public class CellSensReader extends FormatReader {
           store.setDetectorSettingsBinning(
             getBinning(pyramid.binningX + "x" + pyramid.binningY), ii, c);
 
+          if (c == 0) {
+            store.setDetectorSettingsGain(pyramid.redGain, ii, c);
+            store.setDetectorSettingsOffset(pyramid.redOffset, ii, c);
+          }
+          else if (c == 1) {
+            store.setDetectorSettingsGain(pyramid.greenGain, ii, c);
+            store.setDetectorSettingsOffset(pyramid.greenOffset, ii, c);
+          }
+          else if (c == 2) {
+            store.setDetectorSettingsGain(pyramid.blueGain, ii, c);
+            store.setDetectorSettingsOffset(pyramid.blueOffset, ii, c);
+          }
+
           if (c < pyramid.channelNames.size()) {
             store.setChannelName(pyramid.channelNames.get(c), ii, c);
           }
@@ -1347,7 +1360,7 @@ public class CellSensReader extends FormatReader {
             vsi.getFilePointer() < vsi.length())
           {
             long start = vsi.getFilePointer();
-            readTags(vsi, populateMetadata, getVolumeName(tag));
+            readTags(vsi, populateMetadata || inDimensionProperties, getVolumeName(tag));
             long end = vsi.getFilePointer();
             if (start == end) {
               break;
@@ -1538,7 +1551,7 @@ public class CellSensReader extends FormatReader {
               else if (tag == DEVICE_MANUFACTURER) {
                 pyramid.deviceManufacturers.add(value);
               }
-              else if (tag == EXPOSURE_TIME) {
+              else if (tag == EXPOSURE_TIME && tagPrefix.length() == 0) {
                 pyramid.exposureTimes.add(new Long(value));
               }
               else if (tag == CREATION_TIME && pyramid.acquisitionTime == null) {
@@ -1576,6 +1589,24 @@ public class CellSensReader extends FormatReader {
               }
               else if (tag == CAMERA_OFFSET) {
                 pyramid.offset = new Double(value);
+              }
+              else if (tag == RED_GAIN) {
+                pyramid.redGain = new Double(value);
+              }
+              else if (tag == GREEN_GAIN) {
+                pyramid.greenGain = new Double(value);
+              }
+              else if (tag == BLUE_GAIN) {
+                pyramid.blueGain = new Double(value);
+              }
+              else if (tag == RED_OFFSET) {
+                pyramid.redOffset = new Double(value);
+              }
+              else if (tag == GREEN_OFFSET) {
+                pyramid.greenOffset = new Double(value);
+              }
+              else if (tag == BLUE_OFFSET) {
+                pyramid.blueOffset = new Double(value);
               }
               else if (tag == VALUE) {
                 if (tagPrefix.equals("Channel Wavelength ")) {
@@ -2238,6 +2269,13 @@ public class CellSensReader extends FormatReader {
     public Integer binningY;
     public Double gain;
     public Double offset;
+
+    public Double redGain;
+    public Double greenGain;
+    public Double blueGain;
+    public Double redOffset;
+    public Double greenOffset;
+    public Double blueOffset;
 
     public ArrayList<String> channelNames = new ArrayList<String>();
     public ArrayList<Double> channelWavelengths = new ArrayList<Double>();

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -859,6 +859,7 @@ public class CellSensReader extends FormatReader {
     if (usePyramid) {
       int finalResolution = 1;
       double aspectRatio = (double) ms.sizeX / ms.sizeY;
+      int initialCoreSize = core.size();
       for (int i=1; i<maxResolution; i++) {
         CoreMetadata newResolution = new CoreMetadata(ms);
 
@@ -905,7 +906,7 @@ public class CellSensReader extends FormatReader {
         if (Math.abs(newAspect - aspectRatio) < Constants.EPSILON) {
           core.add(newResolution);
           fileMap.put(core.size() - 1, file);
-          finalResolution = core.size();
+          finalResolution = core.size() - initialCoreSize + 1;
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -380,8 +380,8 @@ public class CellSensReader extends FormatReader {
   private ArrayList<Integer> tileX = new ArrayList<Integer>();
   private ArrayList<Integer> tileY = new ArrayList<Integer>();
 
-  private ArrayList<HashMap<TileCoordinate, Integer>> tileMap =
-    new ArrayList<HashMap<TileCoordinate, Integer>>();
+  private ArrayList<ArrayList<TileCoordinate>> tileMap =
+    new ArrayList<ArrayList<TileCoordinate>>();
   private ArrayList<Integer> nDimensions = new ArrayList<Integer>();
   private boolean inDimensionProperties = false;
   private boolean foundChannelTag = false;
@@ -913,8 +913,9 @@ public class CellSensReader extends FormatReader {
       t.coordinate[t.coordinate.length - 1] = resIndex;
     }
 
-    Integer index = (Integer) tileMap.get(getCoreIndex()).get(t);
-    if (index == null) {
+    ArrayList<TileCoordinate> map = tileMap.get(getCoreIndex());
+    Integer index = map.indexOf(t);
+    if (index == null || index < 0) {
       // fill in the tile with the stored background color
       // usually this is either black or white
       byte[] tile = new byte[getTileSize()];
@@ -1185,10 +1186,9 @@ public class CellSensReader extends FormatReader {
       cols.add(1);
     }
 
-    HashMap<TileCoordinate, Integer> map =
-      new HashMap<TileCoordinate, Integer>();
+    ArrayList<TileCoordinate> map = new ArrayList<TileCoordinate>();
     for (int i=0; i<tmpTiles.size(); i++) {
-      map.put(tmpTiles.get(i), i);
+      map.add(tmpTiles.get(i));
     }
     tileMap.add(map);
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import loci.common.ByteArrayHandle;
+import loci.common.Constants;
 import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
@@ -803,6 +804,8 @@ public class CellSensReader extends FormatReader {
 
     ms.pixelType = convertPixelType(pixelType);
     if (usePyramid) {
+      int finalResolution = 0;
+      double aspectRatio = (double) ms.sizeX / ms.sizeY;
       for (int i=1; i<maxResolution; i++) {
         CoreMetadata newResolution = new CoreMetadata(ms);
 
@@ -844,11 +847,16 @@ public class CellSensReader extends FormatReader {
 
         newResolution.metadataComplete = true;
         newResolution.dimensionOrder = "XYCZT";
-        core.add(newResolution);
-        fileMap.put(core.size() - 1, file);
+
+        double newAspect = (double) newResolution.sizeX / newResolution.sizeY;
+        if (Math.abs(newAspect - aspectRatio) < Constants.EPSILON) {
+          core.add(newResolution);
+          fileMap.put(core.size() - 1, file);
+          finalResolution = core.size();
+        }
       }
 
-      ms.resolutionCount = maxResolution;
+      ms.resolutionCount = finalResolution;
     }
     etsFile.close();
   }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -413,7 +413,7 @@ public class CellSensReader extends FormatReader {
     files.add(file.getAbsolutePath());
     usedFiles = files.toArray(new String[files.size()]);
 
-    int seriesCount = files.size() - 1 + ifds.size();
+    int seriesCount = files.size();
     core.clear();
 
     IFDList exifs = parser.getExifIFDs();

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -2031,6 +2031,8 @@ public class CellSensReader extends FormatReader {
         return "Value";
       case 175208:
         return "Snapshot Count";
+      case 175209:
+        return "Scanning Time (seconds)";
       case 120210:
         return "Device Configuration Position";
       case 120211:

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -54,6 +54,7 @@ import loci.formats.tiff.IFDList;
 import loci.formats.tiff.PhotoInterp;
 import loci.formats.tiff.TiffParser;
 
+import ome.units.UNITS;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
@@ -721,7 +722,8 @@ public class CellSensReader extends FormatReader {
       Pyramid pyramid = pyramids.get(i);
       store.setObjectiveID(MetadataTools.createLSID("Objective", 0, i), 0, i);
       store.setObjectiveNominalMagnification(pyramid.magnification, 0, i);
-      store.setObjectiveWorkingDistance(pyramid.workingDistance, 0, i);
+      store.setObjectiveWorkingDistance(
+        FormatTools.createLength(pyramid.workingDistance, UNITS.MICROM), 0, i);
 
       for (int q=0; q<pyramid.objectiveTypes.size(); q++) {
         if (pyramid.objectiveTypes.get(q) == 1) {
@@ -799,10 +801,13 @@ public class CellSensReader extends FormatReader {
                 exp = pyramid.exposureTimes.get(c);
               }
               if (exp != null) {
-                store.setPlaneExposureTime(exp / 1000000.0, ii, nextPlane);
+                store.setPlaneExposureTime(
+                  FormatTools.createTime(exp / 1000000.0, UNITS.S), ii, nextPlane);
               }
-              store.setPlanePositionX(pyramid.originX, ii, nextPlane);
-              store.setPlanePositionY(pyramid.originY, ii, nextPlane);
+              store.setPlanePositionX(
+                FormatTools.createLength(pyramid.originX, UNITS.MICROM), ii, nextPlane);
+              store.setPlanePositionY(
+                FormatTools.createLength(pyramid.originY, UNITS.MICROM), ii, nextPlane);
               nextPlane++;
             }
           }
@@ -834,10 +839,10 @@ public class CellSensReader extends FormatReader {
         store.setObjectiveSettingsRefractiveIndex(pyramid.refractiveIndex, ii);
 
         if (pyramid.physicalSizeX > 0) {
-          store.setPixelsPhysicalSizeX(new PositiveFloat(pyramid.physicalSizeX), ii);
+          store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(pyramid.physicalSizeX), ii);
         }
         if (pyramid.physicalSizeY > 0) {
-          store.setPixelsPhysicalSizeY(new PositiveFloat(pyramid.physicalSizeY), ii);
+          store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(pyramid.physicalSizeY), ii);
         }
 
         if (pyramid.acquisitionTime != null) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -481,7 +481,7 @@ public class CellSensReader extends FormatReader {
 
     // make sure magnification order matches resolution order
 
-    Double maxMag = magnifications.get(0);
+    Double maxMag = magnifications.size() > 0 ? magnifications.get(0) : 0d;
     if (magnifications.size() > 1) {
       HashMap<Integer, Integer> xDims = new HashMap<Integer, Integer>();
       for (int i=0; i<core.size();) {
@@ -524,6 +524,10 @@ public class CellSensReader extends FormatReader {
           i += core.get(i).resolutionCount;
         }
         else {
+          if (i == 0) {
+            store.setPixelsPhysicalSizeX(new PositiveFloat(physicalSizeX), i);
+            store.setPixelsPhysicalSizeY(new PositiveFloat(physicalSizeY), i);
+          }
           break;
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -678,6 +678,14 @@ public class CellSensReader extends FormatReader {
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
 
+    String instrument = MetadataTools.createLSID("Instrument", 0);
+    store.setInstrumentID(instrument, 0);
+
+    for (int i=0; i<magnifications.size(); i++) {
+      store.setObjectiveID(MetadataTools.createLSID("Objective", 0, i), 0, i);
+      store.setObjectiveNominalMagnification(magnifications.get(i), 0, i);
+    }
+
     int nextSize = 0;
     int channelIndex = 0;
     for (int i=0; i<core.size();) {
@@ -717,6 +725,8 @@ public class CellSensReader extends FormatReader {
         }
       }
 
+      store.setImageInstrumentRef(instrument, ii);
+
       if (nextSize < imageNames.size()) {
         String imageName = imageNames.get(nextSize);
         boolean duplicate = false;
@@ -731,6 +741,23 @@ public class CellSensReader extends FormatReader {
           imageName += " #" + ii;
         }
         store.setImageName(imageName, ii);
+
+        int mag = magnifications.size() - 1;
+        if (imageNames.get(nextSize).endsWith("x")) {
+          int nameMag = 0;
+          try {
+            imageName = imageName.substring(0, imageName.indexOf("x"));
+            nameMag = Integer.parseInt(imageName);
+          }
+          catch (NumberFormatException e) {
+          }
+          for (int magnification=0; magnification<magnifications.size(); magnification++) {
+            if (magnifications.get(magnification).intValue() == nameMag) {
+              mag = magnification;
+            }
+          }
+        }
+        store.setObjectiveSettingsID(MetadataTools.createLSID("Objective", 0, mag), ii);
       }
       else {
         store.setImageName("Macro Image", ii);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -719,8 +719,15 @@ public class CellSensReader extends FormatReader {
 
       if (nextSize < imageNames.size()) {
         String imageName = imageNames.get(nextSize);
+        boolean duplicate = false;
+        for (int q=0; q<imageNames.size(); q++) {
+          if (q != nextSize && imageName.equals(imageNames.get(q))) {
+            duplicate = true;
+            break;
+          }
+        }
 
-        if (!imageName.equals("Overview") && !imageName.equals("Label")) {
+        if (!imageName.equals("Overview") && !imageName.equals("Label") && duplicate) {
           imageName += " #" + ii;
         }
         store.setImageName(imageName, ii);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -792,15 +792,18 @@ public class CellSensReader extends FormatReader {
                 new PositiveInteger(wave), ii, c);
             }
           }
-          if (c < pyramid.exposureTimes.size()) {
-            for (int z=0; z<core.get(i).sizeZ; z++) {
-              for (int t=0; t<core.get(i).sizeT; t++) {
-                store.setPlaneExposureTime(
-                  pyramid.exposureTimes.get(c) / 1000000.0, ii, nextPlane);
-                store.setPlanePositionX(pyramid.originX, ii, nextPlane);
-                store.setPlanePositionY(pyramid.originY, ii, nextPlane);
-                nextPlane++;
+          for (int z=0; z<core.get(i).sizeZ; z++) {
+            for (int t=0; t<core.get(i).sizeT; t++) {
+              Long exp = pyramid.defaultExposureTime;
+              if (c < pyramid.exposureTimes.size()) {
+                exp = pyramid.exposureTimes.get(c);
               }
+              if (exp != null) {
+                store.setPlaneExposureTime(exp / 1000000.0, ii, nextPlane);
+              }
+              store.setPlanePositionX(pyramid.originX, ii, nextPlane);
+              store.setPlanePositionY(pyramid.originY, ii, nextPlane);
+              nextPlane++;
             }
           }
         }
@@ -1560,6 +1563,9 @@ public class CellSensReader extends FormatReader {
               else if (tag == EXPOSURE_TIME && tagPrefix.length() == 0) {
                 pyramid.exposureTimes.add(new Long(value));
               }
+              else if (tag == EXPOSURE_TIME) {
+                pyramid.defaultExposureTime = new Long(value);
+              }
               else if (tag == CREATION_TIME && pyramid.acquisitionTime == null) {
                 pyramid.acquisitionTime = new Long(value);
               }
@@ -2288,6 +2294,7 @@ public class CellSensReader extends FormatReader {
     public ArrayList<String> channelNames = new ArrayList<String>();
     public ArrayList<Double> channelWavelengths = new ArrayList<Double>();
     public ArrayList<Long> exposureTimes = new ArrayList<Long>();
+    public Long defaultExposureTime;
 
     public ArrayList<String> objectiveNames = new ArrayList<String>();
     public ArrayList<Integer> objectiveTypes = new ArrayList<Integer>();

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -752,8 +752,9 @@ public class CellSensReader extends FormatReader {
       int ii = coreIndexToSeries(i);
 
       if (pyramid != null) {
-       int nextPlane = 0;
-        for (int c=0; c<core.get(i).sizeC; c++) {
+        int nextPlane = 0;
+        int effectiveSizeC = core.get(i).rgb ? 1 : core.get(i).sizeC;
+        for (int c=0; c<effectiveSizeC; c++) {
           store.setDetectorSettingsID(
             MetadataTools.createLSID("Detector", 0, nextPyramid - 1), ii, c);
           store.setDetectorSettingsBinning(

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -481,6 +481,7 @@ public class CellSensReader extends FormatReader {
 
     // make sure magnification order matches resolution order
 
+    Double maxMag = 0d;
     if (magnifications.size() > 1) {
       HashMap<Integer, Integer> xDims = new HashMap<Integer, Integer>();
       for (int i=0; i<core.size();) {
@@ -502,6 +503,9 @@ public class CellSensReader extends FormatReader {
       }
       for (Double magnification : magnifications) {
         addGlobalMetaList("Magnification", magnification);
+        if (magnification > maxMag) {
+          maxMag = magnification;
+        }
       }
     }
 
@@ -509,10 +513,10 @@ public class CellSensReader extends FormatReader {
       store.setPixelsPhysicalSizeX(new PositiveFloat(physicalSizeX), 0);
       store.setPixelsPhysicalSizeY(new PositiveFloat(physicalSizeY), 0);
 
-      int nextMag = 1;
-      for (int i=core.get(0).resolutionCount; i<core.size();) {
+      int nextMag = 0;
+      for (int i=0; i<core.size();) {
         if (nextMag < magnifications.size()) {
-          double mult = magnifications.get(nextMag) / magnifications.get(0);
+          double mult = maxMag / magnifications.get(nextMag);
           int ii = coreIndexToSeries(i);
           store.setPixelsPhysicalSizeX(new PositiveFloat(physicalSizeX * mult), ii);
           store.setPixelsPhysicalSizeY(new PositiveFloat(physicalSizeY * mult), ii);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -789,7 +789,7 @@ public class CellSensReader extends FormatReader {
             int wave = pyramid.channelWavelengths.get(c).intValue();
             if (wave > 0) {
               store.setChannelEmissionWavelength(
-                new PositiveInteger(wave), ii, c);
+                FormatTools.getEmissionWavelength((double) wave), ii, c);
             }
           }
           for (int z=0; z<core.get(i).sizeZ; z++) {


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org.uk/ome/ticket/9805.  CellSens datasets (including test_images_good/cellsens) should now have PhysicalSizeX and PhysicalSizeY set for the largest resolution in each pyramid.  Smaller resolutions in the pyramid will not have physical sizes set, by design.