### PR TITLE
TIFF: fix plane count calculation for pyramids with multiple planes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -449,8 +449,9 @@ public class MinimalTiffReader extends FormatReader {
     tiffParser.setAssumeEqualStrips(equalStrips);
     for (IFD ifd : ifds) {
       tiffParser.fillInIFD(ifd);
-      if (ifd.getCompression() == TiffCompression.JPEG_2000
-          || ifd.getCompression() == TiffCompression.JPEG_2000_LOSSY) {
+      if ((ifd.getCompression() == TiffCompression.JPEG_2000
+          || ifd.getCompression() == TiffCompression.JPEG_2000_LOSSY) &&
+          ifd.getImageWidth() == ifds.get(0).getImageWidth()) {
         LOGGER.debug("Found IFD with JPEG 2000 compression");
         long[] stripOffsets = ifd.getStripOffsets();
         long[] stripByteCounts = ifd.getStripByteCounts();
@@ -558,8 +559,8 @@ public class MinimalTiffReader extends FormatReader {
       }
 
       if (ifds.size() + 1 < ms0.sizeT) {
-        ms0.sizeT -= (ifds.size() + 1);
-        ms0.imageCount -= (ifds.size() + 1);
+        ms0.sizeT = subResolutionIFDs.size();
+        ms0.imageCount = ms0.sizeT;
       }
 
       if (ms0.sizeT <= 0) {

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -558,10 +558,8 @@ public class MinimalTiffReader extends FormatReader {
         ms0.resolutionCount = seriesCount;
       }
 
-      if (ifds.size() + 1 < ms0.sizeT) {
-        ms0.sizeT = subResolutionIFDs.size();
-        ms0.imageCount = ms0.sizeT;
-      }
+      ms0.sizeT = subResolutionIFDs.size();
+      ms0.imageCount = ms0.sizeT;
 
       if (ms0.sizeT <= 0) {
         ms0.sizeT = 1;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/12617.  To test, import the files from QA 10321 and verify that all Z sections (7 for the larger files, 1 for the smaller file) can be viewed without an exception in Blitz-0.log after pyramid generation completes.  Pyramids generated without this change should be read correctly as well, so reimport should not be strictly necessary if all files were previously imported into a develop server.

/cc @jburel, @zeb