### PR TITLE
Updated XSLT for units conversion

### DIFF
--- a/components/specification/samples/develop/2013-10to06-downgrade-fail-generic.ome
+++ b/components/specification/samples/develop/2013-10to06-downgrade-fail-generic.ome
@@ -113,7 +113,9 @@
 	<Instrument ID="Instrument:0">
 		<Microscope Type="Dissection"/>
 		<LightSource ID="LightSource:0">
-			<Arc/>
+			<GenericExcitationSource>
+				<Map><M K="a">1</M><M K="b">2</M><M K="c">3</M></Map>
+			</GenericExcitationSource>
 		</LightSource>
 		<LightSource ID="LightSource:1" Manufacturer="OME-Inc">
 			<Laser Wavelength="655.3" Tuneable="false"/>
@@ -190,11 +192,11 @@
 				<test2/>
 			</SA:Value>
 		</SA:XMLAnnotation>
-		<SA:XMLAnnotation ID="Annotation:2">
+		<SA:MapAnnotation ID="Annotation:2">
 			<SA:Value>
 				<M K="a">1</M><M K="b">2</M><M K="c">3</M>
 			</SA:Value>
-		</SA:XMLAnnotation>
+		</SA:MapAnnotation>
 		<SA:LongAnnotation ID="Annotation:Detector:0">
 			<SA:Value>1</SA:Value>
 		</SA:LongAnnotation>

--- a/components/specification/samples/develop/2013-10to06-downgrade.ome
+++ b/components/specification/samples/develop/2013-10to06-downgrade.ome
@@ -151,7 +151,7 @@
 		<ExperimenterRef ID="Experimenter:1"/>
 		<ImagingEnvironment 
 			AirPressure="999" AirPressureUnit="mbar"
-			Temperature="23.3" TemperatureUnit="°C"
+			Temperature="73.94" TemperatureUnit="°F"
 			CO2Percent="0.05" Humidity="0.35"/>
 		<Pixels DimensionOrder="XYCZT" ID="Pixels:0:0"
 			PhysicalSizeX="10000.0" PhysicalSizeXUnit="nm"

--- a/components/specification/samples/develop/2013-10to06-downgrade.ome
+++ b/components/specification/samples/develop/2013-10to06-downgrade.ome
@@ -116,7 +116,7 @@
 			<Arc/>
 		</LightSource>
 		<LightSource ID="LightSource:1" Manufacturer="OME-Inc">
-			<Laser Wavelength="655.3" Tuneable="false"/>
+			<Laser Wavelength="655300" WavelengthUnit="pm" Tuneable="false"/>
 		</LightSource>
 		<LightSource ID="LightSource:2" Power="2.3">
 			<Laser Wavelength="755" LaserMedium="Alexandrite"/>
@@ -124,6 +124,12 @@
 		<LightSource ID="LightSource:3">
 			<Arc Type="Hg"/>
 			<SA:AnnotationRef ID="Annotation:LightSource:3"/>
+		</LightSource>
+		<LightSource ID="LightSource:4" Manufacturer="OME-Inc">
+			<Laser Wavelength="655000" WavelengthUnit="pm" Tuneable="false"/>
+		</LightSource>
+		<LightSource ID="LightSource:5" Power="2.3">
+			<Laser Wavelength="755.8" LaserMedium="Alexandrite"/>
 		</LightSource>
 		<Detector ID="Detector:0">
 			<SA:AnnotationRef ID="Annotation:Detector:0"/>
@@ -154,7 +160,7 @@
 			<Channel AcquisitionMode="LaserScanningConfocalMicroscopy" Color="-1147483648"
 				EmissionWavelength="577.2" ExcitationWavelength="655.8"
 				ID="Channel:0">
-				<LightSourceSettings ID="LightSource:1" Wavelength="0.6554" WavelengthUnit="mm"/>
+				<LightSourceSettings ID="LightSource:1" Wavelength="0.000655" WavelengthUnit="mm"/>
 				<LightPath>
 					<ExcitationFilterRef ID="Filter:0"/>
 					<DichroicRef ID="Dichroic:0"/>

--- a/components/specification/transforms/2013-10-dev-5-to-2013-06.xsl
+++ b/components/specification/transforms/2013-10-dev-5-to-2013-06.xsl
@@ -88,7 +88,7 @@
 	<!-- strip Wavelength from LightSourceSettings ONLY if it is not an integer -->
 	<xsl:template match="OME:LightSourceSettings">
 		<xsl:element name="OME:LightSourceSettings" namespace="{$newOMENS}">
-			<xsl:for-each select="@* [not(name() = 'Wavelength')]">
+			<xsl:for-each select="@* [not(name() = 'Wavelength' or name() = 'WavelengthUnit')]">
 				<xsl:attribute name="{local-name(.)}">
 					<xsl:value-of select="."/>
 				</xsl:attribute>
@@ -108,12 +108,19 @@
 	<!-- strip Wavelength from Laser ONLY if it is not an integer -->
 	<xsl:template match="OME:Laser">
 		<xsl:element name="OME:Laser" namespace="{$newOMENS}">
-			<xsl:for-each select="@* [not(name() = 'Wavelength')]">
+			<xsl:for-each select="@* [not(name() = 'Wavelength' or name() = 'WavelengthUnit')]">
 				<xsl:attribute name="{local-name(.)}">
 					<xsl:value-of select="."/>
 				</xsl:attribute>
 			</xsl:for-each>
-			<xsl:variable name="theValue" select="@Wavelength"/>
+			<xsl:variable name="theValue">
+				<xsl:call-template name="ConvertValueToDefault">
+					<xsl:with-param name="theValue"><xsl:value-of select="@Wavelength"/></xsl:with-param>
+					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@WavelengthUnit"/></xsl:with-param>
+					<xsl:with-param name="theAttributeName">Wavelength</xsl:with-param>
+					<xsl:with-param name="theElementName">Laser</xsl:with-param>
+				</xsl:call-template>
+			</xsl:variable>
 			<xsl:for-each select="@* [name() = 'Wavelength']">
 				<xsl:if test="$theValue=round($theValue)">
 					<xsl:attribute name="{local-name(.)}">

--- a/components/specification/transforms/2013-10-dev-5-to-2013-06.xsl
+++ b/components/specification/transforms/2013-10-dev-5-to-2013-06.xsl
@@ -65,7 +65,7 @@
 					<xsl:value-of select="."/>
 				</xsl:attribute>
 			</xsl:for-each>
-			<xsl:variable name="theValueEm">
+			<xsl:variable name="theConvertedValueEm">
 				<xsl:call-template name="ConvertValueToDefault">
 					<xsl:with-param name="theValue"><xsl:value-of select="@EmissionWavelength"/></xsl:with-param>
 					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@EmissionWavelengthUnit"/></xsl:with-param>
@@ -73,15 +73,14 @@
 					<xsl:with-param name="theElementName">Channel</xsl:with-param>
 				</xsl:call-template>
 			</xsl:variable>
-			<xsl:variable name="theValueEm" select="@EmissionWavelength"/>
 			<xsl:for-each select="@* [name() = 'EmissionWavelength']">
-				<xsl:if test="$theValueEm=round($theValueEm)">
+				<xsl:if test="$theConvertedValueEm=round($theConvertedValueEm)">
 					<xsl:attribute name="{local-name(.)}">
-						<xsl:value-of select="round($theValueEm)"/>
+						<xsl:value-of select="round($theConvertedValueEm)"/>
 					</xsl:attribute>
 				</xsl:if>
 			</xsl:for-each>
-			<xsl:variable name="theValueEx">
+			<xsl:variable name="theConvertedValueEx">
 				<xsl:call-template name="ConvertValueToDefault">
 					<xsl:with-param name="theValue"><xsl:value-of select="@ExcitationWavelength"/></xsl:with-param>
 					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@ExcitationWavelengthUnit"/></xsl:with-param>
@@ -90,9 +89,9 @@
 				</xsl:call-template>
 			</xsl:variable>
 			<xsl:for-each select="@* [name() = 'ExcitationWavelength']">
-				<xsl:if test="$theValueEx=round($theValueEx)">
+				<xsl:if test="$theConvertedValueEx=round($theConvertedValueEx)">
 					<xsl:attribute name="{local-name(.)}">
-						<xsl:value-of select="round($theValueEx)"/>
+						<xsl:value-of select="round($theConvertedValueEx)"/>
 					</xsl:attribute>
 				</xsl:if>
 			</xsl:for-each>
@@ -108,7 +107,7 @@
 					<xsl:value-of select="."/>
 				</xsl:attribute>
 			</xsl:for-each>
-			<xsl:variable name="theValue">
+			<xsl:variable name="theConvertedValue">
 				<xsl:call-template name="ConvertValueToDefault">
 					<xsl:with-param name="theValue"><xsl:value-of select="@Wavelength"/></xsl:with-param>
 					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@WavelengthUnit"/></xsl:with-param>
@@ -117,9 +116,9 @@
 				</xsl:call-template>
 			</xsl:variable>
 			<xsl:for-each select="@* [name() = 'Wavelength']">
-				<xsl:if test="$theValue=round($theValue)">
+				<xsl:if test="$theConvertedValue=round($theConvertedValue)">
 					<xsl:attribute name="{local-name(.)}">
-						<xsl:value-of select="round($theValue)"/>
+						<xsl:value-of select="round($theConvertedValue)"/>
 					</xsl:attribute>
 				</xsl:if>
 			</xsl:for-each>
@@ -135,7 +134,7 @@
 					<xsl:value-of select="."/>
 				</xsl:attribute>
 			</xsl:for-each>
-			<xsl:variable name="theValue">
+			<xsl:variable name="theConvertedValue">
 				<xsl:call-template name="ConvertValueToDefault">
 					<xsl:with-param name="theValue"><xsl:value-of select="@Wavelength"/></xsl:with-param>
 					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@WavelengthUnit"/></xsl:with-param>
@@ -144,9 +143,9 @@
 				</xsl:call-template>
 			</xsl:variable>
 			<xsl:for-each select="@* [name() = 'Wavelength']">
-				<xsl:if test="$theValue=round($theValue)">
+				<xsl:if test="$theConvertedValue=round($theConvertedValue)">
 					<xsl:attribute name="{local-name(.)}">
-						<xsl:value-of select="round($theValue)"/>
+						<xsl:value-of select="round($theConvertedValue)"/>
 					</xsl:attribute>
 				</xsl:if>
 			</xsl:for-each>
@@ -298,23 +297,34 @@
 		<xsl:for-each select="@*">
 			<xsl:choose>
 				<xsl:when test="substring(name(), string-length(name()) - string-length('Unit') +1) = 'Unit'">
-					<xsl:message>Skipping: <xsl:value-of select="name()"/></xsl:message>
+					<!-- Units attribute so do not copy -->
 				</xsl:when>
 				<xsl:when test="$unit-attributes-count != 0">
-					<xsl:message>Checking: <xsl:value-of select="name()"/></xsl:message>
 					<xsl:variable name="match-name"><xsl:value-of select="name()"/>Unit</xsl:variable>
 					<xsl:choose>
 						<xsl:when test="count($unit-attributes[name() = $match-name]) = 1">
-							<xsl:message>Match: <xsl:value-of select="name()"/></xsl:message>
-							<xsl:apply-templates select="."/>
+							<!-- This attribute has units specified so convert -->
+							<xsl:variable name="theUnitName"><xsl:value-of select="local-name()"/>Unit</xsl:variable>
+							<xsl:variable name="theConvertedValue">
+								<xsl:call-template name="ConvertValueToDefault">
+									<xsl:with-param name="theValue"><xsl:value-of select="."/></xsl:with-param>
+									<xsl:with-param name="theCurrentUnit"><xsl:value-of select="../@*[name() = $theUnitName]"/></xsl:with-param>
+									<xsl:with-param name="theAttributeName"><xsl:value-of select="local-name(.)"/></xsl:with-param>
+									<xsl:with-param name="theElementName"><xsl:value-of select="local-name(parent::node())"/></xsl:with-param>
+								</xsl:call-template>
+							</xsl:variable>
+							<xsl:attribute name="{local-name(.)}">
+								<xsl:value-of select="$theConvertedValue"/>
+							</xsl:attribute>
 						</xsl:when>
 						<xsl:otherwise>
-							<xsl:message>No match: <xsl:value-of select="name()"/></xsl:message>
+							<!-- Units used but this attribute has no units specified -->
 							<xsl:apply-templates select="."/>
 						</xsl:otherwise>
 					</xsl:choose>
 				</xsl:when>
 				<xsl:otherwise>
+					<!-- No units being used -->
 					<xsl:apply-templates select="."/>
 				</xsl:otherwise>
 			</xsl:choose>

--- a/components/specification/transforms/2013-10-dev-5-to-2013-06.xsl
+++ b/components/specification/transforms/2013-10-dev-5-to-2013-06.xsl
@@ -65,6 +65,14 @@
 					<xsl:value-of select="."/>
 				</xsl:attribute>
 			</xsl:for-each>
+			<xsl:variable name="theValueEm">
+				<xsl:call-template name="ConvertValueToDefault">
+					<xsl:with-param name="theValue"><xsl:value-of select="@EmissionWavelength"/></xsl:with-param>
+					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@EmissionWavelengthUnit"/></xsl:with-param>
+					<xsl:with-param name="theAttributeName">EmissionWavelength</xsl:with-param>
+					<xsl:with-param name="theElementName">Channel</xsl:with-param>
+				</xsl:call-template>
+			</xsl:variable>
 			<xsl:variable name="theValueEm" select="@EmissionWavelength"/>
 			<xsl:for-each select="@* [name() = 'EmissionWavelength']">
 				<xsl:if test="$theValueEm=round($theValueEm)">
@@ -73,7 +81,14 @@
 					</xsl:attribute>
 				</xsl:if>
 			</xsl:for-each>
-			<xsl:variable name="theValueEx" select="@ExcitationWavelength"/>
+			<xsl:variable name="theValueEx">
+				<xsl:call-template name="ConvertValueToDefault">
+					<xsl:with-param name="theValue"><xsl:value-of select="@ExcitationWavelength"/></xsl:with-param>
+					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@ExcitationWavelengthUnit"/></xsl:with-param>
+					<xsl:with-param name="theAttributeName">ExcitationWavelength</xsl:with-param>
+					<xsl:with-param name="theElementName">Channel</xsl:with-param>
+				</xsl:call-template>
+			</xsl:variable>
 			<xsl:for-each select="@* [name() = 'ExcitationWavelength']">
 				<xsl:if test="$theValueEx=round($theValueEx)">
 					<xsl:attribute name="{local-name(.)}">
@@ -93,7 +108,14 @@
 					<xsl:value-of select="."/>
 				</xsl:attribute>
 			</xsl:for-each>
-			<xsl:variable name="theValue" select="@Wavelength"/>
+			<xsl:variable name="theValue">
+				<xsl:call-template name="ConvertValueToDefault">
+					<xsl:with-param name="theValue"><xsl:value-of select="@Wavelength"/></xsl:with-param>
+					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="@WavelengthUnit"/></xsl:with-param>
+					<xsl:with-param name="theAttributeName">Wavelength</xsl:with-param>
+					<xsl:with-param name="theElementName">LightSourceSettings</xsl:with-param>
+				</xsl:call-template>
+			</xsl:variable>
 			<xsl:for-each select="@* [name() = 'Wavelength']">
 				<xsl:if test="$theValue=round($theValue)">
 					<xsl:attribute name="{local-name(.)}">

--- a/components/specification/transforms/units-conversion.xsl
+++ b/components/specification/transforms/units-conversion.xsl
@@ -92,15 +92,28 @@
 			<xsl:when test="$theNewUnit = ''">
 				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion of [<xsl:value-of select="$theCurrentUnit"/>] to an unknown unit.</xsl:message>
 			</xsl:when>
-			<xsl:when test="$theCurrentUnit = $theNewUnit"><xsl:value-of select="$theValue"/></xsl:when>
+			<xsl:when test="$theNewUnit = $theCurrentUnit"><xsl:value-of select="$theValue"/></xsl:when>
 			<!-- codegen begin - convert -->
-			<xsl:when test="$theCurrentUnit = 'mm' and $theNewUnit = 'nm'"><xsl:value-of select="$theValue * 1000000"/></xsl:when>
-			<xsl:when test="$theCurrentUnit = 'pm' and $theNewUnit = 'nm'"><xsl:value-of select="$theValue div 1000"/></xsl:when>
-			<xsl:when test="$theCurrentUnit = '°F' and $theNewUnit = '°C'"><xsl:value-of select="(($theValue - 32) * 5) div 9"/></xsl:when>
-			
+			<xsl:when test="$theNewUnit = 'nm'">
+				<xsl:choose>
+					<xsl:when test="$theCurrentUnit = 'mm'"><xsl:value-of select="$theValue * 1000000"/></xsl:when>
+					<xsl:when test="$theCurrentUnit = 'pm'"><xsl:value-of select="$theValue div 1000"/></xsl:when>
+					<xsl:otherwise>
+						<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion, [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:message>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:when>
+			<xsl:when test="$theNewUnit = '°C'">
+				<xsl:choose>
+					<xsl:when test="$theCurrentUnit = '°F'"><xsl:value-of select="(($theValue - 32) * 5) div 9"/></xsl:when>
+					<xsl:otherwise>
+						<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion, [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:message>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:when>
 			<!-- codegen end - convert -->
 			<xsl:otherwise>
-				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:message>
+				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion from any unit to [<xsl:value-of select="$theNewUnit"/>].</xsl:message>
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>

--- a/components/specification/transforms/units-conversion.xsl
+++ b/components/specification/transforms/units-conversion.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Copyright (C) 2014 Open Microscopy Environment
+#       Massachusetts Institute of Technology,
+#       National Institutes of Health,
+#       University of Dundee,
+#       University of Wisconsin at Madison
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+
+<!--
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Written by:  Andrew Patterson: ajpatterson at lifesci.dundee.ac.uk
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	exclude-result-prefixes="xs"
+	version="2.0">
+
+	<!-- codegen here -->
+	
+	<!-- getDefault function (AttributeName, NodeName, ParentNodeName?) -->
+	<!-- 	returns the default as string -->
+
+	<!-- convert function (value, currentUnit, defaultUnit) -->
+	<!-- 	returns the value in the default units -->
+	<!-- 	error and terminate if conversion not possible e.g. pixel->nm -->
+
+</xsl:stylesheet>

--- a/components/specification/transforms/units-conversion.xsl
+++ b/components/specification/transforms/units-conversion.xsl
@@ -45,9 +45,12 @@
 			<!-- codegen begin - defaults -->
 			<xsl:when test="$theAttributeName = 'Wavelength' and $theElementName = 'Laser'">nm</xsl:when>
 			<xsl:when test="$theAttributeName = 'Wavelength' and $theElementName = 'LightSourceSettings'">nm</xsl:when>
+			<xsl:when test="$theAttributeName = 'AirPressure' and $theElementName = 'ImagingEnvironment'">mbar</xsl:when>
+			<xsl:when test="$theAttributeName = 'Temperature' and $theElementName = 'ImagingEnvironment'">°C</xsl:when>
+			<xsl:when test="$theAttributeName = 'PhysicalSizeX' and $theElementName = 'Pixels'">nm</xsl:when>
+			<xsl:when test="$theAttributeName = 'PhysicalSizeY' and $theElementName = 'Pixels'">nm</xsl:when>
 			<!-- codegen end - defaults -->
 			<xsl:otherwise>
-				<xsl:comment>GetDefaultUnit, the default for [<xsl:value-of select="$theAttributeName"/>] in element [<xsl:value-of select="$theElementName"/>] is not supported.</xsl:comment>
 				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - GetDefaultUnit, the default for [<xsl:value-of select="$theAttributeName"/>] in element [<xsl:value-of select="$theElementName"/>] is not supported.</xsl:message>
 			</xsl:otherwise>
 		</xsl:choose>
@@ -60,6 +63,7 @@
 		<xsl:param name="theCurrentUnit"/>
 		<xsl:param name="theAttributeName"/>
 		<xsl:param name="theElementName"/>
+		<xsl:message>OME-XSLT: units-conversion.xsl - Message - ConvertValueToDefault, (<xsl:value-of select="$theValue"/>, <xsl:value-of select="$theCurrentUnit"/>, <xsl:value-of select="$theAttributeName"/>, <xsl:value-of select="$theElementName"/>).</xsl:message>
 		<xsl:choose>
 			<xsl:when test="$theCurrentUnit = ''">
 				<!-- Already using default units so no conversion necessary -->
@@ -85,16 +89,17 @@
 		<xsl:param name="theCurrentUnit"/>
 		<xsl:param name="theNewUnit"/>
 		<xsl:choose>
-			<!-- codegen begin - convert -->
 			<xsl:when test="$theNewUnit = ''">
-				<xsl:comment>ConvertValueToUnit, cannot perform conversion of [<xsl:value-of select="$theCurrentUnit"/>] to an unknown unit.</xsl:comment>
 				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion of [<xsl:value-of select="$theCurrentUnit"/>] to an unknown unit.</xsl:message>
 			</xsl:when>
+			<xsl:when test="$theCurrentUnit = $theNewUnit"><xsl:value-of select="$theValue"/></xsl:when>
+			<!-- codegen begin - convert -->
 			<xsl:when test="$theCurrentUnit = 'mm' and $theNewUnit = 'nm'"><xsl:value-of select="$theValue * 1000000"/></xsl:when>
 			<xsl:when test="$theCurrentUnit = 'pm' and $theNewUnit = 'nm'"><xsl:value-of select="$theValue div 1000"/></xsl:when>
+			<xsl:when test="$theCurrentUnit = '°F' and $theNewUnit = '°C'"><xsl:value-of select="(($theValue - 32) * 5) div 9"/></xsl:when>
+			
 			<!-- codegen end - convert -->
 			<xsl:otherwise>
-				<xsl:comment>ConvertValueToUnit, cannot perform conversion [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:comment>
 				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:message>
 			</xsl:otherwise>
 		</xsl:choose>

--- a/components/specification/transforms/units-conversion.xsl
+++ b/components/specification/transforms/units-conversion.xsl
@@ -36,13 +36,56 @@
 	exclude-result-prefixes="xs"
 	version="2.0">
 
-	<!-- codegen here -->
-	
 	<!-- getDefault function (AttributeName, NodeName, ParentNodeName?) -->
 	<!-- 	returns the default as string -->
+	<xsl:template name="GetDefaultUnit">
+		<xsl:param name="theAttributeName"/>
+		<xsl:param name="theElementName"/>
+		<xsl:choose>
+			<!-- codegen begin - defaults -->
+			<xsl:when test="$theAttributeName = 'Wavelength' and $theElementName = 'Laser'">nm</xsl:when>
+			<!-- codegen end - defaults -->
+			<xsl:otherwise>
+				<xsl:comment>GetDefaultUnit, the default for [<xsl:value-of select="$theAttributeName"/>] in element [<xsl:value-of select="$theElementName"/>] is not supported.</xsl:comment>
+				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - GetDefaultUnit, the default for [<xsl:value-of select="$theAttributeName"/>] in element [<xsl:value-of select="$theElementName"/>] is not supported.</xsl:message>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
 
 	<!-- convert function (value, currentUnit, defaultUnit) -->
 	<!-- 	returns the value in the default units -->
 	<!-- 	error and terminate if conversion not possible e.g. pixel->nm -->
+
+	<xsl:template name="ConvertValueToDefault">
+		<xsl:param name="theValue"/>
+		<xsl:param name="theCurrentUnit"/>
+		<xsl:param name="theAttributeName"/>
+		<xsl:param name="theElementName"/>
+		<xsl:call-template name="ConvertValueToUnit">
+			<xsl:with-param name="theValue"><xsl:value-of select="$theValue"/></xsl:with-param>
+			<xsl:with-param name="theCurrentUnit"><xsl:value-of select="$theCurrentUnit"/></xsl:with-param>
+			<xsl:with-param name="theNewUnit">
+				<xsl:call-template name="GetDefaultUnit">
+					<xsl:with-param name="theAttributeName"><xsl:value-of select="$theAttributeName"/></xsl:with-param>
+					<xsl:with-param name="theElementName"><xsl:value-of select="$theElementName"/></xsl:with-param>
+				</xsl:call-template>
+			</xsl:with-param>
+		</xsl:call-template>
+	</xsl:template>
+
+	<xsl:template name="ConvertValueToUnit">
+		<xsl:param name="theValue"/>
+		<xsl:param name="theCurrentUnit"/>
+		<xsl:param name="theNewUnit"/>
+		<xsl:choose>
+			<!-- codegen begin - convert -->
+			<xsl:when test="$theCurrentUnit = 'cm' and $theNewUnit = 'm'"><xsl:value-of select="$theValue * 10"/></xsl:when>
+			<!-- codegen end - convert -->
+			<xsl:otherwise>
+				<xsl:comment>ConvertValueToUnit, cannot perform conversion [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:comment>
+				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:message>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
 
 </xsl:stylesheet>

--- a/components/specification/transforms/units-conversion.xsl
+++ b/components/specification/transforms/units-conversion.xsl
@@ -44,6 +44,7 @@
 		<xsl:choose>
 			<!-- codegen begin - defaults -->
 			<xsl:when test="$theAttributeName = 'Wavelength' and $theElementName = 'Laser'">nm</xsl:when>
+			<xsl:when test="$theAttributeName = 'Wavelength' and $theElementName = 'LightSourceSettings'">nm</xsl:when>
 			<!-- codegen end - defaults -->
 			<xsl:otherwise>
 				<xsl:comment>GetDefaultUnit, the default for [<xsl:value-of select="$theAttributeName"/>] in element [<xsl:value-of select="$theElementName"/>] is not supported.</xsl:comment>
@@ -52,25 +53,31 @@
 		</xsl:choose>
 	</xsl:template>
 
-	<!-- convert function (value, currentUnit, defaultUnit) -->
 	<!-- 	returns the value in the default units -->
 	<!-- 	error and terminate if conversion not possible e.g. pixel->nm -->
-
 	<xsl:template name="ConvertValueToDefault">
 		<xsl:param name="theValue"/>
 		<xsl:param name="theCurrentUnit"/>
 		<xsl:param name="theAttributeName"/>
 		<xsl:param name="theElementName"/>
-		<xsl:call-template name="ConvertValueToUnit">
-			<xsl:with-param name="theValue"><xsl:value-of select="$theValue"/></xsl:with-param>
-			<xsl:with-param name="theCurrentUnit"><xsl:value-of select="$theCurrentUnit"/></xsl:with-param>
-			<xsl:with-param name="theNewUnit">
-				<xsl:call-template name="GetDefaultUnit">
-					<xsl:with-param name="theAttributeName"><xsl:value-of select="$theAttributeName"/></xsl:with-param>
-					<xsl:with-param name="theElementName"><xsl:value-of select="$theElementName"/></xsl:with-param>
+		<xsl:choose>
+			<xsl:when test="$theCurrentUnit = ''">
+				<!-- Already using default units so no conversion necessary -->
+				<xsl:value-of select="$theValue"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:call-template name="ConvertValueToUnit">
+					<xsl:with-param name="theValue"><xsl:value-of select="$theValue"/></xsl:with-param>
+					<xsl:with-param name="theCurrentUnit"><xsl:value-of select="$theCurrentUnit"/></xsl:with-param>
+					<xsl:with-param name="theNewUnit">
+						<xsl:call-template name="GetDefaultUnit">
+							<xsl:with-param name="theAttributeName"><xsl:value-of select="$theAttributeName"/></xsl:with-param>
+							<xsl:with-param name="theElementName"><xsl:value-of select="$theElementName"/></xsl:with-param>
+						</xsl:call-template>
+					</xsl:with-param>
 				</xsl:call-template>
-			</xsl:with-param>
-		</xsl:call-template>
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:template>
 
 	<xsl:template name="ConvertValueToUnit">
@@ -79,7 +86,12 @@
 		<xsl:param name="theNewUnit"/>
 		<xsl:choose>
 			<!-- codegen begin - convert -->
-			<xsl:when test="$theCurrentUnit = 'cm' and $theNewUnit = 'm'"><xsl:value-of select="$theValue * 10"/></xsl:when>
+			<xsl:when test="$theNewUnit = ''">
+				<xsl:comment>ConvertValueToUnit, cannot perform conversion of [<xsl:value-of select="$theCurrentUnit"/>] to an unknown unit.</xsl:comment>
+				<xsl:message terminate="yes">OME-XSLT: units-conversion.xsl - ERROR - ConvertValueToUnit, cannot perform conversion of [<xsl:value-of select="$theCurrentUnit"/>] to an unknown unit.</xsl:message>
+			</xsl:when>
+			<xsl:when test="$theCurrentUnit = 'mm' and $theNewUnit = 'nm'"><xsl:value-of select="$theValue * 1000000"/></xsl:when>
+			<xsl:when test="$theCurrentUnit = 'pm' and $theNewUnit = 'nm'"><xsl:value-of select="$theValue div 1000"/></xsl:when>
 			<!-- codegen end - convert -->
 			<xsl:otherwise>
 				<xsl:comment>ConvertValueToUnit, cannot perform conversion [<xsl:value-of select="$theCurrentUnit"/>] to [<xsl:value-of select="$theNewUnit"/>] is not supported.</xsl:comment>


### PR DESCRIPTION
XSLT changes which allow downgrading units to the standard representation. Some values are not yet convertible -- see https://github.com/openmicroscopy/bioformats/pull/1479#issuecomment-70631062 about the ongoing work.

There are currently no automated tests, but ideas for creating one are welcome. To check in the UI:
 * import a file with a non-default unit (this can be done with a `.fake` if necessary)
 * export the file applying a downgrade
 * re-import the downgraded file and compare the values in the UI.

/cc @pwalczysko @jburel

----

--no-rebase
