### PR TITLE
Command line profiling

### DIFF
--- a/components/autogen/src/gen-meta-support.sh
+++ b/components/autogen/src/gen-meta-support.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###
 # #%L

--- a/components/test-suite/bftest
+++ b/components/test-suite/bftest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # bftest: a script for running the Bio-Formats automated test suite
 

--- a/docs/sphinx/users/comlinetools/index.txt
+++ b/docs/sphinx/users/comlinetools/index.txt
@@ -101,5 +101,4 @@ something like this:
     1.6.0_24-b24;java.vm.vendor=Sun+Microsystems+Inc.;bioformats.caller=
     Bio-Formats+utilities
 
-To avoid this issue, call the tool with the ``-no-upgrade`` parameter.
-
+To avoid this issue, call the tool with the :option:`-no-upgrade` parameter.

--- a/docs/sphinx/users/comlinetools/index.txt
+++ b/docs/sphinx/users/comlinetools/index.txt
@@ -102,3 +102,15 @@ something like this:
     Bio-Formats+utilities
 
 To avoid this issue, call the tool with the :option:`-no-upgrade` parameter.
+
+Profiling
+---------
+
+For debugging errors or investigating performance issues, it can be useful to
+use profiling tools while running Bio-Formats. The command-line tools can
+invoke the HPROF_ agent library to profile Heap and CPU usage. Setting the
+:envvar:`BF_PROFILE` environment variable allows to turn profiling on, e.g.::
+
+    BF_PROFILE=true showinf -nopix -no-upgrade myfile
+
+.. _HPROF: http://docs.oracle.com/javase/7/docs/technotes/samples/hprof.html

--- a/tools/bf.bat
+++ b/tools/bf.bat
@@ -33,7 +33,7 @@ if not "%BF_PROFILE%" == "" (
     rem Set default profiling depth
     set BF_PROFILE_DEPTH=30
   )
-  set BF_FLAGS=%$BF_FLAGS% -Xrunhprof:cpu=samples,depth=%BF_PROFILE_DEPTH%,file=%BF_PROG%.hprof
+  set BF_FLAGS=%$BF_FLAGS% -agentlib:hprof=cpu=samples,depth=%BF_PROFILE_DEPTH%,file=%BF_PROG%.hprof
 fi
 )
 

--- a/tools/bf.bat
+++ b/tools/bf.bat
@@ -2,7 +2,7 @@
 
 rem bf.bat: the batch file that actually launches a command line tool
 
-setlocal
+setlocal enabledelayedexpansion
 set BF_DIR=%~dp0
 if "%BF_DIR:~-1%" == "\" set BF_DIR=%BF_DIR:~0,-1%
 
@@ -33,8 +33,7 @@ if not "%BF_PROFILE%" == "" (
     rem Set default profiling depth
     set BF_PROFILE_DEPTH=30
   )
-  set BF_FLAGS=%$BF_FLAGS% -agentlib:hprof=cpu=samples,depth=%BF_PROFILE_DEPTH%,file=%BF_PROG%.hprof
-fi
+  set BF_FLAGS=%BF_FLAGS% -agentlib:hprof=cpu=samples,depth=!BF_PROFILE_DEPTH!,file=%BF_PROG%.hprof
 )
 
 

--- a/tools/bf.bat
+++ b/tools/bf.bat
@@ -27,6 +27,17 @@ if not "%NO_UPDATE_CHECK%" == "" (
   set BF_FLAGS=%BF_FLAGS% -Dbioformats_can_do_upgrade_check=false
 )
 
+rem Run profiling if the BF_PROFILE flag is set.
+if not "%BF_PROFILE%" == "" (
+  if "%BF_PROFILE_DEPTH%" == "" (
+    rem Set default profiling depth
+    set BF_PROFILE_DEPTH=30
+  )
+  set BF_FLAGS=%$BF_FLAGS% -Xrunhprof:cpu=samples,depth=%BF_PROFILE_DEPTH%,file=%BF_PROG%.hprof
+fi
+)
+
+
 rem Use any available proxy settings.
 set BF_FLAGS=%BF_FLAGS% -Dhttp.proxyHost=%PROXY_HOST% -Dhttp.proxyPort=%PROXY_PORT%
 

--- a/tools/bf.sh
+++ b/tools/bf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # bf.sh: the script that actually launches a command line tool
 

--- a/tools/bf.sh
+++ b/tools/bf.sh
@@ -28,6 +28,17 @@ then
   BF_FLAGS="$BF_FLAGS -Dbioformats_can_do_upgrade_check=false"
 fi
 
+# Run profiling if the BF_PROFILE flag is set.
+if [ -n "$BF_PROFILE" ]
+then
+  # Set default profiling depth
+  if [ -z "$BF_PROFILE_DEPTH" ]
+  then
+    BF_PROFILE_DEPTH="30"
+  fi
+  BF_FLAGS="$BF_FLAGS -Xrunhprof:cpu=samples,depth=$BF_PROFILE_DEPTH,file=$BF_PROG.hprof"
+fi
+
 # Use any available proxy settings.
 BF_FLAGS="$BF_FLAGS -Dhttp.proxyHost=$PROXY_HOST -Dhttp.proxyPort=$PROXY_PORT"
 

--- a/tools/bf.sh
+++ b/tools/bf.sh
@@ -36,7 +36,7 @@ then
   then
     BF_PROFILE_DEPTH="30"
   fi
-  BF_FLAGS="$BF_FLAGS -Xrunhprof:cpu=samples,depth=$BF_PROFILE_DEPTH,file=$BF_PROG.hprof"
+  BF_FLAGS="$BF_FLAGS -agentlib:hprof=cpu=samples,depth=$BF_PROFILE_DEPTH,file=$BF_PROG.hprof"
 fi
 
 # Use any available proxy settings.

--- a/tools/bfconvert
+++ b/tools/bfconvert
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # bfconvert: a script for converting image files between formats
 

--- a/tools/config.sh
+++ b/tools/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # config.sh: master configuration file for the scripts
 

--- a/tools/domainlist
+++ b/tools/domainlist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # domainlist: a script for listing supported domains in Bio-Formats
 

--- a/tools/formatlist
+++ b/tools/formatlist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # formatlist: a script for listing supported formats in Bio-Formats
 

--- a/tools/ijview
+++ b/tools/ijview
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ijview: a script for displaying an image file in ImageJ
 #         using the Bio-Formats Importer plugin

--- a/tools/mkfake
+++ b/tools/mkfake
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # mkfake: a script for creating a fake file / directory structures
 #         on the file system

--- a/tools/showinf
+++ b/tools/showinf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # showinf: a script for displaying information about a given
 #          image file, while displaying it in the image viewer

--- a/tools/tiffcomment
+++ b/tools/tiffcomment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tiffcomment: a script for extracting the comment
 #              (OME-XML block or otherwise) from a TIFF file

--- a/tools/update_copyright
+++ b/tools/update_copyright
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 # Script for updating copyright headers across the code
 
 if $(sed --version 2>/dev/null | head -n1 | grep -q "GNU");

--- a/tools/xmlindent
+++ b/tools/xmlindent
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # xmlindent: a script for prettifying blocks of XML
 

--- a/tools/xmlvalid
+++ b/tools/xmlvalid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # xmlvalid: a script for validating XML files
 


### PR DESCRIPTION
As we'll run more and more into performance testing, standardizing the way we collect and curate profiling traces across the board will become crucial. Since some of this profiling will be performed on remote machines, a requirement on JVisualVM is certainly overkill.
This PR makes a simple proposal: having a `BF_PROFILE` flag for command-line tools which enables `hprof` profiling and outputs an `.hprof` file to be examined via GUI tools.

Couple of remarks/questions at this point:
- is `hprof` the best candidate here? see http://www.brendangregg.com/blog/2014-06-09/java-cpu-sampling-using-hprof.html for a discussion and I know @joshmoore had other ideas
- where is the best place for documenting this (as well as other command-line tools environment variables), I started working on `users/comlinetools/index.txt` but then wondered wether we should not have a developers page for these features /cc @hflynn