### PR TITLE
FormatReader/FormatTools Modulo improvements

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1092,11 +1092,23 @@ public abstract class FormatReader extends FormatHandler
     return FormatTools.getIndex(this, z, c, t);
   }
 
+  /* @see IFormatReader#getIndex(int, int, int, int, int, int) */
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+    FormatTools.assertId(currentId, true, 1);
+    return FormatTools.getIndex(this, z, c, t, moduloZ, moduloC, moduloT);
+  }
+
   /* @see IFormatReader#getZCTCoords(int) */
   @Override
   public int[] getZCTCoords(int index) {
     FormatTools.assertId(currentId, true, 1);
     return FormatTools.getZCTCoords(this, index);
+  }
+
+  /* @see IFormatReader#getZCTModuloCoords(int) */
+  public int[] getZCTModuloCoords(int index) {
+    FormatTools.assertId(currentId, true, 1);
+    return FormatTools.getZCTModuloCoords(this, index);
   }
 
   /* @see IFormatReader#getMetadataValue(String) */

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -315,7 +315,7 @@ public final class FormatTools {
 
   /**
    * Gets the rasterized index corresponding
-   * to the given Z, C and T coordinates.
+   * to the given Z, C and T coordinates (real sizes).
    */
   public static int getIndex(IFormatReader reader, int z, int c, int t) {
     String order = reader.getDimensionOrder();
@@ -328,7 +328,11 @@ public final class FormatTools {
 
   /**
    * Gets the rasterized index corresponding to the given Z, C, T,
-   * ModuloZ, ModuloC and ModuloT coordinates.
+   * ModuloZ, ModuloC and ModuloT coordinates (effective sizes).  Note
+   * that the Z, C and T coordinates take the modulo dimension sizes
+   * into account.  The effective size for each of these dimensions is
+   * limited to the total size of the dimension divided by the modulo
+   * size.
    */
   public static int getIndex(IFormatReader reader, int z, int c, int t,
                              int moduloZ, int moduloC, int moduloT) {
@@ -350,17 +354,17 @@ public final class FormatTools {
 
   /**
    * Gets the rasterized index corresponding
-   * to the given Z, C and T coordinates.
+   * to the given Z, C and T coordinates (real sizes).
    *
    * @param order Dimension order.
-   * @param zSize Total number of focal planes.
-   * @param cSize Total number of channels.
-   * @param tSize Total number of time points.
+   * @param zSize Total number of focal planes (real size).
+   * @param cSize Total number of channels (real size).
+   * @param tSize Total number of time points (real size).
    * @param num Total number of image planes (zSize * cSize * tSize),
    *   specified as a consistency check.
-   * @param z Z coordinate of ZCT coordinate triple to convert to 1D index.
-   * @param c C coordinate of ZCT coordinate triple to convert to 1D index.
-   * @param t T coordinate of ZCT coordinate triple to convert to 1D index.
+   * @param z Z coordinate of ZCT coordinate triple to convert to 1D index (real size).
+   * @param c C coordinate of ZCT coordinate triple to convert to 1D index (real size).
+   * @param t T coordinate of ZCT coordinate triple to convert to 1D index (real size).
    */
   public static int getIndex(String order, int zSize, int cSize, int tSize,
     int num, int z, int c, int t)
@@ -428,23 +432,27 @@ public final class FormatTools {
 
   /**
    * Gets the rasterized index corresponding to the given Z, C, T,
-   * ModuloZ, ModuloC, ModuloT coordinates.
+   * ModuloZ, ModuloC, ModuloT coordinates (effective sizes).  Note
+   * that the Z, C and T coordinates take the modulo dimension sizes
+   * into account.  The effective size for each of these dimensions is
+   * limited to the total size of the dimension divided by the modulo
+   * size.
    *
    * @param order Dimension order.
-   * @param zSize Total number of focal planes.
-   * @param cSize Total number of channels.
-   * @param tSize Total number of time points.
-   * @param moduloZSize Total number of ModuloZ planes.
-   * @param moduloCSize Total number of ModuloC planes.
-   * @param moduloTSize Total number of ModuloT planes.
+   * @param zSize Total number of focal planes (real size).
+   * @param cSize Total number of channels (real size).
+   * @param tSize Total number of time points (real size).
+   * @param moduloZSize Total number of ModuloZ planes (real size).
+   * @param moduloCSize Total number of ModuloC planes (real size).
+   * @param moduloTSize Total number of ModuloT planes (real size).
    * @param num Total number of image planes (zSize * cSize * tSize),
    *   specified as a consistency check.
-   * @param z Z coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-   * @param c C coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-   * @param t T coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-   * @param moduloZ ModuloZ coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-   * @param moduloC ModuloC coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-   * @param moduloT ModuloT coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   * @param z Z coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+   * @param c C coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+   * @param t T coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+   * @param moduloZ ModuloZ coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+   * @param moduloC ModuloC coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+   * @param moduloT ModuloT coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
    */
   public static int getIndex(String order,
     int zSize, int cSize, int tSize,
@@ -464,7 +472,7 @@ public final class FormatTools {
 
   /**
    * Gets the Z, C and T coordinates corresponding
-   * to the given rasterized index value.
+   * to the given rasterized index value (real sizes).
    */
   public static int[] getZCTCoords(IFormatReader reader, int index) {
     String order = reader.getDimensionOrder();
@@ -477,7 +485,12 @@ public final class FormatTools {
 
   /**
    * Gets the Z, C, T, ModuloZ, ModuloC and ModuloZ coordinates
-   * corresponding to the given rasterized index value.
+   * corresponding to the given rasterized index value (effective
+   * sizes).  Note that the Z, C and T coordinates are not the same as
+   * those returned by getZCTCoords(IFormatReader, int) because the
+   * size of the modulo dimensions is taken into account.  The
+   * effective size for each of these dimensions is limited to the
+   * total size of the dimension divided by the modulo size.
    */
   public static int[] getZCTModuloCoords(IFormatReader reader, int index) {
     String order = reader.getDimensionOrder();
@@ -493,12 +506,12 @@ public final class FormatTools {
 
   /**
    * Gets the Z, C and T coordinates corresponding to the given rasterized
-   * index value.
+   * index value (real sizes).
    *
    * @param order Dimension order.
-   * @param zSize Total number of focal planes.
-   * @param cSize Total number of channels.
-   * @param tSize Total number of time points.
+   * @param zSize Total number of focal planes (real size).
+   * @param cSize Total number of channels (real size).
+   * @param tSize Total number of time points (real size).
    * @param num Total number of image planes (zSize * cSize * tSize),
    *   specified as a consistency check.
    * @param index 1D (rasterized) index to convert to ZCT coordinate triple.
@@ -567,16 +580,21 @@ public final class FormatTools {
   }
 
   /**
-   * Gets the Z, C and T coordinates corresponding to the given rasterized
-   * index value.
+   * Gets the Z, C and T coordinates corresponding to the given
+   * rasterized index value.  Note that the Z, C and T coordinates are
+   * not the same as those returned by getZCTCoords(String, int, int,
+   * int, int, int) because the size of the modulo dimensions is taken
+   * into account.  The effective size for each of these dimensions is
+   * limited to the total size of the dimension divided by the modulo
+   * size.
    *
    * @param order Dimension order.
-   * @param zSize Total number of focal planes.
-   * @param cSize Total number of channels.
-   * @param tSize Total number of time points.
-   * @param moduloZSize Total number of ModuloZ planes.
-   * @param moduloCSize Total number of ModuloC planes.
-   * @param moduloTSize Total number of ModuloT planes.
+   * @param zSize Total number of focal planes (real size).
+   * @param cSize Total number of channels (real size).
+   * @param tSize Total number of time points (real size).
+   * @param moduloZSize Total number of ModuloZ planes (real size).
+   * @param moduloCSize Total number of ModuloC planes (real size).
+   * @param moduloTSize Total number of ModuloT planes (real size).
    * @param num Total number of image planes (zSize * cSize * tSize),
    *   specified as a consistency check.
    * @param index 1D (rasterized) index to convert to ZCT coordinate triple.
@@ -623,9 +641,9 @@ public final class FormatTools {
    *
    * @param origOrder Original dimension order.
    * @param newOrder New dimension order.
-   * @param zSize Total number of focal planes.
-   * @param cSize Total number of channels.
-   * @param tSize Total number of time points.
+   * @param zSize Total number of focal planes (real size).
+   * @param cSize Total number of channels (real size).
+   * @param tSize Total number of time points (real size).
    * @param num Total number of image planes (zSize * cSize * tSize),
    *   specified as a consistency check.
    * @param newIndex 1D (rasterized) index according to new dimension order.

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -327,6 +327,28 @@ public final class FormatTools {
   }
 
   /**
+   * Gets the rasterized index corresponding to the given Z, C, T,
+   * ModuloZ, ModuloC and ModuloT coordinates.
+   */
+  public static int getIndex(IFormatReader reader, int z, int c, int t,
+                             int moduloZ, int moduloC, int moduloT) {
+    String order = reader.getDimensionOrder();
+    int zSize = reader.getSizeZ();
+    int cSize = reader.getEffectiveSizeC();
+    int tSize = reader.getSizeT();
+    int moduloZSize = reader.getModuloZ().length();
+    int moduloCSize = reader.getModuloC().length();
+    int moduloTSize = reader.getModuloT().length();
+    int num = reader.getImageCount();
+    return getIndex(order,
+                    zSize, cSize, tSize,
+                    moduloZSize, moduloCSize, moduloTSize,
+                    num,
+                    z, c, t,
+                    moduloZ, moduloC, moduloT);
+  }
+
+  /**
    * Gets the rasterized index corresponding
    * to the given Z, C and T coordinates.
    *
@@ -405,6 +427,42 @@ public final class FormatTools {
   }
 
   /**
+   * Gets the rasterized index corresponding to the given Z, C, T,
+   * ModuloZ, ModuloC, ModuloT coordinates.
+   *
+   * @param order Dimension order.
+   * @param zSize Total number of focal planes.
+   * @param cSize Total number of channels.
+   * @param tSize Total number of time points.
+   * @param moduloZSize Total number of ModuloZ planes.
+   * @param moduloCSize Total number of ModuloC planes.
+   * @param moduloTSize Total number of ModuloT planes.
+   * @param num Total number of image planes (zSize * cSize * tSize),
+   *   specified as a consistency check.
+   * @param z Z coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   * @param c C coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   * @param t T coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   * @param moduloZ ModuloZ coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   * @param moduloC ModuloC coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   * @param moduloT ModuloT coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+   */
+  public static int getIndex(String order,
+    int zSize, int cSize, int tSize,
+    int moduloZSize, int moduloCSize, int moduloTSize,
+    int num,
+    int z, int c, int t,
+    int moduloZ, int moduloC, int moduloT) {
+    return getIndex(order,
+                    zSize,
+                    cSize,
+                    tSize,
+                    num,
+                    (z * moduloZSize) + moduloZ,
+                    (c * moduloCSize) + moduloC,
+                    (t * moduloTSize) + moduloT);
+  }
+
+  /**
    * Gets the Z, C and T coordinates corresponding
    * to the given rasterized index value.
    */
@@ -415,6 +473,22 @@ public final class FormatTools {
     int tSize = reader.getSizeT();
     int num = reader.getImageCount();
     return getZCTCoords(order, zSize, cSize, tSize, num, index);
+  }
+
+  /**
+   * Gets the Z, C, T, ModuloZ, ModuloC and ModuloZ coordinates
+   * corresponding to the given rasterized index value.
+   */
+  public static int[] getZCTModuloCoords(IFormatReader reader, int index) {
+    String order = reader.getDimensionOrder();
+    int zSize = reader.getSizeZ();
+    int cSize = reader.getEffectiveSizeC();
+    int tSize = reader.getSizeT();
+    int moduloZSize = reader.getModuloZ().length();
+    int moduloCSize = reader.getModuloC().length();
+    int moduloTSize = reader.getModuloT().length();
+    int num = reader.getImageCount();
+    return getZCTCoords(order, zSize, cSize, tSize, moduloZSize, moduloCSize, moduloTSize, num, index);
   }
 
   /**
@@ -490,6 +564,37 @@ public final class FormatTools {
     int t = it == 0 ? v0 : (it == 1 ? v1 : v2);
 
     return new int[] {z, c, t};
+  }
+
+  /**
+   * Gets the Z, C and T coordinates corresponding to the given rasterized
+   * index value.
+   *
+   * @param order Dimension order.
+   * @param zSize Total number of focal planes.
+   * @param cSize Total number of channels.
+   * @param tSize Total number of time points.
+   * @param moduloZSize Total number of ModuloZ planes.
+   * @param moduloCSize Total number of ModuloC planes.
+   * @param moduloTSize Total number of ModuloT planes.
+   * @param num Total number of image planes (zSize * cSize * tSize),
+   *   specified as a consistency check.
+   * @param index 1D (rasterized) index to convert to ZCT coordinate triple.
+   */
+  public static int[] getZCTCoords(String order,
+    int zSize, int cSize, int tSize,
+    int moduloZSize, int moduloCSize, int moduloTSize,
+    int num, int index) {
+    int[] coords = getZCTCoords(order, zSize, cSize, tSize, num, index);
+
+    return new int[] {
+        coords[0] / moduloZSize,
+        coords[1] / moduloCSize,
+        coords[2] / moduloTSize,
+        coords[0] % moduloZSize,
+        coords[1] % moduloCSize,
+        coords[2] % moduloTSize
+    };
   }
 
   /**

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -390,10 +390,26 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
   int getIndex(int z, int c, int t);
 
   /**
+   * Gets the rasterized index corresponding to the given Z, C, T,
+   * moduloZ, moduloC and moduloT coordinates.  Note that the Z, C and
+   * T coordinates take the modulo dimension sizes into account.
+   */
+  int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT);
+
+  /**
    * Gets the Z, C and T coordinates corresponding
    * to the given rasterized index value.
    */
   int[] getZCTCoords(int index);
+
+  /**
+   * Gets the Z, C, T, moduloZ, moduloC and moduloT coordinates
+   * corresponding to the given rasterized index value.  Note that the
+   * Z, C and T coordinates are not the same as those returned by
+   * getZCTCoords(int) because the size of the modulo dimensions is
+   * taken into account.
+   */
+  int[] getZCTModuloCoords(int index);
 
   /**
    * Obtains the specified metadata field's value for the current file.

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -385,29 +385,34 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
 
   /**
    * Gets the rasterized index corresponding
-   * to the given Z, C and T coordinates.
+   * to the given Z, C and T coordinates (real sizes).
    */
   int getIndex(int z, int c, int t);
 
   /**
    * Gets the rasterized index corresponding to the given Z, C, T,
-   * moduloZ, moduloC and moduloT coordinates.  Note that the Z, C and
-   * T coordinates take the modulo dimension sizes into account.
+   * moduloZ, moduloC and moduloT coordinates (effective sizes).  Note
+   * that the Z, C and T coordinates take the modulo dimension sizes
+   * into account.  The effective size for each of these dimensions is
+   * limited to the total size of the dimension divided by the modulo
+   * size.
    */
   int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT);
 
   /**
-   * Gets the Z, C and T coordinates corresponding
-   * to the given rasterized index value.
+   * Gets the Z, C and T coordinates (real sizes) corresponding to the
+   * given rasterized index value.
    */
   int[] getZCTCoords(int index);
 
   /**
    * Gets the Z, C, T, moduloZ, moduloC and moduloT coordinates
-   * corresponding to the given rasterized index value.  Note that the
-   * Z, C and T coordinates are not the same as those returned by
-   * getZCTCoords(int) because the size of the modulo dimensions is
-   * taken into account.
+   * (effective sizes) corresponding to the given rasterized index
+   * value.  Note that the Z, C and T coordinates are not the same as
+   * those returned by getZCTCoords(int) because the size of the
+   * modulo dimensions is taken into account.  The effective size for
+   * each of these dimensions is limited to the total size of the
+   * dimension divided by the modulo size.
    */
   int[] getZCTModuloCoords(int index);
 

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -527,10 +527,22 @@ public class ImageReader implements IFormatReader {
     return getReader().getIndex(z, c, t);
   }
 
+  /* @see IFormatReader#getIndex(int, int, int, int, int, int) */
+  @Override
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+    return getReader().getIndex(z, c, t, moduloZ, moduloC, moduloT);
+  }
+
   /* @see IFormatReader#getZCTCoords(int) */
   @Override
   public int[] getZCTCoords(int index) {
     return getReader().getZCTCoords(index);
+  }
+
+  /* @see IFormatReader#getZCTModuloCoords(int) */
+  @Override
+  public int[] getZCTModuloCoords(int index) {
+    return getReader().getZCTModuloCoords(index);
   }
 
   /* @see IFormatReader#getMetadataValue(String) */

--- a/components/formats-api/src/loci/formats/Modulo.java
+++ b/components/formats-api/src/loci/formats/Modulo.java
@@ -62,7 +62,8 @@ public class Modulo {
     if (labels != null) {
       return labels.length;
     }
-    return (int) Math.rint((end - start) / step) + 1;
+    int len = (int) Math.rint((end - start) / step) + 1;
+    return (len < 1) ? 1 : len; // Can't ever be less than 1.
   }
 
   public String toXMLAnnotation() {

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -458,8 +458,18 @@ public abstract class ReaderWrapper implements IFormatReader {
   }
 
   @Override
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+    return reader.getIndex(z, c, t, moduloZ, moduloC, moduloT);
+  }
+
+  @Override
   public int[] getZCTCoords(int index) {
     return reader.getZCTCoords(index);
+  }
+
+  @Override
+  public int[] getZCTModuloCoords(int index) {
+    return reader.getZCTModuloCoords(index);
   }
 
   @Override

--- a/components/formats-bsd/src/loci/formats/ChannelMerger.java
+++ b/components/formats-bsd/src/loci/formats/ChannelMerger.java
@@ -176,6 +176,11 @@ public class ChannelMerger extends ReaderWrapper {
   }
 
   @Override
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+      return FormatTools.getIndex(this, z, c, t, moduloZ, moduloC, moduloT);
+  }
+
+  @Override
   public int getIndex(int z, int c, int t) {
     return FormatTools.getIndex(this, z, c, t);
   }
@@ -183,6 +188,11 @@ public class ChannelMerger extends ReaderWrapper {
   @Override
   public int[] getZCTCoords(int index) {
     return FormatTools.getZCTCoords(this, index);
+  }
+
+  @Override
+  public int[] getZCTModuloCoords(int index) {
+    return FormatTools.getZCTModuloCoords(this, index);
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -261,8 +261,18 @@ public class ChannelSeparator extends ReaderWrapper {
   }
 
   @Override
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+      return FormatTools.getIndex(this, z, c, t, moduloZ, moduloC, moduloT);
+  }
+
+  @Override
   public int[] getZCTCoords(int index) {
     return FormatTools.getZCTCoords(this, index);
+  }
+
+  @Override
+  public int[] getZCTModuloCoords(int index) {
+    return FormatTools.getZCTModuloCoords(this, index);
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-bsd/src/loci/formats/DimensionSwapper.java
+++ b/components/formats-bsd/src/loci/formats/DimensionSwapper.java
@@ -261,10 +261,20 @@ public class DimensionSwapper extends ReaderWrapper {
     return FormatTools.getZCTCoords(this, no);
   }
 
+  @Override
+  public int[] getZCTModuloCoords(int index) {
+    return FormatTools.getZCTModuloCoords(this, index);
+  }
+
   /* @see IFormatReader#getIndex(int, int, int) */
   @Override
   public int getIndex(int z, int c, int t) {
     return FormatTools.getIndex(this, z, c, t);
+  }
+
+  @Override
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+      return FormatTools.getIndex(this, z, c, t, moduloZ, moduloC, moduloT);
   }
 
   /* @see IFormatReader#getCoreMetadataList() */

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -766,6 +766,13 @@ public class FileStitcher extends ReaderWrapper {
     return FormatTools.getIndex(this, z, c, t);
   }
 
+  /* @see IFormatReader#getIndex(int, int, int, int, int, int) */
+  @Override
+  public int getIndex(int z, int c, int t, int moduloZ, int moduloC, int moduloT) {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    return FormatTools.getIndex(this, z, c, t, moduloZ, moduloC, moduloT);
+  }
+
   /* @see IFormatReader#getZCTCoords(int) */
   @Override
   public int[] getZCTCoords(int index) {
@@ -773,6 +780,17 @@ public class FileStitcher extends ReaderWrapper {
     return noStitch ? reader.getZCTCoords(index) :
       FormatTools.getZCTCoords(core.get(getCoreIndex()).dimensionOrder,
       getSizeZ(), getEffectiveSizeC(), getSizeT(), getImageCount(), index);
+  }
+
+  /* @see IFormatReader#getZCTModuloCoords(int) */
+  @Override
+  public int[] getZCTModuloCoords(int index) {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    return noStitch ? reader.getZCTModuloCoords(index) :
+      FormatTools.getZCTCoords(core.get(getCoreIndex()).dimensionOrder,
+      getSizeZ(), getEffectiveSizeC(), getSizeT(),
+      getModuloZ().length(), getModuloC().length(), getModuloT().length(),
+      getImageCount(), index);
   }
 
   /* @see IFormatReader#getSeriesMetadata() */

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -769,9 +769,9 @@ namespace ome
        *
        * The index is computed using the DimensionOrder.
        *
-       * @param z the @c Z coordinate.
-       * @param c the @c C coordinate.
-       * @param t the @c T coordinate.
+       * @param z the @c Z coordinate (real size).
+       * @param c the @c C coordinate (real size).
+       * @param t the @c T coordinate (real size).
        * @returns the linear index.
        *
        * @todo unify with the pixel buffer dimension indexes.
@@ -790,12 +790,17 @@ namespace ome
        *
        * The index is computed using the DimensionOrder.
        *
-       * @param z the @c Z coordinate.
-       * @param c the @c C coordinate.
-       * @param t the @c T coordinate.
-       * @param moduloZ the @c ModuloZ coordinate.
-       * @param moduloC the @c ModuloC coordinate.
-       * @param moduloT the @c ModuloT coordinate.
+       * @note The @c Z, @c C and @c T coordinates take the modulo
+       * dimension sizes into account.  The effective size for each of
+       * these dimensions is limited to the total size of the
+       * dimension divided by the modulo size.
+       *
+       * @param z the @c Z coordinate (effective size).
+       * @param c the @c C coordinate (effective size).
+       * @param t the @c T coordinate (effective size).
+       * @param moduloZ the @c ModuloZ coordinate (effective size).
+       * @param moduloC the @c ModuloC coordinate (effective size).
+       * @param moduloT the @c ModuloT coordinate (effective size).
        * @returns the linear index.
        *
        * @todo unify with the pixel buffer dimension indexes.
@@ -815,7 +820,8 @@ namespace ome
        * Get the @c Z, @c C and @c T coordinate of a linear index.
        *
        * @param index the linear index.
-       * @returns an array containing @c Z, @c C and @c T values.
+       * @returns an array containing @c Z, @c C and @c T values (real
+       * sizes).
        *
        * @todo unify with the pixel buffer dimension indexes.
        */
@@ -827,9 +833,15 @@ namespace ome
        * Get the @c Z, @c C, @c T, @c ModuloZ, @c ModuloC and @c
        * ModuloT coordinate of a linear index.
        *
+       * @note The @c Z, @c C and @c T coordinates are not the same as
+       * those returned by getZCTCoords(dimension_size_type) because
+       * the size of the modulo dimensions is taken into account.  The
+       * effective size for each of these dimensions is limited to the
+       * total size of the dimension divided by the modulo size.
+       *
        * @param index the linear index.
        * @returns an array containing @c Z, @c C, @c T, @c ModuloZ, @c
-       * ModuloC and @c ModuloT values.
+       * ModuloC and @c ModuloT values (effective sizes).
        *
        * @todo unify with the pixel buffer dimension indexes.
        */

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -785,6 +785,33 @@ namespace ome
                dimension_size_type t) const = 0;
 
       /**
+       * Get the linear index of a @c Z, @c C, @c T, @c ModuloZ, @c
+       * ModuloC and @c ModuloT coordinate.
+       *
+       * The index is computed using the DimensionOrder.
+       *
+       * @param z the @c Z coordinate.
+       * @param c the @c C coordinate.
+       * @param t the @c T coordinate.
+       * @param moduloZ the @c ModuloZ coordinate.
+       * @param moduloC the @c ModuloC coordinate.
+       * @param moduloT the @c ModuloT coordinate.
+       * @returns the linear index.
+       *
+       * @todo unify with the pixel buffer dimension indexes.
+       * @todo Don't use separate values to match the return of
+       * getZCTModuloCoords.
+       */
+      virtual
+      dimension_size_type
+      getIndex(dimension_size_type z,
+               dimension_size_type c,
+               dimension_size_type t,
+               dimension_size_type moduloZ,
+               dimension_size_type moduloC,
+               dimension_size_type moduloT) const = 0;
+
+      /**
        * Get the @c Z, @c C and @c T coordinate of a linear index.
        *
        * @param index the linear index.
@@ -795,6 +822,20 @@ namespace ome
       virtual
       std::array<dimension_size_type, 3>
       getZCTCoords(dimension_size_type index) const = 0;
+
+      /**
+       * Get the @c Z, @c C, @c T, @c ModuloZ, @c ModuloC and @c
+       * ModuloT coordinate of a linear index.
+       *
+       * @param index the linear index.
+       * @returns an array containing @c Z, @c C, @c T, @c ModuloZ, @c
+       * ModuloC and @c ModuloT values.
+       *
+       * @todo unify with the pixel buffer dimension indexes.
+       */
+      virtual
+      std::array<dimension_size_type, 6>
+      getZCTModuloCoords(dimension_size_type index) const = 0;
 
       /**
        * Get a global metadata value.

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -57,7 +57,7 @@ namespace ome
       {
         boost::format fmt("Invalid %1% %2%: %3%");
         fmt % dim % what % value;
-        throw new std::logic_error(fmt.str());
+        throw std::logic_error(fmt.str());
       }
 
       void
@@ -68,7 +68,7 @@ namespace ome
       {
         boost::format fmt("Invalid %1% %2%: %3%/%4%");
         fmt % dim % what % value1 % value2;
-        throw new std::logic_error(fmt.str());
+        throw std::logic_error(fmt.str());
       }
 
       void
@@ -85,7 +85,7 @@ namespace ome
           {
             boost::format fmt("Invalid dimension order: %1%");
             fmt % order;
-            throw new std::logic_error(fmt.str());
+            throw std::logic_error(fmt.str());
           }
 
         std::string::size_type sz, st, sc;
@@ -99,7 +99,7 @@ namespace ome
           {
             boost::format fmt("Invalid dimension order: %1%");
             fmt % order;
-            throw new std::logic_error(fmt.str());
+            throw std::logic_error(fmt.str());
           }
 
         iz = sz - 2;
@@ -123,7 +123,7 @@ namespace ome
           {
             boost::format fmt("Invalid image count: %1%");
             fmt % num;
-            throw new std::logic_error(fmt.str());
+            throw std::logic_error(fmt.str());
           }
 
         if (num != (zSize * cSize * tSize))
@@ -133,7 +133,7 @@ namespace ome
             // else the input file is invalid
             boost::format fmt("ZCT/image count mismatch (sizeZ=%1%, sizeT=%2%, sizeC=%3%, total=%4%");
             fmt % zSize % tSize % cSize % num;
-            throw new std::logic_error(fmt.str());
+            throw std::logic_error(fmt.str());
           }
       }
 

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -273,7 +273,7 @@ namespace ome
                  dimension_size_type num,
                  dimension_size_type index)
     {
-      dimension_size_type iz, it, ic;
+      dimension_size_type iz = 0, it = 0, ic = 0;
       validate_dimensions(order, zSize, cSize, tSize, num, iz, ic, it);
 
       // assign rasterization order

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -265,6 +265,33 @@ namespace ome
       return v0 + (v1 * len0) + (v2 * len0 * len1);
     }
 
+    dimension_size_type
+    getIndex(const std::string& order,
+             dimension_size_type zSize,
+             dimension_size_type cSize,
+             dimension_size_type tSize,
+             dimension_size_type moduloZSize,
+             dimension_size_type moduloCSize,
+             dimension_size_type moduloTSize,
+             dimension_size_type num,
+             dimension_size_type z,
+             dimension_size_type c,
+             dimension_size_type t,
+             dimension_size_type moduloZ,
+             dimension_size_type moduloC,
+             dimension_size_type moduloT)
+    {
+      return getIndex(order,
+                      zSize,
+                      cSize,
+                      tSize,
+                      num,
+                      (z * moduloZSize) + moduloZ,
+                      (c * moduloCSize) + moduloC,
+                      (t * moduloTSize) + moduloT);
+
+    }
+
     std::array<dimension_size_type, 3>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
@@ -287,6 +314,36 @@ namespace ome
       ret[0] = iz == 0 ? v0 : (iz == 1 ? v1 : v2); // z
       ret[1] = ic == 0 ? v0 : (ic == 1 ? v1 : v2); // c
       ret[2] = it == 0 ? v0 : (it == 1 ? v1 : v2); // t
+
+      return ret;
+    }
+
+    std::array<dimension_size_type, 6>
+    getZCTCoords(const std::string& order,
+                 dimension_size_type zSize,
+                 dimension_size_type cSize,
+                 dimension_size_type tSize,
+                 dimension_size_type moduloZSize,
+                 dimension_size_type moduloCSize,
+                 dimension_size_type moduloTSize,
+                 dimension_size_type num,
+                 dimension_size_type index)
+    {
+      std::array<dimension_size_type, 3> coords
+        (getZCTCoords(order,
+                      zSize,
+                      cSize,
+                      tSize,
+                      num,
+                      index));
+
+      std::array<dimension_size_type, 6> ret;
+      ret[0] = coords[0] / moduloZSize;
+      ret[1] = coords[1] / moduloCSize;
+      ret[2] = coords[2] / moduloTSize;
+      ret[3] = coords[0] % moduloZSize;
+      ret[4] = coords[1] % moduloCSize;
+      ret[5] = coords[2] % moduloTSize;
 
       return ret;
     }

--- a/cpp/lib/ome/bioformats/FormatTools.h
+++ b/cpp/lib/ome/bioformats/FormatTools.h
@@ -79,17 +79,17 @@ namespace ome
 
     /**
      * Get the rasterized index corresponding to the given @c Z, @c C
-     * and @c T coordinates.
+     * and @c T coordinates (real sizes).
      *
      * @param order dimension order.
-     * @param zSize total number of focal planes.
-     * @param cSize total number of channels.
-     * @param tSize total number of time points.
+     * @param zSize total number of focal planes  (real size).
+     * @param cSize total number of channels  (real size).
+     * @param tSize total number of time points  (real size).
      * @param num total number of image planes (zSize * cSize * tSize),
      *   specified as a consistency check.
-     * @param z the @c Z coordinate of ZCT coordinate triple to convert to 1D index.
-     * @param c the @c C coordinate of ZCT coordinate triple to convert to 1D index.
-     * @param t the @c T coordinate of ZCT coordinate triple to convert to 1D index.
+     * @param z the @c Z coordinate of ZCT coordinate triple to convert to 1D index (real size).
+     * @param c the @c C coordinate of ZCT coordinate triple to convert to 1D index (real size).
+     * @param t the @c T coordinate of ZCT coordinate triple to convert to 1D index (real size).
      * @returns the 1D index.
      */
     dimension_size_type
@@ -104,23 +104,29 @@ namespace ome
 
     /**
      * Get the rasterized index corresponding to the given @c Z, @c C,
-     * @c T, @c ModuloZ, @c ModuloC and @c ModuloT coordinates.
+     * @c T, @c ModuloZ, @c ModuloC and @c ModuloT coordinates
+     * (effective sizes).
+     *
+     * @note The @c Z, @c C and @c T coordinates take the modulo
+     * dimension sizes into account.  The effective size for each of
+     * these dimensions is limited to the total size of the dimension
+     * divided by the modulo size.
      *
      * @param order dimension order.
-     * @param zSize total number of focal planes.
-     * @param cSize total number of channels.
-     * @param tSize total number of time points.
-     * @param moduloZSize total number of ModuloZ planes.
-     * @param moduloCSize total number of ModuloC channels.
-     * @param moduloTSize total number of ModuloT time points.
+     * @param zSize total number of focal planes (real size).
+     * @param cSize total number of channels (real size).
+     * @param tSize total number of time points (real size).
+     * @param moduloZSize total number of ModuloZ planes (real size).
+     * @param moduloCSize total number of ModuloC channels (real size).
+     * @param moduloTSize total number of ModuloT time points (real size).
      * @param num total number of image planes (zSize * cSize * tSize),
      *   specified as a consistency check.
-     * @param z the @c Z coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-     * @param c the @c C coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-     * @param t the @c T coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-     * @param moduloZ the @c ModuloZ coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-     * @param moduloC the @c ModuloC coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
-     * @param moduloT the @c ModuloT coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @param z the @c Z coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+     * @param c the @c C coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+     * @param t the @c T coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+     * @param moduloZ the @c ModuloZ coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+     * @param moduloC the @c ModuloC coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
+     * @param moduloT the @c ModuloT coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index (effective size).
      * @returns the 1D index.
      */
     dimension_size_type
@@ -140,17 +146,17 @@ namespace ome
              dimension_size_type moduloT);
 
     /**
-     * Get the @c Z, @c C and @c T coordinates corresponding to the
-     * given rasterized index value.
+     * Get the @c Z, @c C and @c T coordinates (real
+     * sizes) corresponding to the given rasterized index value.
      *
      * @param order dimension order.
-     * @param zSize total number of focal planes.
-     * @param cSize total number of channels.
-     * @param tSize total number of time points.
+     * @param zSize total number of focal planes (real size).
+     * @param cSize total number of channels (real size).
+     * @param tSize total number of time points (real size).
      * @param num total number of image planes (zSize * cSize * tSize),
      *   specified as a consistency check.
      * @param index 1D (rasterized) index to convert to ZCT coordinates.
-     * @returns an array containing the ZCT coordinates (in that order).
+     * @returns an array containing the ZCT coordinates (real sizes, in that order).
      */
     std::array<dimension_size_type, 3>
     getZCTCoords(const std::string& order,
@@ -162,20 +168,30 @@ namespace ome
 
     /**
      * Get the @c Z, @c C, @c T, @c ModuloZ, @c ModuloC and @c ModuloT
-     * coordinates corresponding to the given rasterized index value.
+     * coordinates (effective sizes) corresponding to the given
+     * rasterized index value.
+     *
+     * @note The @c Z, @c C and @c T coordinates are not the same as
+     * those returned by ome::bioformats::getZCTCoords(const
+     * std::string&, dimension_size_type, dimension_size_type,
+     * dimension_size_type, dimension_size_type, dimension_size_type)
+     * because the size of the modulo dimensions is taken into
+     * account.  The effective size for each of these dimensions is
+     * limited to the total size of the dimension divided by the
+     * modulo size.
      *
      * @param order dimension order.
-     * @param zSize total number of focal planes.
-     * @param cSize total number of channels.
-     * @param tSize total number of time points.
-     * @param moduloZSize total number of ModuloZ planes.
-     * @param moduloCSize total number of ModuloC channels.
-     * @param moduloTSize total number of ModuloT time points.
+     * @param zSize total number of focal planes (effective size).
+     * @param cSize total number of channels (effective size).
+     * @param tSize total number of time points (effective size).
+     * @param moduloZSize total number of ModuloZ planes (effective size).
+     * @param moduloCSize total number of ModuloC channels (effective size).
+     * @param moduloTSize total number of ModuloT time points (effective size).
      * @param num total number of image planes (zSize * cSize * tSize),
      *   specified as a consistency check.
      * @param index 1D (rasterized) index to convert to ZCTmZmCmT
      * coordinates.
-     * @returns an array containing the ZCTmZmCmT coordinates (in that
+     * @returns an array containing the ZCTmZmCmT coordinates (effective sizes, in that
      * order).
      */
     std::array<dimension_size_type, 6>

--- a/cpp/lib/ome/bioformats/FormatTools.h
+++ b/cpp/lib/ome/bioformats/FormatTools.h
@@ -78,8 +78,8 @@ namespace ome
     getDomain(Domain domain);
 
     /**
-     * Get the rasterized index corresponding to the given Z, C and T
-     * coordinates.
+     * Get the rasterized index corresponding to the given @c Z, @c C
+     * and @c T coordinates.
      *
      * @param order dimension order.
      * @param zSize total number of focal planes.
@@ -87,9 +87,9 @@ namespace ome
      * @param tSize total number of time points.
      * @param num total number of image planes (zSize * cSize * tSize),
      *   specified as a consistency check.
-     * @param z Z coordinate of ZCT coordinate triple to convert to 1D index.
-     * @param c C coordinate of ZCT coordinate triple to convert to 1D index.
-     * @param t T coordinate of ZCT coordinate triple to convert to 1D index.
+     * @param z the @c Z coordinate of ZCT coordinate triple to convert to 1D index.
+     * @param c the @c C coordinate of ZCT coordinate triple to convert to 1D index.
+     * @param t the @c T coordinate of ZCT coordinate triple to convert to 1D index.
      * @returns the 1D index.
      */
     dimension_size_type
@@ -103,8 +103,45 @@ namespace ome
              dimension_size_type t);
 
     /**
-     * Get the Z, C and T coordinates corresponding to the given rasterized
-     * index value.
+     * Get the rasterized index corresponding to the given @c Z, @c C,
+     * @c T, @c ModuloZ, @c ModuloC and @c ModuloT coordinates.
+     *
+     * @param order dimension order.
+     * @param zSize total number of focal planes.
+     * @param cSize total number of channels.
+     * @param tSize total number of time points.
+     * @param moduloZSize total number of ModuloZ planes.
+     * @param moduloCSize total number of ModuloC channels.
+     * @param moduloTSize total number of ModuloT time points.
+     * @param num total number of image planes (zSize * cSize * tSize),
+     *   specified as a consistency check.
+     * @param z the @c Z coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @param c the @c C coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @param t the @c T coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @param moduloZ the @c ModuloZ coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @param moduloC the @c ModuloC coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @param moduloT the @c ModuloT coordinate of ZCTmZmCmT coordinate sextuple to convert to 1D index.
+     * @returns the 1D index.
+     */
+    dimension_size_type
+    getIndex(const std::string& order,
+             dimension_size_type zSize,
+             dimension_size_type cSize,
+             dimension_size_type tSize,
+             dimension_size_type moduloZSize,
+             dimension_size_type moduloCSize,
+             dimension_size_type moduloTSize,
+             dimension_size_type num,
+             dimension_size_type z,
+             dimension_size_type c,
+             dimension_size_type t,
+             dimension_size_type moduloZ,
+             dimension_size_type moduloC,
+             dimension_size_type moduloT);
+
+    /**
+     * Get the @c Z, @c C and @c T coordinates corresponding to the
+     * given rasterized index value.
      *
      * @param order dimension order.
      * @param zSize total number of focal planes.
@@ -120,6 +157,35 @@ namespace ome
                  dimension_size_type zSize,
                  dimension_size_type cSize,
                  dimension_size_type tSize,
+                 dimension_size_type num,
+                 dimension_size_type index);
+
+    /**
+     * Get the @c Z, @c C, @c T, @c ModuloZ, @c ModuloC and @c ModuloT
+     * coordinates corresponding to the given rasterized index value.
+     *
+     * @param order dimension order.
+     * @param zSize total number of focal planes.
+     * @param cSize total number of channels.
+     * @param tSize total number of time points.
+     * @param moduloZSize total number of ModuloZ planes.
+     * @param moduloCSize total number of ModuloC channels.
+     * @param moduloTSize total number of ModuloT time points.
+     * @param num total number of image planes (zSize * cSize * tSize),
+     *   specified as a consistency check.
+     * @param index 1D (rasterized) index to convert to ZCTmZmCmT
+     * coordinates.
+     * @returns an array containing the ZCTmZmCmT coordinates (in that
+     * order).
+     */
+    std::array<dimension_size_type, 6>
+    getZCTCoords(const std::string& order,
+                 dimension_size_type zSize,
+                 dimension_size_type cSize,
+                 dimension_size_type tSize,
+                 dimension_size_type moduloZSize,
+                 dimension_size_type moduloCSize,
+                 dimension_size_type moduloTSize,
                  dimension_size_type num,
                  dimension_size_type index);
 

--- a/cpp/lib/ome/bioformats/Modulo.cpp
+++ b/cpp/lib/ome/bioformats/Modulo.cpp
@@ -67,7 +67,8 @@ namespace ome
       /**
        * @todo Use proper rounding (compat function for round(3)).
        */
-      return static_cast<size_type>(floor(((end - start) / step) + 0.5) + 1.0);
+      return std::max(static_cast<size_type>(floor(((end - start) / step) + 0.5) + 1.0),
+                      size_type(1U));
     }
 
    std::string

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -955,6 +955,27 @@ namespace ome
                                          z, c, t);
       }
 
+      dimension_size_type
+      FormatReader::getIndex(dimension_size_type z,
+                             dimension_size_type c,
+                             dimension_size_type t,
+                             dimension_size_type moduloZ,
+                             dimension_size_type moduloC,
+                             dimension_size_type moduloT) const
+      {
+        assertId(currentId, true);
+        return ome::bioformats::getIndex(getDimensionOrder(),
+                                         getSizeZ(),
+                                         getEffectiveSizeC(),
+                                         getSizeT(),
+                                         getModuloZ().size(),
+                                         getModuloC().size(),
+                                         getModuloT().size(),
+                                         getImageCount(),
+                                         z, c, t,
+                                         moduloZ, moduloC, moduloT);
+      }
+
       std::array<dimension_size_type, 3>
       FormatReader::getZCTCoords(dimension_size_type index) const
       {
@@ -963,6 +984,21 @@ namespace ome
                                              getSizeZ(),
                                              getEffectiveSizeC(),
                                              getSizeT(),
+                                             getImageCount(),
+                                             index);
+      }
+
+      std::array<dimension_size_type, 6>
+      FormatReader::getZCTModuloCoords(dimension_size_type index) const
+      {
+        assertId(currentId, true);
+        return ome::bioformats::getZCTCoords(getDimensionOrder(),
+                                             getSizeZ(),
+                                             getEffectiveSizeC(),
+                                             getSizeT(),
+                                             getModuloZ().size(),
+                                             getModuloC().size(),
+                                             getModuloT().size(),
                                              getImageCount(),
                                              index);
       }

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -637,8 +637,21 @@ namespace ome
                  dimension_size_type t) const;
 
         // Documented in superclass.
+        dimension_size_type
+        getIndex(dimension_size_type z,
+                 dimension_size_type c,
+                 dimension_size_type t,
+                 dimension_size_type moduloZ,
+                 dimension_size_type moduloC,
+                 dimension_size_type moduloT) const;
+
+        // Documented in superclass.
         std::array<dimension_size_type, 3>
         getZCTCoords(dimension_size_type index) const;
+
+        // Documented in superclass.
+        std::array<dimension_size_type, 6>
+        getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.
         const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&

--- a/cpp/lib/ome/test/main.cpp
+++ b/cpp/lib/ome/test/main.cpp
@@ -45,3 +45,11 @@ main (int   argc,
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+bool
+verbose ()
+{
+  static bool v(getenv("BIOFORMATS_TEST_VERBOSE")
+                && std::string(getenv("BIOFORMATS_TEST_VERBOSE")) == "true");
+  return v;
+}

--- a/cpp/lib/ome/test/test.h
+++ b/cpp/lib/ome/test/test.h
@@ -57,4 +57,12 @@
 
 #include <ome/test/config.h>
 
+/**
+ * Tests issue verbose output.
+ *
+ * @returns @c true if verbose, @c false if quiet.
+ */
+bool
+verbose();
+
 #endif // OME_TEST_TEST_H

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -611,18 +611,18 @@ TEST_P(FormatReaderTest, FlatSeries)
 
     moddims modcoords[] =
     {
-      moddims(0,  0, 0, 0, 0, 0),
-      moddims(0,  0, 0, 1, 0, 0),
-      moddims(0,  1, 0, 0, 0, 0),
-      moddims(0,  0, 1, 0, 0, 0),
-      moddims(0,  1, 0, 1, 0, 0),
-      moddims(0,  0, 1, 1, 0, 0),
-      moddims(0,  1, 1, 0, 0, 0),
-      moddims(0,  1, 1, 1, 0, 0),
-      moddims(0,  2, 1, 3, 0, 0),
-      moddims(2,  3, 0, 2, 0, 0),
-      moddims(1,  2, 1, 3, 0, 0),
-      moddims(3,  3, 1, 4, 0, 0)
+      moddims(0, 0, 0, 0, 0, 0),
+      moddims(0, 0, 0, 1, 0, 0),
+      moddims(0, 1, 0, 0, 0, 0),
+      moddims(0, 0, 1, 0, 0, 0),
+      moddims(0, 1, 0, 1, 0, 0),
+      moddims(0, 0, 1, 1, 0, 0),
+      moddims(0, 1, 1, 0, 0, 0),
+      moddims(0, 1, 1, 1, 0, 0),
+      moddims(0, 2, 1, 3, 0, 0),
+      moddims(2, 3, 0, 2, 0, 0),
+      moddims(1, 2, 1, 3, 0, 0),
+      moddims(3, 3, 1, 4, 0, 0)
     };
 
   dimension_size_type indexes[] =

--- a/cpp/test/ome-bioformats/formattools.cpp
+++ b/cpp/test/ome-bioformats/formattools.cpp
@@ -62,6 +62,15 @@ namespace std
   {
     return os << '(' << d[0] << ',' << d[1] << ',' << d[2] << ')';
   }
+
+  template<class charT, class traits>
+  inline std::basic_ostream<charT,traits>&
+  operator<< (std::basic_ostream<charT,traits>& os,
+              const moddims& d)
+  {
+    return os << '(' << d[0] << ',' << d[1] << ',' << d[2]
+              << d[3] << ',' << d[4] << ',' << d[5] << ')';
+  }
 }
 
 class DimensionTestParameters

--- a/cpp/test/ome-bioformats/formattools.cpp
+++ b/cpp/test/ome-bioformats/formattools.cpp
@@ -51,6 +51,7 @@ using ome::bioformats::getZCTCoords;
 using ome::xml::model::enums::DimensionOrder;
 
 typedef std::array<dimension_size_type, 3> dims;
+typedef std::array<dimension_size_type, 6> moddims;
 
 namespace std
 {
@@ -69,19 +70,25 @@ public:
 
   std::string order;
   dims sizes;
+  moddims modsizes;
   dimension_size_type totalsize;
   dims coords;
+  moddims modcoords;
   dimension_size_type index;
 
   DimensionTestParameters(const std::string& order,
                           const dims& sizes,
+                          const moddims& modsizes,
                           dimension_size_type totalsize,
                           const dims& coords,
+                          const moddims& modcoords,
                           dimension_size_type index):
     order(order),
     sizes(sizes),
+    modsizes(modsizes),
     totalsize(totalsize),
     coords(coords),
+    modcoords(modcoords),
     index(index)
   {}
 };
@@ -91,8 +98,13 @@ inline std::basic_ostream<charT,traits>&
 operator<< (std::basic_ostream<charT,traits>& os,
             const DimensionTestParameters& tp)
 {
-  os << tp.order << " dimsizes=(" << tp.sizes[0] << ',' << tp.sizes[1] << ',' << tp.sizes[2]
-     << ") coords=(" << tp.coords[0] << ',' << tp.coords[1] << ',' << tp.coords[2] << ") index= " << tp.index;
+  os << tp.order
+     << " dimsizes=(" << tp.sizes[0] << ',' << tp.sizes[1] << ',' << tp.sizes[2]
+     << ") coords=(" << tp.coords[0] << ',' << tp.coords[1] << ',' << tp.coords[2]
+     << ") moddimmodsizes=(" << tp.modsizes[0] << ',' << tp.modsizes[1] << ',' << tp.modsizes[2] << ',' << tp.modsizes[3] << ',' << tp.modsizes[4] << ',' << tp.modsizes[5]
+     << ") modcoords=(" << tp.modcoords[0] << ',' << tp.modcoords[1] << ',' << tp.modcoords[2] << ',' << tp.modcoords[3] << ',' << tp.modcoords[4] << ',' << tp.modcoords[5]
+     << ") totalsize=" << tp.totalsize
+     << " index=" << tp.index;
 
   return os;
 }
@@ -114,6 +126,22 @@ TEST_P(DimensionTest, GetCoords)
                          params.index));
 }
 
+TEST_P(DimensionTest, GetModuloCoords)
+{
+  const DimensionTestParameters& params = GetParam();
+
+  ASSERT_EQ(params.modcoords,
+            getZCTCoords(params.order,
+                         params.sizes[0],
+                         params.sizes[1],
+                         params.sizes[2],
+                         params.modsizes[3],
+                         params.modsizes[4],
+                         params.modsizes[5],
+                         params.totalsize,
+                         params.index));
+}
+
 TEST_P(DimensionTest, GetIndex)
 {
   const DimensionTestParameters& params = GetParam();
@@ -127,6 +155,27 @@ TEST_P(DimensionTest, GetIndex)
                      params.coords[0],
                      params.coords[1],
                      params.coords[2]));
+}
+
+TEST_P(DimensionTest, GetModuloIndex)
+{
+  const DimensionTestParameters& params = GetParam();
+
+  ASSERT_EQ(params.index,
+            getIndex(params.order,
+                     params.sizes[0],
+                     params.sizes[1],
+                     params.sizes[2],
+                     params.modsizes[3],
+                     params.modsizes[4],
+                     params.modsizes[5],
+                     params.totalsize,
+                     params.modcoords[0],
+                     params.modcoords[1],
+                     params.modcoords[2],
+                     params.modcoords[3],
+                     params.modcoords[4],
+                     params.modcoords[5]));
 }
 
 namespace
@@ -148,9 +197,17 @@ namespace
     const DimensionOrder::value_map_type& orders = DimensionOrder::values();
 
     dims sizes;
-    sizes[0] = 7;
-    sizes[1] = 3;
-    sizes[2] = 5;
+    moddims modsizes;
+
+    sizes[0] = 9;
+    sizes[1] = 8;
+    sizes[2] = 15;
+    modsizes[0] = 3;
+    modsizes[1] = 4;
+    modsizes[2] = 3;
+    modsizes[3] = 3;
+    modsizes[4] = 2;
+    modsizes[5] = 5;
     dimension_size_type totalsize = sizes[0] * sizes[1] * sizes[2];
 
     for (DimensionOrder::value_map_type::const_iterator order = orders.begin();
@@ -158,6 +215,7 @@ namespace
          ++order)
       {
         dimension_size_type d0size, d1size, d2size;
+        dimension_size_type md0size, md1size, md2size;
 
         switch(order->first)
           {
@@ -165,31 +223,56 @@ namespace
             d0size = sizes[0];
             d1size = sizes[1];
             d2size = sizes[2];
+
+            md0size = modsizes[3];
+            md1size = modsizes[4];
+            md2size = modsizes[5];
             break;
           case DimensionOrder::XYZTC:
             d0size = sizes[0];
             d1size = sizes[2];
             d2size = sizes[1];
+
+            md0size = modsizes[3];
+            md1size = modsizes[5];
+            md2size = modsizes[4];
             break;
           case DimensionOrder::XYCTZ:
             d0size = sizes[1];
             d1size = sizes[2];
             d2size = sizes[0];
+
+            md0size = modsizes[4];
+            md1size = modsizes[5];
+            md2size = modsizes[3];
             break;
           case DimensionOrder::XYCZT:
             d0size = sizes[1];
             d1size = sizes[0];
             d2size = sizes[2];
+
+            md0size = modsizes[4];
+            md1size = modsizes[3];
+            md2size = modsizes[5];
+
             break;
           case DimensionOrder::XYTCZ:
             d0size = sizes[2];
             d1size = sizes[1];
             d2size = sizes[0];
+
+            md0size = modsizes[5];
+            md1size = modsizes[4];
+            md2size = modsizes[3];
             break;
           case DimensionOrder::XYTZC:
             d0size = sizes[2];
             d1size = sizes[0];
             d2size = sizes[1];
+
+            md0size = modsizes[5];
+            md1size = modsizes[3];
+            md2size = modsizes[4];
             break;
           }
 
@@ -199,6 +282,7 @@ namespace
             for (dimension_size_type d0 = 0; d0 < d0size; ++d0)
               {
                 dims coords;
+                moddims modcoords;
 
                 switch(order->first)
                   {
@@ -206,37 +290,83 @@ namespace
                     coords[0] = d0;
                     coords[1] = d1;
                     coords[2] = d2;
+
+                    modcoords[0] = d0 / md0size;
+                    modcoords[1] = d1 / md1size;
+                    modcoords[2] = d2 / md2size;
+                    modcoords[3] = d0 % md0size;
+                    modcoords[4] = d1 % md1size;
+                    modcoords[5] = d2 % md2size;
                     break;
                   case DimensionOrder::XYZTC:
                     coords[0] = d0;
                     coords[1] = d2;
                     coords[2] = d1;
+
+                    modcoords[0] = d0 / md0size;
+                    modcoords[1] = d2 / md2size;
+                    modcoords[2] = d1 / md1size;
+                    modcoords[3] = d0 % md0size;
+                    modcoords[4] = d2 % md2size;
+                    modcoords[5] = d1 % md1size;
                     break;
                   case DimensionOrder::XYCTZ:
                     coords[0] = d2;
                     coords[1] = d0;
                     coords[2] = d1;
+
+                    modcoords[0] = d2 / md2size;
+                    modcoords[1] = d0 / md0size;
+                    modcoords[2] = d1 / md1size;
+                    modcoords[3] = d2 % md2size;
+                    modcoords[4] = d0 % md0size;
+                    modcoords[5] = d1 % md1size;
                     break;
                   case DimensionOrder::XYCZT:
                     coords[0] = d1;
                     coords[1] = d0;
                     coords[2] = d2;
+
+                    modcoords[0] = d1 / md1size;
+                    modcoords[1] = d0 / md0size;
+                    modcoords[2] = d2 / md2size;
+                    modcoords[3] = d1 % md1size;
+                    modcoords[4] = d0 % md0size;
+                    modcoords[5] = d2 % md2size;
                     break;
                   case DimensionOrder::XYTCZ:
                     coords[0] = d2;
                     coords[1] = d1;
                     coords[2] = d0;
+
+                    modcoords[0] = d2 / md2size;
+                    modcoords[1] = d1 / md1size;
+                    modcoords[2] = d0 / md0size;
+                    modcoords[3] = d2 % md2size;
+                    modcoords[4] = d1 % md1size;
+                    modcoords[5] = d0 % md0size;
                     break;
                   case DimensionOrder::XYTZC:
                     coords[0] = d1;
                     coords[1] = d2;
                     coords[2] = d0;
+
+                    modcoords[0] = d1 / md1size;
+                    modcoords[1] = d2 / md2size;
+                    modcoords[2] = d0 / md0size;
+                    modcoords[3] = d1 % md1size;
+                    modcoords[4] = d2 % md2size;
+                    modcoords[5] = d0 % md0size;
                     break;
                   }
 
-                std::cerr << "DO=" << order->second << "(" << coords[0] << ","<<coords[1]<<","<<coords[2]<<")\n";
+                if (verbose())
+                  std::cerr << "DO="
+                            << order->second
+                            << "(" << coords[0] << "," << coords[1] << "," << coords[2]
+                            << "(" << modcoords[0] << "," << modcoords[1] << "," << modcoords[2] << modcoords[3] << "," << modcoords[4] << "," << modcoords[5] <<")\n";
 
-                params.push_back(DimensionTestParameters(order->second, sizes, totalsize, coords, index));
+                params.push_back(DimensionTestParameters(order->second, sizes, modsizes, totalsize, coords, modcoords, index));
                 ++index;
               }
       }

--- a/cpp/test/ome-compat/module.cpp
+++ b/cpp/test/ome-compat/module.cpp
@@ -59,15 +59,6 @@ public:
 
 class ModulePathTest : public ::testing::TestWithParam<ModulePathTestParameters>
 {
-public:
-  bool verbose;
-
-  void
-  SetUp()
-  {
-    verbose = (getenv("BIOFORMATS_TEST_VERBOSE")
-               && std::string(getenv("BIOFORMATS_TEST_VERBOSE")) == "true");
-  }
 };
 
 TEST_P(ModulePathTest, CheckPath)
@@ -79,18 +70,18 @@ TEST_P(ModulePathTest, CheckPath)
   try
     {
       boost::filesystem::path path(ome::compat::module_runtime_path(params.dtype));
-      if (verbose)
+      if (verbose())
         std::cout << params.dtype << " path is: " << path << '\n';
     }
   catch (const std::runtime_error& e)
     {
-      if (verbose)
+      if (verbose())
         std::cout << params.dtype << " threw a runtime_error: " << e.what() << '\n';
       ASSERT_FALSE(params.logic_error);
     }
   catch (const std::logic_error& e)
     {
-      if (verbose)
+      if (verbose())
         std::cout << params.dtype << " threw a logic_error: " << e.what() << '\n';
       ASSERT_TRUE(params.logic_error);
     }


### PR DESCRIPTION
When implementing a modulo-aware viewer, it became quickly clear that computing dimension coordinates when using Modulo was a real pain.  It requires all calculations to be done by the user, which quickly gets quite annoying.  This PR implements Modulo-aware variants of getIndex and getZCTCoords in both FormatReader and FormatTools, and updates the dependent classes to use them.  This allows direct computation of the full ZCTmZmCmT sextuple from an index and vice-versa.  Here, the ZCT coordinates are modified to take the Modulo sizes into account, so the user can work easily using the effective ZCTmZmCmT ranges.

Outstanding question: getIndex overloads naturally due to having extra arguments.  getZCTCoords does not, so was supplemented with getZCTModuloCoords.  In FormatTools, the getZCTCoords parameters allow overloading, but this could be renamed to ModuloCoords if desired.

--------

Testing:

The C++ implementation has a comprehensive set of testcases.  The Java code didn't have unit tests for ZCT, so ZCTmZmCmT variants were not added, but the logic is identical to the C++ implementation.