### PR TITLE
Inveon: fix offsets for files larger than 2GB

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InveonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InveonReader.java
@@ -110,7 +110,7 @@ public class InveonReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    int planeSize = FormatTools.getPlaneSize(this);
+    long planeSize = (long) FormatTools.getPlaneSize(this);
     int index = getCoreIndex();
 
     RandomAccessInputStream dat = new RandomAccessInputStream(datFile);


### PR DESCRIPTION
See
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-December/004972.html

Builds should remain green with this change; the only thing to verify is that the offset passed to ```dat.seek``` is calculated using long (not int) arithmetic.