### PR TITLE
ImageJ: enable min/max calculation if any series contains float data (rebased onto dev_5_0)

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -523,17 +523,7 @@ public class ImportProcess implements StatusReporter {
     r = channelSeparator = new ChannelSeparator(r);
     r = dimensionSwapper = new DimensionSwapper(r);
 
-    boolean hasFloatingPoint = false;
-    for (int s=0; s<r.getSeriesCount(); s++) {
-      r.setSeries(s);
-      if (FormatTools.isFloatingPoint(r.getPixelType())) {
-        hasFloatingPoint = true;
-        break;
-      }
-    }
-    r.setSeries(0);
-
-    if (options.isAutoscale() || hasFloatingPoint) {
+    if (options.isAutoscale() || FormatTools.isFloatingPoint(r)) {
       r = minMaxCalculator = new MinMaxCalculator(r);
     }
     if (options.doStitchTiles()) {

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -522,8 +522,18 @@ public class ImportProcess implements StatusReporter {
 
     r = channelSeparator = new ChannelSeparator(r);
     r = dimensionSwapper = new DimensionSwapper(r);
-    if (options.isAutoscale() || FormatTools.isFloatingPoint(r.getPixelType()))
-    {
+
+    boolean hasFloatingPoint = false;
+    for (int s=0; s<r.getSeriesCount(); s++) {
+      r.setSeries(s);
+      if (FormatTools.isFloatingPoint(r.getPixelType())) {
+        hasFloatingPoint = true;
+        break;
+      }
+    }
+    r.setSeries(0);
+
+    if (options.isAutoscale() || hasFloatingPoint) {
       r = minMaxCalculator = new MinMaxCalculator(r);
     }
     if (options.doStitchTiles()) {

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -648,6 +648,25 @@ public final class FormatTools {
   }
 
   /**
+   * Determines whether the given reader represents any floating point data.
+   * @param reader the reader to check
+   * @return true if any of the reader's series have a floating point pixel type
+   * @see #isFloatingPoint(int)
+   */
+  public static boolean isFloatingPoint(IFormatReader reader) {
+    int originalSeries = reader.getSeries();
+    for (int s=0; s<reader.getSeriesCount(); s++) {
+      reader.setSeries(s);
+      if (isFloatingPoint(reader.getPixelType())) {
+        reader.setSeries(originalSeries);
+        return true;
+      }
+    }
+    reader.setSeries(originalSeries);
+    return false;
+  }
+
+  /**
    * Determines whether the given pixel type is floating point or integer.
    * @param pixelType the pixel type as retrieved from
    *   {@link IFormatReader#getPixelType()}.


### PR DESCRIPTION


This is the same as gh-1495 but rebased onto dev_5_0.

----

Fixes the bug noted in https://github.com/openmicroscopy/bioformats/pull/1480#issuecomment-66973008.  The issue only appeared when the ```Autoscale``` option is turned off, the first image does not contain floating point data, and a subsequent image does contain floating point data and is the one selected to be opened.  

With this change, repeating the test from gh-1480 should result in the image being opened without an exception.

/cc @pwalczysko 

                    