### PR TITLE
C++: Additional metadata additions

### DIFF
--- a/cpp/lib/ome/bioformats/MetadataMap.h
+++ b/cpp/lib/ome/bioformats/MetadataMap.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_METADATAMAP_H
 #define OME_BIOFORMATS_METADATAMAP_H
 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <map>
@@ -394,6 +395,63 @@ namespace ome
       erase(iterator pos)
       {
         discriminating_map.erase(pos);
+      }
+
+    private:
+      /// Functor to get a map key.
+      struct getkey
+      {
+        /**
+         * Get key from pair.
+         *
+         * @param pair the pair to use.
+         * @returns the key.
+         */
+        template <typename T>
+        typename T::first_type operator()(T pair) const
+        {
+          return pair.first;
+        }
+      };
+
+    public:
+      /**
+       * Get a list of keys in the map.
+       *
+       * @note This is inefficient, and exists solely for
+       * compatibility with the Java implementation.  Using the
+       * iterator interface directly should be preferred.
+       *
+       * @returns a sorted list of keys.
+       */
+      std::vector<key_type>
+      keys() const
+      {
+        std::vector<key_type> ret;
+        std::transform(begin(), end(), std::back_inserter(ret), getkey());
+        std::sort(ret.begin(), ret.end());
+
+        return ret;
+      }
+
+      /**
+       * Merge a separate map into this map.
+       *
+       * @param map the map to merge.
+       * @param prefix a prefix to append to the keys of the map being
+       * merged.
+       */
+      void
+      merge(const MetadataMap& map,
+            const std::string& prefix)
+      {
+        for (const_iterator i = map.begin();
+             i != map.end();
+             ++i)
+          {
+            map_type::value_type v(prefix + i->first, i->second);
+            insert(v);
+          }
       }
 
       /**

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -427,5 +427,35 @@ namespace ome
         }
     }
 
+    ome::xml::model::enums::DimensionOrder
+    createDimensionOrder(const std::string& order)
+    {
+      // A set could be used here, but given the tiny string length, a
+      // linear scan is quicker than an index lookup.
+
+      static const std::string validchars("XYZTC");
+
+      std::string validorder;
+
+      for (std::string::const_iterator i = order.begin();
+           i != order.end();
+           ++i)
+        {
+          if (validchars.find_first_of(*i) != std::string::npos &&
+              validorder.find_first_of(*i) == std::string::npos)
+              validorder += *i;
+        }
+
+      for (std::string::const_iterator i = validchars.begin();
+           i != validchars.end();
+           ++i)
+        {
+          if (validorder.find_first_of(*i) == std::string::npos)
+            validorder += *i;
+        }
+
+      return ome::xml::model::enums::DimensionOrder(validorder);
+    }
+
   }
 }

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -44,6 +44,7 @@
 
 #include <ome/internal/version.h>
 
+#include <ome/xml/meta/Convert.h>
 #include <ome/xml/meta/OMEXMLMetadataRoot.h>
 
 #include <ome/xml/model/Image.h>
@@ -170,8 +171,7 @@ namespace ome
           else
             {
               ret = std::shared_ptr<Metadata>(new OMEXMLMetadata());
-              // @todo Implement convertMetadata.
-              // convertMetadata(metadata, ret);
+              ome::xml::meta::convert(*retrieve, *ret);
             }
         }
 

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -46,6 +46,8 @@
 #include <ome/xml/meta/MetadataRoot.h>
 #include <ome/xml/meta/OMEXMLMetadata.h>
 
+#include <ome/xml/model/enums/DimensionOrder.h>
+
 #ifndef OME_BIOFORMATS_METADATATOOLS_H
 #define OME_BIOFORMATS_METADATATOOLS_H
 
@@ -320,6 +322,22 @@ namespace ome
     setDefaultCreationDate(::ome::xml::meta::MetadataStore& store,
                            dimension_size_type              series,
                            const boost::filesystem::path&   id);
+
+    /**
+     * Create a valid DimensionOrder from string.
+     *
+     * Any duplicate dimension will have all duplicates following the
+     * initial instance removed.  Any missing dimension will be
+     * suffixed to the resulting dimension order; the order of these
+     * dimensions is unspecified (since they weren't provided, the
+     * expectation is that the caller did not care).
+     *
+     * @param order the string dimension order.
+     * @returns the dimension order.
+     * @throws std::logic_error if the provided order is invalid.
+     */
+    ome::xml::model::enums::DimensionOrder
+    createDimensionOrder(const std::string& order);
 
   }
 }

--- a/cpp/test/ome-bioformats/metadatamap.cpp
+++ b/cpp/test/ome-bioformats/metadatamap.cpp
@@ -329,6 +329,35 @@ TEST_F(MetadataMapTest, EraseIter)
   ASSERT_EQ(m.size(), 1U);
 }
 
+TEST_F(MetadataMapTest, Keys)
+{
+  std::vector<std::string> keys = m.keys();
+  ASSERT_EQ(m.size(), keys.size());
+}
+
+TEST_F(MetadataMapTest, Merge)
+{
+  MetadataMap m2;
+  MetadataMap::map_type::value_type i1("merge1", int32_t(12));
+  m2.insert(i1);
+  MetadataMap::map_type::value_type i2("merge2", int32_t(13));
+  m2.insert(i2);
+  MetadataMap::map_type::value_type i3("int1", int32_t(14));
+  m2.insert(i3);
+
+  ASSERT_EQ(m.size(), 3U);
+  m.merge(m2, "merge-");
+  ASSERT_EQ(m.size(), 6U);
+
+  MetadataMap::iterator f1 = m.find("merge-merge1");
+  ASSERT_TRUE(f1 != m.end());
+  MetadataMap::iterator f2 = m.find("merge-merge2");
+  ASSERT_TRUE(f2 != m.end());
+  MetadataMap::iterator f3 = m.find("merge-int1");
+  ASSERT_TRUE(f3 != m.end());
+
+}
+
 TEST_F(MetadataMapTest, Flatten)
 {
   // Vector flattening with suffix padding.

--- a/cpp/test/ome-bioformats/metadatatools.cpp
+++ b/cpp/test/ome-bioformats/metadatatools.cpp
@@ -42,7 +42,11 @@
 
 #include <ome/test/test.h>
 
+#include <ome/xml/model/enums/EnumerationException.h>
+
 using ome::bioformats::createID;
+using ome::bioformats::createDimensionOrder;
+using ome::xml::model::enums::DimensionOrder;
 
 TEST(MetadataToolsTest, CreateID1)
 {
@@ -95,4 +99,16 @@ TEST(MetadataToolsTest, CreateID4)
 TEST(MetadataToolsTest, ModelVersion)
 {
   ASSERT_EQ(std::string(OME_MODEL_VERSION), ome::bioformats::getModelVersion());
+}
+
+TEST(MetadataToolsTest, CreateDimensionOrder)
+{
+  EXPECT_EQ(DimensionOrder::XYZTC, createDimensionOrder(""));
+  EXPECT_EQ(DimensionOrder::XYZTC, createDimensionOrder("XYXYZTCZ"));
+  EXPECT_EQ(DimensionOrder::XYCZT, createDimensionOrder("XYC"));
+  EXPECT_EQ(DimensionOrder::XYTZC, createDimensionOrder("XYTZ"));
+
+  EXPECT_THROW(createDimensionOrder("CXY"), ome::xml::model::enums::EnumerationException);
+  EXPECT_THROW(createDimensionOrder("Y"), ome::xml::model::enums::EnumerationException);
+  EXPECT_THROW(createDimensionOrder("YC"), ome::xml::model::enums::EnumerationException);
 }


### PR DESCRIPTION
Additional MetadataTools and related additions.  These are all fairly straightforward changes.

- Use ConvertMetadata
- Add DimensionOrder creation from string
- Add merge/keys methods to MetadataMap

--------

Testing:

No users of ConvertMetadata yet, and no unit tests.  The latter two changes have unit tests.