### PR TITLE
LZW: fix one more off-by-one (rebased onto dev_5_0)

### DIFF
--- a/components/formats-bsd/src/loci/formats/codec/LZWCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LZWCodec.java
@@ -341,7 +341,7 @@ public class LZWCodec extends BaseCodec {
           if (currCode == EOI_CODE) break;
             // write string[curr_code] to output
             // -- but here we are sure that string consists of a single byte
-            if (currOutPos >= output.length - 1) break;
+            if (currOutPos >= output.length) break;
             output[currOutPos++] = newBytes[currCode];
             oldCode = currCode;
         }


### PR DESCRIPTION


This is the same as gh-1497 but rebased onto dev_5_0.

----

See http://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7705.  For each of the three files linked in the forum thread, the values of the last column of pixels should be compared against the last column of pixels returned by ```imread``` in Matlab.  Without this change, each of the files should have a handful of rows for which the values differ; with this change, the values should match for all rows.

See also gh-1200.

                    