### PR TITLE
Add note about running data tests on Windows

### DIFF
--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -35,6 +35,12 @@ Run the tests, where $DATA is the path to the full data repository:
 
     $ ant -Dtestng.directory=$DATA/metamorph test-automated
 
+On Windows, the arguments to the test command must be quoted:
+
+::
+
+    > ant "-Dtestng.directory=$DATA\metamorph" test-automated
+
 By default, 512 MB of memory are allocated to the JVM. You can increase
 this by adding the '-Dtestng.memory=XXXm' option. You should now see
 output similar to this:


### PR DESCRIPTION
The original ```test-automated``` command will fail on Windows, but adding quotes around each ```-D``` argument should work.