### PR TITLE
Fix Leica .lei timestamp formatting

### DIFF
--- a/components/formats-common/src/loci/common/DateTools.java
+++ b/components/formats-common/src/loci/common/DateTools.java
@@ -34,6 +34,8 @@ package loci.common;
 
 import java.text.FieldPosition;
 import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -259,20 +261,10 @@ public final class DateTools {
    * (in Unix format: milliseconds since January 1, 1970).
    */
   public static long getTime(String date, String format) {
-    final DateTimeFormatter parser =
-      DateTimeFormat.forPattern(format).withZone(DateTimeZone.UTC);
-    Instant timestamp = null;
-    try {
-      timestamp = Instant.parse(date, parser);
-    }
-    catch (IllegalArgumentException e) {
-      LOGGER.debug("Invalid timestamp '{}'", date);
-    }
-    catch (UnsupportedOperationException e) {
-      LOGGER.debug("Error parsing timestamp '{}'", date, e);
-    }
-    if (timestamp == null) return -1;
-    return timestamp.getMillis();
+    SimpleDateFormat f = new SimpleDateFormat(format);
+    Date d = f.parse(date, new ParsePosition(0));
+    if (d == null) return -1;
+    return d.getTime();
   }
 
   /**

--- a/components/formats-common/src/loci/common/DateTools.java
+++ b/components/formats-common/src/loci/common/DateTools.java
@@ -34,8 +34,6 @@ package loci.common;
 
 import java.text.FieldPosition;
 import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -261,10 +259,20 @@ public final class DateTools {
    * (in Unix format: milliseconds since January 1, 1970).
    */
   public static long getTime(String date, String format) {
-    SimpleDateFormat f = new SimpleDateFormat(format);
-    Date d = f.parse(date, new ParsePosition(0));
-    if (d == null) return -1;
-    return d.getTime();
+    final DateTimeFormatter parser =
+      DateTimeFormat.forPattern(format).withZone(DateTimeZone.UTC);
+    Instant timestamp = null;
+    try {
+      timestamp = Instant.parse(date, parser);
+    }
+    catch (IllegalArgumentException e) {
+      LOGGER.debug("Invalid timestamp '{}'", date);
+    }
+    catch (UnsupportedOperationException e) {
+      LOGGER.debug("Error parsing timestamp '{}'", date, e);
+    }
+    if (timestamp == null) return -1;
+    return timestamp.getMillis();
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -1153,6 +1153,8 @@ public class LeicaReader extends FormatReader {
     timestamps[seriesIndex] = new String[numStamps];
     for (int j=0; j<numStamps; j++) {
       timestamps[seriesIndex][j] = getString(64);
+      timestamps[seriesIndex][j] = DateTools.convertDate(
+        getTime(timestamps[seriesIndex][j]), DateTools.UNIX, DATE_FORMAT + ":SSS");
       addSeriesMetaList("Timestamp", timestamps[seriesIndex][j]);
     }
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -83,7 +83,7 @@ public class LeicaReader extends FormatReader {
   private static final int LEICA_MAGIC_TAG = 33923;
 
   /** Format for dates. */
-  private static final String DATE_FORMAT = "yyyy:MM:dd,HH:mm:ss:SSS";
+  private static final String DATE_FORMAT = "yyyy:MM:dd,HH:mm:ss";
 
   /** IFD tags. */
   private static final Integer SERIES = new Integer(10);
@@ -670,7 +670,7 @@ public class LeicaReader extends FormatReader {
       if (i < timestamps.length && timestamps[i] != null &&
         timestamps[i].length > 0)
       {
-        firstPlane = DateTools.getTime(timestamps[i][0], DATE_FORMAT);
+        firstPlane = getTime(timestamps[i][0]);
         String date = DateTools.formatDate(timestamps[i][0], DATE_FORMAT);
         if (date != null) {
           store.setImageAcquisitionDate(new Timestamp(date), i);
@@ -735,7 +735,7 @@ public class LeicaReader extends FormatReader {
 
       for (int j=0; j<ms.imageCount; j++) {
         if (timestamps[i] != null && j < timestamps[i].length) {
-          long time = DateTools.getTime(timestamps[i][j], DATE_FORMAT);
+          long time = getTime(timestamps[i][j]);
           double elapsedTime = (double) (time - firstPlane) / 1000;
           store.setPlaneDeltaT(new Time(elapsedTime, UNITS.S), i, j);
           if (exposureTime[i] > 0) {
@@ -1670,6 +1670,13 @@ public class LeicaReader extends FormatReader {
     table.put(new Integer(5832782), "logical y-wide");
     table.put(new Integer(5898318), "logical z-wide");
     return table;
+  }
+
+  private long getTime(String stamp) {
+    int msSeparator = stamp.lastIndexOf(":");
+    String newStamp = stamp.substring(0, msSeparator);
+    long ms = Long.parseLong(stamp.substring(msSeparator + 1));
+    return DateTools.getTime(newStamp, DATE_FORMAT) + ms;
   }
 
   // -- Helper class --

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -1152,9 +1152,8 @@ public class LeicaReader extends FormatReader {
     addSeriesMeta("Number of time-stamps", numStamps);
     timestamps[seriesIndex] = new String[numStamps];
     for (int j=0; j<numStamps; j++) {
-      timestamps[seriesIndex][j] = getString(64);
       timestamps[seriesIndex][j] = DateTools.convertDate(
-        getTime(timestamps[seriesIndex][j]), DateTools.UNIX, DATE_FORMAT + ":SSS");
+        getTime(getString(64)), DateTools.UNIX, DATE_FORMAT + ":SSS");
       addSeriesMetaList("Timestamp", timestamps[seriesIndex][j]);
     }
 


### PR DESCRIPTION
Millisecond parsing in Joda has different results than with Date/SimpleDateFormat.  If the number of ms digits in the format string exceeds the number of ms digits in the date string, then zero padding happens on the wrong side (e.g. 93 becomes 930 instead of 093).  If the number of ms digits in the date string exceeds the number of ms digits in the format string, then parsing fails.

See https://github.com/JodaOrg/joda-time/issues/62.

Fixes http://trac.openmicroscopy.org/ome/ticket/12117.