### PR TITLE
Update copyright headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/components/autogen/src/Entity.java
+++ b/components/autogen/src/Entity.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/EntityList.java
+++ b/components/autogen/src/EntityList.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/FormatPageAutogen.java
+++ b/components/autogen/src/FormatPageAutogen.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/MetaEntityList.java
+++ b/components/autogen/src/MetaEntityList.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/MetaSupportAutogen.java
+++ b/components/autogen/src/MetaSupportAutogen.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/MetaSupportList.java
+++ b/components/autogen/src/MetaSupportList.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/OriginalMetadataAutogen.java
+++ b/components/autogen/src/OriginalMetadataAutogen.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/Property.java
+++ b/components/autogen/src/Property.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/VelocityTools.java
+++ b/components/autogen/src/VelocityTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats autogen package for programmatically generating source code.
  * %%
- * Copyright (C) 2007 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2007 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/autogen/src/gen-meta-support.sh
+++ b/components/autogen/src/gen-meta-support.sh
@@ -4,7 +4,7 @@
 # #%L
 # Bio-Formats autogen package for programmatically generating source code.
 # %%
-# Copyright (C) 2007 - 2014 Open Microscopy Environment:
+# Copyright (C) 2007 - 2015 Open Microscopy Environment:
 #   - Board of Regents of the University of Wisconsin-Madison
 #   - Glencoe Software, Inc.
 #   - University of Dundee

--- a/components/autogen/src/package.html
+++ b/components/autogen/src/package.html
@@ -2,7 +2,7 @@
   #%L
   Bio-Formats autogen package for programmatically generating source code.
   %%
-  Copyright (C) 2007 - 2014 Open Microscopy Environment:
+  Copyright (C) 2007 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/About.java
+++ b/components/bio-formats-plugins/src/loci/plugins/About.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/BF.java
+++ b/components/bio-formats-plugins/src/loci/plugins/BF.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/LociExporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/LociExporter.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/LociImporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/LociImporter.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/Slicer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/Slicer.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/Updater.java
+++ b/components/bio-formats-plugins/src/loci/plugins/Updater.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/ConfigWindow.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/ConfigWindow.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/FlexWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/FlexWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/FormatEntry.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/FormatEntry.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/IFormatWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/IFormatWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/InstallWizard.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/InstallWizard.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/LibraryEntry.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/LibraryEntry.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/LociConfig.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/LociConfig.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/LociInstaller.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/LociInstaller.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/ND2Widgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/ND2Widgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/PictWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/PictWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/QTWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/QTWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/SDTWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/SDTWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/SpringUtilities.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/SpringUtilities.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/TextAreaWriter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/TextAreaWriter.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/TiffDelegateWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/TiffDelegateWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/config/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/Calibrator.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Calibrator.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ColorDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ColorDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/Concatenator.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Concatenator.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/CropDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/CropDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/IdDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/IdDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportStep.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportStep.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterMetadata.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterMetadata.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/LocationDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/LocationDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/MemoryDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MemoryDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/RangeDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/RangeDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/SeriesDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/SeriesDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/SwapDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/SwapDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/UpgradeDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/UpgradeDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/in/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/in/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/macro/MacroFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/MacroFunctions.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/macro/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/out/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/out/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/BooleanOption.java
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/BooleanOption.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/DoubleOption.java
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/DoubleOption.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/Option.java
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/Option.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/OptionsDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/OptionsDialog.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/OptionsList.java
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/OptionsList.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/StringOption.java
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/StringOption.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/prefs/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/prefs/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/shortcut/ShortcutPanel.java
+++ b/components/bio-formats-plugins/src/loci/plugins/shortcut/ShortcutPanel.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/shortcut/ShortcutTransferHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/shortcut/ShortcutTransferHandler.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/shortcut/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/shortcut/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/BFVirtualStack.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/BFVirtualStack.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/BrowserOptionsWindow.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/BrowserOptionsWindow.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/DataBrowser.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/DataBrowser.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/IJStatusEchoer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/IJStatusEchoer.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/ImageProcessorReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ImageProcessorReader.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/ImageProcessorSource.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ImageProcessorSource.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/LociPrefs.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LociPrefs.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/LuraWave.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LuraWave.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/RecordedImageProcessor.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/RecordedImageProcessor.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/SearchableWindow.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/SearchableWindow.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/VirtualImagePlus.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/VirtualImagePlus.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/VirtualReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/VirtualReader.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/WindowTools.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/WindowTools.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/util/package.html
+++ b/components/bio-formats-plugins/src/loci/plugins/util/package.html
@@ -4,7 +4,7 @@
   Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
   Data Browser and Stack Slicer.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/bio-formats-plugins/src/plugins.config
+++ b/components/bio-formats-plugins/src/plugins.config
@@ -4,7 +4,7 @@
 # Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
 # Data Browser and Stack Slicer.
 # %%
-# Copyright (C) 2006 - 2014 Open Microscopy Environment:
+# Copyright (C) 2006 - 2015 Open Microscopy Environment:
 #   - Board of Regents of the University of Wisconsin-Madison
 #   - Glencoe Software, Inc.
 #   - University of Dundee

--- a/components/bio-formats-plugins/test/loci/plugins/in/AutoscaleTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/AutoscaleTest.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/test/loci/plugins/in/MacroTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/MacroTest.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/utils/Mass_Importer.java
+++ b/components/bio-formats-plugins/utils/Mass_Importer.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/utils/Read_Image.java
+++ b/components/bio-formats-plugins/utils/Read_Image.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/utils/Simple_Read.java
+++ b/components/bio-formats-plugins/utils/Simple_Read.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats command line tools for reading and converting files
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageFaker.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageFaker.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats command line tools for reading and converting files
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Bio-Formats command line tools for reading and converting files
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/bmp/BMPImageWriteParam.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/bmp/BMPImageWriteParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/bmp/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/bmp/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/bmp/package.html
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/bmp/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of JAI Image I/O Tools.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/jpeg2000/J2KImageReadParam.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/jpeg2000/J2KImageReadParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/jpeg2000/J2KImageWriteParam.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/jpeg2000/J2KImageWriteParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/jpeg2000/package.html
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/jpeg2000/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of JAI Image I/O Tools.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/pnm/PNMImageWriteParam.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/pnm/PNMImageWriteParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/pnm/package.html
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/pnm/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of JAI Image I/O Tools.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/BaselineTIFFTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/BaselineTIFFTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFGPSTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFGPSTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFInteroperabilityTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFInteroperabilityTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFParentTIFFTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFParentTIFFTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFTIFFTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/EXIFTIFFTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/FaxTIFFTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/FaxTIFFTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/GeoTIFFTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/GeoTIFFTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFColorConverter.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFColorConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFDirectory.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFDirectory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFField.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFImageReadParam.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFImageReadParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFImageWriteParam.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFImageWriteParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFTag.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFTag.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFTagSet.java
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/TIFFTagSet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/package.html
+++ b/components/forks/jai/src/com/sun/media/imageio/plugins/tiff/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of JAI Image I/O Tools.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/FileChannelImageInputStream.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/FileChannelImageInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/FileChannelImageOutputStream.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/FileChannelImageOutputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/RawImageInputStream.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/RawImageInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/SegmentedImageInputStream.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/SegmentedImageInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/StreamSegment.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/StreamSegment.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/StreamSegmentMapper.java
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/StreamSegmentMapper.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageio/stream/package.html
+++ b/components/forks/jai/src/com/sun/media/imageio/stream/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of JAI Image I/O Tools.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/BitFile.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/BitFile.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/BogusColorSpace.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/BogusColorSpace.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/I18NImpl.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/I18NImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/ImageUtil.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/ImageUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/InvertedCMYKColorSpace.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/InvertedCMYKColorSpace.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/LZWCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/LZWCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/LZWStringTable.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/LZWStringTable.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/PackageUtil.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/PackageUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/PaletteBuilder.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/PaletteBuilder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/SimpleCMYKColorSpace.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/SimpleCMYKColorSpace.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/SimpleRenderedImage.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/SimpleRenderedImage.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/SingleTileRenderedImage.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/SingleTileRenderedImage.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPConstants.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/BMPMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/bmp/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/clib/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/clib/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/clib/InputStreamAdapter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/clib/InputStreamAdapter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/clib/OutputStreamAdapter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/clib/OutputStreamAdapter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFStreamMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFStreamMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFStreamMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFStreamMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFStreamMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFStreamMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFWritableImageMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFWritableImageMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFWritableStreamMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFWritableStreamMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/BitsPerComponentBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/BitsPerComponentBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/Box.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/Box.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ChannelDefinitionBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ChannelDefinitionBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ColorSpecificationBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ColorSpecificationBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ComponentMappingBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ComponentMappingBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/DataEntryURLBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/DataEntryURLBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/FileTypeBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/FileTypeBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/HeaderBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/HeaderBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/IISRandomAccessIO.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/IISRandomAccessIO.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ImageInputStreamWrapper.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ImageInputStreamWrapper.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReadParamJava.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReadParamJava.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReaderResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReaderResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriteParamJava.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriteParamJava.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriterResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriterResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KReadState.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KReadState.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KRenderedImage.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KRenderedImage.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/PaletteBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/PaletteBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/RenderedImageSrc.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/RenderedImageSrc.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ResolutionBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/ResolutionBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/SignatureBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/SignatureBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/UUIDBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/UUIDBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/UUIDListBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/UUIDListBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/XMLBox.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/XMLBox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXConstants.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pcx/PCXMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/png/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/png/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/pnm/PNMMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageWriteParam.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageWriteParam.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawRenderedImage.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/raw/RawRenderedImage.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFAttrInfo.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFAttrInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFBaseJPEGCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFBaseJPEGCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFCIELabColorConverter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFCIELabColorConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFDeflateCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFDeflateCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFDeflateDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFDeflateDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFDeflater.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFDeflater.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFEXIFJPEGCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFEXIFJPEGCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFElementInfo.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFElementInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFFaxCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFFaxCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFFaxDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFFaxDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFFieldNode.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFFieldNode.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFIFD.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFIFD.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFJPEGCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFJPEGCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFJPEGDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFJPEGDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLSBCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLSBCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLSBDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLSBDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLZWCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLZWCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLZWDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLZWDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLZWUtil.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFLZWUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFNullCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFNullCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFNullDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFNullDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFOldJPEGDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFOldJPEGDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFPackBitsCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFPackBitsCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFPackBitsDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFPackBitsDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFPackBitsUtil.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFPackBitsUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFRLECompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFRLECompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFRenderedImage.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFRenderedImage.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFStreamMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFStreamMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFStreamMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFStreamMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFStreamMetadataFormatResources.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFStreamMetadataFormatResources.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFT4Compressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFT4Compressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFT6Compressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFT6Compressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFYCbCrColorConverter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFYCbCrColorConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFYCbCrDecompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFYCbCrDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFZLibCompressor.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/tiff/TIFFZLibCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/I18N.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageReaderSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageReaderSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageWriterSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPImageWriterSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPMetadata.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPMetadataFormat.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/wbmp/WBMPMetadataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/stream/ChannelImageInputStreamSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/stream/ChannelImageInputStreamSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/imageioimpl/stream/ChannelImageOutputStreamSpi.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/stream/ChannelImageOutputStreamSpi.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/jai/imageioimpl/I18N.java
+++ b/components/forks/jai/src/com/sun/media/jai/imageioimpl/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/jai/operator/I18N.java
+++ b/components/forks/jai/src/com/sun/media/jai/operator/I18N.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/com/sun/media/jai/operator/package.html
+++ b/components/forks/jai/src/com/sun/media/jai/operator/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of JAI Image I/O Tools.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/IntegerSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/IntegerSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/JJ2KExceptionHandler.java
+++ b/components/forks/jai/src/jj2000/j2k/JJ2KExceptionHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/JJ2KInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/JJ2KInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/ModuleSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/ModuleSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/NoNextElementException.java
+++ b/components/forks/jai/src/jj2000/j2k/NoNextElementException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/NotImplementedError.java
+++ b/components/forks/jai/src/jj2000/j2k/NotImplementedError.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/StringSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/StringSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/CBlkCoordInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/CBlkCoordInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/CoordInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/CoordInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/CorruptedCodestreamException.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/CorruptedCodestreamException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/HeaderInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/HeaderInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/Markers.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/Markers.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/PrecCoordInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/PrecCoordInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/PrecInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/PrecInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/ProgressionType.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/ProgressionType.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/BitstreamReaderAgent.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/BitstreamReaderAgent.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/CBlkInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/CBlkInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/FileBitstreamReaderAgent.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/FileBitstreamReaderAgent.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/HeaderDecoder.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/HeaderDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/PktDecoder.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/PktDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/PktHeaderBitReader.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/PktHeaderBitReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/PktInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/PktInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/reader/TagTreeDecoder.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/reader/TagTreeDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/writer/BitOutputBuffer.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/writer/BitOutputBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/writer/CodestreamWriter.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/writer/CodestreamWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/writer/FileCodestreamWriter.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/writer/FileCodestreamWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/writer/HeaderEncoder.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/writer/HeaderEncoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/writer/PktEncoder.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/writer/PktEncoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/codestream/writer/TagTreeEncoder.java
+++ b/components/forks/jai/src/jj2000/j2k/codestream/writer/TagTreeEncoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/decoder/DecoderSpecs.java
+++ b/components/forks/jai/src/jj2000/j2k/decoder/DecoderSpecs.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/CBlkSizeSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/CBlkSizeSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/CodedCBlk.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/CodedCBlk.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/PrecinctSizeSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/PrecinctSizeSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/Progression.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/Progression.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/ProgressionSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/ProgressionSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/StdEntropyCoderOptions.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/StdEntropyCoderOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/ByteInputBuffer.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/ByteInputBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/ByteToBitInput.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/ByteToBitInput.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/CodedCBlkDataSrcDec.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/CodedCBlkDataSrcDec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/DecLyrdCBlk.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/DecLyrdCBlk.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/EntropyDecoder.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/EntropyDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/MQDecoder.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/MQDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/decoder/StdEntropyDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/BitToByteOutput.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/BitToByteOutput.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/ByteOutputBuffer.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/ByteOutputBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/CBlkRateDistStats.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/CBlkRateDistStats.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/CodedCBlkDataSrcEnc.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/CodedCBlkDataSrcEnc.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/EBCOTLayer.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/EBCOTLayer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/EBCOTRateAllocator.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/EBCOTRateAllocator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/EntropyCoder.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/EntropyCoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/LayersInfo.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/LayersInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/MQCoder.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/MQCoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/PostCompRateAllocator.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/PostCompRateAllocator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
+++ b/components/forks/jai/src/jj2000/j2k/entropy/encoder/StdEntropyCoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/fileformat/FileFormatBoxes.java
+++ b/components/forks/jai/src/jj2000/j2k/fileformat/FileFormatBoxes.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/fileformat/reader/FileFormatReader.java
+++ b/components/forks/jai/src/jj2000/j2k/fileformat/reader/FileFormatReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/fileformat/writer/FileFormatWriter.java
+++ b/components/forks/jai/src/jj2000/j2k/fileformat/writer/FileFormatWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/BlkImgDataSrc.java
+++ b/components/forks/jai/src/jj2000/j2k/image/BlkImgDataSrc.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/CompTransfSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/image/CompTransfSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/DataBlk.java
+++ b/components/forks/jai/src/jj2000/j2k/image/DataBlk.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/DataBlkFloat.java
+++ b/components/forks/jai/src/jj2000/j2k/image/DataBlkFloat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/DataBlkInt.java
+++ b/components/forks/jai/src/jj2000/j2k/image/DataBlkInt.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/ImgData.java
+++ b/components/forks/jai/src/jj2000/j2k/image/ImgData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/ImgDataAdapter.java
+++ b/components/forks/jai/src/jj2000/j2k/image/ImgDataAdapter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/ImgDataConverter.java
+++ b/components/forks/jai/src/jj2000/j2k/image/ImgDataConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/ImgDataJoiner.java
+++ b/components/forks/jai/src/jj2000/j2k/image/ImgDataJoiner.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/Tiler.java
+++ b/components/forks/jai/src/jj2000/j2k/image/Tiler.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/forwcomptransf/ForwCompTransf.java
+++ b/components/forks/jai/src/jj2000/j2k/image/forwcomptransf/ForwCompTransf.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/forwcomptransf/ForwCompTransfSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/image/forwcomptransf/ForwCompTransfSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/input/ImgReader.java
+++ b/components/forks/jai/src/jj2000/j2k/image/input/ImgReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/input/ImgReaderPGM.java
+++ b/components/forks/jai/src/jj2000/j2k/image/input/ImgReaderPGM.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/image/invcomptransf/InvCompTransf.java
+++ b/components/forks/jai/src/jj2000/j2k/image/invcomptransf/InvCompTransf.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/io/BEBufferedRandomAccessFile.java
+++ b/components/forks/jai/src/jj2000/j2k/io/BEBufferedRandomAccessFile.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/io/BinaryDataInput.java
+++ b/components/forks/jai/src/jj2000/j2k/io/BinaryDataInput.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/io/BinaryDataOutput.java
+++ b/components/forks/jai/src/jj2000/j2k/io/BinaryDataOutput.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/io/BufferedRandomAccessFile.java
+++ b/components/forks/jai/src/jj2000/j2k/io/BufferedRandomAccessFile.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/io/EndianType.java
+++ b/components/forks/jai/src/jj2000/j2k/io/EndianType.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/io/RandomAccessIO.java
+++ b/components/forks/jai/src/jj2000/j2k/io/RandomAccessIO.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/GuardBitsSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/GuardBitsSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/QuantStepSizeSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/QuantStepSizeSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/QuantTypeSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/QuantTypeSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/QuantizationType.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/QuantizationType.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/CBlkQuantDataSrcDec.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/CBlkQuantDataSrcDec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/Dequantizer.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/Dequantizer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/DequantizerParams.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/DequantizerParams.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/StdDequantizer.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/StdDequantizer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/StdDequantizerParams.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/dequantizer/StdDequantizerParams.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/quantizer/CBlkQuantDataSrcEnc.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/quantizer/CBlkQuantDataSrcEnc.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/quantizer/Quantizer.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/quantizer/Quantizer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/quantization/quantizer/StdQuantizer.java
+++ b/components/forks/jai/src/jj2000/j2k/quantization/quantizer/StdQuantizer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/MaxShiftSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/MaxShiftSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/ROIDeScaler.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/ROIDeScaler.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/ArbROIMaskGenerator.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/ArbROIMaskGenerator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/ROI.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/ROI.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/ROIMaskGenerator.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/ROIMaskGenerator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/ROIScaler.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/ROIScaler.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/RectROIMaskGenerator.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/RectROIMaskGenerator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/SubbandROIMask.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/SubbandROIMask.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/roi/encoder/SubbandRectROIMask.java
+++ b/components/forks/jai/src/jj2000/j2k/roi/encoder/SubbandRectROIMask.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/ArrayUtil.java
+++ b/components/forks/jai/src/jj2000/j2k/util/ArrayUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/CodestreamManipulator.java
+++ b/components/forks/jai/src/jj2000/j2k/util/CodestreamManipulator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/FacilityManager.java
+++ b/components/forks/jai/src/jj2000/j2k/util/FacilityManager.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/ISRandomAccessIO.java
+++ b/components/forks/jai/src/jj2000/j2k/util/ISRandomAccessIO.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/MathUtil.java
+++ b/components/forks/jai/src/jj2000/j2k/util/MathUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/MsgLogger.java
+++ b/components/forks/jai/src/jj2000/j2k/util/MsgLogger.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/MsgPrinter.java
+++ b/components/forks/jai/src/jj2000/j2k/util/MsgPrinter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/NativeServices.java
+++ b/components/forks/jai/src/jj2000/j2k/util/NativeServices.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/ProgressWatch.java
+++ b/components/forks/jai/src/jj2000/j2k/util/ProgressWatch.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/StreamMsgLogger.java
+++ b/components/forks/jai/src/jj2000/j2k/util/StreamMsgLogger.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/StringFormatException.java
+++ b/components/forks/jai/src/jj2000/j2k/util/StringFormatException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/util/ThreadPool.java
+++ b/components/forks/jai/src/jj2000/j2k/util/ThreadPool.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/FilterTypes.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/FilterTypes.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/Subband.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/Subband.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/WTDecompSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/WTDecompSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/WTFilterSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/WTFilterSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/WaveletFilter.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/WaveletFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/WaveletTransform.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/WaveletTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilter.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterFloat.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterFloat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterFloatLift9x7.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterFloatLift9x7.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterInt.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterInt.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterIntLift5x3.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterIntLift5x3.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/AnWTFilterSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTData.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTDataFloat.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTDataFloat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTDataInt.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTDataInt.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTDataSrc.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/CBlkWTDataSrc.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwWT.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwWT.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwWTDataProps.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwWTDataProps.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwWTFull.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwWTFull.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwardWT.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/ForwardWT.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/analysis/SubbandAn.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/analysis/SubbandAn.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/CBlkWTDataSrcDec.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/CBlkWTDataSrcDec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWT.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWT.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWTAdapter.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWTAdapter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWTData.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWTData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWTFull.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InvWTFull.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InverseWT.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/InverseWT.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/MultiResImgData.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/MultiResImgData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/MultiResImgDataAdapter.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/MultiResImgDataAdapter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SubbandSyn.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SubbandSyn.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilter.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterFloat.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterFloat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterFloatLift9x7.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterFloatLift9x7.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterInt.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterInt.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterIntLift5x3.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterIntLift5x3.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterSpec.java
+++ b/components/forks/jai/src/jj2000/j2k/wavelet/synthesis/SynWTFilterSpec.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of JAI Image I/O Tools.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/ColumnComparator.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/ColumnComparator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/Data.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/Data.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/DataSource.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/DataSource.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/Engine.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/Engine.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/MemoryData.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/MemoryData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/RewindableData.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/RewindableData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/SelectEngine.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/SelectEngine.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/Table.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/Table.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/Tests.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/Tests.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Aggregate.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Aggregate.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/ConCat.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/ConCat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Count.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Count.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Function.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Function.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Length.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Length.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Lower.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Lower.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Max.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Max.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Min.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Min.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Sum.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Sum.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/functions/Upper.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/functions/Upper.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/Condition.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/Condition.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/Equation.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/Equation.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/FQColumn.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/FQColumn.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/FunctionDef.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/FunctionDef.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/Join.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/Join.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/OrderBy.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/OrderBy.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/SQL.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/SQL.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/Select.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/Select.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/sql/Util.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/sql/Util.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/tasks/AggregateQuery.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/tasks/AggregateQuery.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/tasks/FilterData.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/tasks/FilterData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/tasks/LoadData.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/tasks/LoadData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/tasks/NonAggregateQuery.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/tasks/NonAggregateQuery.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/tasks/SimpleSort.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/tasks/SimpleSort.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/dbengine/tasks/Task.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/tasks/Task.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/examples/MemoryRandomAccess.java
+++ b/components/forks/mdbtools/src/mdbtools/examples/MemoryRandomAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/examples/mdb_tables.java
+++ b/components/forks/mdbtools/src/mdbtools/examples/mdb_tables.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/jdbc2/File.java
+++ b/components/forks/mdbtools/src/mdbtools/jdbc2/File.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Catalog.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Catalog.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Constants.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Constants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Data.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Data.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Holder.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Holder.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbAny.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbAny.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbBackend.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbBackend.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbCatalogEntry.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbCatalogEntry.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbColumn.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbColumn.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbFile.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbFile.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbFormatConstants.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbFormatConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbHandle.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbSarg.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbSarg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbStatistics.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbStatistics.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/MdbTableDef.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/MdbTableDef.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Money.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Money.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Sargs.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Sargs.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Table.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Table.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/Util.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/Util.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/backend.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/backend.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/file.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/file.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/macros.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/macros.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb/mem.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb/mem.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb06/javadefines.h
+++ b/components/forks/mdbtools/src/mdbtools/libmdb06/javadefines.h
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/libmdb06util/mdbver.java
+++ b/components/forks/mdbtools/src/mdbtools/libmdb06util/mdbver.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/mdb_export.java
+++ b/components/forks/mdbtools/src/mdbtools/mdb_export.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/mdb_schema.java
+++ b/components/forks/mdbtools/src/mdbtools/mdb_schema.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/mdb_tables.java
+++ b/components/forks/mdbtools/src/mdbtools/mdb_tables.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/publicapi/RandomAccess.java
+++ b/components/forks/mdbtools/src/mdbtools/publicapi/RandomAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/mdbtools/src/mdbtools/tests/ColumnTest.java
+++ b/components/forks/mdbtools/src/mdbtools/tests/ColumnTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of MDB Tools (Java port).
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/POIDocument.java
+++ b/components/forks/poi/src/loci/poi/POIDocument.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/POITextExtractor.java
+++ b/components/forks/poi/src/loci/poi/POITextExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/DefaultEscherRecordFactory.java
+++ b/components/forks/poi/src/loci/poi/ddf/DefaultEscherRecordFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherArrayProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherArrayProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherBSERecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherBSERecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherBitmapBlip.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherBitmapBlip.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherBlipRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherBlipRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherBlipWMFRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherBlipWMFRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherBoolProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherBoolProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherChildAnchorRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherChildAnchorRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherClientAnchorRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherClientAnchorRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherClientDataRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherClientDataRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherComplexProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherComplexProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherContainerRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherContainerRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherDgRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherDgRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherDggRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherDggRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherDump.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherDump.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherMetafileBlip.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherMetafileBlip.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherOptRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherOptRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherPictBlip.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherPictBlip.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherProperties.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherProperties.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherPropertyFactory.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherPropertyFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherPropertyMetaData.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherPropertyMetaData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherRGBProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherRGBProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherRecordFactory.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherRecordFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherSerializationListener.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherSerializationListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherShapePathProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherShapePathProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherSimpleProperty.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherSimpleProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherSpRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherSpRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherSpgrRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherSpgrRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherSplitMenuColorsRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherSplitMenuColorsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/EscherTextboxRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/EscherTextboxRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/NullEscherSerializationListener.java
+++ b/components/forks/poi/src/loci/poi/ddf/NullEscherSerializationListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/UnknownEscherRecord.java
+++ b/components/forks/poi/src/loci/poi/ddf/UnknownEscherRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/ddf/package.html
+++ b/components/forks/poi/src/loci/poi/ddf/package.html
@@ -2,7 +2,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/dev/RecordGenerator.java
+++ b/components/forks/poi/src/loci/poi/dev/RecordGenerator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/ClassID.java
+++ b/components/forks/poi/src/loci/poi/hpsf/ClassID.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/Constants.java
+++ b/components/forks/poi/src/loci/poi/hpsf/Constants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/CustomProperties.java
+++ b/components/forks/poi/src/loci/poi/hpsf/CustomProperties.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/CustomProperty.java
+++ b/components/forks/poi/src/loci/poi/hpsf/CustomProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/DocumentSummaryInformation.java
+++ b/components/forks/poi/src/loci/poi/hpsf/DocumentSummaryInformation.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/HPSFException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/HPSFException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/HPSFRuntimeException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/HPSFRuntimeException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/IllegalPropertySetDataException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/IllegalPropertySetDataException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/IllegalVariantTypeException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/IllegalVariantTypeException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/MarkUnsupportedException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/MarkUnsupportedException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/MissingSectionException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/MissingSectionException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/MutableProperty.java
+++ b/components/forks/poi/src/loci/poi/hpsf/MutableProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/MutablePropertySet.java
+++ b/components/forks/poi/src/loci/poi/hpsf/MutablePropertySet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/MutableSection.java
+++ b/components/forks/poi/src/loci/poi/hpsf/MutableSection.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/NoFormatIDException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/NoFormatIDException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/NoPropertySetStreamException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/NoPropertySetStreamException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/NoSingleSectionException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/NoSingleSectionException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/Property.java
+++ b/components/forks/poi/src/loci/poi/hpsf/Property.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/PropertySet.java
+++ b/components/forks/poi/src/loci/poi/hpsf/PropertySet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/PropertySetFactory.java
+++ b/components/forks/poi/src/loci/poi/hpsf/PropertySetFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/ReadingNotSupportedException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/ReadingNotSupportedException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/Section.java
+++ b/components/forks/poi/src/loci/poi/hpsf/Section.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/SpecialPropertySet.java
+++ b/components/forks/poi/src/loci/poi/hpsf/SpecialPropertySet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/SummaryInformation.java
+++ b/components/forks/poi/src/loci/poi/hpsf/SummaryInformation.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/Thumbnail.java
+++ b/components/forks/poi/src/loci/poi/hpsf/Thumbnail.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/TypeWriter.java
+++ b/components/forks/poi/src/loci/poi/hpsf/TypeWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/UnexpectedPropertySetTypeException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/UnexpectedPropertySetTypeException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/UnsupportedVariantTypeException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/UnsupportedVariantTypeException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/Util.java
+++ b/components/forks/poi/src/loci/poi/hpsf/Util.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/Variant.java
+++ b/components/forks/poi/src/loci/poi/hpsf/Variant.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/VariantSupport.java
+++ b/components/forks/poi/src/loci/poi/hpsf/VariantSupport.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/VariantTypeException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/VariantTypeException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/WritingNotSupportedException.java
+++ b/components/forks/poi/src/loci/poi/hpsf/WritingNotSupportedException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/package.html
+++ b/components/forks/poi/src/loci/poi/hpsf/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/wellknown/PropertyIDMap.java
+++ b/components/forks/poi/src/loci/poi/hpsf/wellknown/PropertyIDMap.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/wellknown/SectionIDMap.java
+++ b/components/forks/poi/src/loci/poi/hpsf/wellknown/SectionIDMap.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hpsf/wellknown/package.html
+++ b/components/forks/poi/src/loci/poi/hpsf/wellknown/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/dev/BiffViewer.java
+++ b/components/forks/poi/src/loci/poi/hssf/dev/BiffViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/dev/EFBiffViewer.java
+++ b/components/forks/poi/src/loci/poi/hssf/dev/EFBiffViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/dev/EFHSSF.java
+++ b/components/forks/poi/src/loci/poi/hssf/dev/EFHSSF.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/dev/FormulaViewer.java
+++ b/components/forks/poi/src/loci/poi/hssf/dev/FormulaViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/dev/HSSF.java
+++ b/components/forks/poi/src/loci/poi/hssf/dev/HSSF.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/dev/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/dev/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventmodel/ERFListener.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventmodel/ERFListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventmodel/EventRecordFactory.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventmodel/EventRecordFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventmodel/ModelFactory.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventmodel/ModelFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventmodel/ModelFactoryListener.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventmodel/ModelFactoryListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventusermodel/AbortableHSSFListener.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventusermodel/AbortableHSSFListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFEventFactory.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFEventFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFListener.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFRequest.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFRequest.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFUserException.java
+++ b/components/forks/poi/src/loci/poi/hssf/eventusermodel/HSSFUserException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/eventusermodel/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/eventusermodel/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/extractor/ExcelExtractor.java
+++ b/components/forks/poi/src/loci/poi/hssf/extractor/ExcelExtractor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/AbstractShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/AbstractShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/CommentShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/CommentShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/ConvertAnchor.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/ConvertAnchor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/DrawingManager.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/DrawingManager.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/DrawingManager2.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/DrawingManager2.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/FormulaParser.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/FormulaParser.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/LineShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/LineShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/Model.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/Model.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/PictureShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/PictureShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/PolygonShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/PolygonShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/Sheet.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/Sheet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/SimpleFilledShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/SimpleFilledShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/TextboxShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/TextboxShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/Workbook.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/Workbook.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/WorkbookRecordList.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/WorkbookRecordList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/model/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/model/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AbstractEscherHolderRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AbstractEscherHolderRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AreaFormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AreaFormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AreaRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AreaRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AxisLineFormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AxisLineFormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AxisOptionsRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AxisOptionsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AxisParentRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AxisParentRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AxisRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AxisRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/AxisUsedRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/AxisUsedRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BOFRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BOFRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BackupRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BackupRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BarRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BarRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BeginRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BeginRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BlankRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BlankRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BookBoolRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BookBoolRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BoolErrRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BoolErrRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BottomMarginRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BottomMarginRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/BoundSheetRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/BoundSheetRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CalcCountRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CalcCountRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CalcModeRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CalcModeRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CategorySeriesAxisRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CategorySeriesAxisRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CellValueRecordInterface.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CellValueRecordInterface.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ChartFormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ChartFormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ChartRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ChartRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CodepageRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CodepageRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ColumnInfoRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ColumnInfoRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CommonObjectDataSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CommonObjectDataSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ContinueRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ContinueRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CountryRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CountryRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/CustomField.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/CustomField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DBCellRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DBCellRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DSFRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DSFRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DataFormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DataFormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DateWindow1904Record.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DateWindow1904Record.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DefaultColWidthRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DefaultColWidthRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DefaultDataLabelTextPropertiesRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DefaultDataLabelTextPropertiesRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DefaultRowHeightRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DefaultRowHeightRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DeltaRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DeltaRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DimensionsRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DimensionsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DrawingGroupRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DrawingGroupRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DrawingRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DrawingRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DrawingRecordForBiffViewer.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DrawingRecordForBiffViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/DrawingSelectionRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/DrawingSelectionRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/EOFRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/EOFRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/EmbeddedObjectRefSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/EmbeddedObjectRefSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/EndRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/EndRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/EndSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/EndSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/EscherAggregate.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/EscherAggregate.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ExtSSTInfoSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ExtSSTInfoSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ExtSSTRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ExtSSTRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ExtendedFormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ExtendedFormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ExternSheetRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ExternSheetRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ExternSheetSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ExternSheetSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FilePassRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FilePassRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FileSharingRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FileSharingRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FnGroupCountRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FnGroupCountRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FontBasisRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FontBasisRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FontIndexRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FontIndexRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FontRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FontRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FooterRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FooterRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FormulaRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FormulaRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/FrameRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/FrameRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/GridsetRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/GridsetRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/GroupMarkerSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/GroupMarkerSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/GutsRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/GutsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/HCenterRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/HCenterRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/HeaderRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/HeaderRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/HideObjRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/HideObjRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/HorizontalPageBreakRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/HorizontalPageBreakRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/IndexRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/IndexRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/InterfaceEndRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/InterfaceEndRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/InterfaceHdrRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/InterfaceHdrRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/IterationRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/IterationRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LabelRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LabelRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LabelSSTRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LabelSSTRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LeftMarginRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LeftMarginRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LegendRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LegendRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LineFormatRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LineFormatRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LinkedDataFormulaField.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LinkedDataFormulaField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/LinkedDataRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/LinkedDataRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/MMSRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/MMSRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/Margin.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/Margin.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/MergeCellsRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/MergeCellsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/MulBlankRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/MulBlankRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/MulRKRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/MulRKRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/NameRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/NameRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/NoteRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/NoteRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/NoteStructureSubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/NoteStructureSubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/NumberFormatIndexRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/NumberFormatIndexRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/NumberRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/NumberRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ObjRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ObjRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ObjectLinkRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ObjectLinkRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ObjectProtectRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ObjectProtectRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PageBreakRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PageBreakRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PaletteRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PaletteRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PaneRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PaneRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PasswordRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PasswordRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PasswordRev4Record.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PasswordRev4Record.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PlotAreaRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PlotAreaRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PlotGrowthRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PlotGrowthRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PrecisionRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PrecisionRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PrintGridlinesRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PrintGridlinesRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PrintHeadersRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PrintHeadersRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/PrintSetupRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/PrintSetupRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ProtectRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ProtectRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ProtectionRev4Record.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ProtectionRev4Record.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RKRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RKRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RecalcIdRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RecalcIdRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/Record.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/Record.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RecordFactory.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RecordFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RecordFormatException.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RecordFormatException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RecordInputStream.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RecordInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RecordProcessor.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RecordProcessor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RefModeRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RefModeRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RefreshAllRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RefreshAllRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RightMarginRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RightMarginRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/RowRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/RowRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SCLRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SCLRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SSTDeserializer.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SSTDeserializer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SSTRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SSTRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SSTRecordHeader.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SSTRecordHeader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SSTRecordSizeCalculator.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SSTRecordSizeCalculator.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SSTSerializer.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SSTSerializer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SaveRecalcRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SaveRecalcRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ScenarioProtectRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ScenarioProtectRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SelectionRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SelectionRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesChartGroupIndexRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesChartGroupIndexRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesIndexRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesIndexRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesLabelsRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesLabelsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesListRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesListRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesTextRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesTextRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SeriesToChartGroupRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SeriesToChartGroupRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SharedFormulaRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SharedFormulaRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SheetPropertiesRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SheetPropertiesRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/StringRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/StringRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/StyleRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/StyleRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SubRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SubRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/SupBookRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/SupBookRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/TabIdRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/TabIdRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/TextObjectBaseRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/TextObjectBaseRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/TextObjectRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/TextObjectRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/TextRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/TextRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/TickRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/TickRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/TopMarginRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/TopMarginRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/UnicodeString.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/UnicodeString.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/UnitsRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/UnitsRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/UnknownRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/UnknownRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/UseSelFSRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/UseSelFSRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/VCenterRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/VCenterRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/ValueRangeRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/ValueRangeRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/VerticalPageBreakRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/VerticalPageBreakRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/WSBoolRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/WSBoolRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/WindowOneRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/WindowOneRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/WindowProtectRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/WindowProtectRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/WindowTwoRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/WindowTwoRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/WriteAccessRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/WriteAccessRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/WriteProtectRecord.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/WriteProtectRecord.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/aggregates/ColumnInfoRecordsAggregate.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/aggregates/ColumnInfoRecordsAggregate.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/aggregates/FormulaRecordAggregate.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/aggregates/FormulaRecordAggregate.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/aggregates/RowRecordsAggregate.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/aggregates/RowRecordsAggregate.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/aggregates/ValueRecordsAggregate.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/aggregates/ValueRecordsAggregate.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/aggregates/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/record/aggregates/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AbstractFunctionPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AbstractFunctionPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AddPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AddPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/Area3DPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/Area3DPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaAPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaAPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaErrPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaErrPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaNAPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaNAPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaNPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaNPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaNVPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaNVPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AreaVPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AreaVPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ArrayPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ArrayPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ArrayPtgA.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ArrayPtgA.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ArrayPtgV.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ArrayPtgV.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/AttrPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/AttrPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/BoolPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/BoolPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ConcatPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ConcatPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ControlPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ControlPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/DeletedArea3DPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/DeletedArea3DPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/DeletedRef3DPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/DeletedRef3DPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/DividePtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/DividePtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/EqualPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/EqualPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ErrPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ErrPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ExpPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ExpPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/FuncPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/FuncPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/FuncVarPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/FuncVarPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/GreaterEqualPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/GreaterEqualPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/GreaterThanPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/GreaterThanPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/IntPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/IntPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/IntersectionPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/IntersectionPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/LessEqualPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/LessEqualPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/LessThanPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/LessThanPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/MemAreaPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/MemAreaPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/MemErrPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/MemErrPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/MemFuncPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/MemFuncPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/MissingArgPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/MissingArgPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/MultiplyPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/MultiplyPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/NamePtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/NamePtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/NameXPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/NameXPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/NotEqualPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/NotEqualPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/NumberPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/NumberPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/OperationPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/OperationPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ParenthesisPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ParenthesisPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/PercentPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/PercentPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/PowerPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/PowerPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/Ptg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/Ptg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RangePtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RangePtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/Ref3DPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/Ref3DPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RefAPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RefAPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RefErrorPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RefErrorPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RefNAPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RefNAPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RefNPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RefNPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RefNVPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RefNVPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/RefVPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/RefVPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/ReferencePtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/ReferencePtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/StringPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/StringPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/SubtractPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/SubtractPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/UnaryMinusPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/UnaryMinusPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/UnaryPlusPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/UnaryPlusPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/UnionPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/UnionPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/UnknownPtg.java
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/UnknownPtg.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/formula/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/record/formula/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/record/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/record/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/DummyGraphics2d.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/DummyGraphics2d.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/EscherGraphics.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/EscherGraphics.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/EscherGraphics2d.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/EscherGraphics2d.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/FontDetails.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/FontDetails.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFAnchor.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFAnchor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFCell.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFCell.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFCellStyle.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFCellStyle.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFChildAnchor.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFChildAnchor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFClientAnchor.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFClientAnchor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFComment.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFComment.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFDataFormat.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFDataFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFDateUtil.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFDateUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFErrorConstants.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFErrorConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFFont.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFFont.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFFooter.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFFooter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFHeader.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFHeader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFName.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFName.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFObjectData.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFObjectData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPalette.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPalette.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPatriarch.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPatriarch.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPicture.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPicture.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPictureData.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPictureData.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPolygon.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPolygon.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPrintSetup.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFPrintSetup.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFRichTextString.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFRichTextString.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFRow.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFRow.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFShapeContainer.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFShapeContainer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFShapeGroup.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFShapeGroup.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFSheet.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFSheet.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFSimpleShape.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFSimpleShape.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFTextbox.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFTextbox.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFWorkbook.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/StaticFontMetrics.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/StaticFontMetrics.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/AreaReference.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/AreaReference.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/CellReference.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/CellReference.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/HSSFColor.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/HSSFColor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/PaneInformation.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/PaneInformation.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/RKUtil.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/RKUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/RangeAddress.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/RangeAddress.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/Region.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/Region.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/SheetReferences.java
+++ b/components/forks/poi/src/loci/poi/hssf/util/SheetReferences.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/hssf/util/package.html
+++ b/components/forks/poi/src/loci/poi/hssf/util/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/common/POIFSConstants.java
+++ b/components/forks/poi/src/loci/poi/poifs/common/POIFSConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/common/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/common/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/dev/POIFSViewEngine.java
+++ b/components/forks/poi/src/loci/poi/poifs/dev/POIFSViewEngine.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/dev/POIFSViewable.java
+++ b/components/forks/poi/src/loci/poi/poifs/dev/POIFSViewable.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/dev/POIFSViewer.java
+++ b/components/forks/poi/src/loci/poi/poifs/dev/POIFSViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/dev/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/dev/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReader.java
+++ b/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReaderEvent.java
+++ b/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReaderEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReaderListener.java
+++ b/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReaderListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReaderRegistry.java
+++ b/components/forks/poi/src/loci/poi/poifs/eventfilesystem/POIFSReaderRegistry.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/eventfilesystem/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/eventfilesystem/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/BATManaged.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/BATManaged.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DirectoryEntry.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DirectoryEntry.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DirectoryNode.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DirectoryNode.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentDescriptor.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentDescriptor.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentEntry.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentEntry.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentInputStream.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentNode.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentNode.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentOutputStream.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/DocumentOutputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/Entry.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/Entry.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/EntryNode.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/EntryNode.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/OfficeXmlFileException.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/OfficeXmlFileException.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSDocument.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSDocument.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSDocumentPath.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSDocumentPath.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSFileSystem.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSFileSystem.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSWriterEvent.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSWriterEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSWriterListener.java
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/POIFSWriterListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/filesystem/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/filesystem/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/Child.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/Child.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/DirectoryProperty.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/DirectoryProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/DocumentProperty.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/DocumentProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/Parent.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/Parent.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/Property.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/Property.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/PropertyConstants.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/PropertyConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/PropertyFactory.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/PropertyFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/PropertyTable.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/PropertyTable.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/RootProperty.java
+++ b/components/forks/poi/src/loci/poi/poifs/property/RootProperty.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/property/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/property/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BATBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BATBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BigBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BigBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BlockAllocationTableReader.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BlockAllocationTableReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BlockAllocationTableWriter.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BlockAllocationTableWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BlockList.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BlockList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BlockListImpl.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BlockListImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/BlockWritable.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/BlockWritable.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/DocumentBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/DocumentBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/HeaderBlockConstants.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/HeaderBlockConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/HeaderBlockReader.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/HeaderBlockReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/HeaderBlockWriter.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/HeaderBlockWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/ListManagedBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/ListManagedBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/PropertyBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/PropertyBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/RawDataBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/RawDataBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/RawDataBlockList.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/RawDataBlockList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/SmallBlockTableReader.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/SmallBlockTableReader.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/SmallBlockTableWriter.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/SmallBlockTableWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/SmallDocumentBlock.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/SmallDocumentBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/SmallDocumentBlockList.java
+++ b/components/forks/poi/src/loci/poi/poifs/storage/SmallDocumentBlockList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/poifs/storage/package.html
+++ b/components/forks/poi/src/loci/poi/poifs/storage/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/ArrayUtil.java
+++ b/components/forks/poi/src/loci/poi/util/ArrayUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/BinaryTree.java
+++ b/components/forks/poi/src/loci/poi/util/BinaryTree.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/BitField.java
+++ b/components/forks/poi/src/loci/poi/util/BitField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/BitFieldFactory.java
+++ b/components/forks/poi/src/loci/poi/util/BitFieldFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/BlockingInputStream.java
+++ b/components/forks/poi/src/loci/poi/util/BlockingInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/ByteField.java
+++ b/components/forks/poi/src/loci/poi/util/ByteField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/CommonsLogger.java
+++ b/components/forks/poi/src/loci/poi/util/CommonsLogger.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/DoubleList.java
+++ b/components/forks/poi/src/loci/poi/util/DoubleList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/DoubleList2d.java
+++ b/components/forks/poi/src/loci/poi/util/DoubleList2d.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/DrawingDump.java
+++ b/components/forks/poi/src/loci/poi/util/DrawingDump.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/FixedField.java
+++ b/components/forks/poi/src/loci/poi/util/FixedField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/HexDump.java
+++ b/components/forks/poi/src/loci/poi/util/HexDump.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/HexRead.java
+++ b/components/forks/poi/src/loci/poi/util/HexRead.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/IOUtils.java
+++ b/components/forks/poi/src/loci/poi/util/IOUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/IntList.java
+++ b/components/forks/poi/src/loci/poi/util/IntList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/IntList2d.java
+++ b/components/forks/poi/src/loci/poi/util/IntList2d.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/IntMapper.java
+++ b/components/forks/poi/src/loci/poi/util/IntMapper.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/IntegerField.java
+++ b/components/forks/poi/src/loci/poi/util/IntegerField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/List2d.java
+++ b/components/forks/poi/src/loci/poi/util/List2d.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/LittleEndian.java
+++ b/components/forks/poi/src/loci/poi/util/LittleEndian.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/LittleEndianConsts.java
+++ b/components/forks/poi/src/loci/poi/util/LittleEndianConsts.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/LongField.java
+++ b/components/forks/poi/src/loci/poi/util/LongField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/NullLogger.java
+++ b/components/forks/poi/src/loci/poi/util/NullLogger.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/POILogFactory.java
+++ b/components/forks/poi/src/loci/poi/util/POILogFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/POILogger.java
+++ b/components/forks/poi/src/loci/poi/util/POILogger.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/ShortField.java
+++ b/components/forks/poi/src/loci/poi/util/ShortField.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/ShortList.java
+++ b/components/forks/poi/src/loci/poi/util/ShortList.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/StringUtil.java
+++ b/components/forks/poi/src/loci/poi/util/StringUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/SystemOutLogger.java
+++ b/components/forks/poi/src/loci/poi/util/SystemOutLogger.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/TempFile.java
+++ b/components/forks/poi/src/loci/poi/util/TempFile.java
@@ -2,7 +2,7 @@
  * #%L
  * Fork of Apache Jakarta POI.
  * %%
- * Copyright (C) 2008 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2008 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/poi/src/loci/poi/util/package.html
+++ b/components/forks/poi/src/loci/poi/util/package.html
@@ -4,7 +4,7 @@
   #%L
   Fork of Apache Jakarta POI.
   %%
-  Copyright (C) 2008 - 2014 Open Microscopy Environment:
+  Copyright (C) 2008 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/forks/turbojpeg/src/TJExample.java
+++ b/components/forks/turbojpeg/src/TJExample.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/TJUnitTest.java
+++ b/components/forks/turbojpeg/src/TJUnitTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJ.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJ.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJCompressor.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJCompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJCustomFilter.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJCustomFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJDecompressor.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJDecompressor.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJLoader.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJLoader.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJScalingFactor.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJScalingFactor.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJTransform.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJTransformer.java
+++ b/components/forks/turbojpeg/src/org/libjpegturbo/turbojpeg/TJTransformer.java
@@ -2,7 +2,7 @@
  * #%L
  * Java bindings and pre-built binaries for libjpeg-turbo.
  * %%
- * Copyright (C) 2013 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/CoreMetadata.java
+++ b/components/formats-api/src/loci/formats/CoreMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/DelegateReader.java
+++ b/components/formats-api/src/loci/formats/DelegateReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/FileInfo.java
+++ b/components/formats-api/src/loci/formats/FileInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/FormatException.java
+++ b/components/formats-api/src/loci/formats/FormatException.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/FormatHandler.java
+++ b/components/formats-api/src/loci/formats/FormatHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/IFormatHandler.java
+++ b/components/formats-api/src/loci/formats/IFormatHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/IMetadataConfigurable.java
+++ b/components/formats-api/src/loci/formats/IMetadataConfigurable.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/MissingLibraryException.java
+++ b/components/formats-api/src/loci/formats/MissingLibraryException.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/Modulo.java
+++ b/components/formats-api/src/loci/formats/Modulo.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/UnknownFormatException.java
+++ b/components/formats-api/src/loci/formats/UnknownFormatException.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/UnsupportedCompressionException.java
+++ b/components/formats-api/src/loci/formats/UnsupportedCompressionException.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/WriterWrapper.java
+++ b/components/formats-api/src/loci/formats/WriterWrapper.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/codec/Codec.java
+++ b/components/formats-api/src/loci/formats/codec/Codec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/codec/CodecOptions.java
+++ b/components/formats-api/src/loci/formats/codec/CodecOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/in/MetadataLevel.java
+++ b/components/formats-api/src/loci/formats/in/MetadataLevel.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/in/MetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/MetadataOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2003-FC-to-2008-09.xsl
+++ b/components/formats-api/src/loci/formats/meta/2003-FC-to-2008-09.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2006-LO-to-2008-09.xsl
+++ b/components/formats-api/src/loci/formats/meta/2006-LO-to-2008-09.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2007-06-to-2008-09.xsl
+++ b/components/formats-api/src/loci/formats/meta/2007-06-to-2008-09.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2008-02-to-2008-09.xsl
+++ b/components/formats-api/src/loci/formats/meta/2008-02-to-2008-09.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2008-09-to-2009-09.xsl
+++ b/components/formats-api/src/loci/formats/meta/2008-09-to-2009-09.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2009-09-to-2010-04.xsl
+++ b/components/formats-api/src/loci/formats/meta/2009-09-to-2010-04.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2010-04-to-2010-06.xsl
+++ b/components/formats-api/src/loci/formats/meta/2010-04-to-2010-06.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2010-06-to-2011-06.xsl
+++ b/components/formats-api/src/loci/formats/meta/2010-06-to-2011-06.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2011-06-to-2012-06.xsl
+++ b/components/formats-api/src/loci/formats/meta/2011-06-to-2012-06.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/2012-06-to-2013-06.xsl
+++ b/components/formats-api/src/loci/formats/meta/2012-06-to-2013-06.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/BaseMetadata.java
+++ b/components/formats-api/src/loci/formats/meta/BaseMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/DummyMetadata.java
+++ b/components/formats-api/src/loci/formats/meta/DummyMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/FilterMetadata.java
+++ b/components/formats-api/src/loci/formats/meta/FilterMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/IMetadata.java
+++ b/components/formats-api/src/loci/formats/meta/IMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/IMinMaxStore.java
+++ b/components/formats-api/src/loci/formats/meta/IMinMaxStore.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/MetadataRetrieve.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataRetrieve.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/MetadataStore.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataStore.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/ModuloAnnotation.java
+++ b/components/formats-api/src/loci/formats/meta/ModuloAnnotation.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/OriginalMetadataAnnotation.java
+++ b/components/formats-api/src/loci/formats/meta/OriginalMetadataAnnotation.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/package.html
+++ b/components/formats-api/src/loci/formats/meta/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/meta/reorder-2008-09.xsl
+++ b/components/formats-api/src/loci/formats/meta/reorder-2008-09.xsl
@@ -3,7 +3,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/ome/AbstractOMEXMLMetadata.java
+++ b/components/formats-api/src/loci/formats/ome/AbstractOMEXMLMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ome/OMEXMLMetadata.java
+++ b/components/formats-api/src/loci/formats/ome/OMEXMLMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ome/OMEXMLMetadataImpl.java
+++ b/components/formats-api/src/loci/formats/ome/OMEXMLMetadataImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/ome/package.html
+++ b/components/formats-api/src/loci/formats/ome/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-api/src/loci/formats/services/OMEXMLService.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLService.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-api/src/loci/formats/version.properties
+++ b/components/formats-api/src/loci/formats/version.properties
@@ -2,7 +2,7 @@
 # #%L
 # BSD implementations of Bio-Formats readers and writers
 # %%
-# Copyright (C) 2005 - 2014 Open Microscopy Environment:
+# Copyright (C) 2005 - 2015 Open Microscopy Environment:
 #   - Board of Regents of the University of Wisconsin-Madison
 #   - Glencoe Software, Inc.
 #   - University of Dundee

--- a/components/formats-bsd/cppwrap/build.sh
+++ b/components/formats-bsd/cppwrap/build.sh
@@ -4,7 +4,7 @@
 # #%L
 # BSD implementations of Bio-Formats readers and writers
 # %%
-# Copyright (C) 2005 - 2014 Open Microscopy Environment:
+# Copyright (C) 2005 - 2015 Open Microscopy Environment:
 #   - Board of Regents of the University of Wisconsin-Madison
 #   - Glencoe Software, Inc.
 #   - University of Dundee

--- a/components/formats-bsd/cppwrap/header.txt
+++ b/components/formats-bsd/cppwrap/header.txt
@@ -1,6 +1,6 @@
 OME Bio-Formats BSD-licensed readers and writers.
 
-Copyright (C) 2005 - 2014 Open Microscopy Environment:
+Copyright (C) 2005 - 2015 Open Microscopy Environment:
   - Board of Regents of the University of Wisconsin-Madison
   - Glencoe Software, Inc.
   - University of Dundee

--- a/components/formats-bsd/cppwrap/minimum_writer.cpp
+++ b/components/formats-bsd/cppwrap/minimum_writer.cpp
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/cppwrap/showinf.cpp
+++ b/components/formats-bsd/cppwrap/showinf.cpp
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/AxisGuesser.java
+++ b/components/formats-bsd/src/loci/formats/AxisGuesser.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/ChannelFiller.java
+++ b/components/formats-bsd/src/loci/formats/ChannelFiller.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/ChannelMerger.java
+++ b/components/formats-bsd/src/loci/formats/ChannelMerger.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/DimensionSwapper.java
+++ b/components/formats-bsd/src/loci/formats/DimensionSwapper.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/FilePatternBlock.java
+++ b/components/formats-bsd/src/loci/formats/FilePatternBlock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/ImageTools.java
+++ b/components/formats-bsd/src/loci/formats/ImageTools.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
+++ b/components/formats-bsd/src/loci/formats/MinMaxCalculator.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/NumberFilter.java
+++ b/components/formats-bsd/src/loci/formats/NumberFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/ResourceNamer.java
+++ b/components/formats-bsd/src/loci/formats/ResourceNamer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
@@ -32,7 +32,7 @@
 /*
  * OME Bio-Formats package for BSD-licensed readers and writers.
  *
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/SwappableMetadata.java
+++ b/components/formats-bsd/src/loci/formats/SwappableMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/UpgradeChecker.java
+++ b/components/formats-bsd/src/loci/formats/UpgradeChecker.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/ByteArraySource.java
+++ b/components/formats-bsd/src/loci/formats/cache/ByteArraySource.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/Cache.java
+++ b/components/formats-bsd/src/loci/formats/cache/Cache.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheEvent.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheException.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheException.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheListener.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheListener.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheReporter.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheReporter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheSource.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheSource.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheStrategy.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheStrategy.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CacheUpdater.java
+++ b/components/formats-bsd/src/loci/formats/cache/CacheUpdater.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/CrosshairStrategy.java
+++ b/components/formats-bsd/src/loci/formats/cache/CrosshairStrategy.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/ICacheSource.java
+++ b/components/formats-bsd/src/loci/formats/cache/ICacheSource.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/ICacheStrategy.java
+++ b/components/formats-bsd/src/loci/formats/cache/ICacheStrategy.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/RectangleStrategy.java
+++ b/components/formats-bsd/src/loci/formats/cache/RectangleStrategy.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/cache/package.html
+++ b/components/formats-bsd/src/loci/formats/cache/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/Base64Codec.java
+++ b/components/formats-bsd/src/loci/formats/codec/Base64Codec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/BaseCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/BaseCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/BitBuffer.java
+++ b/components/formats-bsd/src/loci/formats/codec/BitBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/BitWriter.java
+++ b/components/formats-bsd/src/loci/formats/codec/BitWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/ByteVector.java
+++ b/components/formats-bsd/src/loci/formats/codec/ByteVector.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/CompressionType.java
+++ b/components/formats-bsd/src/loci/formats/codec/CompressionType.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/HuffmanCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/HuffmanCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/HuffmanCodecOptions.java
+++ b/components/formats-bsd/src/loci/formats/codec/HuffmanCodecOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/JPEG2000BoxType.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEG2000BoxType.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/JPEG2000Codec.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEG2000Codec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/JPEG2000CodecOptions.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEG2000CodecOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/JPEG2000SegmentMarker.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEG2000SegmentMarker.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/JPEGCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEGCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/JPEGTileDecoder.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEGTileDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/LZOCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LZOCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/LZWCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LZWCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/LosslessJPEGCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LosslessJPEGCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/LuraWaveCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LuraWaveCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/MJPBCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/MJPBCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/MJPBCodecOptions.java
+++ b/components/formats-bsd/src/loci/formats/codec/MJPBCodecOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/MSRLECodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/MSRLECodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/MSVideoCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/MSVideoCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/NikonCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/NikonCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/NikonCodecOptions.java
+++ b/components/formats-bsd/src/loci/formats/codec/NikonCodecOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/PackbitsCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/PackbitsCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/PassthroughCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/PassthroughCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/QTRLECodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/QTRLECodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/RPZACodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/RPZACodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/TargaRLECodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/TargaRLECodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/ZlibCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/ZlibCodec.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/codec/package.html
+++ b/components/formats-bsd/src/loci/formats/codec/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/BufferedImageReader.java
+++ b/components/formats-bsd/src/loci/formats/gui/BufferedImageReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/BufferedImageSource.java
+++ b/components/formats-bsd/src/loci/formats/gui/BufferedImageSource.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/BufferedImageWriter.java
+++ b/components/formats-bsd/src/loci/formats/gui/BufferedImageWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/CacheComponent.java
+++ b/components/formats-bsd/src/loci/formats/gui/CacheComponent.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/CacheIndicator.java
+++ b/components/formats-bsd/src/loci/formats/gui/CacheIndicator.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/ComboFileFilter.java
+++ b/components/formats-bsd/src/loci/formats/gui/ComboFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/DataConverter.java
+++ b/components/formats-bsd/src/loci/formats/gui/DataConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/ExtensionFileFilter.java
+++ b/components/formats-bsd/src/loci/formats/gui/ExtensionFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/FormatFileFilter.java
+++ b/components/formats-bsd/src/loci/formats/gui/FormatFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/GUITools.java
+++ b/components/formats-bsd/src/loci/formats/gui/GUITools.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/ImageViewer.java
+++ b/components/formats-bsd/src/loci/formats/gui/ImageViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/Index16ColorModel.java
+++ b/components/formats-bsd/src/loci/formats/gui/Index16ColorModel.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/LegacyQTTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/LegacyQTTools.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/NoExtensionFileFilter.java
+++ b/components/formats-bsd/src/loci/formats/gui/NoExtensionFileFilter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/PreviewPane.java
+++ b/components/formats-bsd/src/loci/formats/gui/PreviewPane.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/SignedByteBuffer.java
+++ b/components/formats-bsd/src/loci/formats/gui/SignedByteBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/SignedColorModel.java
+++ b/components/formats-bsd/src/loci/formats/gui/SignedColorModel.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/SignedShortBuffer.java
+++ b/components/formats-bsd/src/loci/formats/gui/SignedShortBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/TwoChannelColorSpace.java
+++ b/components/formats-bsd/src/loci/formats/gui/TwoChannelColorSpace.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/UnsignedIntBuffer.java
+++ b/components/formats-bsd/src/loci/formats/gui/UnsignedIntBuffer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/UnsignedIntColorModel.java
+++ b/components/formats-bsd/src/loci/formats/gui/UnsignedIntColorModel.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/XMLCellRenderer.java
+++ b/components/formats-bsd/src/loci/formats/gui/XMLCellRenderer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/XMLWindow.java
+++ b/components/formats-bsd/src/loci/formats/gui/XMLWindow.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/gui/package.html
+++ b/components/formats-bsd/src/loci/formats/gui/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/APNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/APNGReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/BIFormatReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BIFormatReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/BMPReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BMPReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/FitsReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FitsReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/GIFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/GIFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/ImageIOReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ImageIOReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000MetadataParser.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000MetadataParser.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/LegacyQTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/LegacyQTReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/MNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MNGReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/NRRDReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NRRDReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/PCXReader.java
+++ b/components/formats-bsd/src/loci/formats/in/PCXReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/PGMReader.java
+++ b/components/formats-bsd/src/loci/formats/in/PGMReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/PictReader.java
+++ b/components/formats-bsd/src/loci/formats/in/PictReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/QTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/QTReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/TextReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TextReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/TiffDelegateReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffDelegateReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/TiffJAIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffJAIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/in/ZipReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ZipReader.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/APNGWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/APNGWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/AVIWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/AVIWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/EPSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/EPSWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/ImageIOWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ImageIOWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/JPEG2000Writer.java
+++ b/components/formats-bsd/src/loci/formats/out/JPEG2000Writer.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/JPEGWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/JPEGWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/JavaWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/JavaWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/LegacyQTWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/LegacyQTWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/QTWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/QTWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/out/package.html
+++ b/components/formats-bsd/src/loci/formats/out/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/src/loci/formats/services/JAIIIOService.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOService.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboService.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/services/LuraWaveService.java
+++ b/components/formats-bsd/src/loci/formats/services/LuraWaveService.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/services/LuraWaveServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/LuraWaveServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/IFDList.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFDList.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/IFDType.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFDType.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/OnDemandLongArray.java
+++ b/components/formats-bsd/src/loci/formats/tiff/OnDemandLongArray.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/PhotoInterp.java
+++ b/components/formats-bsd/src/loci/formats/tiff/PhotoInterp.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/TiffCompression.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffCompression.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/TiffConstants.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffConstants.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/TiffIFDEntry.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffIFDEntry.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/TiffRational.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffRational.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tiff/package.html
+++ b/components/formats-bsd/src/loci/formats/tiff/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
+++ b/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/AsciiImage.java
+++ b/components/formats-bsd/src/loci/formats/tools/AsciiImage.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/BioFormatsExtensionPrinter.java
+++ b/components/formats-bsd/src/loci/formats/tools/BioFormatsExtensionPrinter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/CacheConsole.java
+++ b/components/formats-bsd/src/loci/formats/tools/CacheConsole.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/EditTiffG.java
+++ b/components/formats-bsd/src/loci/formats/tools/EditTiffG.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/FakeImage.java
+++ b/components/formats-bsd/src/loci/formats/tools/FakeImage.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java
+++ b/components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/PrintDomains.java
+++ b/components/formats-bsd/src/loci/formats/tools/PrintDomains.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/PrintFormatTable.java
+++ b/components/formats-bsd/src/loci/formats/tools/PrintFormatTable.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/TiffComment.java
+++ b/components/formats-bsd/src/loci/formats/tools/TiffComment.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/UpgradeCheck.java
+++ b/components/formats-bsd/src/loci/formats/tools/UpgradeCheck.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/XMLIndent.java
+++ b/components/formats-bsd/src/loci/formats/tools/XMLIndent.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/XMLValidate.java
+++ b/components/formats-bsd/src/loci/formats/tools/XMLValidate.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/src/loci/formats/tools/package.html
+++ b/components/formats-bsd/src/loci/formats/tools/package.html
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/BaseModelMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/BaseModelMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/BaseModelNoBinDataReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/BaseModelNoBinDataReaderTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/BaseModelReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/BaseModelReaderTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/DimensionSwapperTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/DimensionSwapperTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/EightBitLosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/EightBitLosslessJPEG2000Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FormatToolsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/IsThisTypeTests.java
+++ b/components/formats-bsd/test/loci/formats/utests/IsThisTypeTests.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/JAIIIOServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/JAIIIOServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/LosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/LosslessJPEG2000Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/LuraWaveServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/LuraWaveServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/MinMaxCalculatorTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MinMaxCalculatorTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/MissingJAIIIOServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MissingJAIIIOServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/MissingLuraWaveServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MissingLuraWaveServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/MissingOMEXMLServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MissingOMEXMLServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/ModelMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/ModelMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/OMEXMLServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/OMEXMLServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/PumpWithLightSourceSettingsTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/PumpWithLightSourceSettingsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/ReaderEqualityTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ReaderEqualityTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/SPWModelMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/SPWModelMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/SPWModelReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/SPWModelReaderTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/ServiceFactoryTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ServiceFactoryTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/WrapperTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/WrapperTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/testng-no-jai.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng-no-jai.xml
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/testng-no-lurawave.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng-no-lurawave.xml
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/testng-no-ome-xml.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng-no-ome-xml.xml
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/BaseTiffMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/BaseTiffMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/BitsPerSampleSamplesPerPixelMismatchMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/BitsPerSampleSamplesPerPixelMismatchMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/IFDTypeTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/IFDTypeTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/NonUniformRowsPerStripMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/NonUniformRowsPerStripMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterBigTiffLargeImageWidthTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterBigTiffLargeImageWidthTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterLargeImageWidthTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/OMETiffWriterLargeImageWidthTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/PhotoInterpTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/PhotoInterpTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/RGBTiffMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/RGBTiffMock.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffCompressionCompressTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffCompressionCompressTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffCompressionDecompressTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffCompressionDecompressTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffCompressionTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffCompressionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffParserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffParserTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffPixelsTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffPixelsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffRationalTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffRationalTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffSaverTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffSaverTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/Schema2011_06_File_Upgrade_Test.java
+++ b/components/formats-bsd/test/spec/schema/Schema2011_06_File_Upgrade_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/Schema2011_06_Instrument_Upgrade_Test.java
+++ b/components/formats-bsd/test/spec/schema/Schema2011_06_Instrument_Upgrade_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/Schema2011_06_TO_2012_06_Test.java
+++ b/components/formats-bsd/test/spec/schema/Schema2011_06_TO_2012_06_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/SchemaCurrent_TO_2003_FC_Test.java
+++ b/components/formats-bsd/test/spec/schema/SchemaCurrent_TO_2003_FC_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/SchemaCurrent_TO_2008_02_Test.java
+++ b/components/formats-bsd/test/spec/schema/SchemaCurrent_TO_2008_02_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/SchemaCurrent_TO_2010_06_Test.java
+++ b/components/formats-bsd/test/spec/schema/SchemaCurrent_TO_2010_06_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/samples/Instrument2011_06.java
+++ b/components/formats-bsd/test/spec/schema/samples/Instrument2011_06.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/schema/samples/Upgrade2011_06.java
+++ b/components/formats-bsd/test/spec/schema/samples/Upgrade2011_06.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/spec/testng.xml
+++ b/components/formats-bsd/test/spec/testng.xml
@@ -2,7 +2,7 @@
   #%L
   BSD implementations of Bio-Formats readers and writers
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-bsd/utils/mipav/PlugInBioFormatsImporter.java
+++ b/components/formats-bsd/utils/mipav/PlugInBioFormatsImporter.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/AbstractNIOHandle.java
+++ b/components/formats-common/src/loci/common/AbstractNIOHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/BZip2Handle.java
+++ b/components/formats-common/src/loci/common/BZip2Handle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/ByteArrayHandle.java
+++ b/components/formats-common/src/loci/common/ByteArrayHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/CBZip2InputStream.java
+++ b/components/formats-common/src/loci/common/CBZip2InputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/CRC.java
+++ b/components/formats-common/src/loci/common/CRC.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/CaseInsensitiveLocation.java
+++ b/components/formats-common/src/loci/common/CaseInsensitiveLocation.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/Constants.java
+++ b/components/formats-common/src/loci/common/Constants.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/DateTools.java
+++ b/components/formats-common/src/loci/common/DateTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/FileHandle.java
+++ b/components/formats-common/src/loci/common/FileHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/GZipHandle.java
+++ b/components/formats-common/src/loci/common/GZipHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/HandleException.java
+++ b/components/formats-common/src/loci/common/HandleException.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/IRandomAccess.java
+++ b/components/formats-common/src/loci/common/IRandomAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/IniList.java
+++ b/components/formats-common/src/loci/common/IniList.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/IniTable.java
+++ b/components/formats-common/src/loci/common/IniTable.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/IniWriter.java
+++ b/components/formats-common/src/loci/common/IniWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/Location.java
+++ b/components/formats-common/src/loci/common/Location.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/NIOByteBufferProvider.java
+++ b/components/formats-common/src/loci/common/NIOByteBufferProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/NIOFileHandle.java
+++ b/components/formats-common/src/loci/common/NIOFileHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/NIOInputStream.java
+++ b/components/formats-common/src/loci/common/NIOInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/RandomAccessOutputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessOutputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/ReflectException.java
+++ b/components/formats-common/src/loci/common/ReflectException.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/ReflectedUniverse.java
+++ b/components/formats-common/src/loci/common/ReflectedUniverse.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/Region.java
+++ b/components/formats-common/src/loci/common/Region.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/StatusEvent.java
+++ b/components/formats-common/src/loci/common/StatusEvent.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/StatusListener.java
+++ b/components/formats-common/src/loci/common/StatusListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/StatusReporter.java
+++ b/components/formats-common/src/loci/common/StatusReporter.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/StreamHandle.java
+++ b/components/formats-common/src/loci/common/StreamHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/URLHandle.java
+++ b/components/formats-common/src/loci/common/URLHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/ZipHandle.java
+++ b/components/formats-common/src/loci/common/ZipHandle.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/enumeration/CodedEnum.java
+++ b/components/formats-common/src/loci/common/enumeration/CodedEnum.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/enumeration/EnumException.java
+++ b/components/formats-common/src/loci/common/enumeration/EnumException.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/services/AbstractService.java
+++ b/components/formats-common/src/loci/common/services/AbstractService.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/services/DependencyException.java
+++ b/components/formats-common/src/loci/common/services/DependencyException.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/services/Service.java
+++ b/components/formats-common/src/loci/common/services/Service.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/services/ServiceException.java
+++ b/components/formats-common/src/loci/common/services/ServiceException.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/services/ServiceFactory.java
+++ b/components/formats-common/src/loci/common/services/ServiceFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/services/services.properties
+++ b/components/formats-common/src/loci/common/services/services.properties
@@ -2,7 +2,7 @@
 # #%L
 # Common package for I/O and related utilities
 # %%
-# Copyright (C) 2005 - 2014 Open Microscopy Environment:
+# Copyright (C) 2005 - 2015 Open Microscopy Environment:
 #   - Board of Regents of the University of Wisconsin-Madison
 #   - Glencoe Software, Inc.
 #   - University of Dundee

--- a/components/formats-common/src/loci/common/xml/BaseHandler.java
+++ b/components/formats-common/src/loci/common/xml/BaseHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/xml/MetadataHandler.java
+++ b/components/formats-common/src/loci/common/xml/MetadataHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/xml/ParserErrorHandler.java
+++ b/components/formats-common/src/loci/common/xml/ParserErrorHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/xml/ValidationErrorHandler.java
+++ b/components/formats-common/src/loci/common/xml/ValidationErrorHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/xml/ValidationSAXHandler.java
+++ b/components/formats-common/src/loci/common/xml/ValidationSAXHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/src/loci/common/xml/XMLTools.java
+++ b/components/formats-common/src/loci/common/xml/XMLTools.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/BufferAlignmentReadTest.java
+++ b/components/formats-common/test/loci/common/utests/BufferAlignmentReadTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/BufferAlignmentWriteTest.java
+++ b/components/formats-common/test/loci/common/utests/BufferAlignmentWriteTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/DataToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DataToolsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/EncodingTest.java
+++ b/components/formats-common/test/loci/common/utests/EncodingTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/EndiannessTest.java
+++ b/components/formats-common/test/loci/common/utests/EndiannessTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/LocationTest.java
+++ b/components/formats-common/test/loci/common/utests/LocationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/RandomAccessInputStreamTest.java
+++ b/components/formats-common/test/loci/common/utests/RandomAccessInputStreamTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadByteArrayTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadByteArrayTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadByteBufferTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadByteBufferTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadByteSubArrayTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadByteSubArrayTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadByteTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadByteTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadCharTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadCharTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadDoubleTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadDoubleTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadFloatTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadFloatTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadIntTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadIntTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadLineTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadLineTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadLongTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadLongTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadOnlyTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadOnlyTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadShortTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadShortTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadUnsignedByteTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadUnsignedByteTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/ReadUnsignedShortTest.java
+++ b/components/formats-common/test/loci/common/utests/ReadUnsignedShortTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/SkipBytesTest.java
+++ b/components/formats-common/test/loci/common/utests/SkipBytesTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/TypeDetectionTest.java
+++ b/components/formats-common/test/loci/common/utests/TypeDetectionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/URLHandleTest.java
+++ b/components/formats-common/test/loci/common/utests/URLHandleTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteByteArrayTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteByteArrayTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteByteBufferTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteByteBufferTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteByteTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteByteTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteBytesTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteBytesTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteCharTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteCharTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteCharsTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteCharsTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteDoubleTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteDoubleTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteFloatTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteFloatTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteIntTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteIntTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteLongTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteLongTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteShortTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteShortTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteUTFTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteUTFTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteUnsignedByteTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteUnsignedByteTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/WriteUnsignedShortTest.java
+++ b/components/formats-common/test/loci/common/utests/WriteUnsignedShortTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/BZip2HandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/BZip2HandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/ByteArrayHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/ByteArrayHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/ExistingByteArrayHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/ExistingByteArrayHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/GZipHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/GZipHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/IRandomAccessProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/IRandomAccessProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/IRandomAccessProviderFactory.java
+++ b/components/formats-common/test/loci/common/utests/providers/IRandomAccessProviderFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/NIOFileHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/NIOFileHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/NewByteArrayHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/NewByteArrayHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/URLHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/URLHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/providers/ZipHandleProvider.java
+++ b/components/formats-common/test/loci/common/utests/providers/ZipHandleProvider.java
@@ -2,7 +2,7 @@
  * #%L
  * Common package for I/O and related utilities
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-common/test/loci/common/utests/testng-template.xml
+++ b/components/formats-common/test/loci/common/utests/testng-template.xml
@@ -2,7 +2,7 @@
   #%L
   Common package for I/O and related utilities
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/doc/sorttable.js
+++ b/components/formats-gpl/doc/sorttable.js
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/matlab/bfCheckJavaMemory.m
+++ b/components/formats-gpl/matlab/bfCheckJavaMemory.m
@@ -14,7 +14,7 @@ function [] = bfCheckJavaMemory(varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2014 Open Microscopy Environment:
+% Copyright (C) 2014 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfCheckJavaPath.m
+++ b/components/formats-gpl/matlab/bfCheckJavaPath.m
@@ -23,7 +23,7 @@ function [status, version] = bfCheckJavaPath(varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfGetFileExtensions.m
+++ b/components/formats-gpl/matlab/bfGetFileExtensions.m
@@ -14,7 +14,7 @@ function fileExt = bfGetFileExtensions
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfGetPlane.m
+++ b/components/formats-gpl/matlab/bfGetPlane.m
@@ -22,7 +22,7 @@ function I = bfGetPlane(r, iPlane, varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfGetReader.m
+++ b/components/formats-gpl/matlab/bfGetReader.m
@@ -20,7 +20,7 @@ function r = bfGetReader(varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfOpen3DVolume.m
+++ b/components/formats-gpl/matlab/bfOpen3DVolume.m
@@ -16,7 +16,7 @@ function volume = bfOpen3DVolume(filename)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfUpgradeCheck.m
+++ b/components/formats-gpl/matlab/bfUpgradeCheck.m
@@ -15,7 +15,7 @@ function bfUpgradeCheck(varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -50,7 +50,7 @@ function [result] = bfopen(id, varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2007 - 2014 Open Microscopy Environment:
+% Copyright (C) 2007 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -32,7 +32,7 @@ function bfsave(I, outputPath, varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
+++ b/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
@@ -18,7 +18,7 @@ function metadata = createMinimalOMEXMLMetadata(I, varargin)
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/TileStitcher.java
+++ b/components/formats-gpl/src/loci/formats/TileStitcher.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/AIMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AIMReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ARFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ARFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/AliconaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AliconaReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/AmiraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AmiraReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BioRadReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BioRadSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadSCNReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BrukerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BrukerReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/BurleighReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BurleighReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/CanonRawReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CanonRawReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/Ecat7Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/Ecat7Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/FEIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FEIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/FujiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FujiReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/GatanDM2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanDM2Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/GelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GelReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/HISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HISReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/HRDGDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HRDGDFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/HitachiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HitachiReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/IMODReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IMODReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/INRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/INRReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/IPLabReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPLabReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/IPWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPWReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImaconReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImaconReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImagicReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImagicReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImarisReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImarisTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/InCell3000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCell3000Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/InveonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InveonReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/IvisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IvisionReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/JEOLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JEOLReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/JPKReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JPKReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/JPXReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JPXReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/KhorosReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KhorosReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/KodakReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KodakReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/L2DReader.java
+++ b/components/formats-gpl/src/loci/formats/in/L2DReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LEOReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LEOReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LIMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIMReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MINCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MINCReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MRWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRWReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/MolecularImagingReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MolecularImagingReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NAFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NAFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NikonElementsTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonElementsTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/NikonTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/OpenlabRawReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OpenlabRawReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/OxfordInstrumentsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OxfordInstrumentsReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PCORAWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCORAWReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PDSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PDSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PQBinReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PQBinReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PSDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PSDReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PhotoshopTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PhotoshopTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PovrayReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PovrayReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PrairieMetadata.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PrairieReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/QuesantReader.java
+++ b/components/formats-gpl/src/loci/formats/in/QuesantReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/RHKReader.java
+++ b/components/formats-gpl/src/loci/formats/in/RHKReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SBIGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SBIGReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SDTInfo.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTInfo.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SEQReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SEQReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SIFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SISReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SMCameraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SMCameraReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SeikoReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SeikoReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SlidebookReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlidebookReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SlidebookTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlidebookTiffReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/SpiderReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SpiderReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/TargaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TargaReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/TopometrixReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TopometrixReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/TrestleReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TrestleReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/UBMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/UBMReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/UnisokuReader.java
+++ b/components/formats-gpl/src/loci/formats/in/UnisokuReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/VGSAMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VGSAMReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/VarianFDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VarianFDFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/VisitechReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VisitechReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/VolocityClippingReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VolocityClippingReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/VolocityReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VolocityReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/WATOPReader.java
+++ b/components/formats-gpl/src/loci/formats/in/WATOPReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/WlzReader.java
+++ b/components/formats-gpl/src/loci/formats/in/WlzReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
+++ b/components/formats-gpl/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/loci_formats_in_LegacyND2Reader.h
+++ b/components/formats-gpl/src/loci/formats/in/loci_formats_in_LegacyND2Reader.h
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/in/package.html
+++ b/components/formats-gpl/src/loci/formats/in/package.html
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats package for reading and converting biological file formats.
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/src/loci/formats/out/WlzWriter.java
+++ b/components/formats-gpl/src/loci/formats/out/WlzWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/package.html
+++ b/components/formats-gpl/src/loci/formats/package.html
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats package for reading and converting biological file formats.
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/MDBService.java
+++ b/components/formats-gpl/src/loci/formats/services/MDBService.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/MDBServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/MDBServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/MetakitService.java
+++ b/components/formats-gpl/src/loci/formats/services/MetakitService.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/MetakitServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/MetakitServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/NetCDFService.java
+++ b/components/formats-gpl/src/loci/formats/services/NetCDFService.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/POIService.java
+++ b/components/formats-gpl/src/loci/formats/services/POIService.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/WlzService.java
+++ b/components/formats-gpl/src/loci/formats/services/WlzService.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/services/WlzServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/WlzServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/src/loci/formats/tools/MakeDatasetStructureTable.java
+++ b/components/formats-gpl/src/loci/formats/tools/MakeDatasetStructureTable.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/DeltavisionMetadataConfigurableTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/DeltavisionMetadataConfigurableTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/GetLightSourceTypeTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/GetLightSourceTypeTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/IMetadataBasedOMEModelMock.java
+++ b/components/formats-gpl/test/loci/formats/utests/IMetadataBasedOMEModelMock.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/InOut201004Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/InOut201004Test.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/MDBServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/MDBServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/MetadataConfigurableTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/MetadataConfigurableTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/MissingMDBServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/MissingMDBServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/MissingNetCDFServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/MissingNetCDFServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/MissingPOIServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/MissingPOIServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/NetCDFServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/NetCDFServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/OMEModelMock.java
+++ b/components/formats-gpl/test/loci/formats/utests/OMEModelMock.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/ObjectBasedOMEModelMock.java
+++ b/components/formats-gpl/test/loci/formats/utests/ObjectBasedOMEModelMock.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/POIServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/POIServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/ScreenDetectionTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ScreenDetectionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/XMLAnnotationTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/XMLAnnotationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/codec/CompressionTypeTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/codec/CompressionTypeTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/testng-no-mdb.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng-no-mdb.xml
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats package for reading and converting biological file formats.
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/testng-no-netcdf.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng-no-netcdf.xml
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats package for reading and converting biological file formats.
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/testng-no-poi.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng-no-poi.xml
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats package for reading and converting biological file formats.
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/testng.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng.xml
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats package for reading and converting biological file formats.
   %%
-  Copyright (C) 2005 - 2014 Open Microscopy Environment:
+  Copyright (C) 2005 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/BackReferenceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/BackReferenceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/OMEXMLServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/OMEXMLServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200809Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200809Test.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200909Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200909Test.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201004Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201004Test.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201006Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201006Test.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201106Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201106Test.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/test/matlab/ReaderTest.m
+++ b/components/formats-gpl/test/matlab/ReaderTest.m
@@ -5,7 +5,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2014 Open Microscopy Environment:
+% Copyright (C) 2014 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/test/matlab/TestBfCheckJavaMemory.m
+++ b/components/formats-gpl/test/matlab/TestBfCheckJavaMemory.m
@@ -5,7 +5,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2014 Open Microscopy Environment:
+% Copyright (C) 2014 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/test/matlab/TestBfCheckJavaPath.m
+++ b/components/formats-gpl/test/matlab/TestBfCheckJavaPath.m
@@ -5,7 +5,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/test/matlab/TestBfGetPlane.m
+++ b/components/formats-gpl/test/matlab/TestBfGetPlane.m
@@ -5,7 +5,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/test/matlab/TestBfopen.m
+++ b/components/formats-gpl/test/matlab/TestBfopen.m
@@ -5,7 +5,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/test/matlab/TestBfsave.m
+++ b/components/formats-gpl/test/matlab/TestBfsave.m
@@ -5,7 +5,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2012 - 2014 Open Microscopy Environment:
+% Copyright (C) 2012 - 2015 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/utils/CommentSurgery.java
+++ b/components/formats-gpl/utils/CommentSurgery.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/ConvertToOmeTiff.java
+++ b/components/formats-gpl/utils/ConvertToOmeTiff.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/DumpOMEXML.java
+++ b/components/formats-gpl/utils/DumpOMEXML.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/EditImageName.java
+++ b/components/formats-gpl/utils/EditImageName.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/EditTiffComment.java
+++ b/components/formats-gpl/utils/EditTiffComment.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/ExtractFlexMetadata.java
+++ b/components/formats-gpl/utils/ExtractFlexMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/ExtractSDTData.java
+++ b/components/formats-gpl/utils/ExtractSDTData.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/GetPhysicalMetadata.java
+++ b/components/formats-gpl/utils/GetPhysicalMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/MakeLZW.java
+++ b/components/formats-gpl/utils/MakeLZW.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/MinimumWriter.java
+++ b/components/formats-gpl/utils/MinimumWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/MultiFileExample.java
+++ b/components/formats-gpl/utils/MultiFileExample.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/MultiFileExportExample.java
+++ b/components/formats-gpl/utils/MultiFileExportExample.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/ParallelRead.java
+++ b/components/formats-gpl/utils/ParallelRead.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/PrintLensNA.java
+++ b/components/formats-gpl/utils/PrintLensNA.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/PrintROIs.java
+++ b/components/formats-gpl/utils/PrintROIs.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/PrintTimestamps.java
+++ b/components/formats-gpl/utils/PrintTimestamps.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/ReadWriteInMemory.java
+++ b/components/formats-gpl/utils/ReadWriteInMemory.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/SewTiffs.java
+++ b/components/formats-gpl/utils/SewTiffs.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/SubResolutionExample.java
+++ b/components/formats-gpl/utils/SubResolutionExample.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/SumPlanes.java
+++ b/components/formats-gpl/utils/SumPlanes.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/TiffDumper.java
+++ b/components/formats-gpl/utils/TiffDumper.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/TiledExportExample.java
+++ b/components/formats-gpl/utils/TiledExportExample.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/WritePrecompressedPlanes.java
+++ b/components/formats-gpl/utils/WritePrecompressedPlanes.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/WriteRGBMovie.java
+++ b/components/formats-gpl/utils/WriteRGBMovie.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-gpl/utils/showinfJNI.cpp
+++ b/components/formats-gpl/utils/showinfJNI.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/src/ome/metakit/Column.java
+++ b/components/metakit/src/ome/metakit/Column.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/src/ome/metakit/ColumnMap.java
+++ b/components/metakit/src/ome/metakit/ColumnMap.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/src/ome/metakit/MetakitException.java
+++ b/components/metakit/src/ome/metakit/MetakitException.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/src/ome/metakit/MetakitReader.java
+++ b/components/metakit/src/ome/metakit/MetakitReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/src/ome/metakit/MetakitTools.java
+++ b/components/metakit/src/ome/metakit/MetakitTools.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/test/ome/metakit/utests/ColumnTest.java
+++ b/components/metakit/test/ome/metakit/utests/ColumnTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/test/ome/metakit/utests/RowTest.java
+++ b/components/metakit/test/ome/metakit/utests/RowTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/test/ome/metakit/utests/TableTest.java
+++ b/components/metakit/test/ome/metakit/utests/TableTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Metakit package for reading Metakit database files.
  * %%
- * Copyright (C) 2011 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2011 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/metakit/test/ome/metakit/utests/testng-template.xml
+++ b/components/metakit/test/ome/metakit/utests/testng-template.xml
@@ -2,7 +2,7 @@
   #%L
   OME Metakit package for reading Metakit database files.
   %%
-  Copyright (C) 2011 - 2014 Open Microscopy Environment:
+  Copyright (C) 2011 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/ome-xml/src/ome/xml/meta/AbstractOMEXMLMetadata.java
+++ b/components/ome-xml/src/ome/xml/meta/AbstractOMEXMLMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/meta/BaseMetadata.java
+++ b/components/ome-xml/src/ome/xml/meta/BaseMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/meta/IMetadata.java
+++ b/components/ome-xml/src/ome/xml/meta/IMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/meta/MetadataRoot.java
+++ b/components/ome-xml/src/ome/xml/meta/MetadataRoot.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/meta/OMEXMLMetadata.java
+++ b/components/ome-xml/src/ome/xml/meta/OMEXMLMetadata.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/meta/OMEXMLMetadataRoot.java
+++ b/components/ome-xml/src/ome/xml/meta/OMEXMLMetadataRoot.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/AbstractOMEModelObject.java
+++ b/components/ome-xml/src/ome/xml/model/AbstractOMEModelObject.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/OMEModel.java
+++ b/components/ome-xml/src/ome/xml/model/OMEModel.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/OMEModelImpl.java
+++ b/components/ome-xml/src/ome/xml/model/OMEModelImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/OMEModelObject.java
+++ b/components/ome-xml/src/ome/xml/model/OMEModelObject.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/enums/Enumeration.java
+++ b/components/ome-xml/src/ome/xml/model/enums/Enumeration.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/enums/EnumerationException.java
+++ b/components/ome-xml/src/ome/xml/model/enums/EnumerationException.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/enums/handlers/IEnumerationHandler.java
+++ b/components/ome-xml/src/ome/xml/model/enums/handlers/IEnumerationHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/Color.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/Color.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/NonNegativeFloat.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/NonNegativeFloat.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/NonNegativeInteger.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/NonNegativeInteger.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/NonNegativeLong.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/NonNegativeLong.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/PercentFraction.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/PercentFraction.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/PositiveFloat.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/PositiveFloat.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/PositiveInteger.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/PositiveInteger.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/PositiveLong.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/PositiveLong.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/PrimitiveType.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/PrimitiveType.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/model/primitives/Timestamp.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/Timestamp.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/src/ome/xml/package.html
+++ b/components/ome-xml/src/ome/xml/package.html
@@ -2,7 +2,7 @@
   #%L
   OME-XML Java library for working with OME-XML metadata structures.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Massachusetts Institute of Technology
     - National Institutes of Health
     - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/ColorTest.java
+++ b/components/ome-xml/test/ome/xml/utests/ColorTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/EnumHandlerTest.java
+++ b/components/ome-xml/test/ome/xml/utests/EnumHandlerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/NonNegativeFloatTest.java
+++ b/components/ome-xml/test/ome/xml/utests/NonNegativeFloatTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/NonNegativeIntegerTest.java
+++ b/components/ome-xml/test/ome/xml/utests/NonNegativeIntegerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/NonNegativeLongTest.java
+++ b/components/ome-xml/test/ome/xml/utests/NonNegativeLongTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/PercentFractionTest.java
+++ b/components/ome-xml/test/ome/xml/utests/PercentFractionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/PositiveFloatTest.java
+++ b/components/ome-xml/test/ome/xml/utests/PositiveFloatTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/PositiveIntegerTest.java
+++ b/components/ome-xml/test/ome/xml/utests/PositiveIntegerTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/PositiveLongTest.java
+++ b/components/ome-xml/test/ome/xml/utests/PositiveLongTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/SingularBackReferenceTest.java
+++ b/components/ome-xml/test/ome/xml/utests/SingularBackReferenceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/TimestampTest.java
+++ b/components/ome-xml/test/ome/xml/utests/TimestampTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/ome-xml/test/ome/xml/utests/testng.xml
+++ b/components/ome-xml/test/ome/xml/utests/testng.xml
@@ -2,7 +2,7 @@
   #%L
   OME-XML Java library for working with OME-XML metadata structures.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Massachusetts Institute of Technology
     - National Institutes of Health
     - University of Dundee

--- a/components/specification/released-schema/2003-FC/CLI.xsd
+++ b/components/specification/released-schema/2003-FC/CLI.xsd
@@ -50,7 +50,7 @@
 	<!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Copyright (C) 2003 Open Microscopy Environment
+# Copyright (C) 2003 - 2015 Open Microscopy Environment
 #       Massachusetts Institute of Technology,
 #       National Institutes of Health,
 #       University of Dundee

--- a/components/specification/released-schema/2003-FC/ome.xsd
+++ b/components/specification/released-schema/2003-FC/ome.xsd
@@ -44,7 +44,7 @@
 	<!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Copyright (C) 2003 Open Microscopy Environment
+# Copyright (C) 2003 - 2015 Open Microscopy Environment
 #       Massachusetts Institute of Technology,
 #       National Institutes of Health,
 #       University of Dundee

--- a/components/specification/released-schema/2003-RC1/CLI.xsd
+++ b/components/specification/released-schema/2003-RC1/CLI.xsd
@@ -50,7 +50,7 @@
 	<!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Copyright (C) 2003 Open Microscopy Environment
+# Copyright (C) 2003 - 2015 Open Microscopy Environment
 #       Massachusetts Institute of Technology,
 #       National Institutes of Health,
 #       University of Dundee

--- a/components/specification/samples/inprogress/sample-third-party-pieces.xml
+++ b/components/specification/samples/inprogress/sample-third-party-pieces.xml
@@ -2,7 +2,7 @@
 <!--
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	#
-	# Copyright (C) 2011 Open Microscopy Environment
+	# Copyright (C) 2011 - 2015 Open Microscopy Environment
 	#       Massachusetts Institute of Technology,
 	#       National Institutes of Health,
 	#       University of Dundee,

--- a/components/specification/samples/inprogress/sample-third-party-pieces.xsd
+++ b/components/specification/samples/inprogress/sample-third-party-pieces.xsd
@@ -2,7 +2,7 @@
 <!--
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	#
-	# Copyright (C) 2011 Open Microscopy Environment
+	# Copyright (C) 2011 - 2015 Open Microscopy Environment
 	#       Massachusetts Institute of Technology,
 	#       National Institutes of Health,
 	#       University of Dundee,
@@ -33,7 +33,7 @@
 				Open Microscopy Environment
 				OME Sample Third Party
 				Author: Andrew J Patterson
-				Copyright (C) 2011 Open Microscopy Environment
+				Copyright (C) 2011 - 2015 Open Microscopy Environment
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>

--- a/components/specification/samples/inprogress/sample-third-party.xml
+++ b/components/specification/samples/inprogress/sample-third-party.xml
@@ -2,7 +2,7 @@
 <!--
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	#
-	# Copyright (C) 2011 Open Microscopy Environment
+	# Copyright (C) 2011 - 2015 Open Microscopy Environment
 	#       Massachusetts Institute of Technology,
 	#       National Institutes of Health,
 	#       University of Dundee,

--- a/components/specification/samples/inprogress/sample-third-party.xsd
+++ b/components/specification/samples/inprogress/sample-third-party.xsd
@@ -2,7 +2,7 @@
 <!--
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	#
-	# Copyright (C) 2011 Open Microscopy Environment
+	# Copyright (C) 2011 - 2015 Open Microscopy Environment
 	#       Massachusetts Institute of Technology,
 	#       National Institutes of Health,
 	#       University of Dundee,
@@ -33,7 +33,7 @@
 				Open Microscopy Environment
 				OME Sample Third Party
 				Author: Andrew J Patterson
-				Copyright (C) 2011 Open Microscopy Environment
+				Copyright (C) 2011 - 2015 Open Microscopy Environment
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>

--- a/components/specification/src/ome/specification/OmeValidator.java
+++ b/components/specification/src/ome/specification/OmeValidator.java
@@ -2,7 +2,7 @@
  * #%L
  * The OME Data Model specification
  * %%
- * Copyright (C) 2003 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2003 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/specification/src/ome/specification/SchemaResolver.java
+++ b/components/specification/src/ome/specification/SchemaResolver.java
@@ -2,7 +2,7 @@
  * #%L
  * The OME Data Model specification
  * %%
- * Copyright (C) 2003 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2003 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -2,7 +2,7 @@
  * #%L
  * The OME Data Model specification
  * %%
- * Copyright (C) 2003 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2003 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/specification/src/ome/specification/XMLWriter.java
+++ b/components/specification/src/ome/specification/XMLWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * The OME Data Model specification
  * %%
- * Copyright (C) 2003 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2003 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/specification/transforms/internal/OME-CA2OME.xslt
+++ b/components/specification/transforms/internal/OME-CA2OME.xslt
@@ -2,7 +2,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Copyright (C) 2003 Open Microscopy Environment
+# Copyright (C) 2003 - 2015 Open Microscopy Environment
 #       Massachusetts Institue of Technology,
 #       National Institutes of Health,
 #       University of Dundee

--- a/components/specification/transforms/internal/OME2OME-CA.xslt
+++ b/components/specification/transforms/internal/OME2OME-CA.xslt
@@ -2,7 +2,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Copyright (C) 2003 Open Microscopy Environment
+# Copyright (C) 2003 - 2015 Open Microscopy Environment
 #       Massachusetts Institue of Technology,
 #       National Institutes of Health,
 #       University of Dundee

--- a/components/stubs/lwf-stubs/src/com/luratech/lwf/lwfDecoder.java
+++ b/components/stubs/lwf-stubs/src/com/luratech/lwf/lwfDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * Luratech LWF library stub classes.
  * %%
- * Copyright (C) 2010 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2010 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/IOTester.java
+++ b/components/test-suite/src/loci/tests/IOTester.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/ImageTester.java
+++ b/components/test-suite/src/loci/tests/ImageTester.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/SingularityTest.java
+++ b/components/test-suite/src/loci/tests/SingularityTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/ZipTester.java
+++ b/components/test-suite/src/loci/tests/ZipTester.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/package.html
+++ b/components/test-suite/src/loci/tests/package.html
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats manual and automated test suite.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/CompressDecompressTest.java
+++ b/components/test-suite/src/loci/tests/testng/CompressDecompressTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/ConversionTest.java
+++ b/components/test-suite/src/loci/tests/testng/ConversionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/DotTestListener.java
+++ b/components/test-suite/src/loci/tests/testng/DotTestListener.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/FileHandleTest.java
+++ b/components/test-suite/src/loci/tests/testng/FileHandleTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/FormatWriterTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatWriterTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/FormatWriterTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatWriterTestFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/Jpeg2000GrindTest.java
+++ b/components/test-suite/src/loci/tests/testng/Jpeg2000GrindTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/OpenBytesPerformanceTest.java
+++ b/components/test-suite/src/loci/tests/testng/OpenBytesPerformanceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/OrderingListener.java
+++ b/components/test-suite/src/loci/tests/testng/OrderingListener.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/SubResolutionTest.java
+++ b/components/test-suite/src/loci/tests/testng/SubResolutionTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/ThreadNameBasedDiscriminator.java
+++ b/components/test-suite/src/loci/tests/testng/ThreadNameBasedDiscriminator.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2014 Open Microscopy Environment:
+ * Copyright (C) 2014 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/TiffWriterTest.java
+++ b/components/test-suite/src/loci/tests/testng/TiffWriterTest.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/TimestampedLogFileAppender.java
+++ b/components/test-suite/src/loci/tests/testng/TimestampedLogFileAppender.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/test-suite/src/loci/tests/testng/package.html
+++ b/components/test-suite/src/loci/tests/testng/package.html
@@ -2,7 +2,7 @@
   #%L
   OME Bio-Formats manual and automated test suite.
   %%
-  Copyright (C) 2006 - 2014 Open Microscopy Environment:
+  Copyright (C) 2006 - 2015 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison
     - Glencoe Software, Inc.
     - University of Dundee

--- a/components/test-suite/utils/UnconfiguredFiles.java
+++ b/components/test-suite/utils/UnconfiguredFiles.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats manual and automated test suite.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/xsd-fu/templates-cpp/Enum.template
+++ b/components/xsd-fu/templates-cpp/Enum.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-cpp/Enums.template
+++ b/components/xsd-fu/templates-cpp/Enums.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-cpp/Pojo.template
+++ b/components/xsd-fu/templates-cpp/Pojo.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/AggregateMetadata.template
+++ b/components/xsd-fu/templates-java/AggregateMetadata.template
@@ -170,7 +170,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/DummyMetadata.template
+++ b/components/xsd-fu/templates-java/DummyMetadata.template
@@ -93,7 +93,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/Enum.template
+++ b/components/xsd-fu/templates-java/Enum.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/EnumHandler.template
+++ b/components/xsd-fu/templates-java/EnumHandler.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/FilterMetadata.template
+++ b/components/xsd-fu/templates-java/FilterMetadata.template
@@ -85,7 +85,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-java/MetadataRetrieve.template
@@ -38,7 +38,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/MetadataStore.template
+++ b/components/xsd-fu/templates-java/MetadataStore.template
@@ -38,7 +38,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
+++ b/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
@@ -207,7 +207,7 @@ ${customContent[obj.name][prop.name]}
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/components/xsd-fu/templates-java/Pojo.template
+++ b/components/xsd-fu/templates-java/Pojo.template
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML Java library for working with OME-XML metadata structures.
  * %%
- * Copyright (C) 2006 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/BoostChecks.cmake
+++ b/cpp/cmake/BoostChecks.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/Doxygen.cmake
+++ b/cpp/cmake/Doxygen.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/DoxygenCheck.cmake
+++ b/cpp/cmake/DoxygenCheck.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/GTest.cmake
+++ b/cpp/cmake/GTest.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/RegexChecks.cmake
+++ b/cpp/cmake/RegexChecks.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/Version.cmake
+++ b/cpp/cmake/Version.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/XercesChecks.cmake
+++ b/cpp/cmake/XercesChecks.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/XsdFu.cmake
+++ b/cpp/cmake/XsdFu.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/lib/ome/bioformats/meta/BaseMetadata.cpp
+++ b/cpp/lib/ome/bioformats/meta/BaseMetadata.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/meta/BaseMetadata.h
+++ b/cpp/lib/ome/bioformats/meta/BaseMetadata.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/compat/CMakeLists.txt
+++ b/cpp/lib/ome/compat/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/lib/ome/compat/config.h.in
+++ b/cpp/lib/ome/compat/config.h.in
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/compat/cstdint.h
+++ b/cpp/lib/ome/compat/cstdint.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/compat/memory.h
+++ b/cpp/lib/ome/compat/memory.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/compat/tuple.h
+++ b/cpp/lib/ome/compat/tuple.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-COMPAT C++ library for C++ compatibility/portability
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/CMakeLists.txt
+++ b/cpp/lib/ome/xerces/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/lib/ome/xerces/ErrorReporter.cpp
+++ b/cpp/lib/ome/xerces/ErrorReporter.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/ErrorReporter.h
+++ b/cpp/lib/ome/xerces/ErrorReporter.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/Platform.h
+++ b/cpp/lib/ome/xerces/Platform.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/String.h
+++ b/cpp/lib/ome/xerces/String.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/dom/Element.h
+++ b/cpp/lib/ome/xerces/dom/Element.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/dom/Node.h
+++ b/cpp/lib/ome/xerces/dom/Node.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xerces/dom/NodeList.h
+++ b/cpp/lib/ome/xerces/dom/NodeList.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/lib/ome/xml/model/OMEModel.cpp
+++ b/cpp/lib/ome/xml/model/OMEModel.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/OMEModel.h
+++ b/cpp/lib/ome/xml/model/OMEModel.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/OMEModelImpl.cpp
+++ b/cpp/lib/ome/xml/model/OMEModelImpl.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/OMEModelImpl.h
+++ b/cpp/lib/ome/xml/model/OMEModelImpl.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/OMEModelObject.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/enums/EnumerationException.cpp
+++ b/cpp/lib/ome/xml/model/enums/EnumerationException.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/enums/EnumerationException.h
+++ b/cpp/lib/ome/xml/model/enums/EnumerationException.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/Color.cpp
+++ b/cpp/lib/ome/xml/model/primitives/Color.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/Color.h
+++ b/cpp/lib/ome/xml/model/primitives/Color.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeFloat.cpp
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeFloat.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeFloat.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeFloat.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.cpp
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeLong.cpp
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeLong.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeLong.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeLong.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/NumericConstraints.h
+++ b/cpp/lib/ome/xml/model/primitives/NumericConstraints.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PercentFraction.cpp
+++ b/cpp/lib/ome/xml/model/primitives/PercentFraction.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PercentFraction.h
+++ b/cpp/lib/ome/xml/model/primitives/PercentFraction.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PositiveFloat.cpp
+++ b/cpp/lib/ome/xml/model/primitives/PositiveFloat.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PositiveFloat.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveFloat.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PositiveInteger.cpp
+++ b/cpp/lib/ome/xml/model/primitives/PositiveInteger.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PositiveInteger.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveInteger.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PositiveLong.cpp
+++ b/cpp/lib/ome/xml/model/primitives/PositiveLong.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/PositiveLong.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveLong.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/Timestamp.cpp
+++ b/cpp/lib/ome/xml/model/primitives/Timestamp.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/xml/model/primitives/Timestamp.h
+++ b/cpp/lib/ome/xml/model/primitives/Timestamp.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/test/main.cpp
+++ b/cpp/test/main.cpp
@@ -2,7 +2,7 @@
  * #%L
  * # Bio-Formats C++ libraries (test infrastructure)
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-bioformats/CMakeLists.txt
+++ b/cpp/test/ome-bioformats/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/test/ome-compat/CMakeLists.txt
+++ b/cpp/test/ome-compat/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/test/ome-xerces/CMakeLists.txt
+++ b/cpp/test/ome-xerces/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/test/ome-xerces/xerces.cpp
+++ b/cpp/test/ome-xerces/xerces.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XERCES C++ library for working with Xerces C++.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/CMakeLists.txt
+++ b/cpp/test/ome-xml/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/test/ome-xml/color.cpp
+++ b/cpp/test/ome-xml/color.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/constrained-numeric.h
+++ b/cpp/test/ome-xml/constrained-numeric.h
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/non-negative-float.cpp
+++ b/cpp/test/ome-xml/non-negative-float.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/non-negative-integer.cpp
+++ b/cpp/test/ome-xml/non-negative-integer.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/non-negative-long.cpp
+++ b/cpp/test/ome-xml/non-negative-long.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/percent-fraction.cpp
+++ b/cpp/test/ome-xml/percent-fraction.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/positive-float.cpp
+++ b/cpp/test/ome-xml/positive-float.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/positive-integer.cpp
+++ b/cpp/test/ome-xml/positive-integer.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/positive-long.cpp
+++ b/cpp/test/ome-xml/positive-long.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/test/ome-xml/timestamp.cpp
+++ b/cpp/test/ome-xml/timestamp.cpp
@@ -2,7 +2,7 @@
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
  * %%
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/docs/sphinx/developers/FileConvert.java
+++ b/docs/sphinx/developers/FileConvert.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/docs/sphinx/developers/FileExport.java
+++ b/docs/sphinx/developers/FileExport.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee


### PR DESCRIPTION
Repository: openmicroscopy/bioformats
Already up-to-date.



Generated by build [BIOFORMATS-5.0-latest-copyright#5](http://ci.openmicroscopy.org/job/BIOFORMATS-5.0-latest-copyright/5/).

----
--no-rebase