### PR TITLE
Ant: add 'failonerror' everywhere the 'java' task is used

### DIFF
--- a/components/autogen/build.xml
+++ b/components/autogen/build.xml
@@ -15,7 +15,7 @@ Type "ant -p" for a list of targets.
   <target name="gen-format-pages" depends="compile"
     description="generate Sphinx pages for each supported format">
     <java classname="FormatPageAutogen"
-      classpath="${classes.dir}:${component.runtime-cp}" fork="true">
+      classpath="${classes.dir}:${component.runtime-cp}" fork="true" failonerror="true">
       <arg value="${filelist}"/>
     </java>
   </target>
@@ -23,7 +23,7 @@ Type "ant -p" for a list of targets.
   <target name="gen-original-meta-support" depends="compile"
     description="generate docs for Bio-Formats original metadata support">
     <java classname="OriginalMetadataAutogen"
-      classpath="${classes.dir}:${component.runtime-cp}" fork="true">
+      classpath="${classes.dir}:${component.runtime-cp}" fork="true" failonerror="true">
       <arg value="${filelist}"/>
     </java>
   </target>
@@ -39,7 +39,7 @@ Type "ant -p" for a list of targets.
       <then>
         <java classname="${component.main-class}"
           classpath="${classes.dir}:${component.runtime-cp}"
-          fork="true" dir="${component.meta-support-dir}">
+          fork="true" dir="${component.meta-support-dir}" failonerror="true">
             <arg value="${omexml.version}"/>
         </java>
       </then>

--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -100,7 +100,7 @@ Type "ant -p" for a list of targets.
   <target name="gen-structure-table" depends="compile"
     description="generate the dataset structure table">
     <java classname="loci.formats.tools.MakeDatasetStructureTable"
-      args="../../docs/sphinx/formats/dataset-table.txt"/>
+      args="../../docs/sphinx/formats/dataset-table.txt" failonerror="true" />
   </target>
 
 </project>


### PR DESCRIPTION
In particular, this prevents documentation generation builds from
passing when the autogeneration did not succeed.

See gh-1513 and https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-docs-autogen/151/consoleText.  To test, verify that BIOFORMATS-5.1-merge-docs-autogen fails with this PR merged and before gh-1513 is fixed.

/cc @sbesson