### PR TITLE
Fix link to Leica LAS AF Lite software (rebased onto dev_5_0)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1172,7 +1172,7 @@ developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
 bsd = no
 export = no
 versions = 1.0, 2.0
-software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-af-4-advanced-fluorescence/>`_ (links at bottom of page)
+software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
 weHave = * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
 * a LIF specification document (version 1, from no later than 206 April 3, in PDF) \n
 * numerous LIF datasets

--- a/docs/sphinx/formats/leica-lif.txt
+++ b/docs/sphinx/formats/leica-lif.txt
@@ -23,7 +23,7 @@ Supported Metadata Fields: :doc:`Leica LAS AF LIF (Leica Image File Format) <lei
 
 Freely Available Software:
 
-- `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-af-4-advanced-fluorescence/>`_ (links at bottom of page)
+- `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
 
 
 We currently have:


### PR DESCRIPTION

This is the same as gh-1518 but rebased onto dev_5_0.

----

This should fix the broken link on the Leica LIF format page.

                