### PR TITLE
Parse SignificantBits from OME-XML/OME-TIFF files (rebased onto dev_5_0)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -872,6 +872,9 @@ public class OMETiffReader extends FormatReader {
         }
         m.falseColor = true;
         m.metadataComplete = true;
+        if (meta.getPixelsSignificantBits(i) != null) {
+          m.bitsPerPixel = meta.getPixelsSignificantBits(i).getValue();
+        }
       }
       catch (NullPointerException exc) {
         throw new FormatException("Incomplete Pixels metadata", exc);

--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -304,6 +304,9 @@ public class OMEXMLReader extends FormatReader {
       ms.falseColor = true;
       ms.pixelType = FormatTools.pixelTypeFromString(pixType);
       ms.orderCertain = true;
+      if (omexmlMeta.getPixelsSignificantBits(i) != null) {
+        ms.bitsPerPixel = omexmlMeta.getPixelsSignificantBits(i).getValue();
+      }
     }
     setSeries(oldSeries);
 


### PR DESCRIPTION


This is the same as gh-1514 but rebased onto dev_5_0.

----

The value of SignificantBits/```Bits per pixel``` shown by ```showinf``` should now match the value in the original file's OME-XML.

/cc @sbesson 

                    