### PR TITLE
Exporter

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -38,6 +38,7 @@ import ij.io.FileInfo;
 import ij.io.OpenDialog;
 import ij.measure.Calibration;
 import ij.plugin.frame.Recorder;
+import ij.plugin.frame.RoiManager;
 import ij.process.ByteProcessor;
 import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
@@ -552,7 +553,7 @@ public class Exporter {
                 w.setCompression(compression);
             }
             //Save ROI's
-            if (saveRoi.booleanValue()==true){
+            if (saveRoi.booleanValue()) {
                 ROIHandler.saveROIs(store);
             }
             w.setMetadataRetrieve(store);

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -118,6 +118,7 @@ public class Exporter {
         Boolean splitC = null;
         Boolean splitT = null;
         Boolean saveRoi = null;
+        String compression = null;
 
         if (plugin.arg != null) {
             outfile = Macro.getValue(plugin.arg, "outfile", null);
@@ -126,6 +127,7 @@ public class Exporter {
             String c = Macro.getValue(plugin.arg, "splitC", null);
             String t = Macro.getValue(plugin.arg, "splitT", null);
             String sr = Macro.getValue(plugin.arg, "saveRoi", null);
+            compression = Macro.getValue(plugin.arg, "compression", null);
 
             splitZ = z == null ? null : Boolean.valueOf(z);
             splitC = c == null ? null : Boolean.valueOf(c);
@@ -519,18 +521,29 @@ public class Exporter {
             }
 
             if (codecs != null && codecs.length > 1) {
-                GenericDialog gd =
-                        new GenericDialog("Bio-Formats Exporter Options");
+                boolean selected = false;
+                if (compression != null) {
+                    for (int i = 0; i < codecs.length; i++) {
+                        if (codecs[i].equals(compression)) {
+                            selected = true;
+                            break;
+                        }
+                    }
+                }
+                if (!selected) {
+                    GenericDialog gd =
+                            new GenericDialog("Bio-Formats Exporter Options");
 
 
-                gd.addChoice("Compression type: ", codecs, codecs[0]);
-                gd.addCheckbox("Export ROI's", false);
-                gd.showDialog();
-                saveRoi = gd.getNextBoolean();
+                    gd.addChoice("Compression type: ", codecs, codecs[0]);
+                    gd.addCheckbox("Export ROI's", false);
+                    gd.showDialog();
+                    saveRoi = gd.getNextBoolean();
 
-                if (gd.wasCanceled()) return;
+                    if (gd.wasCanceled()) return;
 
-                w.setCompression(gd.getNextChoice());
+                    w.setCompression(gd.getNextChoice());
+                } else w.setCompression(compression);
             }
 
             //Save ROI's

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -534,9 +534,12 @@ public class Exporter {
                     GenericDialog gd =
                             new GenericDialog("Bio-Formats Exporter Options");
 
-
                     gd.addChoice("Compression type: ", codecs, codecs[0]);
-                    gd.addCheckbox("Export ROI's", false);
+                    if (saveRoi != null) {
+                        gd.addCheckbox("Export ROI's", saveRoi.booleanValue());
+                    } else {
+                        gd.addCheckbox("Export ROI's", false);
+                    }
                     gd.showDialog();
                     saveRoi = gd.getNextBoolean();
 

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -544,11 +544,13 @@ public class Exporter {
                     saveRoi = gd.getNextBoolean();
 
                     if (gd.wasCanceled()) return;
-
-                    w.setCompression(gd.getNextChoice());
-                } else w.setCompression(compression);
+                    compression = gd.getNextChoice();
+                }
             }
 
+            if (compression != null) {
+                w.setCompression(compression);
+            }
             //Save ROI's
             if (saveRoi.booleanValue()==true){
                 ROIHandler.saveROIs(store);

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -537,9 +537,9 @@ public class Exporter {
 
                     gd.addChoice("Compression type: ", codecs, codecs[0]);
                     if (saveRoi != null) {
-                        gd.addCheckbox("Export ROI's", saveRoi.booleanValue());
+                        gd.addCheckbox("Export ROIs", saveRoi.booleanValue());
                     } else {
-                        gd.addCheckbox("Export ROI's", false);
+                        gd.addCheckbox("Export ROIs", false);
                     }
                     gd.showDialog();
                     saveRoi = gd.getNextBoolean();

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -166,6 +166,7 @@ public class ROIHandler {
     public static Roi[] readFromRoiManager(){
 
         RoiManager manager = RoiManager.getInstance();
+        if (manager == null) return null;
         Roi[] rois = manager.getRoisAsArray();
         return rois;
     }
@@ -174,6 +175,7 @@ public class ROIHandler {
     public static void saveROIs(MetadataStore store) {
         Roi[] rois = readFromRoiManager();
 
+        if (rois == null || rois.length == 0) return;
         List<String> discardList = new ArrayList<String>();
         String roiID = null;int cntr = 0;
         for (int i=0; i<rois.length; i++) {


### PR DESCRIPTION
In this PR
 * Add new compression parameter so the exporter can be used w/o dialog popping up.
 * Fix possible NPE when exporting w/o ROI
to test the NPE expection
* Open an image in ImageJ
* Do not draw ROI
* Export the image as OME-TIFF using B-F exporter.
* Select export ROI

For the compression parameter (note that saveroi is also specified), this is tested by going over test 2 of https://github.com/openmicroscopy/openmicroscopy/pull/3329