### PR TITLE
Fix FilePattern grouping Windows (rebased onto dev_5_0)

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -506,6 +506,8 @@ public class FilePattern {
     if (dot < 0) baseSuffix = "";
     else baseSuffix = baseSuffix.substring(dot + 1);
 
+    String absoluteBase = new Location(base).getAbsolutePath();
+
     ArrayList<String> patterns = new ArrayList<String>();
     int[] exclude = new int[] {AxisGuesser.S_AXIS};
     for (String name : nameList) {
@@ -521,9 +523,16 @@ public class FilePattern {
       String checkPattern = findPattern(name, dir, nameList);
       String[] checkFiles = new FilePattern(checkPattern).getFiles();
 
+      // ensure that escaping is consistent with the base file
+      // this is needed to make sure that file grouping works correctly
+      // on Windows
+      for (int q=0; q<checkFiles.length; q++) {
+        checkFiles[q] = new Location(checkFiles[q]).getAbsolutePath();
+      }
+
       if (!patterns.contains(pattern) && (!new Location(pattern).exists() ||
-        base.equals(pattern)) && patternSuffix.equals(baseSuffix) &&
-        DataTools.indexOf(checkFiles, base) >= 0)
+        absoluteBase.equals(pattern)) && patternSuffix.equals(baseSuffix) &&
+        DataTools.indexOf(checkFiles, absoluteBase) >= 0)
       {
         patterns.add(pattern);
       }


### PR DESCRIPTION


This is the same as gh-1509 but rebased onto dev_5_0.

----

This makes sure that file patterns are detected consistently, regardless
of how the file separator is escaped.

To test, run ```ant "-Dtestng.directory=\path\to\test_images_good\eps" test-automated``` on Windows without this PR, and verify that the ```SizeZ``` test fails.  With this PR, the same test should pass.

All builds are expected to remain green.  See also https://trello.com/c/0Rdx4AMl/113-nfs-on-windows

                    