### PR TITLE
OBF: add secondary OME copyright

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -3,7 +3,12 @@
  * BSD implementations of Bio-Formats readers and writers
  * %%
  * Copyright (C) Max Planck Institute for Biophysical Chemistry, 
- * Goettingen, 2014
+ * Goettingen, 2014 - 2015
+ *
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Also updates both copyright blocks to the current year.  See gh-1500.