### PR TITLE
ICS: re-open the correct file when reading from a memo file

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -1407,7 +1407,7 @@ public class ICSReader extends FormatReader {
         m.moduloC.typeDescription = "TCSPC";
         m.moduloC.start = 0;
         m.moduloC.step = 1;
-        m.moduloC.end = clen0;
+        m.moduloC.end = clen0 - 1;
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -739,6 +739,21 @@ public class ICSReader extends FormatReader {
     }
   }
 
+  /* @see loci.formats.IFormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    if (in != null) {
+      in.close();
+    }
+    if (versionTwo) {
+      in = new RandomAccessInputStream(currentIcsId);
+    }
+    else {
+      in = new RandomAccessInputStream(currentIdsId);
+    }
+    in.order(isLittleEndian());
+  }
+
   // -- Internal FormatReader API methods --
 
   /* @see loci.formats.FormatReader#initFile(String) */


### PR DESCRIPTION
If reopenFile() is not overridden, then the .ics file will always be
opened, even if it does not contain the pixel data.

Fixes http://trac.openmicroscopy.org/ome/ticket/12700.  To test, verify that importing ```test_images_good/ics/qdna1.ics``` into OMERO and viewing with Insight shows the same image as opening ```test_images_good/ics/qdna1.ics``` in ImageJ.