### PR TITLE
Another round of Nikon ND2 metadata issues

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
@@ -130,7 +130,7 @@ public class Colorizer {
           // but had at least one lookup table defined. We use the color
           // display mode, with missing LUTs as grayscale.
           mode = CompositeImage.COLOR;
-          luts = makeLUTs(channelLUTs, false); // preserve original LUTs
+          luts = makeLUTs(channelLUTs, true); // preserve original LUTs
         }
         else {
           // NB: The original data had only one channel per plane,

--- a/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
@@ -314,6 +314,12 @@ public class Colorizer {
   }
 
   private LUT[] makeLUTs(ColorModel[] cm, boolean colorize) {
+    // lookup tables can come from one of three places (in order of precedence):
+    //   1) Color attribute defined in the MetadataStore
+    //   2) lookup table returned by the reader's get8BitLookupTable or
+    //      get16BitLookupTable methods
+    //   3) EmissionWavelength attribute defined in the MetadataStore
+
     final ImporterOptions options = process.getOptions();
     final LUT[] luts = new LUT[cm.length];
     for (int c=0; c<luts.length; c++) {
@@ -321,50 +327,50 @@ public class Colorizer {
       else if (cm[c] instanceof IndexColorModel) {
         luts[c] = new LUT((IndexColorModel) cm[c], 0, 255);
       }
-      else {
-        Color color = null;
-        if (colorize) {
-          // rather than always assuming that the first channel is red, the
-          // second green, etc. we will take into account the channel color
-          // metadata and the acquisition wavelength
-          ImageReader reader = process.getImageReader();
-          MetadataStore store = reader.getMetadataStore();
-          if (store instanceof MetadataRetrieve) {
-            MetadataRetrieve retrieve = (MetadataRetrieve) store;
 
-            if (c < retrieve.getChannelCount(reader.getSeries())) {
-              ome.xml.model.primitives.Color metaColor =
-                retrieve.getChannelColor(reader.getSeries(), c);
-              if (metaColor != null) {
-                int r = metaColor.getRed();
-                int g = metaColor.getGreen();
-                int b = metaColor.getBlue();
-                int a = metaColor.getAlpha();
-                color = new Color(r, g, b, a);
-              }
-              else {
-                Length wavelength =
-                  retrieve.getChannelEmissionWavelength(reader.getSeries(), c);
-                if (wavelength != null) {
-                  double wave = wavelength.value(UNITS.NM).doubleValue();
-                  if (wave >= BLUE_MIN && wave < BLUE_TO_GREEN_MIN) {
-                    color = Color.BLUE;
-                  }
-                  else if (wave >= BLUE_TO_GREEN_MIN && wave < GREEN_TO_RED_MIN) {
-                    color = Color.GREEN;
-                  }
-                  else if (wave >= GREEN_TO_RED_MIN && wave <= RED_MAX) {
-                    color = Color.RED;
-                  }
+      Color color = null;
+      if (colorize) {
+        // rather than always assuming that the first channel is red, the
+        // second green, etc. we will take into account the channel color
+        // metadata and the acquisition wavelength
+        ImageReader reader = process.getImageReader();
+        MetadataStore store = reader.getMetadataStore();
+        if (store instanceof MetadataRetrieve) {
+          MetadataRetrieve retrieve = (MetadataRetrieve) store;
+
+          if (c < retrieve.getChannelCount(reader.getSeries())) {
+            ome.xml.model.primitives.Color metaColor =
+              retrieve.getChannelColor(reader.getSeries(), c);
+            if (metaColor != null) {
+              int r = metaColor.getRed();
+              int g = metaColor.getGreen();
+              int b = metaColor.getBlue();
+              int a = metaColor.getAlpha();
+              color = new Color(r, g, b, a);
+            }
+            else if (luts[c] == null) {
+              Length wavelength =
+                retrieve.getChannelEmissionWavelength(reader.getSeries(), c);
+              if (wavelength != null) {
+                double wave = wavelength.value(UNITS.NM).doubleValue();
+                if (wave >= BLUE_MIN && wave < BLUE_TO_GREEN_MIN) {
+                  color = Color.BLUE;
+                }
+                else if (wave >= BLUE_TO_GREEN_MIN && wave < GREEN_TO_RED_MIN) {
+                  color = Color.GREEN;
+                }
+                else if (wave >= GREEN_TO_RED_MIN && wave <= RED_MAX) {
+                  color = Color.RED;
                 }
               }
             }
           }
         }
-        if (color == null) {
-          color = options.getDefaultCustomColor(c);
-        }
-
+      }
+      if (color == null && luts[c] == null) {
+        color = options.getDefaultCustomColor(c);
+      }
+      if (color != null) {
         luts[c] = makeLUT(color);
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -156,20 +156,15 @@ public class NativeND2Reader extends FormatReader {
 
     byte[][] lut = new byte[3][256];
 
-    int index = -1;
-    if (color > 0 && color < 256) index = 0;
-    else if (color >= 256 && color < 65280) index = 1;
-    else if (color > 65280 && color <= 16711680) index = 2;
+    int redMax = color & 0xff;
+    int greenMax = (color & 0xff00) >> 8;
+    int blueMax = (color & 0xff0000) >> 16;
 
     for (int i=0; i<256; i++) {
-      if (index == -1) {
-        lut[0][i] = (byte) i;
-        lut[1][i] = (byte) i;
-        lut[2][i] = (byte) i;
-      }
-      else {
-        lut[index][i] = (byte) i;
-      }
+      double scale = i / 255.0;
+      lut[0][i] = (byte) (redMax * scale);
+      lut[1][i] = (byte) (greenMax * scale);
+      lut[2][i] = (byte) (blueMax * scale);
     }
 
     return lut;
@@ -189,20 +184,16 @@ public class NativeND2Reader extends FormatReader {
 
     short[][] lut = new short[3][65536];
 
-    int index = -1;
-    if (color > 0 && color < 256) index = 0;
-    else if (color >= 256 && color <= 65280) index = 1;
-    else if (color > 65280 && color <= 16711680) index = 2;
+    int redMax = color & 0xff;
+    int greenMax = (color & 0xff00) >> 8;
+    int blueMax = (color & 0xff0000) >> 16;
 
     for (int i=0; i<65536; i++) {
-      if (index == -1) {
-        lut[0][i] = (short) i;
-        lut[1][i] = (short) i;
-        lut[2][i] = (short) i;
-      }
-      else {
-        lut[index][i] = (short) i;
-      }
+      // *Max values are from 0-255; we want LUT values from 0-65535
+      double scale = i / 255.0;
+      lut[0][i] = (short) (redMax * scale);
+      lut[1][i] = (short) (greenMax * scale);
+      lut[2][i] = (short) (blueMax * scale);
     }
 
     return lut;

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -113,7 +113,7 @@ public class NativeND2Reader extends FormatReader {
 
   private double trueSizeX = 0;
   private double trueSizeY = 0;
-  private double trueSizeZ = 0;
+  private Double trueSizeZ = null;
 
   private ArrayList<String> textChannelNames = new ArrayList<String>();
   private ArrayList<Double> textEmissionWavelengths = new ArrayList<Double>();
@@ -328,7 +328,7 @@ public class NativeND2Reader extends FormatReader {
       backupHandler = null;
       trueSizeX = 0;
       trueSizeY = 0;
-      trueSizeZ = 0;
+      trueSizeZ = null;
       textChannelNames.clear();
       textEmissionWavelengths.clear();
       useZ = null;
@@ -1698,6 +1698,9 @@ public class NativeND2Reader extends FormatReader {
           Double wave = Double.parseDouble(value.toString());
           textEmissionWavelengths.add(wave);
         }
+        else if (name.equals("dZStep")) {
+          trueSizeZ = new Double(value.toString());
+        }
 
         if (type != 11 && type != 10) {    // if not level add global meta
           addGlobalMeta(name, value);
@@ -1807,7 +1810,7 @@ public class NativeND2Reader extends FormatReader {
             store.setPixelsPhysicalSizeY(size, i);
           }
         }
-        if (trueSizeZ > 0) {
+        if (trueSizeZ != null && trueSizeZ > 0) {
           store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(trueSizeZ), i);
         }
         else {
@@ -2161,11 +2164,13 @@ public class NativeND2Reader extends FormatReader {
             value = key.substring(8, end);
             key = key.substring(0, 8);
           }
-          try {
-            trueSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
-          }
-          catch (NumberFormatException nfe) {
-            LOGGER.trace("Could not parse step", nfe);
+          if (trueSizeZ == null) {
+            try {
+              trueSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
+            }
+            catch (NumberFormatException nfe) {
+              LOGGER.trace("Could not parse step", nfe);
+            }
           }
         }
         else if (key.equals("Name")) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -519,8 +519,8 @@ public class NativeND2Reader extends FormatReader {
         else if (blockType.startsWith("Image") ||
           blockType.startsWith("CustomDataVa"))
         {
-          foundMetadata = true;
           if (blockType.equals("ImageAttribu")) {
+            foundMetadata = true;
             in.skipBytes(6);
             long endFP = in.getFilePointer() + len - 18;
             while (in.read() == 0);
@@ -691,6 +691,7 @@ public class NativeND2Reader extends FormatReader {
               }
               xml.write(b, off, b.length - off);
             }
+
           }
           skip = 0;
         }
@@ -927,8 +928,10 @@ public class NativeND2Reader extends FormatReader {
         if (getSizeC() == 0) {
           core.get(0).sizeC = 1;
         }
+        planeSize = getSizeX() * getSizeY() * getSizeC() *
+          FormatTools.getBytesPerPixel(getPixelType());
       }
-      else if (planeSize > 0 &&
+      if (planeSize > 0 &&
         availableBytes > DataTools.safeMultiply64(planeSize, 3))
       {
         if (availableBytes < DataTools.safeMultiply64(planeSize, 6)) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -487,6 +487,7 @@ public class NativeND2Reader extends FormatReader {
             imageLengths.clear();
             customDataOffsets.clear();
             customDataLengths.clear();
+            textChannelNames.clear();
             foundMetadata = false;
             extraZDataCount = 0;
             useLastText = true;
@@ -723,9 +724,16 @@ public class NativeND2Reader extends FormatReader {
 
       // parse text blocks
 
+      int nChannelNames = textChannelNames.size();
       for (int i=0; i<textStrings.size(); i++) {
         parseText(textStrings.get(i), imageOffsets.size(),
           validDimensions.get(i));
+      }
+      if (textChannelNames.size() > nChannelNames) {
+        int diff = textChannelNames.size() - nChannelNames;
+        while (textChannelNames.size() > diff) {
+          textChannelNames.remove(0);
+        }
       }
 
       // parse XML blocks
@@ -1741,14 +1749,11 @@ public class NativeND2Reader extends FormatReader {
       else if (channelNames.size() < getEffectiveSizeC()) {
         channelNames = textChannelNames;
       }
-      for (int i=0; i<getSeriesCount(); i++) {
-        for (int c=0; c<getEffectiveSizeC(); c++) {
-          int index = i * getSizeC() + c;
-          if (index < channelNames.size()) {
-            String channelName = channelNames.get(index);
-            Integer channelColor = channelColors.get(channelName);
-            colors[c] = channelColor == null ? 0 : channelColor.intValue();
-          }
+      for (int c=0; c<getEffectiveSizeC(); c++) {
+        if (c < channelNames.size()) {
+          String channelName = channelNames.get(c);
+          Integer channelColor = channelColors.get(channelName);
+          colors[c] = channelColor == null ? 0 : channelColor.intValue();
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -487,7 +487,6 @@ public class NativeND2Reader extends FormatReader {
             imageLengths.clear();
             customDataOffsets.clear();
             customDataLengths.clear();
-            textChannelNames.clear();
             foundMetadata = false;
             extraZDataCount = 0;
             useLastText = true;

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -823,7 +823,7 @@ public class NativeND2Reader extends FormatReader {
         core.add(ms0);
       }
 
-      if ((getSizeZ() == imageOffsets.size() || (extraZDataCount > 1 && getSizeZ() == 1 && imageOffsets.size() % extraZDataCount == 0) || (handler.getXPositions().size() == 0 && (xOffset == 0 && getSizeZ() != getSeriesCount()))) && getSeriesCount() > 1) {
+      if ((getSizeZ() == imageOffsets.size() || (extraZDataCount > 1 && getSizeZ() == 1 && (extraZDataCount == getSizeC())) || (handler.getXPositions().size() == 0 && (xOffset == 0 && getSizeZ() != getSeriesCount()))) && getSeriesCount() > 1) {
         CoreMetadata ms0 = core.get(0);
         if (getSeriesCount() > ms0.sizeZ) {
           ms0.sizeZ = getSeriesCount();
@@ -932,7 +932,7 @@ public class NativeND2Reader extends FormatReader {
           FormatTools.getBytesPerPixel(getPixelType());
       }
 
-      if (availableBytes % planeSize != 0) {
+      if (planeSize > 0 && availableBytes % planeSize != 0) {
         // an extra 4K block of zeros may have been appended
         if ((availableBytes - 4096) % planeSize == 0) {
           availableBytes -= 4096;


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/12548 and http://trac.openmicroscopy.org/ome/ticket/12656.

To test, verify that ```showinf``` or ImageJ show the same dimensions as NIS Elements Viewer for the following files:

* QA 9507
* QA 10100
* QA 10370
* QA 10366

The QA 10366 file should also be checked to verify that PhysicalSizeZ and the channel colors are set correctly (as described in the QA issue).  Builds are expected to remain green.