### PR TITLE
Fix version detection when building outside of Git

### DIFF
--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -90,6 +90,10 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <project.rootdir>${basedir}/../..</project.rootdir>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -37,7 +37,7 @@
   </dependencies>
 
   <properties>
-    <project.rootdir>${basedir}/../..</project.rootdir>
+    <project.rootdir>${basedir}/../../..</project.rootdir>
   </properties>
 
   <build>

--- a/components/bundles/loci-tools/pom.xml
+++ b/components/bundles/loci-tools/pom.xml
@@ -52,7 +52,7 @@
   </dependencies>
 
   <properties>
-    <project.rootdir>${basedir}/../..</project.rootdir>
+    <project.rootdir>${basedir}/../../..</project.rootdir>
   </properties>
 
   <build>

--- a/components/bundles/ome-tools/pom.xml
+++ b/components/bundles/ome-tools/pom.xml
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <project.rootdir>${basedir}/../..</project.rootdir>
+    <project.rootdir>${basedir}/../../..</project.rootdir>
   </properties>
 
   <build>

--- a/components/forks/turbojpeg/pom.xml
+++ b/components/forks/turbojpeg/pom.xml
@@ -32,7 +32,7 @@
   </licenses>
 
   <properties>
-    <project.rootdir>${basedir}/../..</project.rootdir>
+    <project.rootdir>${basedir}/../../..</project.rootdir>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,9 @@
                   // there should be a ant/gitversion.xml file with the
                   // version information used when the package was created
 
-                  def xml = new XmlParser().parse("./ant/gitversion.xml")
+                  def xmlfile = project.properties.get('project.rootdir') + "/ant/gitversion.xml"
+
+                  def xml = new XmlParser().parse(xmlfile)
                   for (property in xml.property) {
                     println "parsing " + property.'@name'
                     if ('release.version' == property.'@name') {


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/11869.  To test, download and unzip the source Zip from BIOFORMATS-5.1-merge-build (after this PR is included) and verify that running ```./tools/test-build cppwrap``` in the source directory is successful (i.e. no ```Build failed``` message).

As this should make cppwrap work outside of Git, documenting the need to build within a Git tree should no longer be necessary.