### PR TITLE
Prevent NumberFormatException in ZeissCZIReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2159,38 +2159,39 @@ public class ZeissCZIReader extends FormatReader {
       for (int i=0; i<groups.getLength(); i++) {
         Element group = (Element) groups.item(i);
 
-        int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
-        int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
-
         Element position = getFirstNode(group, "Position");
+        if (position != null) {
+            int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
+            int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
 
-        String x = position.getAttribute("X");
-        String y = position.getAttribute("Y");
-        String z = position.getAttribute("Z");
+            String x = position.getAttribute("X");
+            String y = position.getAttribute("Y");
+            String z = position.getAttribute("Z");
 
-        Length xPos = null;
-        try {
-          xPos = new Length(Double.valueOf(x), UNITS.REFERENCEFRAME);
-        }
-        catch (NumberFormatException e) { }
-        Length yPos = null;
-        try {
-          yPos = new Length(Double.valueOf(y), UNITS.REFERENCEFRAME);
-        }
-        catch (NumberFormatException e) { }
-        Length zPos = null;
-        try {
-          zPos = new Length(Double.valueOf(z), UNITS.REFERENCEFRAME);
-        }
-        catch (NumberFormatException e) { }
+            Length xPos = null;
+            try {
+              xPos = new Length(Double.valueOf(x), UNITS.REFERENCEFRAME);
+            }
+            catch (NumberFormatException e) { }
+            Length yPos = null;
+            try {
+              yPos = new Length(Double.valueOf(y), UNITS.REFERENCEFRAME);
+            }
+            catch (NumberFormatException e) { }
+            Length zPos = null;
+            try {
+              zPos = new Length(Double.valueOf(z), UNITS.REFERENCEFRAME);
+            }
+            catch (NumberFormatException e) { }
 
-        for (int tile=0; tile<tilesX * tilesY; tile++) {
-          int index = i * tilesX * tilesY + tile;
-          if (index < positionsX.length) {
-            positionsX[index] = xPos;
-            positionsY[index] = yPos;
-            positionsZ[index] = zPos;
-          }
+            for (int tile=0; tile<tilesX * tilesY; tile++) {
+              int index = i * tilesX * tilesY + tile;
+              if (index < positionsX.length) {
+                positionsX[index] = xPos;
+                positionsY[index] = yPos;
+                positionsZ[index] = zPos;
+              }
+            }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2161,37 +2161,37 @@ public class ZeissCZIReader extends FormatReader {
 
         Element position = getFirstNode(group, "Position");
         if (position != null) {
-            int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
-            int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
+          int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
+          int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
 
-            String x = position.getAttribute("X");
-            String y = position.getAttribute("Y");
-            String z = position.getAttribute("Z");
+          String x = position.getAttribute("X");
+          String y = position.getAttribute("Y");
+          String z = position.getAttribute("Z");
 
-            Length xPos = null;
-            try {
-              xPos = new Length(Double.valueOf(x), UNITS.REFERENCEFRAME);
-            }
-            catch (NumberFormatException e) { }
-            Length yPos = null;
-            try {
-              yPos = new Length(Double.valueOf(y), UNITS.REFERENCEFRAME);
-            }
-            catch (NumberFormatException e) { }
-            Length zPos = null;
-            try {
-              zPos = new Length(Double.valueOf(z), UNITS.REFERENCEFRAME);
-            }
-            catch (NumberFormatException e) { }
+          Length xPos = null;
+          try {
+            xPos = new Length(Double.valueOf(x), UNITS.REFERENCEFRAME);
+          }
+          catch (NumberFormatException e) { }
+          Length yPos = null;
+          try {
+            yPos = new Length(Double.valueOf(y), UNITS.REFERENCEFRAME);
+          }
+          catch (NumberFormatException e) { }
+          Length zPos = null;
+          try {
+            zPos = new Length(Double.valueOf(z), UNITS.REFERENCEFRAME);
+          }
+          catch (NumberFormatException e) { }
 
-            for (int tile=0; tile<tilesX * tilesY; tile++) {
-              int index = i * tilesX * tilesY + tile;
-              if (index < positionsX.length) {
-                positionsX[index] = xPos;
-                positionsY[index] = yPos;
-                positionsZ[index] = zPos;
-              }
+          for (int tile=0; tile<tilesX * tilesY; tile++) {
+            int index = i * tilesX * tilesY + tile;
+            if (index < positionsX.length) {
+              positionsX[index] = xPos;
+              positionsY[index] = yPos;
+              positionsZ[index] = zPos;
             }
+          }
         }
       }
     }


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-January/004988.html

To test this PR, check the samples files uploaded with the thread open correctly without throwing a `NumberFormatException` and that the full repository job stays green.