### PR TITLE
Prevent NumberFormatException in ZeissCZIReader (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2143,37 +2143,37 @@ public class ZeissCZIReader extends FormatReader {
 
         Element position = getFirstNode(group, "Position");
         if (position != null) {
-            int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
-            int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
+          int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
+          int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
 
-            String x = position.getAttribute("X");
-            String y = position.getAttribute("Y");
-            String z = position.getAttribute("Z");
+          String x = position.getAttribute("X");
+          String y = position.getAttribute("Y");
+          String z = position.getAttribute("Z");
 
-            Double xPos = null;
-            try {
-              xPos = new Double(x);
-            }
-            catch (NumberFormatException e) { }
-            Double yPos = null;
-            try {
-              yPos = new Double(y);
-            }
-            catch (NumberFormatException e) { }
-            Double zPos = null;
-            try {
-              zPos = new Double(z);
-            }
-            catch (NumberFormatException e) { }
+          Double xPos = null;
+          try {
+            xPos = new Double(x);
+          }
+          catch (NumberFormatException e) { }
+          Double yPos = null;
+          try {
+            yPos = new Double(y);
+          }
+          catch (NumberFormatException e) { }
+          Double zPos = null;
+          try {
+            zPos = new Double(z);
+          }
+          catch (NumberFormatException e) { }
 
-            for (int tile=0; tile<tilesX * tilesY; tile++) {
-              int index = i * tilesX * tilesY + tile;
-              if (index < positionsX.length) {
-                positionsX[index] = xPos;
-                positionsY[index] = yPos;
-                positionsZ[index] = zPos;
-                }
-              }
+          for (int tile=0; tile<tilesX * tilesY; tile++) {
+            int index = i * tilesX * tilesY + tile;
+            if (index < positionsX.length) {
+              positionsX[index] = xPos;
+              positionsY[index] = yPos;
+              positionsZ[index] = zPos;
+            }
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2141,38 +2141,39 @@ public class ZeissCZIReader extends FormatReader {
       for (int i=0; i<groups.getLength(); i++) {
         Element group = (Element) groups.item(i);
 
-        int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
-        int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
-
         Element position = getFirstNode(group, "Position");
+        if (position != null) {
+            int tilesX = Integer.parseInt(getFirstNodeValue(group, "TilesX"));
+            int tilesY = Integer.parseInt(getFirstNodeValue(group, "TilesY"));
 
-        String x = position.getAttribute("X");
-        String y = position.getAttribute("Y");
-        String z = position.getAttribute("Z");
+            String x = position.getAttribute("X");
+            String y = position.getAttribute("Y");
+            String z = position.getAttribute("Z");
 
-        Double xPos = null;
-        try {
-          xPos = new Double(x);
-        }
-        catch (NumberFormatException e) { }
-        Double yPos = null;
-        try {
-          yPos = new Double(y);
-        }
-        catch (NumberFormatException e) { }
-        Double zPos = null;
-        try {
-          zPos = new Double(z);
-        }
-        catch (NumberFormatException e) { }
+            Double xPos = null;
+            try {
+              xPos = new Double(x);
+            }
+            catch (NumberFormatException e) { }
+            Double yPos = null;
+            try {
+              yPos = new Double(y);
+            }
+            catch (NumberFormatException e) { }
+            Double zPos = null;
+            try {
+              zPos = new Double(z);
+            }
+            catch (NumberFormatException e) { }
 
-        for (int tile=0; tile<tilesX * tilesY; tile++) {
-          int index = i * tilesX * tilesY + tile;
-          if (index < positionsX.length) {
-            positionsX[index] = xPos;
-            positionsY[index] = yPos;
-            positionsZ[index] = zPos;
-          }
+            for (int tile=0; tile<tilesX * tilesY; tile++) {
+              int index = i * tilesX * tilesY + tile;
+              if (index < positionsX.length) {
+                positionsX[index] = xPos;
+                positionsY[index] = yPos;
+                positionsZ[index] = zPos;
+                }
+              }
         }
       }
     }


### PR DESCRIPTION

This is the same as gh-1531 but rebased onto dev_5_0.

----

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-January/004988.html

To test this PR, check the samples files uploaded with the thread open correctly without throwing a `NumberFormatException` and that the full repository job stays green.

                