### PR TITLE
Metamorph: reset timepoint count if timelapse was not performed

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -494,6 +494,9 @@ public class MetamorphReader extends BaseTiffReader {
       if (z != null) zc = Integer.parseInt(z);
       if (c != null) cc = Integer.parseInt(c);
       if (t != null) tc = Integer.parseInt(t);
+      else if (!doTimelapse) {
+        tc = 1;
+      }
 
       if (cc == 0) cc = 1;
       if (cc == 1 && bizarreMultichannelAcquisition) {


### PR DESCRIPTION
See QA 10439.

To test, put the files from QA 10439 and QA 10442 in the same directory.  Open the .nd file (showinf, ImageJ, or OMERO) and verify that 15 planes are shown - 5 Z x 3 C.  Without this PR included, the same test should result in an exception as described in the QA issue.
