### PR TITLE
C++: Complete OME-XML serialisation to and from OME model objects

### DIFF
--- a/components/specification/samples/2013-06/2013-06-posix-datetests.ome
+++ b/components/specification/samples/2013-06/2013-06-posix-datetests.ome
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2013-06"
+	xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-06"
+	xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2013-06"
+	xmlns:Bin="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-06"
+	xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06    http://www.openmicroscopy.org/Schemas/OME/2013-06/ome.xsd">
+
+	<OME:Project ID="Project:0">
+		<OME:DatasetRef ID="Dataset:0"/>
+		<SA:AnnotationRef ID="Annotation:0"/>
+	</OME:Project>
+	<OME:Dataset ID="Dataset:0">
+		<OME:ImageRef ID="Image:0"/>
+		<SA:AnnotationRef ID="Annotation:1"/>
+	</OME:Dataset>
+	<SPW:Plate ID="Plate:0">
+		<SPW:Description>Plate 0 Description</SPW:Description>
+		<SPW:Well ID="Well:0" Column="1" Row="1" Color="-2147483648" Type="TheWell0Status">
+			<SPW:WellSample ID="WellSample:0" Index="1">
+				<OME:ImageRef ID="Image:0"/>
+			</SPW:WellSample>
+		</SPW:Well>
+		<SA:AnnotationRef ID="Annotation:0"/>
+		<SPW:PlateAcquisition ID="PlateAcquisition:0">
+			<SPW:Description>Plate Acquisition 0 Description</SPW:Description>
+			<SA:AnnotationRef ID="Annotation:1"/>
+		</SPW:PlateAcquisition>
+	</SPW:Plate>
+	<SPW:Plate ID="Plate:1"/>
+	<SPW:Screen ID="Screen:0" Name="ScreenName0" ProtocolDescription="Protocol Description Test0"
+		ProtocolIdentifier="ProtocolTest0ID" ReagentSetDescription="Reagents Set XYZ"
+		ReagentSetIdentifier="ReagentsXYZ-ID" Type="ScreenType0">
+		<SPW:Description>Screen 0 Description</SPW:Description>
+		<SPW:Reagent ID="Reagent:0"/>
+		<SPW:PlateRef ID="Plate:0"/>
+		<SA:AnnotationRef ID="Annotation:1"/>
+	</SPW:Screen>
+
+	<SPW:Screen ID="Screen:1" Name="ScreenName1" ProtocolDescription="Protocol Description Test1"
+		ProtocolIdentifier="ProtocolTest1ID" ReagentSetDescription="Reagents Set PQR"
+		ReagentSetIdentifier="ReagentsPQR-ID" Type="ScreenType1">
+		<SPW:Description>Screen 1 Description</SPW:Description>
+		<SPW:Reagent ID="Reagent:1"/>
+		<SPW:PlateRef ID="Plate:1"/>
+		<SPW:PlateRef ID="Plate:0"/>
+		<SA:AnnotationRef ID="Annotation:1"/>
+	</SPW:Screen>
+
+	<SPW:Screen ID="Screen:2" Name="ScreenName2" ProtocolDescription="Protocol Description Test2"
+		ProtocolIdentifier="ProtocolTest2ID" ReagentSetDescription="Reagents Set IJK"
+		ReagentSetIdentifier="ReagentsIJK-ID" Type="ScreenType2">
+		<SPW:Description>Screen 2 Description</SPW:Description>
+		<SPW:Reagent ID="Reagent:2"/>
+		<SA:AnnotationRef ID="Annotation:1"/>
+	</SPW:Screen>
+
+	<SPW:Screen ID="Screen:3" Name="ScreenName3" ProtocolDescription="Protocol Description Test3"
+		ProtocolIdentifier="ProtocolTest3ID" ReagentSetDescription="Reagents Set AJP"
+		ReagentSetIdentifier="ReagentsAJP-ID" Type="ScreenType3">
+		<SPW:Description>Screen 3 Description</SPW:Description>
+		<SPW:Reagent ID="Reagent:3"/>
+		<SPW:PlateRef ID="Plate:0"/>
+		<SA:AnnotationRef ID="Annotation:1"/>
+	</SPW:Screen>
+
+	<OME:Experimenter ID="Experimenter:0"/>
+	<OME:Experimenter ID="Experimenter:1" FirstName="John" MiddleName="Andrew" LastName="Smith"
+		Email="john@example.org"> </OME:Experimenter>
+	<OME:Experimenter ID="Experimenter:2"/>
+	<OME:Experimenter ID="Experimenter:3"/>
+	<OME:Experimenter ID="Experimenter:4"/>
+	<OME:Experimenter ID="Experimenter:5"/>
+	<OME:Experimenter ID="Experimenter:6"/>
+
+	<OME:ExperimenterGroup Name="MyGroup - Leader+Contact match" ID="ExperimenterGroup:Group:0">
+		<Description xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06">A description for my group 0. Complete with basic formatting, like new
+			lines.</Description>
+		<OME:ExperimenterRef ID="Experimenter:5"/>
+		<Leader xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" ID="Experimenter:0"/>
+	</OME:ExperimenterGroup>
+
+	<OME:ExperimenterGroup Name="MyOtherGroup" ID="ExperimenterGroup:Group:1">
+		<Description xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06">A description for my group 1. Complete with basic formatting, like new
+			lines.</Description>
+		<OME:ExperimenterRef ID="Experimenter:2"/>
+		<OME:ExperimenterRef ID="Experimenter:3"/>
+		<Leader xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" ID="Experimenter:0"/>
+		<OME:Leader ID="Experimenter:1"/>
+	</OME:ExperimenterGroup>
+
+	<OME:ExperimenterGroup Name="NoMatch" ID="ExperimenterGroup:Group:2">
+		<Description xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06">A description for my group 2. Complete with basic formatting, like new
+			lines.</Description>
+		<OME:ExperimenterRef ID="Experimenter:4"/>
+		<Leader xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" ID="Experimenter:6"/>
+	</OME:ExperimenterGroup>
+
+	<OME:ExperimenterGroup Name="LeaderMatch" ID="ExperimenterGroup:Group:3">
+		<Description xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06">A description for my group 3. Complete with basic formatting, like new
+			lines.</Description>
+		<Leader xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" ID="Experimenter:0"/>
+	</OME:ExperimenterGroup>
+	<OME:ExperimenterGroup Name="ContactMatch" ID="ExperimenterGroup:Group:4">
+		<Description xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06">A description for my group 4. Complete with basic formatting, like new
+			lines.</Description>
+		<OME:Leader ID="Experimenter:0"/>
+	</OME:ExperimenterGroup>
+
+	<Instrument xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" ID="Instrument:0">
+		<Objective ID="Objective:0" LotNumber="123" Manufacturer="OME-Labs"
+			NominalMagnification="20" CalibratedMagnification="20.34"/>
+	</Instrument>
+	<OME:Image ID="Image:0" Name="6x6x1x8-swatch.tif">
+		<OME:AcquisitionDate>2012-03-05T02:48:38</OME:AcquisitionDate>
+		<ExperimenterRef xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+			ID="Experimenter:1"/>
+		<Pixels xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" DimensionOrder="XYCZT"
+			ID="Pixels:0:0" PhysicalSizeX="10000.0" PhysicalSizeY="10000.0" Type="uint8" SizeC="3"
+			SizeT="1" SizeX="6" SizeY="4" SizeZ="1">
+			<Channel AcquisitionMode="LaserScanningConfocalMicroscopy" Color="-1147483648"
+				ID="Channel:0"> </Channel>
+			<Channel AcquisitionMode="LaserScanningConfocalMicroscopy" Color="-1474836488"
+				ID="Channel:1"> </Channel>
+			<Channel AcquisitionMode="MultiPhotonMicroscopy" Color="-2144364811" ID="Channel:2"> </Channel>
+			<Bin:BinData BigEndian="false" Length="32"
+				>/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF</Bin:BinData>
+			<Bin:BinData BigEndian="false" Length="32"
+				>AP+rzuv/AAB5n8Pi/wBHbJO3//8dPGCF</Bin:BinData>
+			<Bin:BinData BigEndian="false" Length="32"
+				>//+szuv/AP95n8PiAABHbZO3AP8dPF+G</Bin:BinData>
+		</Pixels>
+		<ROI:ROIRef ID="ROI:0"/>
+		<ROI:ROIRef ID="ROI:1"/>
+		<ROI:ROIRef ID="ROI:2"/>
+	</OME:Image>
+	<SA:StructuredAnnotations>
+		<SA:XMLAnnotation ID="Annotation:0">
+			<SA:Value>
+				<test1 xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06"/>
+			</SA:Value>
+		</SA:XMLAnnotation>
+		<SA:XMLAnnotation ID="Annotation:1">
+			<SA:Value>
+				<test2 xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06"/>
+			</SA:Value>
+		</SA:XMLAnnotation>
+		<!-- A range of dates, valid in the schema designed to test/stretch/break the model API; includes only valid POSIX timestamps. -->
+		<SA:TimestampAnnotation ID="Annotation:2"
+			Namespace="sample.openmicroscopy.org/time/retirement">
+			<SA:Value>2037-12-15T17:30:00</SA:Value>
+		</SA:TimestampAnnotation>
+		<SA:TimestampAnnotation ID="Annotation:3"
+			Namespace="sample.openmicroscopy.org/time/post1972">
+			<SA:Value>1996-03-23T14:45:00</SA:Value>
+		</SA:TimestampAnnotation>
+		<SA:TimestampAnnotation ID="Annotation:4"
+			Namespace="sample.openmicroscopy.org/time/1970-1972">
+			<SA:Value>1971-05-06T18:34:59</SA:Value>
+		</SA:TimestampAnnotation>
+	</SA:StructuredAnnotations>
+	<ROI:ROI ID="ROI:0">
+		<ROI:Union>
+			<ROI:Shape ID="Shape:0" TheC="0">
+				<ROI:Point X="1" Y="1"/>
+			</ROI:Shape>
+		</ROI:Union>
+	</ROI:ROI>
+	<ROI:ROI ID="ROI:1">
+		<ROI:Union>
+			<ROI:Shape ID="Shape:1" FillRule="NonZero" FontFamily="sans-serif" FontSize="1"
+				FontStyle="Bold" LineCap="Butt" StrokeDashArray="1" StrokeWidth="1" TheC="2"
+				FillColor="1" StrokeColor="1" Text="Hello">
+				<ROI:Point X="1" Y="1"/>
+			</ROI:Shape>
+		</ROI:Union>
+		<ROI:Description>ROI 1 Upgradable description.</ROI:Description>
+	</ROI:ROI>
+	<ROI:ROI ID="ROI:2">
+		<ROI:Union>
+			<ROI:Shape ID="Shape:2" FillRule="EvenOdd" Text="Hi There! (from shape 2)">
+				<ROI:Rectangle X="1" Y="2" Width="3" Height="4"/>
+				<ROI:Transform A00="10" A10="20" A01="30" A11="40" A02="50" A12="60"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:3" FillRule="EvenOdd" FontStyle="Normal" FontFamily="serif"
+				Text="Hello World Text Value!(from shape 3)">
+				<ROI:Label X="1" Y="1"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:4" StrokeWidth="2" StrokeColor="15">
+				<ROI:Polygon Points="1,1 10,20, 20,20 20,10"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:5" StrokeWidth="2" StrokeColor="16">
+				<ROI:Polyline Points="15,15 15,25, 25,25 25,15" MarkerStart="Arrow"
+					MarkerEnd="Arrow"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:6" StrokeWidth="2" StrokeColor="161">
+				<ROI:Polyline Points="1.1,1.1 10.1,20.1, 20.1,20.1 20.1,10.1" MarkerStart="Circle"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:7" StrokeWidth="2" StrokeColor="17">
+				<ROI:Line X1="1.7" Y1="2.7" X2="3.7" Y2="4.7" MarkerStart="Square"
+					MarkerEnd="Circle"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:8" StrokeWidth="2" StrokeColor="171">
+				<ROI:Line X1="1.71" Y1="2.71" X2="3.71" Y2="4.71" MarkerEnd="Circle"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:9" StrokeWidth="2" StrokeColor="172">
+				<ROI:Line X1="1.72" Y1="2.72" X2="3.72" Y2="4.72" MarkerEnd="Circle"/>
+			</ROI:Shape>
+
+		</ROI:Union>
+	</ROI:ROI>
+	<ROI:ROI ID="ROI:3">
+		<ROI:Union>
+			<ROI:Shape ID="Shape:11" Visible="false" Text="Removed Path">
+				<ROI:Label X="0" Y="0"/>
+			</ROI:Shape>
+		</ROI:Union>
+	</ROI:ROI>
+	<ROI:ROI ID="ROI:4">
+		<ROI:Union>
+			<ROI:Shape ID="Shape:12" Visible="false" Text="Removed Path">
+				<ROI:Label X="0" Y="0"/>
+			</ROI:Shape>
+			<ROI:Shape ID="Shape:13" Visible="false" Text="Removed Path">
+				<ROI:Label X="0" Y="0"/>
+			</ROI:Shape>
+		</ROI:Union>
+	</ROI:ROI>
+</OME:OME>

--- a/components/specification/samples/2013-06/6x4y1z1t1c8b-swatch-xmlannotation-multi-value.ome
+++ b/components/specification/samples/2013-06/6x4y1z1t1c8b-swatch-xmlannotation-multi-value.ome
@@ -21,7 +21,7 @@
 		<SA:XMLAnnotation ID="Annotation:1" Namespace="openmicroscopy.org/sample/body/multivalue">
 			<SA:Value>
 				<valueA>A</valueA>
-				<valueB>B</valueB>
+				<valueB xmlns="http://example.com/xmlschema/">B<nestedA><nestedB/></nestedA></valueB>
 			</SA:Value>
 		</SA:XMLAnnotation>
 	</SA:StructuredAnnotations>

--- a/components/xsd-fu/python/ome/modeltools/object.py
+++ b/components/xsd-fu/python/ome/modeltools/object.py
@@ -349,7 +349,7 @@ class OMEModelObject(OMEModelEntity):
         name = self.modelBaseType
 
         if (parent is not None and parent.isAbstractProprietary and
-            self.name not in config.ANNOTATION_OVERRIDE):
+                self.name not in config.ANNOTATION_OVERRIDE):
             name = parent.name
 
         return name
@@ -362,12 +362,14 @@ class OMEModelObject(OMEModelEntity):
         abstract = False
 
         if (parent is not None and parent.isAbstractProprietary and
-            self.name not in config.ANNOTATION_OVERRIDE):
-                abstract = True
+                self.name not in config.ANNOTATION_OVERRIDE):
+            abstract = True
 
         return abstract
     isParentAbstractProprietary = property(
-        _get_isParentAbstractProprietary, doc="""Returns whether or not the model object has an abstract proprietary parent.""")
+        _get_isParentAbstractProprietary,
+        doc="""Returns whether or not the model object has an abstract"""
+        """ proprietary parent.""")
 
     def __str__(self):
         return self.__repr__()

--- a/components/xsd-fu/python/ome/modeltools/object.py
+++ b/components/xsd-fu/python/ome/modeltools/object.py
@@ -166,14 +166,6 @@ class OMEModelObject(OMEModelEntity):
         _get_baseObjectProperties,
         doc="""The model object's base object properties.""")
 
-    def _get_refNodeName(self):
-        if self.base == "Reference":
-            return self.properties["ID"].langType
-        return None
-    refNodeName = property(
-        _get_refNodeName,
-        doc="""The name of this node's reference node; None otherwise.""")
-
     def _get_langType(self):
         return self.name
     langType = property(_get_langType, doc="""The model object's type.""")
@@ -342,26 +334,40 @@ class OMEModelObject(OMEModelEntity):
     parents = property(
         _get_parents, doc="""The parents for this object.""")
 
-    def _get_parentName(self):
+    def _get_parent(self):
         parents = self.model.resolve_parents(self.name)
 
-        name = self.modelBaseType
+        parent = None
 
         if parents is not None:
             parent = self.model.getObjectByName(parents.keys()[0])
-            if (parent is not None and parent.isAbstractProprietary and
-                    self.name not in config.ANNOTATION_OVERRIDE):
-                name = parent.name
+
+        return parent
+
+    def _get_parentName(self):
+        parent = self._get_parent()
+        name = self.modelBaseType
+
+        if (parent is not None and parent.isAbstractProprietary and
+            self.name not in config.ANNOTATION_OVERRIDE):
+            name = parent.name
 
         return name
     parentName = property(
         _get_parentName, doc="""The parent class name for this object.""")
 
-    def isComplex(self):
-        """
-        Returns whether or not the model object has a "complex" content type.
-        """
-        return self.element.isComplex()
+    def _get_isParentAbstractProprietary(self):
+        parent = self._get_parent()
+
+        abstract = False
+
+        if (parent is not None and parent.isAbstractProprietary and
+            self.name not in config.ANNOTATION_OVERRIDE):
+                abstract = True
+
+        return abstract
+    isParentAbstractProprietary = property(
+        _get_isParentAbstractProprietary, doc="""Returns whether or not the model object has an abstract proprietary parent.""")
 
     def __str__(self):
         return self.__repr__()

--- a/components/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/components/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -537,27 +537,6 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         index_type
-        getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      AggregateMetadata::index_type
-      AggregateMetadata::getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const
-      {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
-            if (retrieve)
-              return retrieve->getMapAnnotationAnnotationCount(mapAnnotationIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        index_type
         getTagAnnotationAnnotationCount(index_type tagAnnotationIndex) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
@@ -780,72 +759,6 @@ ${counter(k, o, v)}\
       }
 {% end source %}\
 
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getMapAnnotationValue(index_type mapAnnotationIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      AggregateMetadata::getMapAnnotationValue(index_type mapAnnotationIndex) const
-      {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
-            if (retrieve)
-              return retrieve->getMapAnnotationValue(mapAnnotationIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getGenericExcitationSourceMap(index_type instrumentIndex,
-                                      index_type lightSourceIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      AggregateMetadata::getGenericExcitationSourceMap(index_type instrumentIndex,
-                                                       index_type lightSourceIndex) const
-      {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
-            if (retrieve)
-              return retrieve->getGenericExcitationSourceMap(instrumentIndex,
-                                                             lightSourceIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getImagingEnvironmentMap(index_type imageIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      AggregateMetadata::getImagingEnvironmentMap(index_type imageIndex) const
-      {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
-            if (retrieve)
-              return retrieve->getImagingEnvironmentMap(imageIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
-      }
-{% end source %}\
-
 {% if debug %}\
         // -- Entity retrieval (code generated definitions) --
 
@@ -971,79 +884,6 @@ ${getter(k, o, prop, v)}\
             std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setPixelsBinDataBigEndian(bigEndian, imageIndex, binDataIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                              index_type mapAnnotationIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      AggregateMetadata::setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                               index_type mapAnnotationIndex)
-      {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
-            if (store)
-              store->setMapAnnotationValue(map, mapAnnotationIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                      index_type instrumentIndex,
-                                      index_type lightSourceIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      AggregateMetadata::setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                                       index_type instrumentIndex,
-                                                       index_type lightSourceIndex)
-      {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
-            if (store)
-              store->setGenericExcitationSourceMap(map,
-                                                   instrumentIndex,
-                                                   lightSourceIndex);
-          }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                 index_type imageIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      AggregateMetadata::setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                                  index_type imageIndex)
-      {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
-          {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
-            if (store)
-              store->setImagingEnvironmentMap(map, imageIndex);
           }
         throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
       }

--- a/components/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/components/xsd-fu/templates-cpp/DummyMetadata.template
@@ -384,19 +384,6 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         index_type
-        getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      BaseMetadata::index_type
-      DummyMetadata::getMapAnnotationAnnotationCount(index_type /* mapAnnotationIndex */) const
-      {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        index_type
         getTagAnnotationAnnotationCount(index_type tagAnnotationIndex) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
@@ -546,47 +533,6 @@ ${counter(k, o, v)}\
       }
 {% end source %}\
 
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getMapAnnotationValue(index_type mapAnnotationIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      DummyMetadata::getMapAnnotationValue(index_type /* mapAnnotationIndex */) const
-      {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getGenericExcitationSourceMap(index_type instrumentIndex,
-                                      index_type lightSourceIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      DummyMetadata::getGenericExcitationSourceMap(index_type /* instrumentIndex */,
-                                                   index_type /* lightSourceIndex */) const
-      {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getImagingEnvironmentMap(index_type imageIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      DummyMetadata::getImagingEnvironmentMap(index_type /* imageIndex */) const
-      {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
-      }
-{% end source %}\
-
 {% if debug %}\
         // -- Entity retrieval (code generated definitions) --
 
@@ -696,50 +642,6 @@ ${getter(k, o, prop, v)}\
       DummyMetadata::setPixelsBinDataBigEndian(bool       /* bigEndian */,
                                                index_type /* imageIndex */,
                                                index_type /* binDataIndex */)
-      {
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                              index_type mapAnnotationIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      DummyMetadata::setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& /* map */,
-                                           index_type /* mapAnnotationIndex */)
-      {
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                      index_type instrumentIndex,
-                                      index_type lightSourceIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      DummyMetadata::setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& /* map */,
-                                                   index_type /* instrumentIndex */,
-                                                   index_type /* lightSourceIndex */)
-      {
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                 index_type imageIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      DummyMetadata::setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& /* map */,
-                                              index_type /* imageIndex */)
       {
       }
 {% end source %}\

--- a/components/xsd-fu/templates-cpp/FilterMetadata.template
+++ b/components/xsd-fu/templates-cpp/FilterMetadata.template
@@ -295,53 +295,6 @@ namespace ome
       }
 {% end source %}\
 
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                              index_type mapAnnotationIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      FilterMetadata::setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                            index_type mapAnnotationIndex)
-      {
-        store->setMapAnnotationValue(map, mapAnnotationIndex);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                      index_type instrumentIndex,
-                                      index_type lightSourceIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      FilterMetadata::setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                                    index_type instrumentIndex,
-                                                    index_type lightSourceIndex)
-      {
-        store->setGenericExcitationSourceMap(map, instrumentIndex, lightSourceIndex);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                 index_type imageIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      FilterMetadata::setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                               index_type imageIndex)
-      {
-        store->setImagingEnvironmentMap(map, imageIndex);
-      }
-{% end source %}\
-
 {% if debug %}\
 	// -- Entity storage (code generated definitions) --
 

--- a/components/xsd-fu/templates-cpp/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-cpp/MetadataRetrieve.template
@@ -123,7 +123,6 @@
 
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/model/AffineTransform.h>
-#include <ome/xml/model/MapPairs.h>
 
 {% for include in model.getEnumHeaders() %}\
 #include <${include}>
@@ -287,18 +286,6 @@ namespace ome
         getLongAnnotationAnnotationCount(index_type longAnnotationIndex) const = 0;
 
         /**
-         * Get the number of links to a MapAnnotation.
-         *
-         * This method returns the number of references to the
-         * specified MapAnnotation held by all model objects.
-         *
-         * @param mapAnnotationIndex the MapAnnotation index.
-         * @returns the number of MapAnnotation links.
-         */
-        virtual index_type
-        getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const = 0;
-
-        /**
          * Get the number of links to a TagAnnotation.
          *
          * This method returns the number of references to the
@@ -437,35 +424,6 @@ namespace ome
         virtual bool
         getPixelsBinDataBigEndian(index_type imageIndex,
                                   index_type binDataIndex) const = 0;
-
-	/**
-         * Get the Map value of MapAnnotation.
-         *
-         * @param mapAnnotationIndex the MapAnnotation index.
-         * @returns the Map.
-         */
-        virtual const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getMapAnnotationValue(index_type mapAnnotationIndex) const = 0;
-
-	/**
-         * Get the Map property of GenericExcitationSource.
-         *
-         * @param instrumentIndex the Instrument index.
-         * @param lightSourceIndex the LightSource index.
-         * @returns the Map.
-         */
-        virtual const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getGenericExcitationSourceMap(index_type instrumentIndex,
-                                      index_type lightSourceIndex) const = 0;
-
-	/**
-         * Set the Map property of ImagingEnvironment.
-         *
-         * @param imageIndex the Image index.
-         * @returns the Map.
-         */
-        virtual const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getImagingEnvironmentMap(index_type imageIndex) const = 0;
 
 {% if debug %}\
         // -- Entity retrieval (code generated definitions) --

--- a/components/xsd-fu/templates-cpp/MetadataStore.template
+++ b/components/xsd-fu/templates-cpp/MetadataStore.template
@@ -116,7 +116,6 @@
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/meta/MetadataRoot.h>
 #include <ome/xml/model/AffineTransform.h>
-#include <ome/xml/model/MapPairs.h>
 
 {% for include in model.getEnumHeaders() %}\
 #include <${include}>
@@ -252,38 +251,6 @@ namespace ome
         setPixelsBinDataBigEndian(bool bigEndian,
                                   index_type imageIndex,
                                   index_type binDataIndex = 0) = 0;
-
-	/**
-         * Set the Map value of MapAnnotation.
-         *
-         * @param map Map value.
-         * @param mapAnnotationIndex the MapAnnotation index.
-         */
-        virtual void
-        setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                              index_type mapAnnotationIndex) = 0;
-
-	/**
-         * Set the Map property of GenericExcitationSource.
-         *
-         * @param map Map to set.
-         * @param instrumentIndex the Instrument index.
-         * @param lightSourceIndex the LightSource index.
-         */
-        virtual void
-        setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                      index_type instrumentIndex,
-                                      index_type lightSourceIndex) = 0;
-
-	/**
-         * Set the Map property of ImagingEnvironment.
-         *
-         * @param map Map to set.
-         * @param imageIndex the Image index.
-         */
-        virtual void
-        setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                 index_type imageIndex) = 0;
 
 {% if debug %}\
         // -- Entity storage (code generated definitions) --

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -665,19 +665,6 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        OMEXMLMetadata::index_type
-        getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      OMEXMLMetadata::index_type
-      OMEXMLMetadata::getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const
-      {
-        return root->getStructuredAnnotations()->getMapAnnotation(mapAnnotationIndex)->sizeOfLinkedAnnotationList();
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
         index_type
         getTagAnnotationAnnotationCount(index_type tagAnnotationIndex) const;
 {% end header %}\
@@ -858,52 +845,6 @@ ${counter(k, o, v)}\
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getMapAnnotationValue(index_type mapAnnotationIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      OMEXMLMetadata::getMapAnnotationValue(index_type mapAnnotationIndex) const
-      {
-        return root->getStructuredAnnotations()->getMapAnnotation(mapAnnotationIndex)->getValue()->getMap();
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getGenericExcitationSourceMap(index_type instrumentIndex,
-                                      index_type lightSourceIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      OMEXMLMetadata::getGenericExcitationSourceMap(index_type instrumentIndex,
-                                                    index_type lightSourceIndex) const
-      {
-        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = root->getInstrument(instrumentIndex)->getLightSource(lightSourceIndex);
-        std::shared_ptr<const ::${lang.omexml_model_package}::GenericExcitationSource> o_mostderived = std::dynamic_pointer_cast<const ::${lang.omexml_model_package}::GenericExcitationSource>(o);
-        if (!o_mostderived)
-          throw(std::runtime_error("Internal metadata store inconsistency: LightSource is not a GenericExcitationSource"));
-
-        return o_mostderived->getMap()->getMap();
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        const ::${lang.omexml_model_package}::MapPairs::map_type&
-        getImagingEnvironmentMap(index_type imageIndex) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      const ::${lang.omexml_model_package}::MapPairs::map_type&
-      OMEXMLMetadata::getImagingEnvironmentMap(index_type imageIndex) const
-      {
-        return root->getImage(imageIndex)->getImagingEnvironment()->getMap()->getMap();
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
 {% if debug %}\
         // -- Entity retrieval (code generated definitions) --
 
@@ -1038,103 +979,6 @@ ${getter(k, o, prop, v)}\
         std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         std::shared_ptr<bool> newBool(std::make_shared<bool>(bigEndian));
         o2->setBigEndian(newBool);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                              index_type mapAnnotationIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      OMEXMLMetadata::setMapAnnotationValue(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                            index_type mapAnnotationIndex)
-      {
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
-        if (!o0->getStructuredAnnotations())
-          {
-            std::shared_ptr< ::${lang.omexml_model_package}::StructuredAnnotations> sa(std::make_shared< ::${lang.omexml_model_package}::StructuredAnnotations>());
-            o0->setStructuredAnnotations(sa);
-          }
-        std::shared_ptr< ::${lang.omexml_model_package}::StructuredAnnotations> o1(o0->getStructuredAnnotations());
-        if (o1->sizeOfMapAnnotationList() == mapAnnotationIndex)
-          {
-            std::shared_ptr< ::${lang.omexml_model_package}::MapAnnotation> ma(std::make_shared< ::${lang.omexml_model_package}::MapAnnotation>());
-            o1->addMapAnnotation(ma);
-          }
-        std::shared_ptr< ::${lang.omexml_model_package}::MapAnnotation> o2(o1->getMapAnnotation(mapAnnotationIndex));
-        std::shared_ptr< ::${lang.omexml_model_package}::MapPairs> valueAsPairs(std::make_shared< ::${lang.omexml_model_package}::MapPairs>());
-        valueAsPairs->setMap(map);
-        o2->setValue(valueAsPairs);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                      index_type instrumentIndex,
-                                      index_type lightSourceIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      OMEXMLMetadata::setGenericExcitationSourceMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                                    index_type instrumentIndex,
-                                                    index_type lightSourceIndex)
-      {
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
-        if (o0->sizeOfInstrumentList() == instrumentIndex)
-          {
-            std::shared_ptr< ::${lang.omexml_model_package}::Instrument> i(std::make_shared< ::${lang.omexml_model_package}::Instrument>());
-            o0->addInstrument(i);
-          }
-        std::shared_ptr< ::${lang.omexml_model_package}::Instrument> o1(o0->getInstrument(instrumentIndex));
-        if (o1->sizeOfLightSourceList() == lightSourceIndex)
-          {
-            std::shared_ptr< ::${lang.omexml_model_package}::LightSource> ls(std::make_shared< ::${lang.omexml_model_package}::GenericExcitationSource>());
-            o1->addLightSource(ls);
-          }
-        std::shared_ptr< ::${lang.omexml_model_package}::LightSource> o2(o1->getLightSource(lightSourceIndex));
-        std::shared_ptr< ::${lang.omexml_model_package}::Map> newmap(std::make_shared< ::${lang.omexml_model_package}::Map>());
-        newmap->setMap(map);
-
-        std::shared_ptr< ::${lang.omexml_model_package}::GenericExcitationSource> o2_mostderived(std::static_pointer_cast< ::${lang.omexml_model_package}::GenericExcitationSource>(o2));
-        if (!o2_mostderived)
-          throw(std::runtime_error("Internal metadata store inconsistency: "));
-
-        o2_mostderived->setMap(newmap);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-        // Documented in base class.
-        void
-        setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                 index_type imageIndex);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      void
-      OMEXMLMetadata::setImagingEnvironmentMap(const ::${lang.omexml_model_package}::MapPairs::map_type& map,
-                                               index_type imageIndex)
-      {
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
-        if (o0->sizeOfImageList() == imageIndex)
-          {
-            std::shared_ptr< ::${lang.omexml_model_package}::Image> i(std::make_shared< ::${lang.omexml_model_package}::Image>());
-            o0->addImage(i);
-          }
-        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1(o0->getImage(imageIndex));
-        if (!o1->getImagingEnvironment())
-          {
-            std::shared_ptr< ::${lang.omexml_model_package}::ImagingEnvironment> ie(std::make_shared< ::${lang.omexml_model_package}::ImagingEnvironment>());
-            o1->setImagingEnvironment(ie);
-          }
-        std::shared_ptr< ::${lang.omexml_model_package}::ImagingEnvironment> o2(o1->getImagingEnvironment());
-        std::shared_ptr< ::${lang.omexml_model_package}::Map> newmap(std::make_shared< ::${lang.omexml_model_package}::Map>());
-        newmap->setMap(map);
-        o2->setMap(newmap);
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -539,7 +539,7 @@ namespace ome
 
         resolveReferences();
 
-        ome::xerces::dom::Document doc(ome::xerces::dom::createEmptyDocument("OME"));
+        ome::xerces::dom::Document doc(ome::xerces::dom::createEmptyDocument("${model.getObjectByName("OME").namespace}", "OME"));
         ome::xerces::dom::Element ome = root->asXMLElement(doc);
 
         std::string text;

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -414,13 +414,6 @@ ${customContent[obj.name][prop.name]}
 {% for header in fu.OBJECT_HEADERS %}\
 #include <${header}>
 {% end %}\
-
-namespace
-{
-
-  const std::string xsi_ns("http://www.w3.org/2001/XMLSchema-instance");
-
-}
 {% end source%}\
 
 namespace ome
@@ -547,15 +540,7 @@ namespace ome
         resolveReferences();
 
         ome::xerces::dom::Document doc(ome::xerces::dom::createEmptyDocument("OME"));
-        ome::xerces::dom::Element r = root->asXMLElement(doc);
-
-        std::string ns(root->getXMLNamespace());
-
-        r.setAttribute("xmlns:xsi", xsi_ns);
-        r.setAttribute("xsi:schemaLocation", ns + " " + ns + "/ome.xsd");
-        r.setAttribute("xmlns", ns);
-
-        doc.appendChild(r);
+        ome::xerces::dom::Element ome = root->asXMLElement(doc);
 
         std::string text;
         ome::xerces::dom::writeDocument(doc, text);

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -405,11 +405,22 @@ ${customContent[obj.name][prop.name]}
 
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
+#include <ome/internal/version.h>
+
+#include <ome/xerces/Platform.h>
+
 #include <ome/xml/meta/OMEXMLMetadata.h>
 
 {% for header in fu.OBJECT_HEADERS %}\
 #include <${header}>
 {% end %}\
+
+namespace
+{
+
+  const std::string xsi_ns("http://www.w3.org/2001/XMLSchema-instance");
+
+}
 {% end source%}\
 
 namespace ome
@@ -531,11 +542,24 @@ namespace ome
       std::string
       OMEXMLMetadata::dumpXML()
       {
+        ome::xerces::Platform xmlplat;
+
         resolveReferences();
-        /// @todo Merge implementation from AbstractOMEXMLMetadata.
-        /// @todo remove dummy return
-        //          return dumpXMLImpl();
-        return std::string();
+
+        ome::xerces::dom::Document doc(ome::xerces::dom::createEmptyDocument("OME"));
+        ome::xerces::dom::Element r = root->asXMLElement(doc);
+
+        std::string ns(root->getXMLNamespace());
+
+        r.setAttribute("xmlns:xsi", xsi_ns);
+        r.setAttribute("xsi:schemaLocation", ns + " " + ns + "/ome.xsd");
+        r.setAttribute("xmlns", ns);
+
+        doc.appendChild(r);
+
+        std::string text;
+        ome::xerces::dom::writeDocument(doc, text);
+        return text;
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1132,15 +1132,20 @@ ${customUpdatePropertyContent[prop.name]}
 {% if not klass.isAbstractProprietary %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         /// @copydoc ${lang.omexml_model_package}::OMEModelObject::asXMLElement
-        virtual xerces::dom::Element&
+        virtual xerces::dom::Element
         asXMLElement (xerces::dom::Document& document) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      xerces::dom::Element&
+      xerces::dom::Element
       ${klass.name}::asXMLElement (xerces::dom::Document& document) const
       {
-        xerces::dom::Element nullelem;
-        return asXMLElementInternal(document, nullelem);
+{% if klass.name != "OME" %}\
+        xerces::dom::Element element(document.createElementNS(NAMESPACE, "${klass.name}"));
+{% end if %}\
+{% if klass.name == "OME" %}\
+        xerces::dom::Element element(document.getDocumentElement());
+{% end if %}\
+        return asXMLElementInternal(document, element);
       }
 {% end source %}\
 
@@ -1149,12 +1154,12 @@ ${customUpdatePropertyContent[prop.name]}
 
       protected:
         // Documented in base class.
-        virtual xerces::dom::Element&
+        virtual xerces::dom::Element
         asXMLElementInternal (xerces::dom::Document& document,
                               xerces::dom::Element&  element) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      xerces::dom::Element&
+      xerces::dom::Element
       ${klass.name}::asXMLElementInternal (xerces::dom::Document& document,
                                            xerces::dom::Element&  element) const
       {
@@ -1170,11 +1175,6 @@ ${customUpdatePropertyContent[prop.name]}
             element = abstractElement;
           }
 {% end %}\
-        if (!element)
-          {
-            xerces::dom::Element newElement = document.createElementNS(NAMESPACE, "${klass.name}");
-            element = newElement;
-          }
 
 {% if klass.langBaseType is not None %}\
         // Element's text data

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -365,7 +365,7 @@ ${customContent}\
         }
 {% end %}\
 {% if not klass.isAbstractProprietary %}\
-        std::string tagName(element.getTagName());
+        std::string tagName(stripNamespacePrefix(element.getTagName()));
         if (tagName != "${klass.name}")
           {
             std::clog << "Expecting node name of ${klass.name} got " << tagName << std::endl;

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -300,7 +300,6 @@ namespace ome
         // Documented in superclass.
         const std::string&
         elementName() const;
-
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       const std::string&
@@ -311,8 +310,8 @@ namespace ome
       }
 {% end source %}\
 {% end not Abstract %}\
-{% if len(customContent) > 0 %}\
 
+{% if len(customContent) > 0 %}\
 {% if fu.SOURCE_TYPE == "header" %}\
       private:
         /// Assignment operator (deleted).

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -69,6 +69,7 @@
 #include <ome/xerces/String.h>
 
 #include <ome/xml/model/ModelException.h>
+#include <ome/xml/model/detail/Parse.h>
 
 #include <boost/format.hpp>
 
@@ -348,15 +349,9 @@ ${customContent}\
 {% if klass.langBaseType != 'std::string' %}\
           if (!text.empty())
             {
-              std::istringstream is(text);
-              is.imbue(std::locale::classic());
-
-              if (!(is >> this->value))
-                {
-                  format fmt("Failed to parse ${klass.name} value ‘%1%’");
-                  fmt % text;
-                  throw ModelException(fmt.str());
-                }
+              set_value(text
+                        *this, &${klass.name}::setValue,
+                        "${klass.name}", "value");
             }
 {% end %}\
 {% if klass.langBaseType == 'std::string' %}\
@@ -410,22 +405,9 @@ ${customUpdatePropertyContent[prop.name]}
            {
              // ID property
 {% if klass.langBaseType != 'std::string' %}\
-             ${prop.langTypeNS} id;
-             std::istringstream is(element.getAttribute("${prop.name}"));
-             is.imbue(std::locale::classic());
-{% if prop.langTypeNS != 'bool' %}\
-             is >> id;
-{% end %}\
-{% if prop.langTypeNS == 'bool' %}\
-             is >> std::boolalpha >> id;
-{% end %}\
-             if (!is)
-                {
-                  format fmt("Failed to parse ${klass.name} value ‘%1%’");
-                  fmt % is.str();
-                  throw ModelException(fmt.str());
-                }
-             set${prop.methodName}(id);
+             set_value(element.getAttribute("${prop.name}"),
+                       *this, &${klass.name}::set${prop.methodName},
+                       "${klass.name}", "${prop.name}");
 {% end %}\
 {% if klass.langBaseType == 'std::string' %}\
              set${prop.methodName}(element.getAttribute("${prop.name}"));
@@ -453,34 +435,9 @@ ${customUpdatePropertyContent[prop.name]}
             // Attribute property ${prop.name}
             {
 {% if prop.instanceVariableType != 'std::string' %}\
-              std::istringstream is(element.getAttribute("${prop.name}"));
-              is.imbue(std::locale::classic());
-{% if prop.minOccurs == 0 %}\
-              ${prop.instanceVariableType} attr(std::make_shared< ${prop.langTypeNS}>());
-{% if prop.langTypeNS != 'bool' %}\
-              is >> *attr;
-{% end %}\
-{% if prop.langTypeNS == 'bool' %}\
-              is >> std::boolalpha >> *attr;
-{% end %}\
-{% end %}\
-{% if prop.minOccurs > 0 %}\
-              ${prop.langTypeNS} attr;
-{% if prop.langTypeNS != 'bool' %}\
-              is >> attr;
-{% end %}\
-{% if prop.langTypeNS == 'bool' %}\
-              is >> std::boolalpha >> attr;
-{% end %}\
-{% end %}\
-              if (!is)
-                {
-                  format fmt("Failed to parse ${klass.name} value ‘%1%’");
-                  fmt % is.str();
-                  throw ModelException(fmt.str());
-                }
-
-              set${prop.methodName}(attr);
+              set_value(element.getAttribute("${prop.name}"),
+                        *this, &${klass.name}::set${prop.methodName},
+                        "${klass.name}", "${prop.name}");
 {% end %}\
 {% if prop.instanceVariableType == 'std::string' %}\
               set${prop.methodName}(element.getAttribute("${prop.name}"));
@@ -522,23 +479,9 @@ ${customUpdatePropertyContent[prop.name]}
 {% end %}\
 {% if prop.minOccurs > 0 %}\
 {% if prop.langTypeNS != 'std::string' %}\
-            ${prop.langTypeNS} attr;
-
-            std::istringstream is(text);
-            is.imbue(std::locale::classic());
-{% if prop.langTypeNS != 'bool' %}\
-            if (is >> attr)
-{% end %}\
-{% if prop.langTypeNS == 'bool' %}\
-            if (is >> std::boolalpha >> attr)
-{% end %}\
-              set${prop.methodName}(attr);
-            else
-              {
-                format fmt("Failed to parse ${klass.name} ${prop.name} property value ‘%1%’");
-                fmt % is.str();
-                throw ModelException(fmt.str());
-              }
+             set_value(text,
+                       *this, &${klass.name}::set${prop.methodName},
+                       "${klass.name}", "${prop.name}");
 {% end %}\
 {% if prop.langTypeNS == 'std::string' %}\
             set${prop.methodName}(text);

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -115,6 +115,43 @@ namespace ome
 
       }
 
+      // ModelObject: ${klass.name}
+      // Namespace:   ${klass.namespace}
+      //
+      // Parent:                    ${klass.parentName}
+{% if klass.modelBaseType is not None %}\
+      // InstanceVariableName:      ${klass.instanceVariableName}
+      // ModelBaseType:             ${klass.modelBaseType}
+{% end %}\
+{% if klass.langBaseType is not None %}\
+      // LangBaseType:              ${klass.langBaseType}
+      // LangType:                  ${klass.langType}
+      // LangTypeNS:                ${klass.langTypeNS}
+{% end %}\
+      //
+      // Abstract:                  ${klass.isAbstract}
+      // AbstractProprietary:       ${klass.isAbstractProprietary}
+      // ParentAbstractProprietary: ${klass.isParentAbstractProprietary}
+      // Annotation:                ${klass.isAnnotation}
+      // Annotated:                 ${klass.isAnnotated}
+      // Described:                 ${klass.isDescribed}
+      // Named:                     ${klass.isNamed}
+      // Reference:                 ${klass.isReference}
+      //
+      // Properties:
+{% for prop in klass.instanceVariables %}\
+{% if prop[0] is not None %}\
+      //   ${prop[1]}
+      //     Instance type: ${prop[0]}
+{% if prop[2] is not None %}\
+      //     Default:       ${prop[2]}
+{% end no default %}\
+{% if prop[3] is not None %}\
+      //     Comment:       ${prop[3]}
+{% end no comment %}\
+{% end has instance type %}\
+{% end for %}\
+
 {% end source %}\
 {% if fu.SOURCE_TYPE == "header" %}\
 {% if len(klass.instanceVariables) > 0 %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -385,7 +385,7 @@ ${customUpdatePropertyContent[prop.name]}
              set${prop.methodName}(element.getAttribute("${prop.name}"));
 {% end %}\
              // Adding this model object to the model handler
-             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(shared_from_this());
+             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
              model.addModelObject(getID(), thisptr);
            }
 {% end %}\
@@ -1158,7 +1158,7 @@ ${customUpdatePropertyContent[prop.name]}
       ${klass.name}::asXMLElementInternal (xerces::dom::Document& document,
                                            xerces::dom::Element&  element) const
       {
-        // Creating XML block for ${klass.name}
+        // Create XML block for ${klass.name}
 
 {% if klass.isAbstractProprietary %}\
         // Class is abstract so we may need to create its "container" element
@@ -1215,11 +1215,12 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 // the API to allow consistency for future
                 // refactoring.
                 std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
-                std::shared_ptr<${prop.langTypeNS}> is(*i);
+                std::shared_ptr<${prop.langTypeNS}> is(i->lock());
                 if (is)
                   {
                     o->setID(is->getID());
-                    element.appendChild(o->asXMLElement(document));
+                    xerces::dom::Element child(o->asXMLElement(document));
+                    element.appendChild(child);
                   }
               }
           }
@@ -1231,9 +1232,13 @@ ${customAsXMLElementPropertyContent[prop.name]}
             // shared_ptr, but keep compatible with the rest of the
             // API to allow consistency for future refactoring.
             std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
-            std::shared_ptr<${prop.langTypeNS}> sv(${prop.instanceVariableName});
-            o->setID(sv->getID());
-            element.appendChild(o->asXMLElement(document));
+            std::shared_ptr<${prop.langTypeNS}> sv(${prop.instanceVariableName}.lock());
+            if (sv)
+              {
+                o->setID(sv->getID());
+                xerces::dom::Element child(o->asXMLElement(document));
+                element.appendChild(child);
+              }
           }
 {% end %}\
 {% when prop.isBackReference %}\
@@ -1253,18 +1258,20 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // Element property ${prop.name} which is complex (has
           // sub-elements)
           if (${prop.instanceVariableName})
-            element.appendChild(${prop.instanceVariableName}->asXMLElement(document));
+            {
+              xerces::dom::Element child(${prop.instanceVariableName}->asXMLElement(document));
+              element.appendChild(child);
+            }
 {% end %}\
 {% when prop.maxOccurs == 1 %}\
           // Element property ${prop.name} which is not complex (has no
           // sub-elements)
           {
-            xerces::dom::Element ${prop.instanceVariableName}_element =
-                                                               document.createElementNS(NAMESPACE, "${prop.name}");
+            xerces::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
             std::ostringstream os;
             os << ${prop.instanceVariableName};
-            ${prop.instanceVariableName}_element.setTextContent(os.str());
-            element.appendChild(${prop.instanceVariableName}_element);
+            child.setTextContent(os.str());
+            element.appendChild(child);
           }
 {% end %}\
 {% when prop.maxOccurs > 1 and prop.isComplex() %}\
@@ -1275,7 +1282,11 @@ ${customAsXMLElementPropertyContent[prop.name]}
                  i != ${prop.instanceVariableName}.end();
                  ++i)
               {
-                element.appendChild((*i)->asXMLElement(document));
+                if (*i)
+                  {
+                    xerces::dom::Element child((*i)->asXMLElement(document));
+                    element.appendChild(child);
+                  }
               }
           }
 {% end %}\
@@ -1292,7 +1303,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 std::ostringstream os;
                 os << *i;
                 ${prop.instanceVariableName}_element.setTextContent(os.str());
-                element.appendChild(${prop.instanceVariableName}_element);
+                xerces::dom::Element child(${prop.instanceVariableName}_element);
+                element.appendChild(child);
               }
           }
 {% end %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -110,7 +110,9 @@ namespace ome
 {% if fu.SOURCE_TYPE == "source" %}\
       namespace
       {
+
         const std::string NAMESPACE("${klass.namespace}");
+
       }
 
 {% end source %}\
@@ -1165,6 +1167,12 @@ ${customUpdatePropertyContent[prop.name]}
       {
         // Create XML block for ${klass.name}
 
+{% if klass.name == "OME" %}\
+        static const std::string XSI_NAMESPACE("http://www.w3.org/2001/XMLSchema-instance");
+        element.setAttribute("xmlns:xsi", XSI_NAMESPACE);
+        element.setAttribute("xsi:schemaLocation", NAMESPACE + " " + NAMESPACE + "/ome.xsd");
+        element.setAttribute("xmlns", NAMESPACE);
+{% end %}\
 {% if klass.isAbstractProprietary %}\
         // Class is abstract so we may need to create its "container" element
         if (std::string(element.getTagName()) != "${klass.name}")
@@ -1250,8 +1258,17 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // Attribute property ${prop.name}
           {
             std::ostringstream os;
+{% if prop.minOccurs == 1 %}\
             os << ${prop.instanceVariableName};
             element.setAttribute("${prop.name}", os.str());
+{% end %}\
+{% if prop.minOccurs == 0 %}\
+            if (${prop.instanceVariableName})
+              {
+                os << *${prop.instanceVariableName};
+                element.setAttribute("${prop.name}", os.str());
+              }
+{% end %}\
           }
 {% end %}\
 {% when prop.maxOccurs == 1 and prop.isComplex() %}\
@@ -1267,11 +1284,23 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // Element property ${prop.name} which is not complex (has no
           // sub-elements)
           {
+{% if prop.minOccurs == 1 %}\
             xerces::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
             std::ostringstream os;
             os << ${prop.instanceVariableName};
             child.setTextContent(os.str());
             element.appendChild(child);
+{% end %}\
+{% if prop.minOccurs == 0 %}\
+            if (${prop.instanceVariableName})
+              {
+                xerces::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
+                std::ostringstream os;
+                os << *${prop.instanceVariableName};
+                child.setTextContent(os.str());
+                element.appendChild(child);
+              }
+{% end %}\
           }
 {% end %}\
 {% when prop.maxOccurs > 1 and prop.isComplex() %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -216,54 +216,6 @@ namespace ome
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
-        /**
-         * Construct a ${klass.name} recursively from an XML DOM tree.
-         *
-         * @param element root of the XML DOM tree to from which to
-         * construct the model object graph.
-         * @param model handler for the OME model used to track
-         * instances and references seen during the update.
-         * @throws EnumerationException if there is an error
-         * instantiating an enumeration during model object creation.
-         */
-        ${klass.name} (xerces::dom::Element& element, ${lang.omexml_model_package}::OMEModel& model);
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      ${klass.name}::${klass.name} (xerces::dom::Element& element, ${lang.omexml_model_package}::OMEModel& model):
-{% if klass.parentName is not None %}\
-{% if len(klass.instanceVariables) == 0 %}\
-        ${klass.parentName}()
-{% end has no instance variables %}\
-{% if len(klass.instanceVariables) > 0 %}\
-        ${klass.parentName}(),
-{% end has instance variables %}\
-{% end has parent %}\
-{% for prop in klass.instanceVariables %}\
-{% if prop[0] is not None %}\
-{% if prop == klass.instanceVariables[-1] %}\
-{% if prop[2] is not None %}\
-        ${prop[1]}(${prop[2]})
-{% end has default %}\
-{% if prop[2] is None %}\
-        ${prop[1]}()
-{% end no default %}\
-{% end last member %}\
-{% if prop != klass.instanceVariables[-1] %}\
-{% if prop[2] is not None %}\
-        ${prop[1]}(${prop[2]}),
-{% end has default %}\
-{% if prop[2] is None %}\
-        ${prop[1]}(),
-{% end no default %}\
-{% end not last member %}\
-{% end has instance type %}\
-{% end for %}\
-      {
-        update(element, model);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
         /// Destructor.
         virtual
         ~${klass.name} ();
@@ -272,6 +224,37 @@ namespace ome
 {% if fu.SOURCE_TYPE == "source" %}\
       ${klass.name}::~${klass.name} ()
       {
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+
+        /**
+         * Create a ${klass.name} model object from DOM element.
+         *
+         * @param element root of the XML DOM tree to from which to
+         * construct the model object graph.
+         * @param model handler for the OME model used to track
+         * instances and references seen during the update.
+         * @throws EnumerationException if there is an error
+         * instantiating an enumeration during model object creation,
+         * or ModelException if there are any consistency or validity
+         * errors found during processing.
+         *
+         * @returns a new model object.
+         */
+        static std::shared_ptr< ${klass.name}>
+        create(const xerces::dom::Element& element,
+               ${lang.omexml_model_package}::OMEModel& model);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      std::shared_ptr< ${klass.name}>
+      ${klass.name}::create(const xerces::dom::Element& element,
+                              ${lang.omexml_model_package}::OMEModel& model)
+      {
+        std::shared_ptr< ${klass.name}> newinstance(std::make_shared< ${klass.name}>());
+        newinstance->update(element, model);
+        return newinstance;
       }
 {% end source %}\
 {% if len(customContent) > 0 %}\
@@ -450,7 +433,7 @@ ${customUpdatePropertyContent[prop.name]}
             xerces::dom::Element elem(${prop.name}_nodeList.at(0));
             // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
-            ${prop.instanceVariableType} p(new ${prop.langTypeNS}(elem, model));
+            ${prop.instanceVariableType} p(${prop.langTypeNS}::create(elem, model));
 {% end %}\
 {% if prop.minOccurs > 0 and (lang.hasPrimitiveType(prop.langType) or prop.isEnumeration) %} \
             ${prop.langTypeNS} p(${prop.name}_nodeList.at(0), model);
@@ -507,7 +490,7 @@ ${customUpdatePropertyContent[prop.name]}
                      // While std::make_shared<> works, here,
                      // boost::make_shared<> does not, so use new
                      // directly.
-                     std::shared_ptr<${prop.methodName}> object(new ${inner_prop.langTypeNS}(*elem, model));
+                     std::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
                      object->update(*inner_elem, model);
                      add${prop.methodName}(object);
                    }
@@ -525,7 +508,7 @@ ${customUpdatePropertyContent[prop.name]}
           {
             // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
-            std::shared_ptr<${prop.methodName}> object(new ${prop.langTypeNS}(*elem, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -539,7 +522,7 @@ ${customUpdatePropertyContent[prop.name]}
              ++elem)
           {
             std::string text(element.getTextContent());
-            std::shared_ptr<${prop.methodName}> object(std::make_shared< ${prop.langTypeNS}>(text, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -1183,6 +1166,11 @@ ${customUpdatePropertyContent[prop.name]}
             element = abstractElement;
           }
 {% end %}\
+        if (!element)
+          {
+            xerces::dom::Element newElement = document.createElementNS(NAMESPACE, "${klass.name}");
+            element = newElement;
+          }
 
 {% if klass.langBaseType is not None %}\
         // Element's text data

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1175,7 +1175,6 @@ ${customUpdatePropertyContent[prop.name]}
         static const std::string XSI_NAMESPACE("http://www.w3.org/2001/XMLSchema-instance");
         element.setAttribute("xmlns:xsi", XSI_NAMESPACE);
         element.setAttribute("xsi:schemaLocation", NAMESPACE + " " + NAMESPACE + "/ome.xsd");
-        element.setAttribute("xmlns", NAMESPACE);
 {% end %}\
 {% if klass.isAbstractProprietary %}\
         // Class is abstract so we may need to create its "container" element

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -227,6 +227,7 @@ namespace ome
       }
 {% end source %}\
 
+{% if not klass.isAbstract and not klass.isAbstractProprietary %}\
 {% if fu.SOURCE_TYPE == "header" %}\
 
         /**
@@ -257,6 +258,22 @@ namespace ome
         return newinstance;
       }
 {% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in superclass.
+        const std::string&
+        elementName() const;
+
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      const std::string&
+      ${klass.name}::elementName() const
+      {
+        static const std::string type("${klass.name}");
+        return type;
+      }
+{% end source %}\
+{% end not Abstract %}\
 {% if len(customContent) > 0 %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
@@ -287,8 +304,8 @@ ${customContent}\
                             ${lang.omexml_model_package}::OMEModel& model)
       {
         ${klass.parentName}::update(element, model);
-{% if klass.langBaseType is not None %}\
 
+{% if klass.langBaseType is not None %}\
         {
           // Element's text data
           std::string text(element.getTextContent());

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -349,6 +349,8 @@ ${customContent}\
           if (!text.empty())
             {
               std::istringstream is(text);
+              is.imbue(std::locale::classic());
+
               if (!(is >> this->value))
                 {
                   format fmt("Failed to parse ${klass.name} value ‘%1%’");
@@ -410,7 +412,13 @@ ${customUpdatePropertyContent[prop.name]}
 {% if klass.langBaseType != 'std::string' %}\
              ${prop.langTypeNS} id;
              std::istringstream is(element.getAttribute("${prop.name}"));
+             is.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
              is >> id;
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+             is >> std::boolalpha >> id;
+{% end %}\
              if (!is)
                 {
                   format fmt("Failed to parse ${klass.name} value ‘%1%’");
@@ -446,13 +454,24 @@ ${customUpdatePropertyContent[prop.name]}
             {
 {% if prop.instanceVariableType != 'std::string' %}\
               std::istringstream is(element.getAttribute("${prop.name}"));
+              is.imbue(std::locale::classic());
 {% if prop.minOccurs == 0 %}\
               ${prop.instanceVariableType} attr(std::make_shared< ${prop.langTypeNS}>());
+{% if prop.langTypeNS != 'bool' %}\
               is >> *attr;
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+              is >> std::boolalpha >> *attr;
+{% end %}\
 {% end %}\
 {% if prop.minOccurs > 0 %}\
               ${prop.langTypeNS} attr;
+{% if prop.langTypeNS != 'bool' %}\
               is >> attr;
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+              is >> std::boolalpha >> attr;
+{% end %}\
 {% end %}\
               if (!is)
                 {
@@ -506,7 +525,13 @@ ${customUpdatePropertyContent[prop.name]}
             ${prop.langTypeNS} attr;
 
             std::istringstream is(text);
+            is.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
             if (is >> attr)
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+            if (is >> std::boolalpha >> attr)
+{% end %}\
               set${prop.methodName}(attr);
             else
               {
@@ -1231,7 +1256,13 @@ ${customUpdatePropertyContent[prop.name]}
 {% if klass.langBaseType != 'std::string' %}\
         {
           std::ostringstream os;
+          os.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
           os << this->value;
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+          os << std::boolalpha << this->value;
+{% end %}\
           element.setTextContent(os.str());
         }
 {% end %}\
@@ -1299,14 +1330,25 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // Attribute property ${prop.name}
           {
             std::ostringstream os;
+            os.imbue(std::locale::classic());
 {% if prop.minOccurs == 1 %}\
-            os << ${prop.instanceVariableName};
+{% if prop.langTypeNS != 'bool' %}\
+          os << ${prop.instanceVariableName};
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+          os << std::boolalpha << ${prop.instanceVariableName};
+{% end %}\
             element.setAttribute("${prop.name}", os.str());
 {% end %}\
 {% if prop.minOccurs == 0 %}\
             if (${prop.instanceVariableName})
               {
+{% if prop.langTypeNS != 'bool' %}\
                 os << *${prop.instanceVariableName};
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+                os << std::boolalpha << *${prop.instanceVariableName};
+{% end %}\
                 element.setAttribute("${prop.name}", os.str());
               }
 {% end %}\
@@ -1328,7 +1370,13 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% if prop.minOccurs == 1 %}\
             xerces::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
             std::ostringstream os;
+            os.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
             os << ${prop.instanceVariableName};
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+            os << std::boolalpha << ${prop.instanceVariableName};
+{% end %}\
             child.setTextContent(os.str());
             element.appendChild(child);
 {% end %}\
@@ -1337,7 +1385,13 @@ ${customAsXMLElementPropertyContent[prop.name]}
               {
                 xerces::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
                 std::ostringstream os;
+                os.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
                 os << *${prop.instanceVariableName};
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+                os << std::boolalpha << *${prop.instanceVariableName};
+{% end %}\
                 child.setTextContent(os.str());
                 element.appendChild(child);
               }
@@ -1371,7 +1425,13 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 xerces::dom::Element ${prop.instanceVariableName}_element =
                                                                    document.createElementNS(NAMESPACE, "${prop.name}");
                 std::ostringstream os;
+                os.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
                 os << *i;
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+                os << std::boolalpha << *i;
+{% end %}\
                 ${prop.instanceVariableName}_element.setTextContent(os.str());
                 xerces::dom::Element child(${prop.instanceVariableName}_element);
                 element.appendChild(child);

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -312,6 +312,21 @@ namespace ome
 {% end source %}\
 {% end not Abstract %}\
 
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in superclass.
+        bool
+        validElementName(const std::string& name) const;
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      bool
+      ${klass.name}::validElementName(const std::string& name) const
+      {
+        static const std::string expectedTagName("${klass.name}");
+
+        return expectedTagName == name || ${klass.parentName}::validElementName(name);
+      }
+{% end source %}\
+
 {% if len(customContent) > 0 %}\
 {% if fu.SOURCE_TYPE == "header" %}\
       private:

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -374,13 +374,11 @@ ${customContent}\
 {% end %}\
         }
 {% end %}\
-{% if not klass.isAbstractProprietary %}\
-        std::string tagName(stripNamespacePrefix(element.getTagName()));
-        if (tagName != "${klass.name}")
+        const std::string tagName(stripNamespacePrefix(element.getTagName()));
+        if (!validElementName(tagName))
           {
-            std::clog << "Expecting node name of ${klass.name} got " << tagName << std::endl;
+            std::clog << tagName << " is an invalid element name for ${klass.name}" << std::endl;
           }
-{% end %}\
 {% for prop in klass.properties.values() %}\
 {% choose %}\
 {% when prop.name in customUpdatePropertyContent %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1270,6 +1270,10 @@ ${customUpdatePropertyContent[prop.name]}
         element.setTextContent(this->value);
 {% end %}\
 {% end %}\
+{% if klass.isAnnotation %}\
+		// Ensure any base annotations add their Elements first
+        element = ${klass.parentName}::asXMLElementInternal(document, element);
+{% end if isAnnotation %}\
 {% for prop in klass.properties.values() %}\
 {% if not klass.isAbstractProprietary or prop.isAttribute or not prop.isComplex() or (prop.name in fu.ANNOTATION_OVERRIDE) %}\
         {
@@ -1447,7 +1451,14 @@ ${customAsXMLElementPropertyContent[prop.name]}
         }
 {% end %}\
 {% end %}\
+{% choose %}\
+{% when klass.isAnnotation %}\
+        return element;
+{% end when isAnnotation %}\
+{% otherwise %}\
         return ${klass.parentName}::asXMLElementInternal(document, element);
+{% end otherwise %}\
+{% end choose %}\
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1147,7 +1147,7 @@ ${customUpdatePropertyContent[prop.name]}
 {% end %}\
 {% if fu.SOURCE_TYPE == "header" %}\
 
- protected:
+      protected:
         // Documented in base class.
         virtual xerces::dom::Element&
         asXMLElementInternal (xerces::dom::Document& document,
@@ -1306,6 +1306,20 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% end %}\
 {% end %}\
         return ${klass.parentName}::asXMLElementInternal(document, element);
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+      public:
+       // Documented in superclass.
+       const std::string&
+       getXMLNamespace() const;
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      const std::string&
+      ${klass.name}::getXMLNamespace() const
+      {
+        return NAMESPACE;
       }
 {% end source %}\
 {% if fu.SOURCE_TYPE == "header" %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
@@ -1,15 +1,20 @@
-        std::ostringstream xmldoc;
-        xmldoc << "<Value>" << value << "</Value>";
-        xerces::dom::Document Value_document(ome::xerces::dom::createDocument(xmldoc.str()));
         /// @todo Catch and/or rethrow actual xerces exceptions
+
+        // Don't validate.  Currently fails due to inheriting our
+        // schema if no namespace was explicitly specified.
+        std::string wrappedValue("<wrapped>");
+        wrappedValue += value;
+        wrappedValue += "</wrapped>";
+        xerces::dom::ParseParameters params;
+        params.validationScheme = xercesc::XercesDOMParser::Val_Never;
+        xerces::dom::Document Value_document(ome::xerces::dom::createDocument(wrappedValue, params));
         xerces::dom::Element value_element = document.createElementNS(NAMESPACE, "Value");
-        xerces::dom::NodeList Value_subNodes = Value_document.getChildNodes();
+        xerces::dom::NodeList Value_subNodes = Value_document.getDocumentElement().getChildNodes();
 
         for (xerces::dom::NodeList::iterator elem = Value_subNodes.begin();
              elem != Value_subNodes.end();
              ++elem)
           {
-            /// @todo Wrap importNode in document.
             xerces::dom::Node Value_subNode(document->importNode(elem->get(), true), false);
             value_element.appendChild(Value_subNode);
           }

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
@@ -1,46 +1,83 @@
         std::vector<xerces::dom::Element> Value_nodeList = getChildrenByTagName(element, "Value");
         if (Value_nodeList.size() > 1)
           {
-            // TODO: Should be its own Exception
-            // TODO: Include size informtion.
-            throw std::runtime_error("${klass.name} Value node list size != 1");
+            format fmt("Value node list size %1% != 1");
+            fmt % Value_nodeList.size();
+            throw ModelException(fmt.str());
           }
         else if (Value_nodeList.size() != 0)
           {
-            // TODO: Does this need implementing in C++?  What is its purpose?
-            // May just be to convert the child nodes to string; but if so why need a transform?
-            // Element property Value which is not complex (has no
-            // sub-elements)
-            // java.io.StringWriter sw = new java.io.StringWriter();
-            // javax.xml.transform.stream.StreamResult sr =
-            //   new javax.xml.transform.stream.StreamResult(sw);
-            // javax.xml.transform.TransformerFactory tf =
-            //   javax.xml.transform.TransformerFactory.newInstance();
+            xerces::dom::Element elem(Value_nodeList.at(0));
+            xerces::dom::NodeList nodes(elem.getChildNodes());
 
-            // try
-            //   {
-            //     javax.xml.transform.Transformer t = tf.newTransformer(
-            //                             			      new javax.xml.transform.stream.StreamSource(
-            //                             									  this.getClass().getResourceAsStream("StripWhitespace.xsl")));
-            //     t.setOutputProperty(
-            //                         javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION, "yes");
-            //     t.setOutputProperty(
-            //                         javax.xml.transform.OutputKeys.INDENT, "no");
-            //     NodeList childNodeList = Value_nodeList.get(0).getChildNodes();
-            //     for (int i = 0; i < childNodeList.getLength(); i++)
-            //       {
-            //         try {
-            //           t.transform(new javax.xml.transform.dom.DOMSource(
-            //                             				childNodeList.item(i)), sr);
-            //         }
-            //         catch (javax.xml.transform.TransformerException te) {
-            //           LOGGER.warn("Failed to transform node #" + i, te);
-            //         }
-            //       }
-            //     setValue(sw.toString().trim());
-            //   }
-            // catch (Exception e)
-            //   {
-            //     throw new RuntimeException(e);
-            //   }
+            std::string text;
+
+            for (xerces::dom::NodeList::iterator i = nodes.begin();
+                 i != nodes.end();
+                 ++i)
+              {
+                try
+                  {
+                    xerces::dom::Element e(*i);
+
+                    std::string textvalue;
+                    ome::xerces::dom::writeNode(*i, textvalue);
+
+                    // Trim leading and trailing whitespace
+                    std::string::size_type start(textvalue.find_first_of('<'));
+                    std::string::size_type end(textvalue.find_last_of('>'));
+                    if (end != std::string::npos)
+                      ++end;
+                    if (end >= textvalue.size())
+                      end = std::string::npos;
+                    if (start != std::string::npos)
+                      textvalue = textvalue.substr(start, end - start);
+                    else
+                      textvalue.clear();
+
+                    // If the user did not specify a namespace, it
+                    // will inherit the default (OME) namespace, which
+                    // will almost certainly lead to insertion of the
+                    // incorrect namespace and consequent validation
+                    // errors.  If no namespace was specified or it's
+                    // using the OME namespace (typical document
+                    // default), set it to nothing.
+                    if (e->getNamespaceURI() == 0 ||
+                        element->lookupNamespaceURI(0) != 0)
+                      {
+                        if (element->lookupNamespaceURI(0) != 0)
+                          {
+                            xerces::String currentNS(element->lookupNamespaceURI(0));
+                            if ((*i)->isDefaultNamespace(currentNS))
+                              {
+                                std::string stripNS(static_cast<std::string>(currentNS));
+                                std::string::size_type stripStart(textvalue.find(stripNS));
+                                if (stripStart != std::string::npos &&
+                                    stripStart != 0)
+                                  {
+                                    std::string replacement;
+
+                                    // Start of original text.
+                                    replacement = textvalue.substr(0, stripStart);
+
+                                    // Add remainder of original text.
+                                    std::string::size_type stripEnd(stripStart + stripNS.size());
+                                    if (stripEnd != std::string::npos)
+                                      replacement += textvalue.substr(stripEnd);
+                                    textvalue = replacement;
+                                  }
+                              }
+                          }
+                      }
+
+                    text += textvalue;
+
+                  }
+                catch (const std::exception& e)
+                  {
+                    // Not an Element.
+                  }
+              }
+
+            setValue(text);
           }

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -193,25 +193,6 @@ def main(model, opts):
             customAsXMLElementPropertyContent[propertyName] = content
         # END Custom templates for asXMLElment()
 
-        if opts.debug:
-            if obj.name in ["StructuredAnnotations"]:
-                CUSTOM_CLASS_TEMPLATE = os.path.join(base, '%s_%s%s' % (name, obj.name, extension))
-                customContent = ''
-                if os.path.exists(CUSTOM_CLASS_TEMPLATE):
-                    customTemplate = NewTextTemplate(codecs.open(CUSTOM_CLASS_TEMPLATE, encoding='utf-8'), encoding='utf-8')
-                    customContent = customTemplate.generate(
-                        fu=fu, klass=obj, parents=parents, model=model, opts=opts, lang=opts.lang, debug=opts.debug)
-                    customContent = customContent.render(encoding='utf-8')
-                print("Dump: %s" % obj.__dict__)
-                print("Element Dump: %s" % obj.element.__dict__)
-                print(" +-- %s(base=%s, type=%s)" % (obj.name, obj.base, obj.type))
-                for prop in obj.properties.values():
-                    print("Dump: %s" % prop.__dict__)
-                    print("Delegate Dump: %s" % prop.delegate.__dict__)
-                    print(" +---- %s(%s) [%d:%d]" % \
-                        (prop.name, prop.type, prop.minOccurs, prop.maxOccurs))
-                print("\n")
-
         try:
             fullname = opts.lang.generatedFilename(obj.name, opts.filetype)
             fullname = os.path.join("ome", "xml", "model", fullname)
@@ -240,9 +221,6 @@ def main(model, opts):
             f = codecs.open(fullname, "w", encoding='utf-8')
             f.write(classContent.decode('utf-8'))
             f.close()
-
-        if opts.debug:
-            print(classContent)
 
     if opts.print_depends:
         for file in sorted(used_files):

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -149,6 +149,8 @@ def main(model, opts):
         if obj.name in opts.lang.model_type_map.keys():
             continue
 
+        parents = model.resolve_parents(obj.name)
+
         fu.SOURCE_TYPE = opts.filetype;
 
         CUSTOM_CLASS_TEMPLATE = os.path.join(
@@ -190,7 +192,6 @@ def main(model, opts):
             content = content.render(encoding='utf-8')
             customAsXMLElementPropertyContent[propertyName] = content
         # END Custom templates for asXMLElment()
-        parents = model.resolve_parents(obj.name)
 
         if opts.debug:
             if obj.name in ["StructuredAnnotations"]:

--- a/cpp/bin/showinf/ImageInfo.cpp
+++ b/cpp/bin/showinf/ImageInfo.cpp
@@ -37,6 +37,9 @@
 
 #include <ome/bioformats/in/TIFFReader.h>
 
+#include <ome/xerces/Platform.h>
+#include <ome/xerces/dom/Document.h>
+
 #include <ome/xml/meta/MetadataStore.h>
 #include <ome/xml/meta/MetadataRetrieve.h>
 #include <ome/xml/meta/OMEXMLMetadata.h>
@@ -277,8 +280,33 @@ namespace showinf
         std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omemeta(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(reader->getMetadataStore()));
         if (omemeta)
           {
-            stream << "OME-XML metadata:\n";
-            stream << omemeta->dumpXML();
+            ome::xerces::Platform xmlplat;
+
+            std::string omexml;
+            bool omexml_dumped = false;
+            try
+              {
+                omexml = omemeta->dumpXML();
+                stream << "OME-XML metadata:\n" << omexml << '\n';
+                omexml_dumped = true;
+              }
+            catch (const std::exception& e)
+              {
+                stream << "Failed to get OME-XML metadata: " << e.what() << '\n';
+              }
+
+            if (omexml_dumped && opts.validate)
+              {
+                try
+                  {
+                    ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(omexml));
+                    stream << "OME-XML validation successful\n";
+                  }
+                catch (const std::exception& e)
+                  {
+                    stream << "Failed to validate OME-XML metadata: " << e.what() << '\n';
+                  }
+              }
           }
       }
   }

--- a/cpp/bin/showinf/ImageInfo.cpp
+++ b/cpp/bin/showinf/ImageInfo.cpp
@@ -271,6 +271,16 @@ namespace showinf
       {
         std::cerr << "Failed to get metadata: " << e.what() << '\n';
       }
+
+    if (opts.showomexml)
+      {
+        std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omemeta(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(reader->getMetadataStore()));
+        if (omemeta)
+          {
+            stream << "OME-XML metadata:\n";
+            stream << omemeta->dumpXML();
+          }
+      }
   }
 
   void

--- a/cpp/cmake/XsdFu.cmake
+++ b/cpp/cmake/XsdFu.cmake
@@ -49,7 +49,7 @@ set(XSD_FU_SCRIPT ${PROJECT_SOURCE_DIR}/components/xsd-fu/xsd-fu)
 set(XSD_FU python ${XSD_FU_SCRIPT})
 
 # Version of the OME-XML model to use
-set(MODEL_VERSION 2013-10-dev-3)
+set(MODEL_VERSION 2013-06)
 
 # Path to the model within the source tree
 set(MODEL_PATH ${PROJECT_SOURCE_DIR}/components/specification/released-schema/${MODEL_VERSION})

--- a/cpp/cmake/XsdFu.cmake
+++ b/cpp/cmake/XsdFu.cmake
@@ -36,6 +36,11 @@
 
 cmake_policy(SET CMP0007 NEW)
 
+option(xsdfu-debug "Enable xsd-fu debug output (in generated code)" OFF)
+if(xsdfu-debug)
+  set(XSDFU_DEBUG --debug)
+endif()
+
 # The xsd-fu script
 set(XSD_FU_SCRIPT ${PROJECT_SOURCE_DIR}/components/xsd-fu/xsd-fu)
 
@@ -61,7 +66,7 @@ set(MODEL_FILES
 set(GEN_DIR ${PROJECT_BINARY_DIR}/cpp/lib)
 
 # Default arguments to use when running xsd-fu
-set(XSD_FU_ARGS --language=C++ --output-directory=${GEN_DIR} ${MODEL_FILES})
+set(XSD_FU_ARGS ${XSDFU_DEBUG} --language=C++ --output-directory=${GEN_DIR} ${MODEL_FILES})
 
 # xsd_fu_single: Run xsd-fu for a single filetype
 #

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -165,10 +165,13 @@ namespace ome
      * string.
      *
      * @param omexml the OME-XML metadata store.
+     * @param validate @c true to validate the OME-XML, @c false to
+     * skip validation.
      * @returns the OME-XML metadata as an XML document string.
      */
     std::string
-    getOMEXML(::ome::xml::meta::OMEXMLMetadata& omexml);
+    getOMEXML(::ome::xml::meta::OMEXMLMetadata& omexml,
+              bool                              validate = true);
 
     /**
      * Validate an OME-XML document.
@@ -232,6 +235,39 @@ namespace ome
     addMetadataOnly(::ome::xml::meta::OMEXMLMetadata& omexml,
                     dimension_size_type               series,
                     bool                              resolve = true);
+
+    /**
+     * Get ModuloAlongZ annotation from OME-XML metadata.
+     *
+     * @param omexml the OME-XML metadata store.
+     * @param image the image index.
+     * @returns the Modulo annotation.
+     */
+    Modulo
+    getModuloAlongZ(const ::ome::xml::meta::OMEXMLMetadata& omexml,
+                    dimension_size_type                     image);
+
+    /**
+     * Get ModuloAlongT annotation from OME-XML metadata.
+     *
+     * @param omexml the OME-XML metadata store.
+     * @param image the image index.
+     * @returns the Modulo annotation.
+     */
+    Modulo
+    getModuloAlongT(const ::ome::xml::meta::OMEXMLMetadata& omexml,
+                    dimension_size_type                     image);
+
+    /**
+     * Get ModuloAlongC annotation from OME-XML metadata.
+     *
+     * @param omexml the OME-XML metadata store.
+     * @param image the image index.
+     * @returns the Modulo annotation.
+     */
+    Modulo
+    getModuloAlongC(const ::ome::xml::meta::OMEXMLMetadata& omexml,
+                    dimension_size_type                     image);
 
     /**
      * Get Modulo annotation from OME-XML metadata.

--- a/cpp/lib/ome/xerces/CMakeLists.txt
+++ b/cpp/lib/ome/xerces/CMakeLists.txt
@@ -41,6 +41,7 @@ set(ome_xerces_sources
     EntityResolver.cpp
     ErrorReporter.cpp
     dom/Document.cpp
+    dom/NamedNodeMap.cpp
     dom/NodeList.cpp)
 
 set(ome_xerces_base_headers
@@ -53,6 +54,7 @@ set(ome_xerces_dom_headers
     dom/Base.h
     dom/Document.h
     dom/Element.h
+    dom/NamedNodeMap.h
     dom/Node.h
     dom/NodeList.h
     dom/Wrapper.h)

--- a/cpp/lib/ome/xerces/String.h
+++ b/cpp/lib/ome/xerces/String.h
@@ -98,8 +98,8 @@ namespace ome
        */
       inline
       String(const char *str):
-      narrow(xercesc::XMLString::replicate(str)),
-      wide(xercesc::XMLString::transcode(str))
+        narrow(xercesc::XMLString::replicate(str)),
+        wide(xercesc::XMLString::transcode(str))
       {
         assert(this->narrow != 0);
         assert(this->wide != 0);

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -177,6 +177,18 @@ namespace ome
         {
           return Element((*this)->getDocumentElement(), false);
         }
+
+        /**
+         * Get child elements with a given tag name.
+         *
+         * @param name the element name to use.
+         * @returns the child nodes (if any).
+         */
+        NodeList
+        getElementsByTagName(const std::string& name)
+        {
+          return (*this)->getElementsByTagName(String(name));
+        }
       };
 
       /**

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -390,7 +390,7 @@ namespace ome
                     const WriteParameters& params = WriteParameters());
 
       /**
-       * Write a Document to a stream.
+       * Write a Document to a string.
        *
        * @param document the document to use.
        * @param text the string to store the text in.

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -48,6 +48,7 @@
 #include <ostream>
 
 #include <xercesc/dom/DOMDocument.hpp>
+#include <xercesc/parsers/XercesDOMParser.hpp>
 
 #include <ome/compat/filesystem.h>
 
@@ -192,6 +193,48 @@ namespace ome
       };
 
       /**
+       * Parameters controlling DOM writing.
+       *
+       * The DOMSerializer provides for some control over the process
+       * via DOMConfiguration.  They are settable here to allow their
+       * use at a high level without the need to have access to the
+       * internals of the Xerces-C writing process.  Simply create an
+       * instance of this class, adjust the parameters as needed, and
+       * then pass to a method call which uses WriteParameters as an
+       * optional argument.
+       *
+       * If more precise control of the process is required, use the
+       * Xerces-C classes directly.  These are simply a convienience
+       * for the common case and will not suit every situation.
+       */
+      struct ParseParameters
+      {
+        /// Validation scheme.
+        xercesc::XercesDOMParser::ValSchemes validationScheme;
+        /// Use namespaces?
+        bool doNamespaces;
+        /// Use schemas?
+        bool doSchema;
+        /// Handle multiple imports?
+        bool handleMultipleImports;
+        /// Do full checking during validation?
+        bool validationSchemaFullChecking;
+        /// Create entity reference nodes?
+        bool createEntityReferenceNodes;
+
+        /// Constructor.
+        ParseParameters():
+          validationScheme(xercesc::XercesDOMParser::Val_Auto),
+          doNamespaces(true),
+          doSchema(true),
+          handleMultipleImports(true),
+          validationSchemaFullChecking(true),
+          createEntityReferenceNodes(true)
+        {
+        }
+      };
+
+      /**
        * Construct an empty Document.
        *
        * @param qualifiedName the qualified name of the document type.
@@ -201,31 +244,49 @@ namespace ome
       createEmptyDocument(const std::string& qualifiedName);
 
       /**
-       * Construct a Document from the content of a file.
+       * Construct an empty Document.
        *
-       * @param file the file to read.
+       * @param namespaceURI the namespace URI of the root document
+       * element.
+       * @param qualifiedName the qualified name of the document type.
        * @returns the new Document.
        */
       Document
-      createDocument(const boost::filesystem::path& file);
+      createEmptyDocument(const std::string& namespaceURI,
+                          const std::string& qualifiedName);
+
+      /**
+       * Construct a Document from the content of a file.
+       *
+       * @param file the file to read.
+       * @param params XML parser parameters.
+       * @returns the new Document.
+       */
+      Document
+      createDocument(const boost::filesystem::path& file,
+                     const ParseParameters&         params = ParseParameters());
 
       /**
        * Construct a Document from the content of a string.
        *
        * @param text the string to use.
+       * @param params XML parser parameters.
        * @returns the new Document.
        */
       Document
-      createDocument(const std::string& text);
+      createDocument(const std::string&     text,
+                     const ParseParameters& params = ParseParameters());
 
       /**
        * Construct a Document from the content of an input stream.
        *
        * @param stream the stream to read.
+       * @param params XML parser parameters.
        * @returns the new Document.
        */
       Document
-      createDocument(std::istream& stream);
+      createDocument(std::istream&          stream,
+                     const ParseParameters& params = ParseParameters());
 
       /**
        * Parameters controlling DOM writing.
@@ -303,7 +364,7 @@ namespace ome
       void
       writeNode(xercesc::DOMNode&              node,
                 const boost::filesystem::path& file,
-                const WriteParameters&         params);
+                const WriteParameters& params = WriteParameters());
 
       /**
        * Write a Node to a stream.

--- a/cpp/lib/ome/xerces/dom/Element.h
+++ b/cpp/lib/ome/xerces/dom/Element.h
@@ -137,6 +137,18 @@ namespace ome
         }
 
         /**
+         * Get child elements with a given tag name.
+         *
+         * @param name the element name to use.
+         * @returns the child nodes (if any).
+         */
+        NodeList
+        getElementsByTagName(const std::string& name)
+        {
+          return (*this)->getElementsByTagName(String(name));
+        }
+
+        /**
          * Check if the Element has the specified attribute.
          *
          * @param attr the attribute to check.

--- a/cpp/lib/ome/xerces/dom/NamedNodeMap.cpp
+++ b/cpp/lib/ome/xerces/dom/NamedNodeMap.cpp
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * OME-XERCES C++ library for working with Xerces C++.
+ * %%
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <ome/xerces/String.h>
+#include <ome/xerces/dom/NamedNodeMap.h>
+#include <ome/xerces/dom/Node.h>
+
+namespace ome
+{
+  namespace xerces
+  {
+    namespace dom
+    {
+
+      Node
+      NamedNodeMap::getNamedItem(const std::string& name)
+      {
+        return Node((*this)->getNamedItem(String(name)), false);
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/xerces/dom/NamedNodeMap.h
+++ b/cpp/lib/ome/xerces/dom/NamedNodeMap.h
@@ -1,0 +1,123 @@
+/*
+ * #%L
+ * OME-XERCES C++ library for working with Xerces C++.
+ * %%
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_XERCES_DOM_NAMEDNODEMAP_H
+#define OME_XERCES_DOM_NAMEDNODEMAP_H
+
+#include <ome/compat/config.h>
+
+#include <cassert>
+
+#include <ome/xerces/dom/Base.h>
+#include <ome/xerces/dom/Wrapper.h>
+
+#include <xercesc/dom/DOMNamedNodeMap.hpp>
+
+namespace ome
+{
+  namespace xerces
+  {
+    namespace dom
+    {
+
+      class Node;
+
+      /**
+       * DOM NamedNodeMap wrapper.  The wrapper behaves as though is
+       * the wrapped DOMNamedNodeMap; it can be dereferenced using the
+       * "*" or "->" operators to obtain a reference or pointer to the
+       * wrapped object.  It can also be cast to a pointer to the
+       * wrapped object, so can substitute for it directly.
+       */
+      class NamedNodeMap : public Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >
+      {
+      public:
+        /**
+         * Construct a NULL NamedNodeMap.
+         */
+        NamedNodeMap ():
+          Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >()
+        {
+        }
+
+        /**
+         * Copy construct a NamedNodeMap.
+         *
+         * @param nodelist the NamedNodeMap to copy.
+         */
+        NamedNodeMap (const NamedNodeMap& nodelist):
+          Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >(nodelist)
+        {
+        }
+
+        /**
+         * Construct a NamedNodeMap from a xercesc::DOMNamedNodeMap * (unmanaged).
+         *
+         * @param nodelist the NamedNodeMap to wrap.
+         */
+        NamedNodeMap (xercesc::DOMNamedNodeMap *nodelist):
+          Wrapper<xercesc::DOMNamedNodeMap, Base<xercesc::DOMNamedNodeMap> >(static_cast<base_element_type *>(nodelist))
+        {
+        }
+
+        /// Destructor.
+        ~NamedNodeMap ()
+        {
+        }
+
+        /**
+         * Get an item by name.
+         *
+         * @param name the name of the item
+         * @returns the item, which will be null if not found.
+         */
+        Node
+        getNamedItem(const std::string& name);
+      };
+
+    }
+  }
+}
+
+#endif // OME_XERCES_DOM_NAMEDNODEMAP_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/xerces/dom/Node.h
+++ b/cpp/lib/ome/xerces/dom/Node.h
@@ -41,8 +41,10 @@
 
 #include <ome/compat/config.h>
 
+#include <ome/xerces/String.h>
 #include <ome/xerces/dom/Base.h>
 #include <ome/xerces/dom/NodeList.h>
+#include <ome/xerces/dom/NamedNodeMap.h>
 #include <ome/xerces/dom/Wrapper.h>
 
 #include <xercesc/dom/DOMNode.hpp>
@@ -139,6 +141,39 @@ namespace ome
         getChildNodes()
         {
           return NodeList((*this)->getChildNodes());
+        }
+
+        /**
+         * Get node attributes.
+         *
+         * @returns the attributes.
+         */
+        NamedNodeMap
+        getAttributes()
+        {
+          return NamedNodeMap((*this)->getAttributes());
+        }
+
+        /**
+         * Get node value.
+         *
+         * @returns the node value.
+         */
+        std::string
+        getNodeValue()
+        {
+          return String((*this)->getNodeValue());
+        }
+
+        /**
+         * Get node text content.
+         *
+         * @returns the text content.
+         */
+        std::string
+        getTextContent()
+        {
+          return String((*this)->getTextContent());
         }
       };
 

--- a/cpp/lib/ome/xerces/dom/NodeList.cpp
+++ b/cpp/lib/ome/xerces/dom/NodeList.cpp
@@ -121,6 +121,12 @@ namespace ome
         else return index == rhs.index;
       }
 
+      Node
+      NodeList::at(size_type index)
+      {
+        return Node((*this)->item(index), false);
+      }
+
     }
   }
 }

--- a/cpp/lib/ome/xerces/dom/NodeList.h
+++ b/cpp/lib/ome/xerces/dom/NodeList.h
@@ -237,6 +237,15 @@ namespace ome
         {
           return iterator();
         }
+
+        /**
+         * Get the element at a particular index.
+         *
+         * @param index the index of the element.
+         * @returns the Node at the specified index.
+         */
+        Node
+        at(size_type index);
       };
 
     }

--- a/cpp/lib/ome/xerces/dom/NodeList.h
+++ b/cpp/lib/ome/xerces/dom/NodeList.h
@@ -217,6 +217,17 @@ namespace ome
         }
 
         /**
+         * Check if the NodeList is empty.
+         *
+         * @returns @c true if empty, @c false if not empty.
+         */
+        bool
+        empty() const
+        {
+          return size() == 0;
+        }
+
+        /**
          * Get an iterator pointing to the first element in the NodeList.
          *
          * @returns an iterator pointing to the first element in the NodeList.

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -68,8 +68,7 @@ set(OME_XML_STATIC_SOURCES
   model/primitives/PositiveFloat.cpp
   model/primitives/PositiveInteger.cpp
   model/primitives/PositiveLong.cpp
-  model/primitives/Timestamp.cpp
-  model/MapPairs.cpp)
+  model/primitives/Timestamp.cpp)
 
 # Not installed, internal only.
 set(OME_XML_META_PRIVATE_STATIC_HEADERS
@@ -82,7 +81,6 @@ set(OME_XML_META_STATIC_HEADERS
     meta/OMEXMLMetadataRoot.h)
 
 set(OME_XML_STATIC_MODEL_HEADERS
-    model/MapPairs.h
     model/ModelException.h
     model/OMEModel.h
     model/OMEModelObject.h)

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -58,6 +58,7 @@ set(OME_XML_STATIC_SOURCES
   model/ModelException.cpp
   model/detail/OMEModel.cpp
   model/detail/OMEModelObject.cpp
+  model/detail/Parse.cpp
   model/enums/EnumerationException.cpp
   model/primitives/Color.cpp
   model/primitives/NonNegativeFloat.cpp
@@ -88,7 +89,8 @@ set(OME_XML_STATIC_MODEL_HEADERS
 
 set(OME_XML_STATIC_MODEL_DETAIL_HEADERS
     model/detail/OMEModel.h
-    model/detail/OMEModelObject.h)
+    model/detail/OMEModelObject.h
+    model/detail/Parse.h)
 
 set(OME_XML_STATIC_ENUMS_HEADERS
     model/enums/EnumerationException.h)

--- a/cpp/lib/ome/xml/meta/Convert.cpp
+++ b/cpp/lib/ome/xml/meta/Convert.cpp
@@ -92,7 +92,6 @@ namespace
       convertFileAnnotations();
       convertListAnnotations();
       convertLongAnnotations();
-      convertMapAnnotations();
       convertTagAnnotations();
       convertTermAnnotations();
       convertTimestampAnnotations();
@@ -449,7 +448,6 @@ namespace
               transfer(&MR::getImagingEnvironmentAirPressure, &MS::setImagingEnvironmentAirPressure, i);
               transfer(&MR::getImagingEnvironmentCO2Percent,  &MS::setImagingEnvironmentCO2Percent,  i);
               transfer(&MR::getImagingEnvironmentHumidity,    &MS::setImagingEnvironmentHumidity,    i);
-              transfer(&MR::getImagingEnvironmentMap,         &MS::setImagingEnvironmentMap,         i);
               transfer(&MR::getImagingEnvironmentTemperature, &MS::setImagingEnvironmentTemperature, i);
 
               if (transfer(&MR::getObjectiveSettingsID, &MS::setObjectiveSettingsID, i))
@@ -539,10 +537,6 @@ namespace
                       index_type exFilterRefCount(src.getLightPathExcitationFilterRefCount(i, c));
                       for (index_type q = 0; q < exFilterRefCount; ++q)
                         transfer(&MR::getLightPathExcitationFilterRef, &MS::setLightPathExcitationFilterRef, i, c, q);
-
-                      index_type lightPathAnnotationRefCount(src.getLightPathAnnotationRefCount(i, c));
-                      for (index_type q = 0; q < lightPathAnnotationRefCount; ++q)
-                        transfer(&MR::getLightPathAnnotationRef, &MS::setLightPathAnnotationRef, i, c, q);
                     }
                 }
 
@@ -610,10 +604,6 @@ namespace
                   transfer(&MR::getArcPower,        &MS::setArcPower,        instrumentIndex, lightSource);
                   transfer(&MR::getArcSerialNumber, &MS::setArcSerialNumber, instrumentIndex, lightSource);
                   transfer(&MR::getArcType,         &MS::setArcType,         instrumentIndex, lightSource);
-
-                  index_type lightSourceAnnotationRefCount(src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource));
-                  for (index_type r = 0; r < lightSourceAnnotationRefCount; ++r)
-                    transfer(&MR::getArcAnnotationRef, &MS::setArcAnnotationRef, instrumentIndex, lightSource, r);
                 }
             }
           else if (type == "Filament")
@@ -627,26 +617,6 @@ namespace
                   transfer(&MR::getFilamentPower,        &MS::setFilamentPower,        instrumentIndex, lightSource);
                   transfer(&MR::getFilamentSerialNumber, &MS::setFilamentSerialNumber, instrumentIndex, lightSource);
                   transfer(&MR::getFilamentType,         &MS::setFilamentType,         instrumentIndex, lightSource);
-
-                  index_type lightSourceAnnotationRefCount(src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource));
-                  for (index_type r = 0; r < lightSourceAnnotationRefCount; ++r)
-                    transfer(&MR::getFilamentAnnotationRef, &MS::setFilamentAnnotationRef, instrumentIndex, lightSource, r);
-                }
-            }
-          else if (type == "GenericExcitationSource")
-            {
-              if (transfer(&MR::getGenericExcitationSourceID, &MS::setGenericExcitationSourceID, instrumentIndex, lightSource))
-                {
-                  transfer(&MR::getGenericExcitationSourceMap,          &MS::setGenericExcitationSourceMap,          instrumentIndex, lightSource);
-                  transfer(&MR::getGenericExcitationSourceLotNumber,    &MS::setGenericExcitationSourceLotNumber,    instrumentIndex, lightSource);
-                  transfer(&MR::getGenericExcitationSourceManufacturer, &MS::setGenericExcitationSourceManufacturer, instrumentIndex, lightSource);
-                  transfer(&MR::getGenericExcitationSourceModel,        &MS::setGenericExcitationSourceModel,        instrumentIndex, lightSource);
-                  transfer(&MR::getGenericExcitationSourcePower,        &MS::setGenericExcitationSourcePower,        instrumentIndex, lightSource);
-                  transfer(&MR::getGenericExcitationSourceSerialNumber, &MS::setGenericExcitationSourceSerialNumber, instrumentIndex, lightSource);
-
-                  index_type lightSourceAnnotationRefCount(src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource));
-                  for (index_type r = 0; r < lightSourceAnnotationRefCount; ++r)
-                    transfer(&MR::getGenericExcitationSourceAnnotationRef, &MS::setGenericExcitationSourceAnnotationRef, instrumentIndex, lightSource, r);
                 }
             }
           else if (type == "Laser")
@@ -668,10 +638,6 @@ namespace
                   transfer(&MR::getLaserRepetitionRate,          &MS::setLaserRepetitionRate,          instrumentIndex, lightSource);
                   transfer(&MR::getLaserTuneable,                &MS::setLaserTuneable,                instrumentIndex, lightSource);
                   transfer(&MR::getLaserWavelength,              &MS::setLaserWavelength,              instrumentIndex, lightSource);
-
-                  index_type lightSourceAnnotationRefCount(src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource));
-                  for (index_type r = 0; r < lightSourceAnnotationRefCount; ++r)
-                    transfer(&MR::getLaserAnnotationRef, &MS::setLaserAnnotationRef, instrumentIndex, lightSource, r);
                 }
             }
           else if (type == "LightEmittingDiode")
@@ -683,10 +649,6 @@ namespace
                   transfer(&MR::getLightEmittingDiodeModel,        &MS::setLightEmittingDiodeModel,        instrumentIndex, lightSource);
                   transfer(&MR::getLightEmittingDiodePower,        &MS::setLightEmittingDiodePower,        instrumentIndex, lightSource);
                   transfer(&MR::getLightEmittingDiodeSerialNumber, &MS::setLightEmittingDiodeSerialNumber, instrumentIndex, lightSource);
-
-                  index_type lightSourceAnnotationRefCount(src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource));
-                  for (index_type r = 0; r < lightSourceAnnotationRefCount; ++r)
-                    transfer(&MR::getLightEmittingDiodeAnnotationRef, &MS::setLightEmittingDiodeAnnotationRef, instrumentIndex, lightSource, r);
                 }
             }
         }
@@ -722,10 +684,6 @@ namespace
                       transfer(&MR::getDetectorType,              &MS::setDetectorType,              i, q);
                       transfer(&MR::getDetectorVoltage,           &MS::setDetectorVoltage,           i, q);
                       transfer(&MR::getDetectorZoom,              &MS::setDetectorZoom,              i, q);
-
-                      index_type detectorAnnotationRefCount(src.getDetectorAnnotationRefCount(i, q));
-                      for (index_type r = 0; r < detectorAnnotationRefCount; ++r)
-                        transfer(&MR::getDetectorAnnotationRef, &MS::setDetectorAnnotationRef, i, q, r);
                     }
                 }
 
@@ -738,10 +696,6 @@ namespace
                       transfer(&MR::getDichroicManufacturer, &MS::setDichroicManufacturer, i, q);
                       transfer(&MR::getDichroicModel,        &MS::setDichroicModel,        i, q);
                       transfer(&MR::getDichroicSerialNumber, &MS::setDichroicSerialNumber, i, q);
-
-                      index_type dichroicAnnotationRefCount(src.getDichroicAnnotationRefCount(i,q));
-                      for (index_type r = 0; r < dichroicAnnotationRefCount; ++r)
-                        transfer(&MR::getDichroicAnnotationRef, &MS::setDichroicAnnotationRef, i, q, r);
                     }
                 }
 
@@ -761,10 +715,6 @@ namespace
                       transfer(&MR::getTransmittanceRangeCutOut,          &MS::setTransmittanceRangeCutOut,          i, q);
                       transfer(&MR::getTransmittanceRangeCutOutTolerance, &MS::setTransmittanceRangeCutOutTolerance, i, q);
                       transfer(&MR::getTransmittanceRangeTransmittance,   &MS::setTransmittanceRangeTransmittance,   i, q);
-
-                      index_type filterAnnotationRefCount(src.getFilterAnnotationRefCount(i, q));
-                      for (index_type r = 0; r < filterAnnotationRefCount; ++r)
-                        transfer(&MR::getFilterAnnotationRef, &MS::setFilterAnnotationRef, i, q, r);
                     }
                 }
 
@@ -784,10 +734,6 @@ namespace
                       transfer(&MR::getObjectiveNominalMagnification,    &MS::setObjectiveNominalMagnification,    i, q);
                       transfer(&MR::getObjectiveSerialNumber,            &MS::setObjectiveSerialNumber,            i, q);
                       transfer(&MR::getObjectiveWorkingDistance,         &MS::setObjectiveWorkingDistance,         i, q);
-
-                      index_type objectiveAnnotationRefCount(src.getObjectiveAnnotationRefCount(i, q));
-                      for (index_type r = 0; r < objectiveAnnotationRefCount; ++r)
-                        transfer(&MR::getObjectiveAnnotationRef, &MS::setObjectiveAnnotationRef, i, q, r);
                     }
                 }
 
@@ -813,10 +759,6 @@ namespace
                 }
 
               convertLightSources(i);
-
-              index_type instrumentAnnotationRefCount(src.getInstrumentAnnotationRefCount(i));
-              for (index_type r = 0; r < instrumentAnnotationRefCount; ++r)
-                transfer(&MR::getInstrumentAnnotationRef, &MS::setInstrumentAnnotationRef, i, r);
             }
         }
     }
@@ -858,27 +800,6 @@ namespace
               index_type annotationRefCount(src.getLongAnnotationAnnotationCount(i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getLongAnnotationAnnotationRef, &MS::setLongAnnotationAnnotationRef, i, a);
-            }
-        }
-    }
-
-    /// Convert map annotations.
-    void
-    convertMapAnnotations()
-    {
-      index_type mapAnnotationCount(src.getMapAnnotationCount());
-      for (index_type i = 0; i < mapAnnotationCount; ++i)
-        {
-          if (transfer(&MR::getMapAnnotationID,          &MS::setMapAnnotationID,          i))
-            {
-              transfer(&MR::getMapAnnotationDescription, &MS::setMapAnnotationDescription, i);
-              transfer(&MR::getMapAnnotationNamespace,   &MS::setMapAnnotationNamespace,   i);
-              transfer(&MR::getMapAnnotationValue,       &MS::setMapAnnotationValue,       i);
-              transfer(&MR::getMapAnnotationAnnotator,   &MS::setMapAnnotationAnnotator,   i);
-
-              index_type annotationRefCount(src.getMapAnnotationAnnotationCount(i));
-              for (index_type a = 0; a < annotationRefCount; ++a)
-                transfer(&MR::getMapAnnotationAnnotationRef, &MS::setMapAnnotationAnnotationRef, i, a);
             }
         }
     }
@@ -1031,10 +952,6 @@ namespace
                           transfer(&MR::getEllipseRadiusY,         &MS::setEllipseRadiusY,         i, q);
                           transfer(&MR::getEllipseX,               &MS::setEllipseX,               i, q);
                           transfer(&MR::getEllipseY,               &MS::setEllipseY,               i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getEllipseAnnotationRef, &MS::setEllipseAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Label")
@@ -1059,10 +976,6 @@ namespace
                           transfer(&MR::getLabelVisible,         &MS::setLabelVisible,         i, q);
                           transfer(&MR::getLabelX,               &MS::setLabelX,               i, q);
                           transfer(&MR::getLabelY,               &MS::setLabelY,               i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getLabelAnnotationRef, &MS::setLabelAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Line")
@@ -1091,10 +1004,6 @@ namespace
                           transfer(&MR::getLineX2,              &MS::setLineX2,              i, q);
                           transfer(&MR::getLineY1,              &MS::setLineY1,              i, q);
                           transfer(&MR::getLineY2,              &MS::setLineY2,              i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getLineAnnotationRef, &MS::setLineAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Mask")
@@ -1121,10 +1030,6 @@ namespace
                           transfer(&MR::getMaskWidth,           &MS::setMaskWidth,           i, q);
                           transfer(&MR::getMaskX,               &MS::setMaskX,               i, q);
                           transfer(&MR::getMaskY,               &MS::setMaskY,               i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getMaskAnnotationRef, &MS::setMaskAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Point")
@@ -1149,10 +1054,6 @@ namespace
                           transfer(&MR::getPointVisible,         &MS::setPointVisible,         i, q);
                           transfer(&MR::getPointX,               &MS::setPointX,               i, q);
                           transfer(&MR::getPointY,               &MS::setPointY,               i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getPointAnnotationRef, &MS::setPointAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Polygon")
@@ -1176,10 +1077,6 @@ namespace
                           transfer(&MR::getPolygonTransform,       &MS::setPolygonTransform,       i, q);
                           transfer(&MR::getPolygonVisible,         &MS::setPolygonVisible,         i, q);
                           transfer(&MR::getPolygonPoints,          &MS::setPolygonPoints,          i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getPolygonAnnotationRef, &MS::setPolygonAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Polyline")
@@ -1205,10 +1102,6 @@ namespace
                           transfer(&MR::getPolylineMarkerEnd,       &MS::setPolylineMarkerEnd,       i, q);
                           transfer(&MR::getPolylineMarkerStart,     &MS::setPolylineMarkerStart,     i, q);
                           transfer(&MR::getPolylinePoints,          &MS::setPolylinePoints,          i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getPolylineAnnotationRef, &MS::setPolylineAnnotationRef, i, q, r);
                         }
                     }
                   else if (type == "Rectangle")
@@ -1235,10 +1128,6 @@ namespace
                           transfer(&MR::getRectangleWidth,           &MS::setRectangleWidth,           i, q);
                           transfer(&MR::getRectangleX,               &MS::setRectangleX,               i, q);
                           transfer(&MR::getRectangleY,               &MS::setRectangleY,               i, q);
-
-                          index_type shapeAnnotationRefCount(src.getShapeAnnotationRefCount(i, q));
-                          for (index_type r = 0; r < shapeAnnotationRefCount; ++r)
-                            transfer(&MR::getRectangleAnnotationRef, &MS::setRectangleAnnotationRef, i, q, r);
                         }
                     }
                 }

--- a/cpp/lib/ome/xml/meta/OMEXMLMetadataRoot.cpp
+++ b/cpp/lib/ome/xml/meta/OMEXMLMetadataRoot.cpp
@@ -55,14 +55,6 @@ namespace ome
       {
       }
 
-      OMEXMLMetadataRoot::OMEXMLMetadataRoot(::ome::xerces::dom::Element& element,
-					     ::ome::xml::model::OMEModel& model):
-        ome::xml::model::OMEModelObject(),
-	MetadataRoot(),
-	OME(element, model)
-      {
-      }
-
       OMEXMLMetadataRoot::~OMEXMLMetadataRoot()
       {
       }

--- a/cpp/lib/ome/xml/meta/OMEXMLMetadataRoot.h
+++ b/cpp/lib/ome/xml/meta/OMEXMLMetadataRoot.h
@@ -61,19 +61,6 @@ namespace ome
         /// Constructor.
         OMEXMLMetadataRoot();
 
-	/**
-         * Construct OME-XML model recursively from an XML DOM tree.
-         *
-         * @param element root of the XML DOM tree to from which to
-         * construct the model object graph.
-         * @param model handler for the OME model used to track
-         * instances and references seen during the update.
-         * @throws EnumerationException if there is an error
-         * instantiating an enumeration during model object creation.
-         */
-        OMEXMLMetadataRoot(::ome::xerces::dom::Element& element,
-			   ::ome::xml::model::OMEModel& model);
-
 	/// Copy constructor.
 	OMEXMLMetadataRoot(const OMEXMLMetadataRoot& copy);
 

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -131,14 +131,14 @@ namespace ome
         return false;
       }
 
-      xerces::dom::Element&
+      xerces::dom::Element
       MapPairs::asXMLElement (xerces::dom::Document& document) const
       {
         xerces::dom::Element nullelem;
         return asXMLElementInternal(document, nullelem);
       }
 
-      xerces::dom::Element&
+      xerces::dom::Element
       MapPairs::asXMLElementInternal (xerces::dom::Document& document,
                                       xerces::dom::Element&  element) const
       {

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -40,6 +40,7 @@
 
 #include <ome/internal/version.h>
 
+#include <ome/xml/model/OME.h>
 #include <ome/xml/model/MapPairs.h>
 
 namespace ome
@@ -182,6 +183,17 @@ namespace ome
       MapPairs::setMap (const map_type& map)
       {
         this->map = map;
+      }
+
+      const std::string&
+      MapPairs::getXMLNamespace() const
+      {
+        // This is a hack; we don't have direct access to the
+        // namespace at present since it's emitted by the code
+        // generator.  Copy the namespace from the generated OME
+        // class.
+        OME ome;
+        return ome.getXMLNamespace();
       }
 
     }

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -89,6 +89,13 @@ namespace ome
       {
       }
 
+      const std::string&
+      MapPairs::elementName() const
+      {
+        static const std::string type("MapPairs");
+        return type;
+      }
+
       void
       MapPairs::update(const xerces::dom::Element&  element,
                        ::ome::xml::model::OMEModel& model)

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -96,6 +96,14 @@ namespace ome
         return type;
       }
 
+      bool
+      MapPairs::validElementName(const std::string& name) const
+      {
+        static const std::string expectedTagName("MapPairs");
+
+        return expectedTagName == name || detail::OMEModelObject::validElementName(name);
+      }
+
       void
       MapPairs::update(const xerces::dom::Element&  element,
                        ::ome::xml::model::OMEModel& model)

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -116,6 +116,10 @@ namespace ome
         const std::string&
         elementName() const;
 
+        // Documented in superclass.
+        bool
+        validElementName(const std::string& name) const;
+
         /// @copydoc ome::xml::model::OMEModelObject::update
         virtual void
         update(const xerces::dom::Element&  element,

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -148,12 +148,12 @@ namespace ome
         setMap (const map_type& map);
 
         /// @copydoc ome::xml::model::OMEModelObject::asXMLElement
-        virtual xerces::dom::Element&
+        virtual xerces::dom::Element
         asXMLElement (xerces::dom::Document& document) const;
 
       protected:
         // Documented in base class.
-        virtual xerces::dom::Element&
+        virtual xerces::dom::Element
         asXMLElementInternal (xerces::dom::Document& document,
                               xerces::dom::Element&  element) const;
 

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -112,6 +112,10 @@ namespace ome
         virtual
         ~MapPairs ();
 
+        // Documented in superclass.
+        const std::string&
+        elementName() const;
+
         /// @copydoc ome::xml::model::OMEModelObject::update
         virtual void
         update(const xerces::dom::Element&  element,

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -151,11 +151,16 @@ namespace ome
         virtual xerces::dom::Element&
         asXMLElement (xerces::dom::Document& document) const;
 
- protected:
+      protected:
         // Documented in base class.
         virtual xerces::dom::Element&
         asXMLElementInternal (xerces::dom::Document& document,
                               xerces::dom::Element&  element) const;
+
+      public:
+        // Documented in superclass.
+        const std::string&
+        getXMLNamespace() const;
       };
 
     }

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -165,6 +165,14 @@ namespace ome
         virtual bool
         link (std::shared_ptr<Reference>&      reference,
               std::shared_ptr<OMEModelObject>& object) = 0;
+
+        /**
+         * Get the XML namespace for this model object.
+         *
+         * @returns the XML namespace.
+         */
+        virtual const std::string&
+        getXMLNamespace() const = 0;
       };
 
     }

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -120,7 +120,7 @@ namespace ome
          * @param document document for element creation
          * @returns an XML DOM tree root element for this model object.
          */
-        virtual xerces::dom::Element&
+        virtual xerces::dom::Element
         asXMLElement (xerces::dom::Document& document) const = 0;
 
         /**

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -104,6 +104,16 @@ namespace ome
         ~OMEModelObject ()
         {}
 
+        /**
+         * Get the element name of this model object.
+         *
+         * This will be the most-derived class name.
+         *
+         * @returns the element type.
+         */
+        virtual const std::string&
+        elementName() const = 0;
+
       private:
         /// Copy constructor (deleted).
         OMEModelObject (const OMEModelObject&);

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -114,6 +114,19 @@ namespace ome
         virtual const std::string&
         elementName() const = 0;
 
+        /**
+         * Check if a given element name is valid for processing by
+         * this model object.
+         *
+         * Used for processing nodes when interitance is involved.
+         *
+         * @param name the element name to check.
+         *
+         * @returns @c true if valid, @c false if invalid.
+         */
+        virtual bool
+        validElementName(const std::string& name) const = 0;
+
       private:
         /// Copy constructor (deleted).
         OMEModelObject (const OMEModelObject&);

--- a/cpp/lib/ome/xml/model/detail/OMEModel.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.cpp
@@ -120,7 +120,7 @@ namespace ome
         {
           reference_map_type::iterator i = references.find(a);
 
-          if (i != references.end())
+          if (i == references.end())
             {
               std::pair<reference_map_type::iterator,bool> r =
                 references.insert(std::make_pair(a, reference_map_type::value_type::second_type()));

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -65,6 +65,12 @@ namespace ome
           // Nothing to copy.
         }
 
+        bool
+        OMEModelObject::validElementName(const std::string& /* name */) const
+        {
+          return false;
+        }
+
         xerces::dom::Element
         OMEModelObject::asXMLElementInternal (xerces::dom::Document& /* document */,
                                               xerces::dom::Element&  element) const

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -118,13 +118,11 @@ namespace ome
         OMEModelObject::stripNamespacePrefix (const std::string& value) {
           std::string ret;
           std::string::size_type i = value.find_last_of(':');
-          if (i != std::string::npos)
-            {
-              ++i;
-              if (i < value.size())
-                ret = value.substr(i);
-            }
-          return value;
+          if (i != std::string::npos && ++i < value.size())
+            ret = value.substr(i);
+          else
+            ret = value;
+          return ret;
         }
 
       }

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -65,7 +65,7 @@ namespace ome
           // Nothing to copy.
         }
 
-        xerces::dom::Element&
+        xerces::dom::Element
         OMEModelObject::asXMLElementInternal (xerces::dom::Document& /* document */,
                                               xerces::dom::Element&  element) const
         {

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.h
@@ -80,14 +80,14 @@ namespace ome
           /**
            * Transform the object hierarchy rooted at this element to
            * XML.  This internal implementation of asXMLelement also
-           * requires an XML element, which may be null, or may be
-           * instantiated and passed from superclasses.
+           * requires an XML element, which must not be null, or may
+           * be instantiated and passed from superclasses.
            *
            * @param document XML document for element creation.
            * @param element XML element for setting model data.
            * @returns an XML DOM tree root element for this model object.
            */
-          virtual xerces::dom::Element&
+          virtual xerces::dom::Element
           asXMLElementInternal (xerces::dom::Document& document,
                                 xerces::dom::Element&  element) const = 0;
 

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.h
@@ -76,6 +76,10 @@ namespace ome
            */
           OMEModelObject (const OMEModelObject& copy);
 
+          /// @copydoc ome::xml::model::OMEModelObject::validElementName
+          bool
+          validElementName(const std::string& name) const = 0;
+
         protected:
           /**
            * Transform the object hierarchy rooted at this element to

--- a/cpp/lib/ome/xml/model/detail/Parse.cpp
+++ b/cpp/lib/ome/xml/model/detail/Parse.cpp
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <boost/format.hpp>
+
+#include <ome/xml/model/ModelException.h>
+#include <ome/xml/model/detail/Parse.h>
+
+namespace ome
+{
+  namespace xml
+  {
+    namespace model
+    {
+      namespace detail
+      {
+
+        void
+        parse_value_fail(const std::string& text,
+                         const std::string& klass,
+                         const std::string& property)
+        {
+          boost::format fmt("Failed to parse %1% %2% property value ‘%1%’");
+          fmt % klass % property % text;
+          throw ModelException(fmt.str());
+        }
+
+      }
+    }
+  }
+}

--- a/cpp/lib/ome/xml/model/detail/Parse.h
+++ b/cpp/lib/ome/xml/model/detail/Parse.h
@@ -1,0 +1,235 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_XML_MODEL_DETAIL_PARSE_H
+#define OME_XML_MODEL_DETAIL_PARSE_H
+
+#include <ome/xml/model/OMEModelObject.h>
+
+#include <boost/mpl/bool.hpp>
+#include <boost/type_traits.hpp>
+
+namespace ome
+{
+  namespace xml
+  {
+    namespace model
+    {
+      namespace detail
+      {
+
+        /**
+         * Throw a model exception with an informative message.
+         *
+         * @param text the property text value which failed to parse.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @throws a ModelException.
+         */
+        void
+        parse_value_fail(const std::string& text,
+                         const std::string& klass,
+                         const std::string& property);
+
+        /// Type trait for shared_ptr.
+        template <class T>
+        struct is_shared_ptr
+          : boost::false_type {};
+
+        /// Type trait for shared_ptr.
+        template <class T>
+        struct is_shared_ptr<std::shared_ptr<T> >
+          : boost::true_type {};
+
+        /**
+         * Parse an arbitrary value.
+         *
+         * @param text the text to parse.
+         * @param value the variable to store the parsed value.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @throws a ModelException on failure.
+         */
+        template<typename T>
+        inline void
+        parse_value(const std::string& text,
+                    T&                 value,
+                    const std::string& klass,
+                    const std::string& property)
+        {
+          std::istringstream is(text);
+          is.imbue(std::locale::classic());
+
+          if (!(is >> value))
+            parse_value_fail(text, klass, property);
+        }
+
+        /**
+         * Parse a Boolean value.
+         *
+         * @param text the text to parse.
+         * @param value the variable to store the parsed value.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @throws a ModelException on failure.
+         */
+        template<>
+        inline void
+        parse_value<bool>(const std::string& text,
+                          bool&              value,
+                          const std::string& klass,
+                          const std::string& property)
+        {
+          std::istringstream is(text);
+          is.imbue(std::locale::classic());
+
+          if (!(is >> std::boolalpha >> value))
+            parse_value_fail(text, klass, property);
+        }
+
+        /**
+         * Parse a string value.
+         *
+         * @param text the text to parse.
+         * @param value the variable to store the parsed value.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @throws a ModelException on failure.
+         */
+        template<>
+        inline void
+        parse_value<std::string>(const std::string& text,
+                                 std::string&       value,
+                                 const std::string& klass,
+                                 const std::string& property)
+        {
+          value = text;
+        }
+
+        /**
+         * Parse an arbitrary value.
+         *
+         * @param text the text to parse.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @returns the parsed value.
+         * @throws a ModelException on failure.
+         */
+        template<typename T>
+        inline typename boost::disable_if_c<
+          is_shared_ptr<T>::value,
+          typename boost::remove_const<typename boost::remove_reference<T>::type>::type
+          >::type
+        parse_value(const std::string& text,
+                    const std::string& klass,
+                    const std::string& property)
+        {
+          typedef typename boost::remove_const<typename boost::remove_reference<T>::type>::type raw_type;
+
+          raw_type attr;
+          parse_value(text, attr, klass, property);
+          return attr;
+        }
+
+        /**
+         * Parse an arbitrary shared_ptr value.
+         *
+         * @param text the text to parse.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @returns the parsed value.
+         * @throws a ModelException on failure.
+         */
+        template<typename T>
+        inline typename boost::enable_if_c<
+          is_shared_ptr<T>::value,
+          typename boost::remove_const<typename boost::remove_reference<T>::type>::type
+          >::type
+        parse_value(const std::string& text,
+                    const std::string& klass,
+                    const std::string& property)
+        {
+          typedef typename boost::remove_const<typename boost::remove_reference<T>::type>::type raw_type;
+
+          raw_type attr(std::make_shared<typename raw_type::element_type>());
+          parse_value(text, *attr, klass, property);
+          return attr;
+        }
+
+        /**
+         * Set an arbitrary value.
+         *
+         * The type to set will be obtained from the setter argument
+         * type.
+         *
+         * @param text the text to parse.
+         * @param object on which to set the parsed value.
+         * @param setter the class method to call to set the parsed
+         * value.
+         * @param klass the class owning the property.
+         * @param property the property name.
+         * @returns the parsed value.
+         * @throws a ModelException on failure.
+         */
+        template<class C, typename T>
+        inline void
+        set_value(const std::string&       text,
+                  C&                       object,
+                  void               (C::* setter)(T value),
+                  const std::string&       klass,
+                  const std::string&       property)
+        {
+          typedef typename boost::remove_const<typename boost::remove_reference<T>::type>::type raw_type;
+
+          raw_type attr(parse_value<raw_type>(text, klass, property));
+
+          (object.*setter)(attr);
+        }
+
+      }
+    }
+  }
+}
+
+#endif // OME_XML_MODEL_DETAIL_PARSE_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/xml/model/detail/Parse.h
+++ b/cpp/lib/ome/xml/model/detail/Parse.h
@@ -203,7 +203,6 @@ namespace ome
          * value.
          * @param klass the class owning the property.
          * @param property the property name.
-         * @returns the parsed value.
          * @throws a ModelException on failure.
          */
         template<class C, typename T>

--- a/cpp/test/ome-xerces/xerces.cpp
+++ b/cpp/test/ome-xerces/xerces.cpp
@@ -147,11 +147,26 @@ TEST_P(XercesTest, EmptyDocument)
   ASSERT_TRUE(document);
 }
 
+TEST_P(XercesTest, EmptyDocumentNS)
+{
+  xml::dom::Document document(ome::xerces::dom::createEmptyDocument("http://example.com/test/namespace", "root"));
+  ASSERT_TRUE(document);
+}
+
 TEST_P(XercesTest, EmptyDocumentCreateElement)
 {
   xml::dom::Document document(ome::xerces::dom::createEmptyDocument("root"));
   ASSERT_TRUE(document);
   xml::dom::Element e(document.createElementNS("http://example.com/test/namespace", "test"));
+  xml::dom::Element root(document.getDocumentElement());
+  root.appendChild(e);
+}
+
+TEST_P(XercesTest, EmptyDocumentCreateElementNS)
+{
+  xml::dom::Document document(ome::xerces::dom::createEmptyDocument("http://example.com/test/namespace1", "root"));
+  ASSERT_TRUE(document);
+  xml::dom::Element e(document.createElementNS("http://example.com/test/namespace2", "test"));
   xml::dom::Element root(document.getDocumentElement());
   root.appendChild(e);
 }

--- a/cpp/test/ome-xml/CMakeLists.txt
+++ b/cpp/test/ome-xml/CMakeLists.txt
@@ -71,10 +71,16 @@ if(BUILD_TESTS)
   target_link_libraries(timestamp ome-xml)
   target_link_libraries(timestamp ome-test)
 
+  add_executable(model model.cpp)
+  target_link_libraries(model ome-xml)
+  target_link_libraries(model ome-test)
+
   bf_add_test(ome-xml/color color)
   bf_add_test(ome-xml/enum enum)
   bf_add_test(ome-xml/constrained-numeric constrained-numeric)
   bf_add_test(ome-xml/timestamp timestamp)
+  bf_add_test(ome-xml/model model)
+
 
   if(extended-tests)
     header_test_from_file(ome-xml ome-xml ome/xml)

--- a/cpp/test/ome-xml/model.cpp
+++ b/cpp/test/ome-xml/model.cpp
@@ -1,0 +1,217 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+
+#include <ome/internal/config.h>
+#include <ome/internal/version.h>
+
+#include <ome/test/config.h>
+#include <ome/test/test.h>
+
+#include <ome/xerces/Platform.h>
+#include <ome/xerces/dom/Document.h>
+
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+using namespace boost::filesystem;
+
+struct ModelTestParameters
+{
+  path file;
+};
+
+template<class charT, class traits>
+inline std::basic_ostream<charT,traits>&
+operator<< (std::basic_ostream<charT,traits>& os,
+            const ModelTestParameters& p)
+{
+  return os << p.file;
+}
+
+namespace
+{
+
+  std::vector<ModelTestParameters>
+  find_model_tests()
+  {
+    std::vector<ModelTestParameters> params;
+
+    /// @todo Use the correct model version when available.
+    /// @todo Use all model versions when transforms available.
+    path dir(PROJECT_SOURCE_DIR "/components/specification/samples/" "2013-06");
+    if (exists(dir) && is_directory(dir))
+      {
+        for(directory_iterator i(dir); i != directory_iterator(); ++i)
+          {
+            ModelTestParameters p;
+            p.file = *i;
+
+            // Contains non-POSIX timestamps.
+            if (p.file.filename() == path("2013-06-datetests.ome"))
+              continue;
+
+            if (p.file.extension() == path(".ome") ||
+                p.file.extension() == path(".xml"))
+              params.push_back(p);
+          }
+      }
+
+    return params;
+  }
+
+}
+
+std::vector<ModelTestParameters> tile_params(find_model_tests());
+
+class ModelTest : public ::testing::TestWithParam<ModelTestParameters>
+{
+public:
+  ome::xerces::Platform xmlplat;
+  std::string xmltext;
+  ome::xerces::dom::Document doc;
+
+  virtual void SetUp()
+  {
+    const ModelTestParameters& params = GetParam();
+
+    std::ifstream in(params.file.c_str());
+
+    ASSERT_TRUE(!!in);
+    in.seekg(0, std::ios::end);
+    xmltext.reserve(in.tellg());
+    in.seekg(0, std::ios::beg);
+
+    xmltext.assign(std::istreambuf_iterator<char>(in),
+                   std::istreambuf_iterator<char>());
+
+    doc = ome::xerces::dom::createDocument(xmltext);
+  }
+};
+
+
+TEST_P(ModelTest, Parse)
+{
+  const ModelTestParameters& params = GetParam();
+}
+
+TEST_P(ModelTest, Update)
+{
+  const ModelTestParameters& params = GetParam();
+
+  // Read into OME model objects.
+  ome::xml::meta::OMEXMLMetadata meta;
+  ome::xml::model::detail::OMEModel model;
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::xerces::dom::Element docroot(doc.getDocumentElement());
+  root->update(docroot, model);
+}
+
+TEST_P(ModelTest, CreateXML)
+{
+  const ModelTestParameters& params = GetParam();
+
+  // Read into OME model objects.
+  ome::xml::meta::OMEXMLMetadata meta;
+  ome::xml::model::detail::OMEModel model;
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::xerces::dom::Element docroot(doc.getDocumentElement());
+  root->update(docroot, model);
+
+  // Dump as XML string.
+  std::string omexml(meta.dumpXML());
+
+  // Validate XML.
+  ASSERT_NO_THROW(ome::xerces::dom::createDocument(omexml));
+}
+
+TEST_P(ModelTest, CreateXMLRoundTrip)
+{
+  const ModelTestParameters& params = GetParam();
+
+  // Read into OME model objects.
+  ome::xml::meta::OMEXMLMetadata meta;
+  ome::xml::model::detail::OMEModel model;
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::xerces::dom::Element docroot(doc.getDocumentElement());
+  root->update(docroot, model);
+
+  // Dump as XML string.
+  std::string omexml(meta.dumpXML());
+
+  // Validate XML.
+  ASSERT_NO_THROW(ome::xerces::dom::createDocument(omexml));
+
+  // Repeat read and write.
+
+  // Read into OME model objects.
+  ome::xerces::dom::Document doc2(ome::xerces::dom::createDocument(omexml));
+  ome::xml::meta::OMEXMLMetadata meta2;
+  ome::xml::model::detail::OMEModel model2;
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root2(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
+  ome::xerces::dom::Element docroot2(doc2.getDocumentElement());
+  root2->update(docroot2, model2);
+
+  // Dump as XML string.
+  std::string omexml2(meta2.dumpXML());
+
+  // Validate XML.
+  ASSERT_NO_THROW(ome::xerces::dom::createDocument(omexml2));
+
+  ASSERT_EQ(omexml, omexml2);
+}
+
+TEST(ModelObject, StripNamespacePrefix)
+{
+  ASSERT_EQ(std::string("OME"), ome::xml::model::detail::OMEModelObject::stripNamespacePrefix("OME:OME"));
+  ASSERT_EQ(std::string("Image"), ome::xml::model::detail::OMEModelObject::stripNamespacePrefix("OME:Image"));
+  ASSERT_NE(std::string("Bin:BinData"), ome::xml::model::detail::OMEModelObject::stripNamespacePrefix("Bin:BinData"));
+}
+
+// Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
+// this is solely to work around a missing prototype in gtest.
+#ifdef __GNUC__
+#  if defined __clang__ || defined __APPLE__
+#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#  endif
+#  pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+
+INSTANTIATE_TEST_CASE_P(ModelVariants, ModelTest, ::testing::ValuesIn(tile_params));


### PR DESCRIPTION
- Fixes and additions to the Xerces-C wrappers
- Fixes and additions to the xsd-fu generator and the C++ templates
- Additional helper methods and functions added to ome-xml; parsing helpers move complexity out of the Genshi templates into real C++ templates, which is easier to edit and debug
- Addition of OME-XML output and validation to showinf
- Addition of model testcase to the ome-xml tests
- Add helpers to MetadataTools and XMLTools from Java MetadataTools, XMLTools and OMEXMLServiceImpl
- Revert model to 2013-06 for the 5.1.0 release

Note that the generated source code was changed by the template updates.

--no-rebase

--------

Testing: Unit tests (cpp/test/ome-xml/model) will test all the 2013-06 samples except for one with timestamps we don't currently handle [currently can't store dates prior to the POSIX epoch]; I added a custom version without pre-1970 dates for the time being.  Additional OME-XML could be tested by dropping it into the 2013-06 samples directory.

`showinf` should also display OME-XML metadata for TIFF files.  Run (in the build tree):

```
./bf bin/showinf/showinf --omexml yes --validate yes /path/to/tiff
```

Or in a downloaded binary build:

```
cd /path/to/unpacked/zip
export BIOFORMATS_HOME=$(pwd)
export LD_LIBRARY_PATH="${BIOFORMATS_HOME}/lib"
PATH="${BIOFORMATS_HOME}/bin:$PATH"
showinf --help
showinf --omexml yes --validate yes /path/to/tiff
```

Use `DYLD_LIBRARY_PATH` on MacOS X in place of `LD_LIBRARY_PATH`.

Note it is likely to be missing original metadata annotations at this point, but the OME-XML should validate and contain all the correct dimensions, etc.  (Multi-plane TIFFs will be timeseries and have SizeT==PlaneCount)

/cc @bramalingam @pwalczysko @emilroz 