### PR TITLE
cpp: bioformats: Remove VariantPixelBuffer at method

### DIFF
--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -57,14 +57,12 @@ namespace ome
      * PixelBuffer for all combinations of pixel type (excluding
      * endian variants).
      *
-     * While direct access to the pixel data is possible using this
-     * class, please be aware that this will not provide high
-     * performance.  For high performance access to the pixel data,
-     * use of a @c boost::static_visitor is recommended.  This has the
-     * benefit of generalising the algorithm to operate on all
-     * PixelBuffer types, as well as allowing special casing for
-     * particular types (e.g. integer vs. float, signed vs. unsigned,
-     * simple vs. complex, or any other distinction which affects the
+     * For high performance access to the pixel data, use of a @c
+     * boost::static_visitor is recommended.  This has the benefit of
+     * generalising the algorithm to operate on all PixelBuffer types,
+     * as well as allowing special casing for particular types
+     * (e.g. integer vs. float, signed vs. unsigned, simple
+     * vs. complex, or any other distinction which affects the
      * algorithm).  This will also allow subsetting of the data if
      * required, again for all pixel types with special casing being
      * possible.
@@ -659,52 +657,6 @@ namespace ome
       void
       assign(InputIterator begin,
              InputIterator end);
-
-      /**
-       * Get the pixel value at an index.
-       *
-       * @note If the index is out of bounds, an assertion failure
-       * will immediately abort the program, so take care to ensure it
-       * is always valid.
-       *
-       * @param indices the multi-dimensional array index.
-       * @returns a reference to the pixel value.
-       * @throws if the contained PixelBuffer is not of the specified
-       * type.
-       */
-      template<typename T>
-      T&
-      at(const indices_type& indices)
-      {
-        std::shared_ptr<PixelBuffer<T> >& r
-          = boost::get<std::shared_ptr<PixelBuffer<T> > >(buffer);
-        if (!r)
-          throw std::runtime_error("Null pixel type");
-        return r->array()(indices);
-      }
-
-      /**
-       * Get the pixel value at an index.
-       *
-       * @note If the index is out of bounds, an assertion failure
-       * will immediately abort the program, so take care to ensure it
-       * is always valid.
-       *
-       * @param indices the multi-dimensional array index.
-       * @returns a constant reference to the pixel value.
-       * @throws if the contained PixelBuffer is not of the specified
-       * type.
-       */
-      template<typename T>
-      const T&
-      at(const indices_type& indices) const
-      {
-        const std::shared_ptr<PixelBuffer<T> >& r
-          = boost::get<std::shared_ptr<PixelBuffer<T> > >(buffer);
-        if (!r)
-          throw std::runtime_error("Null pixel type");
-        return r->array()(indices);
-      }
 
       /**
        * Read raw pixel data from a stream in physical storage order.

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -972,6 +972,7 @@ public:
     pngdata_chunky.setBuffer(shape, PT::UINT8, order_chunky);
     pngdata_planar.setBuffer(shape, PT::UINT8, order_planar);
 
+    std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> >& uint8_pngdata_chunky(boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> > >(pngdata_chunky.vbuffer()));
     std::vector<png_bytep> row_pointers(pheight);
     for (dimension_size_type y = 0; y < pheight; ++y)
       {
@@ -983,7 +984,7 @@ public:
           coord[ome::bioformats::DIM_CHANNEL] = coord[ome::bioformats::DIM_MODULO_Z] =
           coord[ome::bioformats::DIM_MODULO_T] = coord[ome::bioformats::DIM_MODULO_C] = 0;
 
-        row_pointers[y] = reinterpret_cast<png_bytep>(&pngdata_chunky.at< PixelProperties<PT::UINT8>::std_type>(coord));
+        row_pointers[y] = reinterpret_cast<png_bytep>(&(uint8_pngdata_chunky->at(coord)));
       }
 
     png_read_image(pngptr, &row_pointers[0]);


### PR DESCRIPTION
This method is an extremely slow and inefficient means to access single pixel values.  It was added for testing purposes, not intended for real use.  Adjust the tests to use direct access to `PixelBuffer` data via existing visitors, allowing its removal.

--no-rebase

----------

Testing: Unit tests should continue to pass.