### PR TITLE
Deltavision: allow for ND filters stored as percent fractions (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2341,11 +2341,16 @@ public class DeltavisionReader extends FormatReader {
         in.skipBytes(4);
         expTime = in.readFloat();
 
-        ndFilter = in.readFloat() / 100;
+        ndFilter = in.readFloat();
         exWavelen = in.readFloat();
         emWavelen = in.readFloat();
         intenScaling = in.readFloat();
         energyConvFactor = in.readFloat();
+
+        // the stored value could be a percent fraction or a percentage
+        if (ndFilter > 1) {
+          ndFilter /= 100;
+        }
       }
       catch (IOException e) {
         LOGGER.debug("Could not parse extended header", e);

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2348,7 +2348,7 @@ public class DeltavisionReader extends FormatReader {
         energyConvFactor = in.readFloat();
 
         // the stored value could be a percent fraction or a percentage
-        if (ndFilter > 1) {
+        if (ndFilter >= 1) {
           ndFilter /= 100;
         }
       }


### PR DESCRIPTION


This is the same as gh-1536 but rebased onto dev_5_0.

----

Fixes http://trac.openmicroscopy.org/ome/ticket/12692.  To test, verify that the ```NDFilter``` on ```Channel``` is ```0.5``` for test_images_good/dv/very_small.d3d.dv.  All builds should remain green.

/cc @will-moore 

                    