### PR TITLE
Metamorph: fix type of UIC1 tag 49 metadata (rebased onto dev_5_0)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1776,11 +1776,10 @@ public class MetamorphReader extends BaseTiffReader {
 
     switch (type) {
       case 1:
-        in.skipBytes(1);
         while (getGlobalMeta("Channel #" + index + " " + key) != null) {
           index++;
         }
-        addGlobalMeta("Channel #" + index + " " + key, in.readDouble());
+        addGlobalMeta("Channel #" + index + " " + key, readRational(in).doubleValue());
         break;
       case 2:
         int valueLength = in.read();


### PR DESCRIPTION


This is the same as gh-1537 but rebased onto dev_5_0.

----

The metadata value's type is TiffRational, not double.

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-January/004995.html.  To test, check the original metadata of the attached .tif file with this PR included.  Unlike the attached original metadata file, there should not be any very small floating point values.  In particular, keys such as ```Channel #0 Camera Bit Depth```, ```Channel #0 _MagNA_```, and ```Channel #0 _MagRI_``` should have much more reasonable values.

                    