### PR TITLE
Zeiss CZI: set plane positions using pixel row/column values

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -849,15 +849,25 @@ public class ZeissCZIReader extends FormatReader {
         if (p.stageX != null) {
           store.setPlanePositionX(p.stageX, i, plane);
         }
-        else if (positionsX != null && i < positionsX.length) {
+        else if (positionsX != null && i < positionsX.length &&
+          positionsX[i] != null)
+        {
           store.setPlanePositionX(positionsX[i], i, plane);
+        }
+        else {
+          store.setPlanePositionX(new Length(p.col, UNITS.REFERENCEFRAME), i, plane);
         }
 
         if (p.stageY != null) {
           store.setPlanePositionY(p.stageY, i, plane);
         }
-        else if (positionsY != null && i < positionsY.length) {
+        else if (positionsY != null && i < positionsY.length &&
+          positionsY[i] != null)
+        {
           store.setPlanePositionY(positionsY[i], i, plane);
+        }
+        else {
+          store.setPlanePositionY(new Length(p.row, UNITS.REFERENCEFRAME), i, plane);
         }
 
         if (p.stageZ != null) {


### PR DESCRIPTION
If physical positions are not present, this means that the PositionX and
PositionY values will be set to the relative positions in pixels.

See QA 10445.  Without this PR, PositionX and PositionY on Plane are not populated for the QA file.  With this PR, ```showinf -omexml``` or ImageJ with ```Display OME-XML metadata``` checked should show both values populated for every plane.

Opening in ImageJ with ```Stitch tiles``` checked will arrange the tiles in order according to PositionX and PositionY, so this can be used to verify that the positions are correct - just note that the tile overlap is intentionally not removed, so the resulting images will not have completely smooth transitions between tiles.