### PR TITLE
Fix NDPI and Leica SCN metadata issues exposed by Virtual Microscope

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -33,6 +33,7 @@ import loci.common.services.ServiceException;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
 import loci.formats.codec.JPEGTileDecoder;
 import loci.formats.meta.MetadataStore;
 import loci.formats.services.JPEGTurboService;
@@ -67,6 +68,10 @@ public class NDPIReader extends BaseTiffReader {
   private int pyramidHeight = 1;
 
   private JPEGTurboService service = new JPEGTurboServiceImpl();
+
+  private Double magnification;
+  private String serialNumber;
+  private String instrumentModel;
 
   // -- Constructor --
 
@@ -241,6 +246,9 @@ public class NDPIReader extends BaseTiffReader {
       initializedPlane = -1;
       sizeZ = 1;
       pyramidHeight = 1;
+      magnification = null;
+      serialNumber = null;
+      instrumentModel = null;
       if (tiffParser != null) {
         tiffParser.getStream().close();
       }
@@ -332,6 +340,7 @@ public class NDPIReader extends BaseTiffReader {
 
     for (int i=1; i<ifds.size(); i++) {
       IFD ifd = ifds.get(i);
+
       if (ifd.getImageWidth() == ifds.get(0).getImageWidth() &&
         ifd.getImageLength() == ifds.get(0).getImageLength())
       {
@@ -409,6 +418,28 @@ public class NDPIReader extends BaseTiffReader {
       ms.dimensionOrder = "XYCZT";
       ms.thumbnail = s != 0;
     }
+
+    String metadataTag = ifds.get(0).getIFDStringValue(METADATA_TAG);
+    if (metadataTag != null) {
+      String[] entries = metadataTag.split("\n");
+      for (String entry : entries) {
+        int eq = entry.indexOf("=");
+       String key = entry.substring(0, eq).trim();
+        String value = entry.substring(eq + 1).trim();
+
+        addGlobalMeta(key, value);
+
+        if (key.equals("Objective.Lens.Magnificant")) { // not a typo
+          magnification = new Double(value);
+        }
+        else if (key.equals("NDP.S/N")) {
+          serialNumber = value;
+        }
+        else if (key.equals("Product")) {
+          instrumentModel = value;
+        }
+      }
+    }
   }
 
   /* @see loci.formats.BaseTiffReader#initMetadataStore() */
@@ -418,8 +449,25 @@ public class NDPIReader extends BaseTiffReader {
 
     MetadataStore store = makeFilterMetadata();
 
+    String instrumentID = MetadataTools.createLSID("Instrument", 0);
+    String objectiveID = MetadataTools.createLSID("Objective", 0, 0);
+
+    store.setInstrumentID(instrumentID, 0);
+    store.setObjectiveID(objectiveID, 0, 0);
+
+    if (instrumentModel != null) {
+      store.setMicroscopeModel(instrumentModel, 0);
+    }
+
+    if (magnification != null) {
+      store.setObjectiveNominalMagnification(magnification, 0, 0);
+    }
+
     for (int i=0; i<getSeriesCount(); i++) {
       store.setImageName("Series " + (i + 1), i);
+
+      store.setImageInstrumentRef(instrumentID, i);
+      store.setObjectiveSettingsID(objectiveID, i);
 
       if (i > 0) {
         int ifdIndex = getIFDIndex(i, 0);
@@ -441,6 +489,9 @@ public class NDPIReader extends BaseTiffReader {
         if (sizeY != null) {
           store.setPixelsPhysicalSizeY(sizeY, i);
         }
+      }
+      else {
+        store.setImageDescription(serialNumber, i);
       }
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -424,7 +424,10 @@ public class NDPIReader extends BaseTiffReader {
       String[] entries = metadataTag.split("\n");
       for (String entry : entries) {
         int eq = entry.indexOf("=");
-       String key = entry.substring(0, eq).trim();
+        if (eq < 0) {
+          continue;
+        }
+        String key = entry.substring(0, eq).trim();
         String value = entry.substring(eq + 1).trim();
 
         addGlobalMeta(key, value);


### PR DESCRIPTION
See files in team/atarkowska/virtual-microscope/VLE_for_edu/.  With this change, magnifications should be parsed and stored for NDPI files, and magnifications/physical pixel sizes should be set correctly for Leica SCN data (regardless of whether or not pyramid resolutions are flattened).  Note that there is also some cleanup of the Leica SCN reader to make it more maintainable going forward.

/cc @aleksandra-tarkowska 