### PR TITLE
bfconvert: fix indexing for z, timepoint, and channel flags

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -345,6 +345,19 @@ public final class ImageConverter {
       dimensionsSet = false;
     }
 
+    if (channel >= reader.getEffectiveSizeC()) {
+      throw new FormatException("Invalid channel '" + channel + "' (" +
+        reader.getEffectiveSizeC() + " channels in source file)");
+    }
+    if (timepoint >= reader.getSizeT()) {
+      throw new FormatException("Invalid timepoint '" + timepoint + "' (" +
+        reader.getSizeT() + " timepoints in source file)");
+    }
+    if (zSection >= reader.getSizeZ()) {
+      throw new FormatException("Invalid Z section '" + zSection + "' (" +
+        reader.getSizeZ() + " Z sections in source file)");
+    }
+
     if (store instanceof MetadataRetrieve) {
       if (series >= 0) {
         try {


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/12110, http://trac.openmicroscopy.org/ome/ticket/12268, and http://trac.openmicroscopy.org/ome/ticket/8464.

Easiest way to test is with a .fake file:

```
export TEST_FILE='bfconvert-test&sizeZ=5&sizeT=4&sizeC=3.fake'
```

With this PR, the following should all throw an exception (without this PR, there is no error and no output file):

```
bfconvert -channel 3 $TEST_FILE bounds-check1.ome.tiff
bfconvert -z 5 $TEST_FILE bounds-check2.ome.tiff
bfconvert -timepoint 4 $TEST_FILE bounds-check3.ome.tiff
```

With this PR, the following should convert the middle Z section, for a total of 12 planes in the output file (without this PR, it will throw an exception):

```
bfconvert -z 2 $TEST_FILE middle-z.ome.tiff
```

Similarly, this should convert the last timepoint, for a total of 15 planes in the output file:

```
bfconvert -timepoint 3 $TEST_FILE last-t.ome.tiff
```