### PR TITLE
Add ROI's to an existing ome-tiff which already has ROI's 

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -177,7 +177,10 @@ public class ROIHandler {
 
         if (rois == null || rois.length == 0) return;
         List<String> discardList = new ArrayList<String>();
-        String roiID = null;int cntr = 0;
+        String roiID = null;
+        OME root = (OME) store.getRoot();
+        int roicount = root.sizeOfROIList();
+        int cntr = roicount;
         for (int i=0; i<rois.length; i++) {
 
             String polylineID = MetadataTools.createLSID("Shape", cntr, 0);


### PR DESCRIPTION
To test,

1) Import an ome-tiff which already has ROI's using the Bioformats_Importer.
2) Clear the list of ROI's in the ROIManger.
3) Draw new ROI's and add them to the ROIManager.
4) Export as ome-tiff using the the Bioformats exporter (with the export roi's checkbox selected).
5) Now reimport the saved image using Plugins > Bio-formats > Bio-formats Importer (“Please select the following checkboxes, "Display ROIs","Display OME-XML metadata" and "Display Metadata” in the bioformats-importer options)

This should have the old and new ROI's.
