### PR TITLE
Fix file grouping and dimension swapping in ImageJ macros

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -132,11 +132,10 @@ public class FilePatternDialog extends ImporterDialog {
       }
     };
     gd.addMessage(
-      "The list of files to be grouped can be specified in one of three ways:");
+      "The list of files to be grouped can be specified in one of the following ways:");
 
     // option one
 
-    gd.addCheckbox("", true);
     int len = id.length() + 1;
     if (len > 80) len = 80;
 
@@ -144,35 +143,40 @@ public class FilePatternDialog extends ImporterDialog {
     fp = new FilePattern(id);
 
     String[] prefixes = fp.getPrefixes();
-    int[] counts = fp.getCount();
-    paddingZeros = new int[counts.length];
-    String[][] elements = fp.getElements();
 
-    BigInteger[] first = fp.getFirst();
-    BigInteger[] step = fp.getStep();
+    if (prefixes.length > 0) {
+      gd.addCheckbox("Dimensions", true);
 
-    for (int i=0; i<prefixes.length; i++) {
-      String prefix = "Axis_" + (i + 1);
-      gd.addStringField(prefix + "_number_of_images", "" + counts[i]);
-      gd.addStringField(prefix + "_axis_first_image", first[i].toString());
-      gd.addStringField(prefix + "_axis_increment", step[i].toString());
+      int[] counts = fp.getCount();
+      paddingZeros = new int[counts.length];
+      String[][] elements = fp.getElements();
 
-      try {
-        paddingZeros[i] = elements[i][0].length() -
-          String.valueOf(Integer.parseInt(elements[i][0])).length();
+      BigInteger[] first = fp.getFirst();
+      BigInteger[] step = fp.getStep();
+
+      for (int i=0; i<prefixes.length; i++) {
+        String prefix = "Axis_" + (i + 1);
+        gd.addStringField(prefix + "_number_of_images", "" + counts[i]);
+        gd.addStringField(prefix + "_axis_first_image", first[i].toString());
+        gd.addStringField(prefix + "_axis_increment", step[i].toString());
+
+        try {
+          paddingZeros[i] = elements[i][0].length() -
+            String.valueOf(Integer.parseInt(elements[i][0])).length();
+        }
+        catch (NumberFormatException e) { }
       }
-      catch (NumberFormatException e) { }
     }
 
     // option two
 
-    gd.addCheckbox("", false);
-    gd.addStringField("File name contains:", "");
+    gd.addCheckbox("File_name", false);
+    gd.addStringField("contains", "");
 
     // option three
 
-    gd.addCheckbox("", false);
-    gd.addStringField("Pattern: ", id, len);
+    gd.addCheckbox("Pattern", false);
+    gd.addStringField("name", id, len);
 
     rebuild(gd);
 
@@ -267,22 +271,24 @@ public class FilePatternDialog extends ImporterDialog {
 
     int row = 1;
 
-    builder.add((Component) labels.get(0), cc.xyw(1, row, 5));
-    row += 2;
-    builder.add((Component) checkboxes.get(0), cc.xy(1, row));
-
-    for (int i=0; i<fields.size()-2; i++) {
-      builder.add((Component) labels.get(i + 1), cc.xy(3, row));
-      builder.add((Component) fields.get(i), cc.xy(5, row));
+    if (checkboxes.size() > 2 && fields.size() > 2) {
+      builder.add((Component) labels.get(0), cc.xyw(1, row, 5));
       row += 2;
+      builder.add((Component) checkboxes.get(0), cc.xy(1, row));
+
+      for (int i=0; i<fields.size()-2; i++) {
+        builder.add((Component) labels.get(i + 1), cc.xy(3, row));
+        builder.add((Component) fields.get(i), cc.xy(5, row));
+        row += 2;
+      }
     }
 
-    builder.add((Component) checkboxes.get(1), cc.xy(1, row));
+    builder.add((Component) checkboxes.get(checkboxes.size() - 2), cc.xy(1, row));
     builder.add((Component) labels.get(labels.size() - 2), cc.xy(3, row));
     builder.add((Component) fields.get(fields.size() - 2), cc.xy(5, row));
     row += 2;
 
-    builder.add((Component) checkboxes.get(2), cc.xy(1, row));
+    builder.add((Component) checkboxes.get(checkboxes.size() - 1), cc.xy(1, row));
     builder.add((Component) labels.get(labels.size() - 1), cc.xy(3, row));
     builder.add((Component) fields.get(fields.size() - 1), cc.xy(5, row));
     row += 2;

--- a/components/bio-formats-plugins/src/loci/plugins/in/SwapDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/SwapDialog.java
@@ -68,8 +68,9 @@ public class SwapDialog extends ImporterDialog implements ItemListener {
     GenericDialog gd = new GenericDialog("Dimension swapping options");
 
     String[] labels = {"Z", "C", "T"};
-    int[] sizes = new int[] {
-      reader.getSizeZ(), reader.getSizeC(), reader.getSizeT()
+    String[] sizes = new String[] {
+      String.valueOf(reader.getSizeZ()), String.valueOf(reader.getSizeC()),
+      String.valueOf(reader.getSizeT())
     };
     for (int s=0; s<seriesCount; s++) {
       if (!options.isSeriesOn(s)) continue;
@@ -78,7 +79,7 @@ public class SwapDialog extends ImporterDialog implements ItemListener {
       gd.addMessage("Series " + (s + 1) + ":\n");
 
       for (int i=0; i<labels.length; i++) {
-        gd.addChoice(sizes[i] + "_planes", labels, labels[i]);
+        gd.addChoice(labels[i] + "_" + (s + 1), sizes, sizes[i]);
       }
     }
 
@@ -103,23 +104,39 @@ public class SwapDialog extends ImporterDialog implements ItemListener {
     for (int s=0; s<seriesCount; s++) {
       if (!options.isSeriesOn(s)) continue;
       reader.setSeries(s);
-      String z = gd.getNextChoice();
-      String c = gd.getNextChoice();
-      String t = gd.getNextChoice();
+      int z = Integer.parseInt(gd.getNextChoice());
+      int c = Integer.parseInt(gd.getNextChoice());
+      int t = Integer.parseInt(gd.getNextChoice());
 
-      if (z.equals(t) || z.equals(c) || c.equals(t)) {
-        // should never occur... ;-)
-        throw new IllegalStateException(
-          "Invalid swapping options - each axis can be used only once.");
-      }
+      int originalZ = reader.getSizeZ();
+      int originalC = reader.getSizeC();
+      int originalT = reader.getSizeT();
 
       String originalOrder = reader.getDimensionOrder();
       StringBuffer sb = new StringBuffer();
       sb.append("XY");
       for (int i=2; i<originalOrder.length(); i++) {
-        if (originalOrder.charAt(i) == 'Z') sb.append(z);
-        else if (originalOrder.charAt(i) == 'C') sb.append(c);
-        else if (originalOrder.charAt(i) == 'T') sb.append(t);
+        int originalValue = 0;
+        switch (originalOrder.charAt(i)) {
+          case 'Z':
+            originalValue = originalZ;
+            break;
+          case 'C':
+            originalValue = originalC;
+            break;
+          case 'T':
+            originalValue = originalT;
+            break;
+        }
+        if (originalValue == z && sb.indexOf("Z") < 0) {
+          sb.append("Z");
+        }
+        else if (originalValue == c && sb.indexOf("C") < 0) {
+          sb.append("C");
+        }
+        else if (originalValue == t && sb.indexOf("T") < 0) {
+          sb.append("T");
+        }
       }
 
       options.setInputOrder(s, sb.toString());


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/12239 and http://trac.openmicroscopy.org/ome/ticket/12238.

To test, choose a single file with SizeZ > 1 or SizeT > 1 (the remaining dimensions should be 1).  I was using ```test_images_good/andor/VESSEL-DEC-Z.tif```.

For ticket 12239:
1. Start ImageJ, select ```Plugins > Macros > Record...```
2. Select ```Plugins > Bio-Formats > Bio-Formats Importer```
3. Select the test file
4. Check the ```Swap dimensions``` box, but leave everything else unchecked
5. Assign the > 1 dimension to something other than the default
6. Verify that the resulting image window reflects what was chosen in step 5.
7. Select the ```Create``` button in the macro recorder window, then ```Macros > Run Macro``` in the new macro window.
8. The image window created as a result of step 7 should match the one from step 5/6, and there should be no error message.

For ticket 12238:
1. Close ImageJ and repeat steps 1 - 3 above
2. Check the ```Group files with similar names``` box, but leave everything else unchecked
3. Check the ```Pattern``` box in the file grouping window
4. Repeat step 7 above
5. Verify that there are now two image windows open with matching contents.  There should be no error message.