### PR TITLE
Remove deprecated methods

### DIFF
--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -161,21 +161,6 @@ public class TestTools {
     return dot < 0 ? name : name.substring(dot + 1);
   }
 
-  /** Creates a new log file. */
-  @Deprecated
-  public static void createLogFile() {
-    LOGGER.info("Start test suite");
-
-    // close log file on exit
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      public void run() {
-        LOGGER.info(DIVIDER);
-        LOGGER.info("Test suite complete.");
-      }
-    });
-  }
-
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig)

--- a/components/xsd-fu/templates-java/AggregateMetadata.template
+++ b/components/xsd-fu/templates-java/AggregateMetadata.template
@@ -301,16 +301,6 @@ public class AggregateMetadata implements IMetadata
 		throw new RuntimeException("Unsupported by AggregateMetadata");
 	}
 
-	/**
-	 * Unsupported with an AggregateMetadata.
-	 * @throws RuntimeException Always.
-	 */
-	@Deprecated
-	public void setRoot(Object root)
-	{
-		throw new RuntimeException("Unsupported by AggregateMetadata");
-	}
-
 	// -- AggregateMetadata API methods --
 
 

--- a/components/xsd-fu/templates-java/DummyMetadata.template
+++ b/components/xsd-fu/templates-java/DummyMetadata.template
@@ -184,11 +184,6 @@ public class DummyMetadata implements IMetadata
 	{
 	}
 
-	@Deprecated
-	public void setRoot(Object root)
-	{
-	}
-
 	// -- Entity counting (manual definitions) --
 
 	public int getPixelsBinDataCount(int imageIndex)

--- a/components/xsd-fu/templates-java/FilterMetadata.template
+++ b/components/xsd-fu/templates-java/FilterMetadata.template
@@ -196,13 +196,6 @@ public class FilterMetadata implements MetadataStore
 		store.setRoot(root);
 	}
 
-	/* @see MetadataStore#setRoot(Object) */
-	@Deprecated
-	public void setRoot(Object root)
-	{
-		store.setRoot(root);
-	}
-
 	/* @see MetadataStore#setUUID(String) */
 	public void setUUID(String uuid)
 	{

--- a/components/xsd-fu/templates-java/MetadataStore.template
+++ b/components/xsd-fu/templates-java/MetadataStore.template
@@ -150,9 +150,6 @@ public interface MetadataStore extends BaseMetadata
 
 	void setRoot(MetadataRoot root);
 
-	@Deprecated
-	void setRoot(Object root);
-
 	// -- Entity storage (manual definitions) --
 
 	void setPixelsBinDataBigEndian(Boolean bigEndian, int imageIndex, int binDataIndex);

--- a/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
+++ b/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
@@ -318,18 +318,6 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 		model = new OMEModelImpl();
 	}
 
-	@Deprecated
-	public void setRoot(Object root)
-	{
-		if (root instanceof OMEXMLMetadataRoot)
-			this.root = (OMEXMLMetadataRoot) root;
-		else if (root instanceof OME)
-			this.root = new OMEXMLMetadataRoot((OME) root);
-		else
-			throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
-		model = new OMEModelImpl();
-	}
-
 	public String dumpXML()
 	{
 		resolveReferences();


### PR DESCRIPTION
This removes a handful of methods that were deprecated in 5.0 (or earlier) and which are now unused.

See https://trello.com/c/iNieNBuZ/77-remove-deprecated-methods