### PR TITLE
Add version history for 5.0.7

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -5,7 +5,7 @@ Version history
 -----------------------
 
 * Several bug fixes, including:
-    - ND filter parsing for Deltavision
+    - ND filter parsing for DeltaVision
     - Timepoint count and original metadata parsing for Metamorph
     - Build issues when Genshi or Git are missing
     - LZW image decoding
@@ -224,7 +224,7 @@ Version history
 -------------------
 
 * Several bug fixes, including:
-   - Fixes for multi-position Deltavision files
+   - Fixes for multi-position DeltaVision files
    - Fixes for MicroManager 1.4 data
    - Fixes for 12 and 14-bit JPEG-2000 data
    - Various fixes for reading Volocity .mvd2 datasets
@@ -355,7 +355,7 @@ Version history
 2008 December 29
 ----------------
 
-* Improved metadata support for Deltavision, Zeiss LSM, MicroManager, and Leica
+* Improved metadata support for DeltaVision, Zeiss LSM, MicroManager, and Leica
   LEI
 * Restructured code base/build system to be component-driven
 * Added support for JPEG and JPEG-2000 codecs within TIFF, OME-TIFF and OME-XML
@@ -659,7 +659,7 @@ Version history
 * Fixed ZVI bugs: metadata truncation, and other problems
 * Fixed bugs in Leica LIF: incorrect calibration, first series labeling
 * Fixed memory bug in Zeiss LSM
-* Many bugfixes: PerkinElmer, Deltavision, Leica LEI, LSM, ND2, and others
+* Many bugfixes: PerkinElmer, DeltaVision, Leica LEI, LSM, ND2, and others
 * IFormatReader.close(boolean) method to close files temporarily
 * Replaced Compression utility class with extensible Compressor interface
 * Improved testing framework to use .bioformats configuration files

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,15 @@
 Version history
 ===============
 
+5.0.7 (2015 February 5)
+-----------------------
+
+* Several bug fixes, including:
+    - ND filter parsing for Deltavision
+    - Timepoint count and original metadata parsing for Metamorph
+    - Build issues when Genshi or Git are missing
+    - LZW image decoding
+
 5.0.6 (2014 November 11)
 ------------------------
 


### PR DESCRIPTION
As usual, the date probably needs updating once we're closer to tagging.