### PR TITLE
Enforce LF line endings on text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 * text eol=lf
+*.svg binary
+*.png binary
+*.jpg binary
+*.pdf binary
+*.zip binary
+*.jar binary
+*.dll binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text eol=lf
 *.svg binary
+*.tiff binary
 *.png binary
 *.jpg binary
 *.pdf binary

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -5,7 +5,7 @@
  * Copyright (C) Max Planck Institute for Biophysical Chemistry, 
  * Goettingen, 2014 - 2015
  *
- * Copyright (C) 2005 - 2015 Open Microscopy Environment:
+ * Copyright (C) 2014 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee


### PR DESCRIPTION
Working on different projects on a Windows system often means switching
between
core.autocrlf=input and core.autocrlf=true.
This is the per-repository solution.

The date fix just slipped in - don't know how to get it 
into a separate pull request.