### PR TITLE
C++: Fixes and additions for OME-TIFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ cmake_policy(VERSION 2.8.0)
 if (POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif(POLICY CMP0042)
+# Use new variable expansion policy.
+if (POLICY CMP0053)
+  cmake_policy(SET CMP0053 NEW)
+endif(POLICY CMP0053)
 
 project(bioformats)
 include(cpp/cmake/Version.cmake)

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -369,7 +369,10 @@ class OMEModelProperty(OMEModelEntity):
         doc="""If the property is an enumeration, its default value.""")
 
     def _get_defaultXsdValue(self):
-        return self.delegate.default
+        if hasattr(self.delegate, 'default'):
+            return self.delegate.default
+        else:
+            return None
     defaultXsdValue = property(
         _get_defaultXsdValue,
         doc="""The default value, if any, that is set on the attribute.""")

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -534,7 +534,9 @@ class OMEModelProperty(OMEModelEntity):
                 itype = "std::shared_ptr<%s>&" % ns_sep
 
         return itype
-    elementArgType = property(_get_elementArgType, doc="""The property's element argument type (for lists).""")
+    elementArgType = property
+        (_get_elementArgType,
+         doc="""The property's element argument type (for lists).""")
 
     def _get_elementRetType(self):
         """
@@ -570,8 +572,9 @@ class OMEModelProperty(OMEModelEntity):
                          '':      "std::shared_ptr<%s>&" % ns_sep}
 
         return itype
-    elementRetType = property(_get_elementRetType,
-                              doc="""The property's element return type (for lists).""")
+    elementRetType = property
+        (_get_elementRetType,
+         doc="""The property's element return type (for lists).""")
 
     def _get_assignableType(self):
         """

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -534,9 +534,9 @@ class OMEModelProperty(OMEModelEntity):
                 itype = "std::shared_ptr<%s>&" % ns_sep
 
         return itype
-    elementArgType = property
-        (_get_elementArgType,
-         doc="""The property's element argument type (for lists).""")
+    elementArgType = property(
+        _get_elementArgType,
+        doc="""The property's element argument type (for lists).""")
 
     def _get_elementRetType(self):
         """
@@ -572,9 +572,9 @@ class OMEModelProperty(OMEModelEntity):
                          '':      "std::shared_ptr<%s>&" % ns_sep}
 
         return itype
-    elementRetType = property
-        (_get_elementRetType,
-         doc="""The property's element return type (for lists).""")
+    elementRetType = property(
+        _get_elementRetType,
+        doc="""The property's element return type (for lists).""")
 
     def _get_assignableType(self):
         """

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -501,8 +501,10 @@ class OMEModelProperty(OMEModelEntity):
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = {' const': "const std::vector<std::shared_ptr<%s> >" % ns_sep,
-                         '':      "std::vector<std::shared_ptr<%s> >" % ns_sep}
+                itype = {' const': "const std::vector<std::shared_ptr<%s> >"
+                         % ns_sep,
+                         '':      "std::vector<std::shared_ptr<%s> >"
+                         % ns_sep}
 
         return itype
     retType = property(_get_retType, doc="""The property's return type.""")
@@ -562,12 +564,14 @@ class OMEModelProperty(OMEModelEntity):
                     self.isAttribute or not self.isComplex() or
                     not self.isChoice):
                 itype = self.argType()
-            elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
+            elif (self.maxOccurs > 1
+                    and not self.parent.isAbstractProprietary):
                 itype = {' const': "const std::shared_ptr<%s>&" % ns_sep,
                          '':      "std::shared_ptr<%s>&" % ns_sep}
 
         return itype
-    elementRetType = property(_get_elementRetType, doc="""The property's element return type (for lists).""")
+    elementRetType = property(_get_elementRetType,
+                              doc="""The property's element return type (for lists).""")
 
     def _get_assignableType(self):
         """
@@ -613,9 +617,12 @@ class OMEModelProperty(OMEModelEntity):
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
-            elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = {' const': "const std::vector<std::shared_ptr<%s> >" % ns_sep,
-                         '':      "std::vector<std::shared_ptr<%s> >" % ns_sep}
+            elif (self.maxOccurs > 1
+                    and not self.parent.isAbstractProprietary):
+                itype = {' const': "const std::vector<std::shared_ptr<%s> >"
+                         % ns_sep,
+                         '':      "std::vector<std::shared_ptr<%s> >"
+                         % ns_sep}
 
         return itype
     assignableType = property(

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -26,11 +26,11 @@
         // Parents: ${repr(parents[obj.name])}
 {% if obj.isReference %}\
         // ${obj.name} is a reference
-        return root->${"->".join(accessor(obj.name, parent, obj.name)[:-1] + ["sizeOfLinked%sList()" % obj.name.replace('Ref', '')])};
+        return ${safe_accessor(['root']+accessor(obj.name, parent, obj.name)[:-1] + ["sizeOfLinked%sList()" % obj.name.replace('Ref', '')])};
 {% end %}\
 {% if not obj.isReference %}\
         // ${obj.name} is not a reference
-        return root->${"->".join(accessor(obj.name, parent, obj.name)[:-1] + ["sizeOf%sList()" % obj.name.replace('Ref', '')])};
+        return ${safe_accessor(['root']+accessor(obj.name, parent, obj.name)[:-1] + ["sizeOf%sList()" % obj.name.replace('Ref', '')])};
 {% end %}\
       }
 {% end source %}\
@@ -81,23 +81,23 @@
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
         // DUMMYLINE
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(root->${"->".join(accessor(obj.name, parent, prop)[:-1])});
-        ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}));
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])});
+        ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
         throw(std::runtime_error("Internal metadata store inconsistency: null object"));
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract proprietary
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(root->${"->".join(accessor(obj.name, parent, prop)[:-1])});
-        ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}());
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])});
+        ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
         throw(std::runtime_error("Internal metadata store inconsistency: null object"));
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract proprietary and not a reference
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(root->${"->".join(accessor(obj.name, parent, prop)[:-1])});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -110,7 +110,7 @@
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(root->${"->".join(accessor(obj.name, parent, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}));
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -118,7 +118,7 @@
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(root->${"->".join(accessor(obj.name, parent, prop))}->getLinked${prop.methodName}());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -127,13 +127,13 @@
 {% otherwise %}\
         // ${prop.name} is not a reference
 {% if prop.minOccurs == 0 %}\
-        ${prop.retType[' const']} ret = root->${"->".join(accessor(obj.name, parent, prop))}->get${prop.methodName}();
+        ${prop.retType[' const']} ret = ${safe_accessor(['root']+accessor(obj.name, parent, prop))}->get${prop.methodName}();
         if (ret)
           return *ret;
         throw(std::runtime_error("Internal metadata store inconsistency: null annotation"));
 {% end %}\
 {% if prop.minOccurs == 1 %}\
-        return root->${"->".join(accessor(obj.name, parent, prop))}->get${prop.methodName}();
+        return ${safe_accessor(['root']+accessor(obj.name, parent, prop))}->get${prop.methodName}();
 {% end %}\
 {% end %}\
 {% end %}\
@@ -185,7 +185,7 @@
         // ${prop.name} is abstract proprietary and is a reference
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(root->${"->".join(accessor(obj.name, parent, prop)[:-1])}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])}));
         std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
@@ -251,7 +251,7 @@
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
         std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject
-          (std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(root->${"->".join(accessor(obj.name, parent, prop))}));
+          (std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop))}));
         std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
@@ -347,6 +347,18 @@ ${customContent[obj.name][prop.name]}
                 if len(results.keys()) == 0:
                         raise Exception("Zero KEYS No accessor for: name:%s parent:%s prop:%s === %s" % (name, parent, prop, results))
                 return results[parent]
+
+        def safe_accessor(calls):
+                ret = None
+                if len(calls) == 1:
+                        ret = "safe_fetch(%s)" % calls[0]
+                else:
+                        for call in range(len(calls)):
+                                if call == 0:
+                                        ret = "safe_fetch(%s)" % (calls[call])
+                                else:
+                                        ret = "safe_fetch(%s->%s)" % (ret, calls[call])
+                return ret
 %}\
 \
 \
@@ -414,6 +426,41 @@ ${customContent[obj.name][prop.name]}
 {% for header in fu.OBJECT_HEADERS %}\
 #include <${header}>
 {% end %}\
+
+namespace
+{
+
+  // Throw an exception if a pointer is invalid.
+  template<typename T>
+  std::shared_ptr<T>
+  safe_fetch(std::shared_ptr<T> ptr)
+  {
+    if (!ptr)
+      throw(std::runtime_error("Internal metadata store inconsistency: "));
+    return ptr;
+  }
+
+  // Throw an exception if a pointer is invalid.
+  template<typename T>
+  std::shared_ptr<T>
+  safe_fetch(std::weak_ptr<T> ptr)
+  {
+    std::shared_ptr<T> shared(ptr.lock());
+    if (!shared)
+      throw(std::runtime_error("Internal metadata store inconsistency: "));
+    return shared;
+  }
+
+  // Pass through for value types.
+  template<typename T>
+  T
+  safe_fetch(T value)
+  {
+    return value;
+  }
+
+}
+
 {% end source%}\
 
 namespace ome
@@ -581,7 +628,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getPixelsBinDataCount(index_type imageIndex) const
       {
-        return root->getImage(imageIndex)->getPixels()->sizeOfBinDataList();
+        return safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->sizeOfBinDataList();
       }
 {% end source %}\
 
@@ -594,7 +641,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getBooleanAnnotationAnnotationCount(index_type booleanAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getBooleanAnnotation(booleanAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getBooleanAnnotation(booleanAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -607,7 +654,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getCommentAnnotationAnnotationCount(index_type commentAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getCommentAnnotation(commentAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getCommentAnnotation(commentAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -620,7 +667,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getDoubleAnnotationAnnotationCount(index_type doubleAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getDoubleAnnotation(doubleAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getDoubleAnnotation(doubleAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -633,7 +680,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getFileAnnotationAnnotationCount(index_type fileAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getFileAnnotation(fileAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getFileAnnotation(fileAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -646,7 +693,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getListAnnotationAnnotationCount(index_type listAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getListAnnotation(listAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getListAnnotation(listAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -659,7 +706,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getLongAnnotationAnnotationCount(index_type longAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getLongAnnotation(longAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getLongAnnotation(longAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -672,7 +719,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getTagAnnotationAnnotationCount(index_type tagAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getTagAnnotation(tagAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getTagAnnotation(tagAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -685,7 +732,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getTermAnnotationAnnotationCount(index_type termAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getTermAnnotation(termAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getTermAnnotation(termAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -698,7 +745,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getTimestampAnnotationAnnotationCount(index_type timestampAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getTimestampAnnotation(timestampAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getTimestampAnnotation(timestampAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -711,7 +758,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getXMLAnnotationAnnotationCount(index_type xmlAnnotationIndex) const
       {
-        return root->getStructuredAnnotations()->getXMLAnnotation(xmlAnnotationIndex)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getXMLAnnotation(xmlAnnotationIndex))->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -726,7 +773,7 @@ namespace ome
       OMEXMLMetadata::getLightSourceType(index_type instrumentIndex,
                                          index_type lightSourceIndex) const
       {
-        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = root->getInstrument(instrumentIndex)->getLightSource(lightSourceIndex);
+        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex))->getLightSource(lightSourceIndex);
         return o->getLightSourceType();
       }
 {% end source %}\
@@ -742,8 +789,7 @@ namespace ome
       OMEXMLMetadata::getShapeType(index_type roiIndex,
                                    index_type shapeIndex) const
       {
-        std::shared_ptr<const ::${lang.omexml_model_package}::Shape> o = root->getROI(roiIndex)->getUnion()->getShape(shapeIndex);
-        return o->getShapeType();
+        return safe_fetch(safe_fetch(safe_fetch(root->getROI(roiIndex))->getUnion())->getShape(shapeIndex))->getShapeType();
       }
 {% end source %}\
 {% if fu.SOURCE_TYPE == "header" %}\
@@ -806,7 +852,7 @@ namespace ome
       ${o.langBaseType}
       OMEXMLMetadata::get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])}) const
       {
-        return root->getImage(imageIndex)->getPixels()->getTiffData(tiffDataIndex)->getUUID()->getValue();
+        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->getTiffData(tiffDataIndex))->getUUID())->getValue();
       }
 {% end source %}\
 
@@ -836,11 +882,14 @@ ${counter(k, o, v)}\
       OMEXMLMetadata::getPixelsBinDataBigEndian(index_type imageIndex,
                                                 index_type binDataIndex) const
       {
-        std::shared_ptr<bool> bigEndian = root->getImage(imageIndex)->getPixels()->getBigEndian();
+        std::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->getBigEndian();
+
         if (bigEndian) { // not null
           return *bigEndian;
         }
-        return root->getImage(imageIndex)->getPixels()->getBinData(binDataIndex)->getBigEndian();
+
+        // Fall back to BinData
+        return safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->getBinData(binDataIndex))->getBigEndian();
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -102,7 +102,17 @@
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
           return *ret;
+{% if prop.maxOccurs != 1 or prop.defaultXsdValue is None %}\
         throw(std::runtime_error("Internal metadata store inconsistency: null annotation"));
+{% end %}\
+{% if prop.maxOccurs == 1 and prop.defaultXsdValue is not None %}\
+{% if prop.langType == 'std::string' or prop.isEnumeration %}\
+        return "${prop.defaultXsdValue}";
+{% end %}\
+{% if prop.langType != 'std::string' and not prop.isEnumeration %}\
+        return ${prop.defaultXsdValue};
+{% end %}\
+{% end %}\
 {% end %}\
 {% if prop.minOccurs == 1 %}\
         return o->get${prop.methodName}();

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1226,7 +1226,7 @@ ${customUpdatePropertyContent[prop.name]}
 {% end %}\
 {% end %}\
 {% if klass.isAnnotation %}\
-		// Ensure any base annotations add their Elements first
+        // Ensure any base annotations add their Elements first
         element = ${klass.parentName}::asXMLElementInternal(document, element);
 {% end if isAnnotation %}\
 {% for prop in klass.properties.values() %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -970,6 +970,7 @@ ${customUpdatePropertyContent[prop.name]}
       }
 {% end source %}\
 
+{% for qualifier in prop.retType.keys() %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         /**
          * Get the ${prop.methodName} list.
@@ -977,17 +978,18 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a reference to the list.
          *
          */
-        const ${prop.instanceVariableType}&
-        get${prop.methodName}List () const;
+        ${prop.retType[qualifier]}&
+        get${prop.methodName}List ()${qualifier};
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const ${prop.instanceVariableType}&
-      ${klass.name}::get${prop.methodName}List () const
+      ${prop.retType[qualifier]}&
+      ${klass.name}::get${prop.methodName}List ()${qualifier}
       {
         return ${prop.instanceVariableName};
       }
 {% end source %}\
 
+{% end qualifier %}\
 {% for qualifier in prop.retType.keys() %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         /**
@@ -997,11 +999,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        ${prop.retType[qualifier]}
+        ${prop.elementRetType[qualifier]}
         get${prop.methodName} (${prop.instanceVariableType}::size_type index)${qualifier};
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ${prop.retType[qualifier]}
+      ${prop.elementRetType[qualifier]}
       ${klass.name}::get${prop.methodName} (${prop.instanceVariableType}::size_type index)${qualifier}
       {
         return ${prop.instanceVariableName}.at(index);
@@ -1019,12 +1021,12 @@ ${customUpdatePropertyContent[prop.name]}
          */
         void
         set${prop.methodName} (${prop.instanceVariableType}::size_type index,
-                               ${prop.argType} ${prop.argumentName});
+                               ${prop.elementArgType} ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
       ${klass.name}::set${prop.methodName} (${prop.instanceVariableType}::size_type index,
-                                            ${prop.argType} ${prop.argumentName})
+                                            ${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
         std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
@@ -1050,11 +1052,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @todo Detect and handle duplicates?
          */
         void
-        add${prop.methodName} (${prop.argType} ${prop.argumentName});
+        add${prop.methodName} (${prop.elementArgType} ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::add${prop.methodName} (${prop.argType} ${prop.argumentName})
+      ${klass.name}::add${prop.methodName} (${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
         std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
@@ -1075,11 +1077,11 @@ ${customUpdatePropertyContent[prop.name]}
          * aren't preventing duplicates on insertion.
          */
         void
-        remove${prop.methodName} (${prop.argType} ${prop.argumentName});
+        remove${prop.methodName} (${prop.elementArgType} ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::remove${prop.methodName} (${prop.argType} ${prop.argumentName})
+      ${klass.name}::remove${prop.methodName} (${prop.elementArgType} ${prop.argumentName})
       {
         ${prop.instanceVariableType}::iterator i = std::find_if(${prop.instanceVariableName}.begin(),
                                                                 ${prop.instanceVariableName}.end(),

--- a/cpp/bin/showinf/ImageInfo.cpp
+++ b/cpp/bin/showinf/ImageInfo.cpp
@@ -162,7 +162,7 @@ namespace showinf
 
     if (opts.showused)
       {
-        const std::vector<std::string> used(reader->getUsedFiles());
+        const std::vector<boost::filesystem::path> used(reader->getUsedFiles());
         if (used.empty())
           {
             stream << "Used files = []";
@@ -174,7 +174,7 @@ namespace showinf
         else
           {
             stream << "Used files\n";
-            for (std::vector<std::string>::const_iterator i = used.begin();
+            for (std::vector<boost::filesystem::path>::const_iterator i = used.begin();
                  i != used.end();
                  ++i)
               {

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -168,6 +168,7 @@ if (NOT MSVC)
       -Wformat=2
       -Wimplicit-atomic-properties
       -Wmissing-declarations
+      -Wno-long-long
       -Wnon-virtual-dtor
       -Wold-style-cast
       -Woverlength-strings

--- a/cpp/lib/ome/bioformats/CoreMetadata.cpp
+++ b/cpp/lib/ome/bioformats/CoreMetadata.cpp
@@ -98,5 +98,9 @@ namespace ome
     {
     }
 
+    CoreMetadata::~CoreMetadata()
+    {
+    }
+
   }
 }

--- a/cpp/lib/ome/bioformats/CoreMetadata.h
+++ b/cpp/lib/ome/bioformats/CoreMetadata.h
@@ -166,6 +166,10 @@ namespace ome
        * @param copy the CoreMetadata to copy.
        */
       CoreMetadata(const CoreMetadata& copy);
+
+      /// Destructor.
+      virtual
+      ~CoreMetadata();
     };
 
     /**

--- a/cpp/lib/ome/bioformats/FileInfo.h
+++ b/cpp/lib/ome/bioformats/FileInfo.h
@@ -41,6 +41,8 @@
 #include <string>
 #include <ostream>
 
+#include <ome/compat/filesystem.h>
+
 namespace ome
 {
   namespace bioformats
@@ -52,7 +54,7 @@ namespace ome
     struct FileInfo
     {
       /// Absolute path to this file.
-      std::string filename;
+      boost::filesystem::path filename;
 
       /**
        * FormatReader implementation used to read this file.

--- a/cpp/lib/ome/bioformats/FormatHandler.h
+++ b/cpp/lib/ome/bioformats/FormatHandler.h
@@ -175,8 +175,16 @@ namespace ome
         bool match = true;
 
         boost::filesystem::path filename(name);
+#if !defined(BOOST_VERSION) || BOOST_VERSION >= 105000 // Boost >= 1.50
         boost::filesystem::path ext;
         ext.replace_extension(suffix); // Adds leading dot if missing
+#else // Boost < 1.50
+        // replace_extension doesn't work nicely with older Boost versions.
+        boost::filesystem::path ext(suffix);
+        std::string suffixString(ext.string());
+        if (!suffixString.empty() && suffixString[0] != '.')
+          ext = boost::filesystem::path(std::string(".") + suffixString);
+#endif // Boost version
 
         while(true)
           {
@@ -248,16 +256,14 @@ namespace ome
                  si != suffixes.end();
                  ++si)
               {
-#if !defined(BOOST_VERSION) || BOOST_VERSION >= 105000
-                // Boost >= 1.50
+#if !defined(BOOST_VERSION) || BOOST_VERSION >= 105000 // Boost >= 1.50
                 boost::filesystem::path suffix(*si);
                 suffix += boost::filesystem::path(".");
                 suffix += *csi;
-#else
-                // Boost < 1.50
+#else // Boost < 1.50
                 boost::filesystem::path suffix(si->parent_path());
                 suffix /= boost::filesystem::path(si->filename().string() + "." + csi->string());
-#endif
+#endif // Boost version
 
                 if (checkSuffix(name, suffix))
                   return true;

--- a/cpp/lib/ome/bioformats/FormatHandler.h
+++ b/cpp/lib/ome/bioformats/FormatHandler.h
@@ -46,6 +46,7 @@
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
+#include <boost/version.hpp>
 
 #include <ome/compat/filesystem.h>
 
@@ -247,9 +248,16 @@ namespace ome
                  si != suffixes.end();
                  ++si)
               {
+#if !defined(BOOST_VERSION) || BOOST_VERSION >= 105000
+                // Boost >= 1.50
                 boost::filesystem::path suffix(*si);
                 suffix += boost::filesystem::path(".");
                 suffix += *csi;
+#else
+                // Boost < 1.50
+                boost::filesystem::path suffix(si->parent_path());
+                suffix /= boost::filesystem::path(si->filename().string() + "." + csi->string());
+#endif
 
                 if (checkSuffix(name, suffix))
                   return true;

--- a/cpp/lib/ome/bioformats/FormatHandler.h
+++ b/cpp/lib/ome/bioformats/FormatHandler.h
@@ -47,6 +47,8 @@
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 
+#include <ome/compat/filesystem.h>
+
 namespace ome
 {
   namespace bioformats
@@ -95,8 +97,8 @@ namespace ome
        */
       virtual
       bool
-      isThisType(const std::string& name,
-                 bool               open = true) const = 0;
+      isThisType(const boost::filesystem::path& name,
+                 bool                           open = true) const = 0;
 
       /**
        * Get the name of this file format.
@@ -122,7 +124,7 @@ namespace ome
        * @returns a list of file suffixes.
        */
       virtual
-      const std::vector<std::string>&
+      const std::vector<boost::filesystem::path>&
       getSuffixes() const = 0;
 
       /**
@@ -131,7 +133,7 @@ namespace ome
        * @returns a list of file suffixes.
        */
       virtual
-      const std::vector<std::string>&
+      const std::vector<boost::filesystem::path>&
       getCompressionSuffixes() const = 0;
 
       /**
@@ -143,7 +145,7 @@ namespace ome
        * @param id the filename to open.
        */
       virtual void
-      setId(const std::string& id) = 0;
+      setId(const boost::filesystem::path& id) = 0;
 
       /**
        * Close the currently open file.
@@ -166,14 +168,34 @@ namespace ome
        * @returns @c true if the suffix is suppored, @c false otherwise.
        */
       static bool
-      checkSuffix(const std::string& name,
-                  const std::string& suffix)
+      checkSuffix(const boost::filesystem::path& name,
+                  const boost::filesystem::path& suffix)
       {
-        std::vector<std::string> suffixes;
-        std::vector<std::string> compression_suffixes;
-        suffixes.push_back(suffix);
+        bool match = true;
 
-        return checkSuffix(name, suffixes, compression_suffixes);
+        boost::filesystem::path filename(name);
+        boost::filesystem::path ext;
+        ext.replace_extension(suffix); // Adds leading dot if missing
+
+        while(true)
+          {
+            boost::filesystem::path filename_ext = filename.extension();
+            boost::filesystem::path current_ext = ext.extension();
+            filename.replace_extension();
+            ext.replace_extension();
+
+            if (filename_ext.empty() && current_ext.empty())
+              break; // End of matches
+            else if (!filename_ext.empty() && !current_ext.empty() &&
+                     filename_ext == current_ext) // Match OK
+              continue;
+
+            // Unbalanced or unequal extensions.
+            match = false;
+            break;
+          }
+
+        return match;
       }
 
       /**
@@ -186,38 +208,51 @@ namespace ome
        * @returns @c true if the suffix is suppored, @c false otherwise.
        */
       static bool
-      checkSuffix(const std::string&              name,
-                  const std::vector<std::string>& suffixes,
-                  const std::vector<std::string>& compression_suffixes)
+      checkSuffix(const boost::filesystem::path&              name,
+                  const std::vector<boost::filesystem::path>& suffixes)
       {
-        std::string lname;
-        std::transform(name.begin(), name.end(),
-                       std::back_inserter(lname),
-                       static_cast<int (*)(int)>(std::tolower));
-
-        for (std::vector<std::string>::const_iterator si = suffixes.begin();
+        for (std::vector<boost::filesystem::path>::const_iterator si = suffixes.begin();
              si != suffixes.end();
              ++si)
           {
-            std::string suffix(".");
-            suffix += *si;
-            if (name >= suffix &&
-                name.compare(name.size()-suffix.size(), suffix.size(), suffix) == 0)
+            if (checkSuffix(name, *si))
               return true;
+          }
 
-            for (std::vector<std::string>::const_iterator csi = compression_suffixes.begin();
-                 csi != compression_suffixes.end();
-                 ++csi)
+        return false;
+      }
+
+      /**
+       * Perform suffix matching for the given filename.
+       *
+       * @param name the name to check.
+       * @param suffixes the suffixes to match.
+       * @param compression_suffixes the compression suffixes to match.
+       *
+       * @returns @c true if the suffix is suppored, @c false otherwise.
+       */
+      static bool
+      checkSuffix(const boost::filesystem::path&              name,
+                  const std::vector<boost::filesystem::path>& suffixes,
+                  const std::vector<boost::filesystem::path>& compression_suffixes)
+      {
+        if (checkSuffix(name, suffixes))
+          return true;
+
+        for (std::vector<boost::filesystem::path>::const_iterator csi = compression_suffixes.begin();
+             csi != compression_suffixes.end();
+             ++csi)
+          {
+            for (std::vector<boost::filesystem::path>::const_iterator si = suffixes.begin();
+                 si != suffixes.end();
+                 ++si)
               {
-                std::string csuffix(suffix);
-                csuffix += "." + *csi;
+                boost::filesystem::path suffix(*si);
+                suffix += boost::filesystem::path(".");
+                suffix += *csi;
 
-                if (name >= csuffix &&
-                    name.compare(name.size()-csuffix.size(), csuffix.size(), csuffix) == 0)
-                  return false;
-                /**
-                 * @todo Should return true when compression suffixes are supported.
-                 */
+                if (checkSuffix(name, suffix))
+                  return true;
               }
           }
         return false;
@@ -235,8 +270,8 @@ namespace ome
        * @throws std::logic_error if the assertion fails.
        */
       static void
-      assertId(const boost::optional<std::string>& id,
-               bool                                notNull = true)
+      assertId(const boost::optional<boost::filesystem::path>& id,
+               bool                                            notNull = true)
       {
         if (!id && notNull)
           {

--- a/cpp/lib/ome/bioformats/FormatHandler.h
+++ b/cpp/lib/ome/bioformats/FormatHandler.h
@@ -212,7 +212,6 @@ namespace ome
        *
        * @param name the name to check.
        * @param suffixes the suffixes to match.
-       * @param compression_suffixes the compression suffixes to match.
        *
        * @returns @c true if the suffix is suppored, @c false otherwise.
        */

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -343,20 +343,25 @@ namespace ome
       isFalseColor() const = 0;
 
       /**
-       * Get the color lookup table associated with the most recently
-       * opened image.
+       * Get the color lookup table associated with an image plane.
        *
        * If no image planes have been opened, or if isIndexed()
        * returns @c false, then this may throw an exception.
        *
-       * @param buf the destination pixel buffer.
+       * The VariantPixelBuffer will use the X dimension for the value
+       * index and the subchannel dimension for the color samples
+       * (order is RGB).  Depending upon the image type, the size of
+       * the X dimension may vary.  It will typically be 2^8 or 2^16,
+       * but other sizes are possible.
        *
-       * @todo use a more specific buffer type.
-       * @todo throw on failure.
+       * @param buf the destination pixel buffer.
+       * @param no the image index within the file.
+       * @throws FormatException if a lookup table could not be obtained.
        */
       virtual
       void
-      getLookupTable(VariantPixelBuffer& buf) const = 0;
+      getLookupTable(VariantPixelBuffer& buf,
+                     dimension_size_type no = 0U) const = 0;
 
       /**
        * Get the Modulo subdivision of the Z dimension.

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -71,6 +71,8 @@ namespace ome
                          virtual public MetadataConfigurable
     {
     public:
+      using FormatHandler::isThisType;
+
       /// File grouping options.
       enum FileGroupOption
         {
@@ -151,8 +153,8 @@ namespace ome
       // Documented in superclass.
       virtual
       bool
-      isThisType(const std::string& name,
-                 bool               open = true) const = 0;
+      isThisType(const boost::filesystem::path& name,
+                 bool                           open = true) const = 0;
 
       /**
        * Check if the given buffer is a valid header for this file format.
@@ -713,7 +715,7 @@ namespace ome
        * @returns a list of filenames.
        */
       virtual
-      const std::vector<std::string>
+      const std::vector<boost::filesystem::path>
       getUsedFiles(bool noPixels = false) const = 0;
 
       /**
@@ -724,7 +726,7 @@ namespace ome
        * @returns a list of filenames.
        */
       virtual
-      const std::vector<std::string>
+      const std::vector<boost::filesystem::path>
       getSeriesUsedFiles(bool noPixels = false) const = 0;
 
       /**
@@ -757,7 +759,7 @@ namespace ome
        * @returns the filename.
        */
       virtual
-      const boost::optional<std::string>&
+      const boost::optional<boost::filesystem::path>&
       getCurrentFile() const = 0;
 
       /**
@@ -995,7 +997,7 @@ namespace ome
        */
       virtual
       bool
-      isSingleFile(const std::string& id) const = 0;
+      isSingleFile(const boost::filesystem::path& id) const = 0;
 
       /**
        * Get required parent directories.

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -137,6 +137,19 @@ namespace ome
           }
       }
 
+      template<typename I>
+      inline std::vector<std::string>
+      domain_strings(I begin,
+                     I end)
+      {
+        std::vector<std::string> ret;
+
+        for (I i = begin; i < end; ++i)
+          ret.push_back(getDomain(*i));
+
+        return ret;
+      }
+
     }
 
     // No switch default to avoid -Wunreachable-code errors.
@@ -154,72 +167,72 @@ namespace ome
 
       switch(domain)
         {
-        case UNKNOWN:
+        case UNKNOWN_DOMAIN:
           {
             return unk;
           }
           break;
-        case HCS:
+        case HCS_DOMAIN:
           {
             static const std::string hcs("High-Content Screening (HCS)");
             return hcs;
           }
           break;
-        case LM:
+        case LM_DOMAIN:
           {
             static const std::string lm("Light Microscopy (LM)");
             return lm;
           }
           break;
-        case EM:
+        case EM_DOMAIN:
           {
             static const std::string em("Electron Microscopy (EM)");
             return em;
           }
           break;
-        case SPM:
+        case SPM_DOMAIN:
           {
             static const std::string spm("Scanning Probe Microscopy (SPM)");
             return spm;
           }
           break;
-        case SEM:
+        case SEM_DOMAIN:
           {
             static const std::string sem("Scanning Electron Microscopy (SEM)");
             return sem;
           }
           break;
-        case FLIM:
+        case FLIM_DOMAIN:
           {
             static const std::string flim("Fluorescence-Lifetime Imaging (FLIM)");
             return flim;
           }
           break;
-        case MEDICAL:
+        case MEDICAL_DOMAIN:
           {
             static const std::string mi("Medical Imaging");
             return mi;
           }
           break;
-        case HISTOLOGY:
+        case HISTOLOGY_DOMAIN:
           {
             static const std::string hs("Histology");
             return hs;
           }
           break;
-        case GEL:
+        case GEL_DOMAIN:
           {
             static const std::string gel("Gel/Blot Imaging");
             return gel;
           }
           break;
-        case ASTRONOMY:
+        case ASTRONOMY_DOMAIN:
           {
             static const std::string astronomy("Astronomy");
             return astronomy;
           }
           break;
-        case GRAPHICS:
+        case GRAPHICS_DOMAIN:
           {
             static const std::string graphics("Graphics");
             return graphics;
@@ -230,6 +243,106 @@ namespace ome
       // Fallback if enum is unknown.
       return unk;
     }
+
+    const std::vector<std::string>&
+    getDomainCollection(DomainCollection domains)
+    {
+      switch(domains)
+        {
+        case NON_GRAPHICS_DOMAINS:
+          {
+            const Domain non_graphics_enums[] =
+              {
+                UNKNOWN_DOMAIN,
+                HCS_DOMAIN,
+                LM_DOMAIN,
+                EM_DOMAIN,
+                SPM_DOMAIN,
+                SEM_DOMAIN,
+                FLIM_DOMAIN,
+                MEDICAL_DOMAIN,
+                HISTOLOGY_DOMAIN,
+                GEL_DOMAIN,
+                ASTRONOMY_DOMAIN
+              };
+            static const std::vector<std::string> non_graphics_domains
+              (domain_strings(non_graphics_enums,
+                              non_graphics_enums + (sizeof(non_graphics_enums) / sizeof(non_graphics_enums[0]))));
+            return non_graphics_domains;
+          }
+          break;
+        case NON_HCS_DOMAINS:
+          {
+            const Domain non_hcs_enums[] =
+              {
+                UNKNOWN_DOMAIN,
+                LM_DOMAIN,
+                EM_DOMAIN,
+                SPM_DOMAIN,
+                SEM_DOMAIN,
+                FLIM_DOMAIN,
+                MEDICAL_DOMAIN,
+                HISTOLOGY_DOMAIN,
+                GEL_DOMAIN,
+                ASTRONOMY_DOMAIN
+              };
+            static const std::vector<std::string> non_hcs_domains
+              (domain_strings(non_hcs_enums,
+                              non_hcs_enums + (sizeof(non_hcs_enums) / sizeof(non_hcs_enums[0]))));
+            return non_hcs_domains;
+          }
+          break;
+        case NON_SPECIAL_DOMAINS:
+          {
+            const Domain non_special_enums[] =
+              {
+                UNKNOWN_DOMAIN,
+                LM_DOMAIN,
+                EM_DOMAIN,
+                SPM_DOMAIN,
+                SEM_DOMAIN,
+                FLIM_DOMAIN,
+                MEDICAL_DOMAIN,
+                HISTOLOGY_DOMAIN,
+                GEL_DOMAIN,
+                ASTRONOMY_DOMAIN
+              };
+            static const std::vector<std::string> non_special_domains
+              (domain_strings(non_special_enums,
+                              non_special_enums + (sizeof(non_special_enums) / sizeof(non_special_enums[0]))));
+            return non_special_domains;
+          }
+          break;
+        case ALL_DOMAINS:
+          {
+            const Domain all_enums[] =
+              {
+                UNKNOWN_DOMAIN,
+                HCS_DOMAIN,
+                LM_DOMAIN,
+                EM_DOMAIN,
+                SPM_DOMAIN,
+                SEM_DOMAIN,
+                FLIM_DOMAIN,
+                MEDICAL_DOMAIN,
+                HISTOLOGY_DOMAIN,
+                GEL_DOMAIN,
+                ASTRONOMY_DOMAIN,
+                GRAPHICS_DOMAIN
+              };
+            static const std::vector<std::string> all_domains
+              (domain_strings(all_enums,
+                              all_enums + (sizeof(all_enums) / sizeof(all_enums[0]))));
+            return all_domains;
+          }
+          break;
+        }
+
+      // Fallback if enum is unknown.
+      static const std::vector<std::string> unk;
+      return unk;
+    }
+
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop

--- a/cpp/lib/ome/bioformats/FormatTools.h
+++ b/cpp/lib/ome/bioformats/FormatTools.h
@@ -54,18 +54,29 @@ namespace ome
      */
     enum Domain
       {
-        UNKNOWN,   ///< Unknown
-        HCS,       ///< High-Content Screening (HCS)
-        LM,        ///< Light Microscopy (LM)
-        EM,        ///< Electron Microscopy (EM)
-        SPM,       ///< Scanning Probe Microscopy (SPM)
-        SEM,       ///< Scanning Electron Microscopy (SEM)
-        FLIM,      ///< Fluorescence-Lifetime Imaging (FLIM)
-        MEDICAL,   ///< Medical Imaging
-        HISTOLOGY, ///< Histology
-        GEL,       ///< Gel/Blot Imaging
-        ASTRONOMY, ///< Astronomy
-        GRAPHICS   ///< Graphics
+        UNKNOWN_DOMAIN,   ///< Unknown
+        HCS_DOMAIN,       ///< High-Content Screening (HCS)
+        LM_DOMAIN,        ///< Light Microscopy (LM)
+        EM_DOMAIN,        ///< Electron Microscopy (EM)
+        SPM_DOMAIN,       ///< Scanning Probe Microscopy (SPM)
+        SEM_DOMAIN,       ///< Scanning Electron Microscopy (SEM)
+        FLIM_DOMAIN,      ///< Fluorescence-Lifetime Imaging (FLIM)
+        MEDICAL_DOMAIN,   ///< Medical Imaging
+        HISTOLOGY_DOMAIN, ///< Histology
+        GEL_DOMAIN,       ///< Gel/Blot Imaging
+        ASTRONOMY_DOMAIN, ///< Astronomy
+        GRAPHICS_DOMAIN   ///< Graphics
+      };
+
+    /**
+     * Imaging domain collections.
+     */
+    enum DomainCollection
+      {
+        NON_GRAPHICS_DOMAINS,
+        NON_HCS_DOMAINS,
+        NON_SPECIAL_DOMAINS,
+        ALL_DOMAINS
       };
 
     /**
@@ -76,6 +87,15 @@ namespace ome
      */
     const std::string&
     getDomain(Domain domain);
+
+    /**
+     * Get the strings corresponding to a particular Domain collection.
+     *
+     * @param domains the Domain collection to use.
+     * @returns the string descriptions of the Domain collection.
+     */
+    const std::vector<std::string>&
+    getDomainCollection(DomainCollection domains);
 
     /**
      * Get the rasterized index corresponding to the given @c Z, @c C

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -370,7 +370,7 @@ namespace ome
        */
       virtual
       void
-      changeOutputFile(const std::string& id) = 0;
+      changeOutputFile(const boost::filesystem::path& id) = 0;
 
       /**
        * Write planes sequentially.

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -179,7 +179,18 @@ namespace ome
     {
       // Parse OME-XML into DOM Document.
       ome::xerces::Platform xmlplat;
-      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(file));
+      ome::xerces::dom::Document doc;
+      try
+        {
+          doc = ome::xerces::dom::createDocument(file);
+        }
+      catch (const std::runtime_error&)
+        {
+          ome::xerces::dom::ParseParameters params;
+          params.doSchema = false;
+          params.validationSchemaFullChecking = false;
+          doc = ome::xerces::dom::createDocument(file, params);
+        }
       return createOMEXMLMetadata(doc);
     }
 
@@ -188,7 +199,19 @@ namespace ome
     {
       // Parse OME-XML into DOM Document.
       ome::xerces::Platform xmlplat;
-      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(text));
+      ome::xerces::dom::Document doc;
+      try
+        {
+          doc = ome::xerces::dom::createDocument(text, ome::xerces::dom::ParseParameters(),
+                                                 "OME-XML");
+        }
+      catch (const std::runtime_error&)
+        {
+          ome::xerces::dom::ParseParameters params;
+          params.doSchema = false;
+          params.validationSchemaFullChecking = false;
+          doc = ome::xerces::dom::createDocument(text, params, "Broken OME-XML");
+        }
       return createOMEXMLMetadata(doc);
     }
 
@@ -197,7 +220,19 @@ namespace ome
     {
       // Parse OME-XML into DOM Document.
       ome::xerces::Platform xmlplat;
-      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(stream));
+      ome::xerces::dom::Document doc;
+      try
+        {
+          doc = ome::xerces::dom::createDocument(stream, ome::xerces::dom::ParseParameters(),
+                                                 "OME-XML");
+        }
+      catch (const std::runtime_error&)
+        {
+          ome::xerces::dom::ParseParameters params;
+          params.doSchema = false;
+          params.validationSchemaFullChecking = false;
+          doc = ome::xerces::dom::createDocument(stream, params, "Broken OME-XML");
+        }
       return createOMEXMLMetadata(doc);
     }
 

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -516,6 +516,37 @@ namespace ome
         }
     }
 
+    void
+    removeBinData(::ome::xml::meta::OMEXMLMetadata& omexml)
+    {
+      omexml.resolveReferences();
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      if (root)
+        {
+          std::vector<std::shared_ptr<ome::xml::model::Image> >& images(root->getImageList());
+          for(std::vector<std::shared_ptr<ome::xml::model::Image> >::const_iterator image = images.begin();
+              image != images.end();
+              ++image)
+            {
+              std::shared_ptr<ome::xml::model::Pixels> pixels((*image)->getPixels());
+              if (pixels)
+                {
+                  // Note a copy not a reference to avoid iterator
+                  // invalidation during removal.
+                  std::vector<std::shared_ptr<ome::xml::model::BinData> > binData(pixels->getBinDataList());
+                  for (std::vector<std::shared_ptr<ome::xml::model::BinData> >::iterator bin = binData.begin();
+                   bin != binData.end();
+                       ++bin)
+                    {
+                      pixels->removeBinData(*bin);
+                    }
+                  std::shared_ptr<ome::xml::model::MetadataOnly> metadataOnly;
+                  pixels->setMetadataOnly(metadataOnly);
+                }
+            }
+        }
+    }
+
     std::string
     getModelVersion()
     {

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -150,7 +150,7 @@ namespace ome
       return fmt.str();
     }
 
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::xerces::dom::Document& document)
     {
       ome::xerces::dom::Element docroot(document.getDocumentElement());
@@ -160,10 +160,10 @@ namespace ome
       std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
       root->update(docroot, model);
 
-      return std::static_pointer_cast< ::ome::xml::meta::Metadata>(meta);
+      return meta;
     }
 
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file)
     {
       // Parse OME-XML into DOM Document.
@@ -171,7 +171,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text)
     {
       // Parse OME-XML into DOM Document.
@@ -179,7 +179,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream)
     {
       // Parse OME-XML into DOM Document.
@@ -187,12 +187,12 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr<Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane,
                          bool                doImageName)
     {
-      std::shared_ptr<Metadata> metadata(std::make_shared<OMEXMLMetadata>());
+      std::shared_ptr<OMEXMLMetadata> metadata(std::make_shared<OMEXMLMetadata>());
       std::shared_ptr<MetadataStore> store(std::static_pointer_cast<MetadataStore>(metadata));
       fillMetadata(*store, reader, doPlane, doImageName);
       return metadata;
@@ -207,21 +207,21 @@ namespace ome
       return meta ? meta->getRoot() : std::shared_ptr< ::ome::xml::meta::MetadataRoot>();
     }
 
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
     {
-      std::shared_ptr<Metadata> ret;
+      std::shared_ptr<OMEXMLMetadata> ret;
 
       if (retrieve)
         {
           std::shared_ptr<OMEXMLMetadata> omexml(std::dynamic_pointer_cast<OMEXMLMetadata>(retrieve));
           if (omexml)
             {
-              ret = std::static_pointer_cast<Metadata>(omexml);
+              ret = omexml;
             }
           else
             {
-              ret = std::shared_ptr<Metadata>(new OMEXMLMetadata());
+              ret = std::shared_ptr<OMEXMLMetadata>(std::make_shared<OMEXMLMetadata>());
               ome::xml::meta::convert(*retrieve, *ret);
             }
         }

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -151,11 +151,9 @@ namespace ome
     }
 
     std::shared_ptr< ::ome::xml::meta::Metadata>
-    createOMEXMLMetadata(const std::string& document)
+    createOMEXMLMetadata(ome::xerces::dom::Document& document)
     {
-      // Parse OME-XML into DOM Document.
-      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(document));
-      ome::xerces::dom::Element docroot(doc.getDocumentElement());
+      ome::xerces::dom::Element docroot(document.getDocumentElement());
 
       std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
       ome::xml::model::detail::OMEModel model;
@@ -163,6 +161,30 @@ namespace ome
       root->update(docroot, model);
 
       return std::static_pointer_cast< ::ome::xml::meta::Metadata>(meta);
+    }
+
+    std::shared_ptr< ::ome::xml::meta::Metadata>
+    createOMEXMLMetadata(const boost::filesystem::path& file)
+    {
+      // Parse OME-XML into DOM Document.
+      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(file));
+      return createOMEXMLMetadata(doc);
+    }
+
+    std::shared_ptr< ::ome::xml::meta::Metadata>
+    createOMEXMLMetadata(const std::string& text)
+    {
+      // Parse OME-XML into DOM Document.
+      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(text));
+      return createOMEXMLMetadata(doc);
+    }
+
+    std::shared_ptr< ::ome::xml::meta::Metadata>
+    createOMEXMLMetadata(std::istream& stream)
+    {
+      // Parse OME-XML into DOM Document.
+      ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(stream));
+      return createOMEXMLMetadata(doc);
     }
 
     std::shared_ptr<Metadata>

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -77,11 +77,11 @@ using ome::xml::meta::OMEXMLMetadataRoot;
 using ome::xml::model::Image;
 using ome::xml::model::MetadataOnly;
 using ome::xml::model::ModelException;
+using ome::xml::model::OMEModel;
+using ome::xml::model::OriginalMetadataAnnotation;
 using ome::xml::model::Pixels;
 using ome::xml::model::StructuredAnnotations;
 using ome::xml::model::XMLAnnotation;
-using ome::xml::model::OriginalMetadataAnnotation;
-using ome::xml::model::OMEModel;
 using ome::xml::model::primitives::Timestamp;
 using ome::xml::model::primitives::PositiveInteger;
 

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -54,6 +54,7 @@
 #include <ome/xml/meta/OMEXMLMetadataRoot.h>
 
 #include <ome/xml/model/Annotation.h>
+#include <ome/xml/model/Channel.h>
 #include <ome/xml/model/Image.h>
 #include <ome/xml/model/MetadataOnly.h>
 #include <ome/xml/model/OMEModel.h>
@@ -542,6 +543,33 @@ namespace ome
                     }
                   std::shared_ptr<ome::xml::model::MetadataOnly> metadataOnly;
                   pixels->setMetadataOnly(metadataOnly);
+                }
+            }
+        }
+    }
+
+    void
+    removeChannels(::ome::xml::meta::OMEXMLMetadata& omexml,
+                   dimension_size_type               image,
+                   dimension_size_type               sizeC)
+    {
+      omexml.resolveReferences();
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      if (root)
+        {
+          std::shared_ptr<ome::xml::model::Image>& imageref(root->getImage(image));
+          if (image)
+            {
+              std::shared_ptr<ome::xml::model::Pixels> pixels(imageref->getPixels());
+              if (pixels)
+                {
+                  std::vector<std::shared_ptr<ome::xml::model::Channel> > channels(pixels->getChannelList());
+                  for (Metadata::index_type c = 0U; c < channels.size(); ++c)
+                    {
+                      std::shared_ptr<ome::xml::model::Channel> channel(channels.at(c));
+                      if (channel->getID().empty() || c >= sizeC)
+                        pixels->removeChannel(channel);
+                    }
                 }
             }
         }

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -178,6 +178,7 @@ namespace ome
     createOMEXMLMetadata(const boost::filesystem::path& file)
     {
       // Parse OME-XML into DOM Document.
+      ome::xerces::Platform xmlplat;
       ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(file));
       return createOMEXMLMetadata(doc);
     }
@@ -186,6 +187,7 @@ namespace ome
     createOMEXMLMetadata(const std::string& text)
     {
       // Parse OME-XML into DOM Document.
+      ome::xerces::Platform xmlplat;
       ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(text));
       return createOMEXMLMetadata(doc);
     }
@@ -194,6 +196,7 @@ namespace ome
     createOMEXMLMetadata(std::istream& stream)
     {
       // Parse OME-XML into DOM Document.
+      ome::xerces::Platform xmlplat;
       ome::xerces::dom::Document doc(ome::xerces::dom::createDocument(stream));
       return createOMEXMLMetadata(doc);
     }
@@ -432,6 +435,7 @@ namespace ome
             {
               try
                 {
+                  ome::xerces::Platform xmlplat;
                   ::ome::xerces::dom::Document xmlroot(::ome::xerces::dom::createDocument(xmlannotation->getValue()));
                   ::ome::xerces::dom::NodeList nodes(xmlroot.getElementsByTagName(tag));
 
@@ -611,6 +615,7 @@ namespace ome
                   // Fall back to parsing by hand.
                   try
                     {
+                      xerces::Platform xmlplat;
                       xerces::dom::ParseParameters params;
                       params.validationScheme = xercesc::XercesDOMParser::Val_Never;
                       xerces::dom::Document doc(ome::xerces::dom::createDocument(annotation->getValue()));

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -237,12 +237,12 @@ namespace ome
         {
           reader.setSeries(s);
 
-          const boost::optional<std::string>& cfile(reader.getCurrentFile());
+          const boost::optional<boost::filesystem::path>& cfile(reader.getCurrentFile());
 
           std::ostringstream nos;
           if (doImageName && !!cfile)
             {
-              nos << *cfile;
+              nos << (*cfile).native();
               if (reader.getSeriesCount() > 1)
                 nos << " #" << (s + 1);
             }
@@ -253,7 +253,7 @@ namespace ome
           if (!imageName.empty())
             store.setImageID(createID("Image", s), s);
           if (!!cfile)
-            setDefaultCreationDate(store, s, boost::filesystem::path(*cfile));
+            setDefaultCreationDate(store, s, *cfile);
 
           fillPixels(store, reader);
 

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -318,7 +318,7 @@ namespace ome
      */
     void
     verifyMinimum(::ome::xml::meta::MetadataRetrieve& retrieve,
-                    dimension_size_type               series = 0U);
+                  dimension_size_type                 series = 0U);
 
     /**
      * Check if default creation date is enabled.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -116,13 +116,40 @@ namespace ome
              dimension_size_type idx4);
 
     /**
-     * Create OME-XML metadata from XML document.
+     * Create OME-XML metadata from DOM Document.
      *
-     * @param document the XML document source.
+     * @param document the XML document.
      * @returns the OME-XML metadata.
      */
     std::shared_ptr< ::ome::xml::meta::Metadata>
-    createOMEXMLMetadata(const std::string& document);
+    createOMEXMLMetadata(ome::xerces::dom::Document& document);
+
+    /**
+     * Create OME-XML metadata from XML file.
+     *
+     * @param file the XML file.
+     * @returns the OME-XML metadata.
+     */
+    std::shared_ptr< ::ome::xml::meta::Metadata>
+    createOMEXMLMetadata(const boost::filesystem::path& file);
+
+    /**
+     * Create OME-XML metadata from XML string.
+     *
+     * @param text the XML string.
+     * @returns the OME-XML metadata.
+     */
+    std::shared_ptr< ::ome::xml::meta::Metadata>
+    createOMEXMLMetadata(const std::string& text);
+
+    /**
+     * Create OME-XML metadata from XML input stream.
+     *
+     * @param stream the XML input stream.
+     * @returns the OME-XML metadata.
+     */
+    std::shared_ptr< ::ome::xml::meta::Metadata>
+    createOMEXMLMetadata(std::istream& stream);
 
     /**
      * Create OME-XML metadata from reader core metadata.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -321,6 +321,14 @@ namespace ome
                   dimension_size_type                 series = 0U);
 
     /**
+     * Remove all BinData elements from OME-XML metadata.
+     *
+     * @param omexml the OME-XML metadata store.
+     */
+    void
+    removeBinData(::ome::xml::meta::OMEXMLMetadata& omexml);
+
+    /**
      * Check if default creation date is enabled.
      *
      * @returns @c true if enabled, @c false otherwise.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -342,6 +342,15 @@ namespace ome
                    dimension_size_type               sizeC);
 
     /**
+     * Get original metadata from OME-XML metadata StructuredAnnotations.
+     *
+     * @param omexml the OME-XML metadata store.
+     * @returns a map of the original metadata annotations.
+     */
+    MetadataMap
+    getOriginalMetadata(::ome::xml::meta::OMEXMLMetadata& omexml);
+
+    /**
      * Check if default creation date is enabled.
      *
      * @returns @c true if enabled, @c false otherwise.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -329,6 +329,19 @@ namespace ome
     removeBinData(::ome::xml::meta::OMEXMLMetadata& omexml);
 
     /**
+     * Remove all but the specified number of valid Channel elements
+     * from OME-XML metadata.
+     *
+     * @param omexml the OME-XML metadata store.
+     * @param image the image index.
+     * @param sizeC the number of channels to retain.
+     */
+    void
+    removeChannels(::ome::xml::meta::OMEXMLMetadata& omexml,
+                   dimension_size_type               image,
+                   dimension_size_type               sizeC);
+
+    /**
      * Check if default creation date is enabled.
      *
      * @returns @c true if enabled, @c false otherwise.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -121,7 +121,7 @@ namespace ome
      * @param document the XML document.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::xerces::dom::Document& document);
 
     /**
@@ -130,7 +130,7 @@ namespace ome
      * @param file the XML file.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file);
 
     /**
@@ -139,7 +139,7 @@ namespace ome
      * @param text the XML string.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text);
 
     /**
@@ -148,7 +148,7 @@ namespace ome
      * @param stream the XML input stream.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream);
 
     /**
@@ -159,7 +159,7 @@ namespace ome
      * @param doImageName set image name if @c true.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane = false,
                          bool                doImageName = true);
@@ -182,7 +182,7 @@ namespace ome
      * @param retrieve the metadata to use.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::Metadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
 
     /**

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -117,13 +117,13 @@ namespace ome
         return readerProperties.description;
       }
 
-      const std::vector<std::string>&
+      const std::vector<boost::filesystem::path>&
       FormatReader::getSuffixes() const
       {
         return readerProperties.suffixes;
       }
 
-      const std::vector<std::string>&
+      const std::vector<boost::filesystem::path>&
       FormatReader::getCompressionSuffixes() const
       {
         return readerProperties.compression_suffixes;
@@ -136,12 +136,12 @@ namespace ome
       }
 
       void
-      FormatReader::initFile(const std::string& id)
+      FormatReader::initFile(const boost::filesystem::path& id)
       {
         if (currentId)
           {
-            const std::vector<std::string>& s = getUsedFiles();
-            for (std::vector<std::string>::const_iterator i = s.begin();
+            const std::vector<path>& s = getUsedFiles();
+            for (std::vector<path>::const_iterator i = s.begin();
                  i != s.end();
                  ++i)
               {
@@ -164,7 +164,7 @@ namespace ome
       }
 
       bool
-      FormatReader::isUsedFile(const std::string& file)
+      FormatReader::isUsedFile(const boost::filesystem::path& file)
       {
         bool used = false;
 
@@ -173,8 +173,8 @@ namespace ome
             path thisfile = ome::compat::canonical(path(file));
 
             /// @todo: Use a set rather than a list?
-            const std::vector<std::string>& s = getUsedFiles();
-            for (std::vector<std::string>::const_iterator i = s.begin();
+            const std::vector<path>& s = getUsedFiles();
+            for (std::vector<path>::const_iterator i = s.begin();
                  i != s.end();
                  ++i)
               {
@@ -414,8 +414,8 @@ namespace ome
       }
 
       bool
-      FormatReader::isThisType(const std::string& name,
-                               bool               open) const
+      FormatReader::isThisType(const boost::filesystem::path& name,
+                               bool                           open) const
       {
         // if file extension ID is insufficient and we can't open the file, give up
         if (!suffixSufficient && !open)
@@ -467,7 +467,7 @@ namespace ome
       }
 
       bool
-      FormatReader::isFilenameThisTypeImpl(const std::string& /* name */) const
+      FormatReader::isFilenameThisTypeImpl(const boost::filesystem::path& /* name */) const
       {
         return false;
       }
@@ -850,29 +850,29 @@ namespace ome
         return saveOriginalMetadata;
       }
 
-      const std::vector<std::string>
+      const std::vector<boost::filesystem::path>
       FormatReader::getUsedFiles(bool noPixels) const
       {
         SaveSeries sentry(*this);
-        std::set<std::string> files;
+        std::set<path> files;
         for (dimension_size_type i = 0; i < getSeriesCount(); ++i)
           {
             setSeries(i);
-            std::vector<std::string> s = getSeriesUsedFiles(noPixels);
-            for (std::vector<std::string>::const_iterator file = s.begin();
+            std::vector<path> s = getSeriesUsedFiles(noPixels);
+            for (std::vector<path>::const_iterator file = s.begin();
                  file != s.end();
                  ++file)
               {
                 files.insert(*file);
               }
           }
-        return std::vector<std::string>(files.begin(), files.end());
+        return std::vector<path>(files.begin(), files.end());
       }
 
-      const std::vector<std::string>
+      const std::vector<boost::filesystem::path>
       FormatReader::getSeriesUsedFiles(bool noPixels) const
       {
-        std::vector<std::string> ret;
+        std::vector<path> ret;
         if (!noPixels && currentId)
           ret.push_back(currentId.get());
         return ret;
@@ -881,10 +881,10 @@ namespace ome
       std::vector<FileInfo>
       FormatReader::getAdvancedUsedFiles(bool noPixels) const
       {
-        std::vector<std::string> files = getUsedFiles(noPixels);
+        std::vector<path> files = getUsedFiles(noPixels);
         std::vector<FileInfo> infos(files.size());
 
-        for (std::vector<std::string>::iterator file = files.begin();
+        for (std::vector<path>::iterator file = files.begin();
              file != files.end();
              ++file)
           {
@@ -893,11 +893,11 @@ namespace ome
             info.reader = getFormat();
             info.usedToInitialize = false;
 
-            const boost::optional<std::string> currentid = getCurrentFile();
+            const boost::optional<path> currentid = getCurrentFile();
             if (currentid)
               {
-                path current = ome::compat::canonical(path(currentid.get()));
-                path thisfile = ome::compat::canonical(path(*file));
+                path current = ome::compat::canonical(currentid.get());
+                path thisfile = ome::compat::canonical(*file);
 
                 info.usedToInitialize = (thisfile == current);
               }
@@ -910,10 +910,10 @@ namespace ome
       std::vector<FileInfo>
       FormatReader::getAdvancedSeriesUsedFiles(bool noPixels) const
       {
-        std::vector<std::string> files = getSeriesUsedFiles(noPixels);
+        std::vector<path> files = getSeriesUsedFiles(noPixels);
         std::vector<FileInfo> infos(files.size());
 
-        for (std::vector<std::string>::iterator file = files.begin();
+        for (std::vector<path>::iterator file = files.begin();
              file != files.end();
              ++file)
           {
@@ -922,11 +922,11 @@ namespace ome
             info.reader = getFormat();
             info.usedToInitialize = false;
 
-            const boost::optional<std::string> currentid = getCurrentFile();
+            const boost::optional<path> currentid = getCurrentFile();
             if (currentid)
               {
-                path current = ome::compat::canonical(path(currentid.get()));
-                path thisfile = ome::compat::canonical(path(*file));
+                path current = ome::compat::canonical(currentid.get());
+                path thisfile = ome::compat::canonical(*file);
 
                 info.usedToInitialize = (thisfile == current);
               }
@@ -936,7 +936,7 @@ namespace ome
         return infos;
       }
 
-      const boost::optional<std::string>&
+      const boost::optional<boost::filesystem::path>&
       FormatReader::getCurrentFile() const
       {
         return currentId;
@@ -1080,7 +1080,7 @@ namespace ome
       }
 
       bool
-      FormatReader::isSingleFile(const std::string& /* id */) const
+      FormatReader::isSingleFile(const boost::filesystem::path& /* id */) const
       {
         return true;
       }
@@ -1305,7 +1305,7 @@ namespace ome
       }
 
       void
-      FormatReader::setId(const std::string& id)
+      FormatReader::setId(const boost::filesystem::path& id)
       {
         //    LOGGER.debug("{} initializing {}", getFormat(), id);
         if (!currentId || id != currentId.get())

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -591,7 +591,8 @@ namespace ome
       }
 
       void
-      FormatReader::getLookupTable(VariantPixelBuffer& /* buf */) const
+      FormatReader::getLookupTable(VariantPixelBuffer& /* buf */,
+                                   dimension_size_type /* no */) const
       {
         throw std::runtime_error("Reader does not implement lookup tables");
       }

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -1310,7 +1310,16 @@ namespace ome
         //    LOGGER.debug("{} initializing {}", getFormat(), id);
         if (!currentId || id != currentId.get())
           {
-            initFile(id);
+            path canonicalID(id);
+            try
+              {
+                // Attempt to canonicalise the path.
+                canonicalID = ome::compat::canonical(id);
+              }
+            catch (const std::exception& /* e */)
+              {
+              }
+            initFile(canonicalID);
 
             const std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
               std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -1313,7 +1313,7 @@ namespace ome
             path canonicalID(id);
             try
               {
-                // Attempt to canonicalise the path.
+                // Attempt to canonicalize the path.
                 canonicalID = ome::compat::canonical(id);
               }
             catch (const std::exception& /* e */)

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -460,7 +460,8 @@ namespace ome
 
         // Documented in superclass.
         void
-        getLookupTable(VariantPixelBuffer& buf) const;
+        getLookupTable(VariantPixelBuffer& buf,
+                       dimension_size_type no) const;
 
         // Documented in superclass.
         Modulo&

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -76,6 +76,12 @@ namespace ome
         /// Supported metadata levels.  A typical default is {METADATA_MINIMUM,METADATA_NO_OVERLAYS,METADATA_ALL}.
         std::set<MetadataOptions::MetadataLevel> metadata_levels;
 
+        /**
+         * Constructor.
+         *
+         * @param name the format name.
+         * @param description a short description of the format.
+         */
         ReaderProperties(const std::string& name,
                          const std::string& description):
           name(name),
@@ -303,8 +309,8 @@ namespace ome
          *
          * @param index the core index.
          * @returns the CoreMetadata.
-         * @throws @c std::range_error if the core index is invalid,
-         * or @c std::logic_error if the metadata is null.
+         * @throws std::range_error if the core index is invalid.
+         * @throws std::logic_error if the metadata is null.
          */
         const CoreMetadata&
         getCoreMetadata(dimension_size_type index) const
@@ -320,8 +326,8 @@ namespace ome
          *
          * @param index the core index.
          * @returns the CoreMetadata.
-         * @throws @c std::range_error if the core index is invalid,
-         * or @c std::logic_error if the metadata is null.
+         * @throws std::range_error if the core index is invalid.
+         * @throws std::logic_error if the metadata is null.
          */
         CoreMetadata&
         getCoreMetadata(dimension_size_type index)

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -70,11 +70,22 @@ namespace ome
         /// Format description.
         std::string description;
         /// Filename suffixes this format can handle.
-        std::vector<std::string> suffixes;
+        std::vector<boost::filesystem::path> suffixes;
         /// Filename compression suffixes this format can handle.
-        std::vector<std::string> compression_suffixes;
+        std::vector<boost::filesystem::path> compression_suffixes;
         /// Supported metadata levels.  A typical default is {METADATA_MINIMUM,METADATA_NO_OVERLAYS,METADATA_ALL}.
         std::set<MetadataOptions::MetadataLevel> metadata_levels;
+
+        ReaderProperties(const std::string& name,
+                         const std::string& description):
+          name(name),
+          description(description),
+          suffixes(),
+          compression_suffixes(),
+          metadata_levels()
+        {
+          compression_suffixes.push_back(boost::filesystem::path(""));
+        }
       };
 
       /**
@@ -100,7 +111,7 @@ namespace ome
         const ReaderProperties& readerProperties;
 
         /// The identifier (path) of the currently open file.
-        boost::optional<std::string> currentId;
+        boost::optional<boost::filesystem::path> currentId;
 
         /// Current input.
         std::shared_ptr<std::istream> in;
@@ -217,7 +228,7 @@ namespace ome
          */
         virtual
         void
-        initFile(const std::string& id);
+        initFile(const boost::filesystem::path& id);
 
         /**
          * Check if a file is in the used files list.
@@ -227,7 +238,7 @@ namespace ome
          */
         virtual
         bool
-        isUsedFile(const std::string& file);
+        isUsedFile(const boost::filesystem::path& file);
 
         /**
          * Read a raw plane.
@@ -355,8 +366,8 @@ namespace ome
 
         // Documented in superclass.
         bool
-        isThisType(const std::string& name,
-                   bool               open = true) const;
+        isThisType(const boost::filesystem::path& name,
+                   bool                           open = true) const;
 
         // Documented in superclass.
         bool
@@ -387,7 +398,7 @@ namespace ome
          */
         virtual
         bool
-        isFilenameThisTypeImpl(const std::string& name) const;
+        isFilenameThisTypeImpl(const boost::filesystem::path& name) const;
 
         /**
          * isThisType stream implementation for readers.
@@ -612,11 +623,11 @@ namespace ome
         isOriginalMetadataPopulated() const;
 
         // Documented in superclass.
-        const std::vector<std::string>
+        const std::vector<boost::filesystem::path>
         getUsedFiles(bool noPixels = false) const;
 
         // Documented in superclass.
-        const std::vector<std::string>
+        const std::vector<boost::filesystem::path>
         getSeriesUsedFiles(bool noPixels = false) const;
 
         // Documented in superclass.
@@ -628,7 +639,7 @@ namespace ome
         getAdvancedSeriesUsedFiles(bool noPixels = false) const;
 
         // Documented in superclass.
-        const boost::optional<std::string>&
+        const boost::optional<boost::filesystem::path>&
         getCurrentFile() const;
 
         // Documented in superclass.
@@ -684,7 +695,7 @@ namespace ome
 
         // Documented in superclass.
         bool
-        isSingleFile(const std::string& id) const;
+        isSingleFile(const boost::filesystem::path& id) const;
 
         // Documented in superclass.
         uint32_t
@@ -752,7 +763,7 @@ namespace ome
 
         // Documented in superclass.
         void
-        setId(const std::string& id);
+        setId(const boost::filesystem::path& id);
 
         // Documented in superclass.
         const std::string&
@@ -763,11 +774,11 @@ namespace ome
         getFormatDescription() const;
 
         // Documented in superclass.
-        const std::vector<std::string>&
+        const std::vector<boost::filesystem::path>&
         getSuffixes() const;
 
         // Documented in superclass.
-        const std::vector<std::string>&
+        const std::vector<boost::filesystem::path>&
         getCompressionSuffixes() const;
       };
 

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -93,7 +93,7 @@ namespace ome
       }
 
       void
-      FormatWriter::setId(const std::string& id)
+      FormatWriter::setId(const boost::filesystem::path& id)
       {
         if (!currentId || id != currentId.get())
           {
@@ -133,8 +133,8 @@ namespace ome
       }
 
       bool
-      FormatWriter::isThisType(const std::string& name,
-                               bool               /* open */) const
+      FormatWriter::isThisType(const boost::filesystem::path& name,
+                               bool                           /* open */) const
       {
         return checkSuffix(name,
                            writerProperties.suffixes,
@@ -241,7 +241,7 @@ namespace ome
       }
 
       void
-      FormatWriter::changeOutputFile(const std::string& id)
+      FormatWriter::changeOutputFile(const boost::filesystem::path& id)
       {
         assertId(currentId, true);
 
@@ -295,13 +295,13 @@ namespace ome
         return writerProperties.description;
       }
 
-      const std::vector<std::string>&
+      const std::vector<boost::filesystem::path>&
       FormatWriter::getSuffixes() const
       {
         return writerProperties.suffixes;
       }
 
-      const std::vector<std::string>&
+      const std::vector<boost::filesystem::path>&
       FormatWriter::getCompressionSuffixes() const
       {
         return writerProperties.compression_suffixes;

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -74,6 +74,12 @@ namespace ome
         /// Stacks are supported.
         bool stacks;
 
+        /**
+         * Constructor.
+         *
+         * @param name the format name.
+         * @param description a short description of the format.
+         */
         WriterProperties(const std::string& name,
                          const std::string& description):
           name(name),

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -64,15 +64,28 @@ namespace ome
         /// Format description.
         std::string description;
         /// Filename suffixes this format can handle.
-        std::vector<std::string> suffixes;
+        std::vector<boost::filesystem::path> suffixes;
         /// Filename compression suffixes this format can handle.
-        std::vector<std::string> compression_suffixes;
+        std::vector<boost::filesystem::path> compression_suffixes;
         /// Supported compression types.
         std::set<std::string> compression_types;
         /// Supported pixel types.
         codec_pixel_type_map codec_pixel_types;
         /// Stacks are supported.
         bool stacks;
+
+        WriterProperties(const std::string& name,
+                         const std::string& description):
+          name(name),
+          description(description),
+          suffixes(),
+          compression_suffixes(),
+          compression_types(),
+          codec_pixel_types(),
+          stacks()
+        {
+          compression_suffixes.push_back(boost::filesystem::path(""));
+        }
       };
 
       /**
@@ -94,7 +107,7 @@ namespace ome
         const WriterProperties& writerProperties;
 
         /// The identifier (path) of the currently open file.
-        boost::optional<std::string> currentId;
+        boost::optional<boost::filesystem::path> currentId;
 
         /// Current output.
         std::shared_ptr<std::ostream> out;
@@ -136,8 +149,8 @@ namespace ome
 
         // Documented in superclass.
         bool
-        isThisType(const std::string& name,
-                   bool               open = true) const;
+        isThisType(const boost::filesystem::path& name,
+                   bool                           open = true) const;
 
         // Documented in superclass.
         void
@@ -220,7 +233,7 @@ namespace ome
 
         // Documented in superclass.
         void
-        changeOutputFile(const std::string& id);
+        changeOutputFile(const boost::filesystem::path& id);
 
         // Documented in superclass.
         void
@@ -232,7 +245,7 @@ namespace ome
 
         // Documented in superclass.
         void
-        setId(const std::string& id);
+        setId(const boost::filesystem::path& id);
 
         // Documented in superclass.
         void
@@ -247,11 +260,11 @@ namespace ome
         getFormatDescription() const;
 
         // Documented in superclass.
-        const std::vector<std::string>&
+        const std::vector<boost::filesystem::path>&
         getSuffixes() const;
 
         // Documented in superclass.
-        const std::vector<std::string>&
+        const std::vector<boost::filesystem::path>&
         getCompressionSuffixes() const;
       };
 

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -238,35 +238,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        dimension_size_type series = getSeries();
-
-        if (series >= series_ifd_map.size())
-          {
-            boost::format fmt("Invalid series number ‘%1%’");
-            fmt % series;
-            throw FormatException(fmt.str());
-          }
-        const series_ifd_map_type::value_type range(series_ifd_map.at(series));
-
-        // Compute timepoint and subchannel from plane number.
-        dimension_size_type plane = no;
-        dimension_size_type S = 0U;
-        if (isRGB())
-          {
-            plane = no / getSizeC();
-            S = no % getSizeC();
-          }
-        dimension_size_type ifdidx = range.first + plane;
-        assert(range.first <= plane && plane < range.second);
-
-        if (plane >= (range.second - range.first))
-          {
-            boost::format fmt("Invalid plane number ‘%1%’ for series ‘%2%’");
-            fmt % plane % series;
-            throw FormatException(fmt.str());
-          }
-
-        const std::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
 
         if (isRGB())
           {
@@ -274,6 +246,7 @@ namespace ome
             VariantPixelBuffer tmp;
             ifd->readImage(tmp, x, y, w, h);
 
+            dimension_size_type S = no % getSizeC();
             detail::CopySubchannelVisitor v(buf, S);
             boost::apply_visitor(v, tmp.vbuffer());
           }

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -67,12 +67,11 @@ namespace ome
         ReaderProperties
         tiff_properties()
         {
-          ReaderProperties p;
+          ReaderProperties p("MinimalTIFF",
+                             "Baseline Tagged Image File Format");
 
-          p.name = "MinimalTIFF";
-          p.description = "Baseline Tagged Image File Format";
-          p.suffixes = std::vector<std::string>(suffixes,
-                                                suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
+          p.suffixes = std::vector<boost::filesystem::path>(suffixes,
+                                                            suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
           p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
           p.metadata_levels.insert(MetadataOptions::METADATA_NO_OVERLAYS);
           p.metadata_levels.insert(MetadataOptions::METADATA_ALL);
@@ -108,7 +107,7 @@ namespace ome
       }
 
       bool
-      MinimalTIFFReader::isFilenameThisTypeImpl(const std::string& name) const
+      MinimalTIFFReader::isFilenameThisTypeImpl(const boost::filesystem::path& name) const
       {
         return static_cast<bool>(TIFF::open(name, "r"));
       }
@@ -156,7 +155,7 @@ namespace ome
       }
 
       void
-      MinimalTIFFReader::initFile(const std::string& id)
+      MinimalTIFFReader::initFile(const boost::filesystem::path& id)
       {
         ::ome::bioformats::detail::FormatReader::initFile(id);
 
@@ -165,7 +164,7 @@ namespace ome
         if (!tiff)
           {
             boost::format fmt("Failed to open ‘%1%’");
-            fmt % id;
+            fmt % id.native();
             throw FormatException(fmt.str());
           }
 

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -90,7 +90,7 @@ namespace ome
         tiff(),
         series_ifd_map()
       {
-        domains.push_back(getDomain(GRAPHICS));
+        domains.push_back(getDomain(GRAPHICS_DOMAIN));
       }
 
       MinimalTIFFReader::MinimalTIFFReader(const ReaderProperties& readerProperties):
@@ -98,7 +98,7 @@ namespace ome
         tiff(),
         series_ifd_map()
       {
-        domains.push_back(getDomain(GRAPHICS));
+        domains.push_back(getDomain(GRAPHICS_DOMAIN));
       }
 
       MinimalTIFFReader::~MinimalTIFFReader()

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -229,6 +229,26 @@ namespace ome
       }
 
       void
+      MinimalTIFFReader::getLookupTable(VariantPixelBuffer& buf,
+                                        dimension_size_type no) const
+      {
+        assertId(currentId, true);
+
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+
+        try
+          {
+            ifd->readLookupTable(buf);
+          }
+        catch (const std::exception& e)
+          {
+            boost::format fmt("Failed to get lookup table:");
+            fmt % e.what();
+            throw FormatException(fmt.str());
+          }
+      }
+
+      void
       MinimalTIFFReader::openBytesImpl(dimension_size_type no,
                                        VariantPixelBuffer& buf,
                                        dimension_size_type x,

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -89,7 +89,7 @@ namespace ome
       protected:
         // Documented in superclass.
         void
-        initFile(const std::string& id);
+        initFile(const boost::filesystem::path& id);
 
         /**
          * Read metadata from IFDs.
@@ -100,7 +100,7 @@ namespace ome
 
         // Documented in superclass.
         bool
-        isFilenameThisTypeImpl(const std::string& name) const;
+        isFilenameThisTypeImpl(const boost::filesystem::path& name) const;
 
         /**
          * Get the IFD index for a plane in the current series.

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -50,6 +50,7 @@ namespace ome
     {
 
       class TIFF;
+      class IFD;
 
     }
 
@@ -100,6 +101,16 @@ namespace ome
         // Documented in superclass.
         bool
         isFilenameThisTypeImpl(const std::string& name) const;
+
+        /**
+         * Get the IFD index for a plane in the current series.
+         *
+         * @param no the image index within the file.
+         * @returns the IFD index.
+         * @throws FormatException if out of range.
+         */
+        const std::shared_ptr<const tiff::IFD>
+        ifdAtIndex(dimension_size_type no) const;
 
       public:
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -117,6 +117,11 @@ namespace ome
         void
         close(bool fileOnly = false);
 
+        // Documented in superclass.
+        void
+        getLookupTable(VariantPixelBuffer& buf,
+                       dimension_size_type no) const;
+
       protected:
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -62,12 +62,9 @@ namespace ome
         ReaderProperties
         tiff_properties()
         {
-          ReaderProperties p;
-
-          p.name = "TIFF";
-          p.description = "Tagged Image File Format";
-          p.suffixes = std::vector<std::string>(suffixes,
-                                                suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
+          ReaderProperties p("TIFF", "Tagged Image File Format");
+          p.suffixes = std::vector<boost::filesystem::path>(suffixes,
+                                                            suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
           p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
           p.metadata_levels.insert(MetadataOptions::METADATA_NO_OVERLAYS);
           p.metadata_levels.insert(MetadataOptions::METADATA_ALL);
@@ -77,8 +74,8 @@ namespace ome
 
         const ReaderProperties props(tiff_properties());
 
-        std::vector<std::string> companion_suffixes(companion_suffixes_array,
-                                                    companion_suffixes_array + (sizeof(companion_suffixes_array) / sizeof(companion_suffixes_array[0])));
+        std::vector<boost::filesystem::path> companion_suffixes(companion_suffixes_array,
+                                                                companion_suffixes_array + (sizeof(companion_suffixes_array) / sizeof(companion_suffixes_array[0])));
 
       }
 

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -447,6 +447,14 @@ namespace ome
                   dimension_size_type h) const;
 
         /**
+         * Read a lookup table into a pixel buffer.
+         *
+         * @param buf the destination pixel buffer.
+         */
+        void
+        readLookupTable(VariantPixelBuffer& buf) const;
+
+        /**
          * Write a whole image plane from a pixel buffer.
          *
          * @param buf the source pixel buffer.

--- a/cpp/lib/ome/bioformats/tiff/ImageJMetadata.h
+++ b/cpp/lib/ome/bioformats/tiff/ImageJMetadata.h
@@ -115,7 +115,7 @@ namespace ome
          *
          * @param key the key name.
          * @param value the value which failed to parse.
-         * @throws @c std::runtime_error.
+         * @throws std::runtime_error.
          */
         static
         void
@@ -130,7 +130,7 @@ namespace ome
          *
          * @param key the key name.
          * @param value the value to store the key's parsed string value.
-         * @throws @c std::runtime_error on parse errors.
+         * @throws std::runtime_error on parse errors.
          */
         template<typename T>
         void
@@ -162,7 +162,7 @@ namespace ome
          *
          * @param key the key name.
          * @param value the value to store the key's parsed string value.
-         * @throws @c std::runtime_error on parse errors.
+         * @throws std::runtime_error on parse errors.
          */
         void
         parse_value(const std::string& key,
@@ -176,7 +176,7 @@ namespace ome
          *
          * @param key the key name.
          * @param value the value to store the key's parsed string value.
-         * @throws @c std::runtime_error on parse errors.
+         * @throws std::runtime_error on parse errors.
          */
         void
         parse_value(const std::string& key,

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -84,8 +84,8 @@ namespace ome
         class TIFFConcrete : public TIFF
         {
         public:
-          TIFFConcrete(const std::string& filename,
-                       const std::string& mode):
+          TIFFConcrete(const boost::filesystem::path& filename,
+                       const std::string&             mode):
             TIFF(filename, mode)
           {
           }
@@ -115,13 +115,13 @@ namespace ome
          * @param filename the filename to open.
          * @param mode the file open mode.
          */
-        Impl(const std::string& filename,
-             const std::string& mode):
+        Impl(const boost::filesystem::path& filename,
+             const std::string&             mode):
           tiff()
         {
           Sentry sentry;
 
-          tiff = TIFFOpen(filename.c_str(), mode.c_str());
+          tiff = TIFFOpen(filename.native().c_str(), mode.c_str());
           if (!tiff)
             sentry.error();
         }
@@ -177,8 +177,8 @@ namespace ome
       };
 
       // Note boost::make_shared can't be used here.
-      TIFF::TIFF(const std::string& filename,
-                 const std::string& mode):
+      TIFF::TIFF(const boost::filesystem::path& filename,
+                 const std::string&             mode):
         impl(std::shared_ptr<Impl>(new Impl(filename, mode)))
       {
         registerImageJTags();
@@ -195,7 +195,7 @@ namespace ome
       }
 
       std::shared_ptr<TIFF>
-      TIFF::open(const std::string& filename,
+      TIFF::open(const boost::filesystem::path& filename,
                  const std::string& mode)
       {
         std::shared_ptr<TIFF> ret;

--- a/cpp/lib/ome/bioformats/tiff/TIFF.h
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.h
@@ -45,6 +45,7 @@
 #include <ome/bioformats/tiff/Types.h>
 
 #include <ome/compat/cstdint.h>
+#include <ome/compat/filesystem.h>
 #include <ome/compat/memory.h>
 
 namespace ome
@@ -161,8 +162,8 @@ namespace ome
 
       protected:
         /// Constructor (non-public).
-        TIFF(const std::string& filename,
-             const std::string& mode);
+        TIFF(const boost::filesystem::path& filename,
+             const std::string&             mode);
 
       private:
         /// Copy constructor (deleted).
@@ -189,8 +190,8 @@ namespace ome
          * @throws an Exception on failure.
          */
         static std::shared_ptr<TIFF>
-        open(const std::string& filename,
-             const std::string& mode);
+        open(const boost::filesystem::path& filename,
+             const std::string&             mode);
 
         /**
          * Close the TIFF file.

--- a/cpp/lib/ome/xerces/dom/Document.cpp
+++ b/cpp/lib/ome/xerces/dom/Document.cpp
@@ -236,13 +236,14 @@ namespace ome
 
       Document
       createDocument(const std::string&     text,
-                     const ParseParameters& params)
+                     const ParseParameters& params,
+                     const std::string&     id)
       {
         Platform xmlplat;
 
  	xercesc::MemBufInputSource source(reinterpret_cast<const XMLByte *>(text.c_str()),
                                           static_cast<XMLSize_t>(text.size()),
-                                          String("membuf"));
+                                          String(id));
 
         xercesc::XercesDOMParser parser;
         setup_parser(parser, params);
@@ -253,7 +254,8 @@ namespace ome
 
       Document
       createDocument(std::istream&          stream,
-                     const ParseParameters& params)
+                     const ParseParameters& params,
+                     const std::string&     id)
       {
         Platform xmlplat;
 
@@ -273,7 +275,7 @@ namespace ome
 
  	xercesc::MemBufInputSource source(reinterpret_cast<const XMLByte *>(data.c_str()),
                                           static_cast<XMLSize_t>(data.size()),
-                                          String("membuf"));
+                                          String(id));
 
         xercesc::XercesDOMParser parser;
         setup_parser(parser, params);

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -169,6 +169,20 @@ namespace ome
         }
 
         /**
+         * Create Element without namespace.
+         *
+         * @param name the element name.
+         * @returns the created Element.
+         */
+        Element
+        createElement(const std::string& name)
+        {
+          xerces::String xname(name);
+
+          return Element((*this)->createElement(xname), false);
+        }
+
+        /**
          * Get the root element of this document.
          *
          * @returns the root element.

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -275,7 +275,8 @@ namespace ome
        */
       Document
       createDocument(const std::string&     text,
-                     const ParseParameters& params = ParseParameters());
+                     const ParseParameters& params = ParseParameters(),
+                     const std::string&     id = "membuf");
 
       /**
        * Construct a Document from the content of an input stream.
@@ -286,7 +287,8 @@ namespace ome
        */
       Document
       createDocument(std::istream&          stream,
-                     const ParseParameters& params = ParseParameters());
+                     const ParseParameters& params = ParseParameters(),
+                     const std::string&     id = "streambuf");
 
       /**
        * Parameters controlling DOM writing.

--- a/cpp/lib/ome/xerces/dom/Document.h
+++ b/cpp/lib/ome/xerces/dom/Document.h
@@ -285,6 +285,7 @@ namespace ome
        *
        * @param text the string to use.
        * @param params XML parser parameters.
+       * @param id document filename (for error reporting only).
        * @returns the new Document.
        */
       Document
@@ -297,6 +298,7 @@ namespace ome
        *
        * @param stream the stream to read.
        * @param params XML parser parameters.
+       * @param id document filename (for error reporting only).
        * @returns the new Document.
        */
       Document

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -83,11 +83,13 @@ set(OME_XML_META_STATIC_HEADERS
 set(OME_XML_STATIC_MODEL_HEADERS
     model/ModelException.h
     model/OMEModel.h
-    model/OMEModelObject.h)
+    model/OMEModelObject.h
+    model/OriginalMetadataAnnotation.h)
 
 set(OME_XML_STATIC_MODEL_DETAIL_HEADERS
     model/detail/OMEModel.h
     model/detail/OMEModelObject.h
+    model/OriginalMetadataAnnotation.cpp
     model/detail/Parse.h)
 
 set(OME_XML_STATIC_ENUMS_HEADERS

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -1,0 +1,237 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2006 - 2013 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <iostream>
+
+#include <ome/internal/version.h>
+
+#include <boost/format.hpp>
+
+#include <boost/format.hpp>
+
+#include <ome/xerces/Platform.h>
+
+#include <ome/xml/model/ModelException.h>
+#include <ome/xml/model/OMEModel.h>
+#include <ome/xml/model/OriginalMetadataAnnotation.h>
+
+using boost::format;
+
+namespace ome
+{
+  namespace xml
+  {
+    namespace model
+    {
+
+      namespace
+      {
+        const std::string MAP_NAMESPACE("http://www.openmicroscopy.org/Schemas/SA/" OME_MODEL_VERSION);
+        const std::string PAIRS_NAMESPACE("http://www.openmicroscopy.org/Schemas/OME/" OME_MODEL_VERSION);
+      }
+
+      OriginalMetadataAnnotation::OriginalMetadataAnnotation ():
+        ::ome::xml::model::OMEModelObject(),
+        XMLAnnotation(),
+        metadata()
+      {
+      }
+
+      OriginalMetadataAnnotation::OriginalMetadataAnnotation (const OriginalMetadataAnnotation& copy):
+        ::ome::xml::model::OMEModelObject(),
+        XMLAnnotation(copy),
+        metadata(copy.metadata)
+      {
+      }
+
+      OriginalMetadataAnnotation::OriginalMetadataAnnotation (const metadata_type& metadata):
+        ::ome::xml::model::OMEModelObject(),
+        XMLAnnotation(),
+        metadata(metadata)
+      {
+      }
+
+      OriginalMetadataAnnotation::OriginalMetadataAnnotation (xerces::dom::Element&        element,
+                          ::ome::xml::model::OMEModel& model):
+        XMLAnnotation(),
+        metadata()
+      {
+        update(element, model);
+      }
+
+      OriginalMetadataAnnotation::~OriginalMetadataAnnotation ()
+      {
+      }
+
+      const std::string&
+      OriginalMetadataAnnotation::elementName() const
+      {
+        static const std::string type("OriginalMetadataAnnotation");
+        return type;
+      }
+
+      bool
+      OriginalMetadataAnnotation::validElementName(const std::string& name) const
+      {
+        static const std::string expectedTagName("OriginalMetadataAnnotation");
+
+        return expectedTagName == name || XMLAnnotation::validElementName(name);
+      }
+
+      void
+      OriginalMetadataAnnotation::update(const xerces::dom::Element&  element,
+                                         ::ome::xml::model::OMEModel& model)
+      {
+        // Delegate checking of element type.
+        XMLAnnotation::update(element, model);
+
+        std::vector<xerces::dom::Element> XMLValue_nodeList = getChildrenByTagName(element, "Value");
+        if (XMLValue_nodeList.size() > 1)
+          {
+            format fmt("Value node list size %1% != 1");
+            fmt % XMLValue_nodeList.size();
+            throw ModelException(fmt.str());
+          }
+        else if (XMLValue_nodeList.size() != 0)
+          {
+            std::vector<xerces::dom::Element> OriginalMetadataValue_nodeList = getChildrenByTagName(XMLValue_nodeList.at(0), "OriginalMetadata");
+            if (OriginalMetadataValue_nodeList.size() > 1)
+              {
+                format fmt("Value node list size %1% != 1");
+                fmt % OriginalMetadataValue_nodeList.size();
+                throw ModelException(fmt.str());
+              }
+            else if (OriginalMetadataValue_nodeList.size() != 0)
+              {
+                std::vector<xerces::dom::Element> Key_nodeList = getChildrenByTagName(OriginalMetadataValue_nodeList.at(0), "Key");
+                if (Key_nodeList.size() > 1)
+                  {
+                    format fmt("Key node list size %1% != 1");
+                    fmt % Key_nodeList.size();
+                    throw ModelException(fmt.str());
+                  }
+                else if (Key_nodeList.size() != 0)
+                  {
+                    metadata.first = Key_nodeList.at(0).getTextContent();
+                  }
+                std::vector<xerces::dom::Element> Value_nodeList = getChildrenByTagName(OriginalMetadataValue_nodeList.at(0), "Value");
+                if (Value_nodeList.size() > 1)
+                  {
+                    format fmt("Value node list size %1% != 1");
+                    fmt % Value_nodeList.size();
+                    throw ModelException(fmt.str());
+                  }
+                else if (Value_nodeList.size() != 0)
+                  {
+                    metadata.second = Value_nodeList.at(0).getTextContent();
+                  }
+              }
+          }
+    }
+
+      bool
+      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
+                      std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      {
+        if (XMLAnnotation::link(reference, object))
+          {
+            return true;
+          }
+        std::clog << "Unable to handle reference of type: " << typeid(reference).name() << std::endl;
+        return false;
+      }
+
+      xerces::dom::Element
+      OriginalMetadataAnnotation::asXMLElement (xerces::dom::Document& document) const
+      {
+        xerces::dom::Element nullelem;
+        return asXMLElementInternal(document, nullelem);
+      }
+
+      xerces::dom::Element
+      OriginalMetadataAnnotation::asXMLElementInternal (xerces::dom::Document& document,
+                                      xerces::dom::Element&  element) const
+      {
+
+        return XMLAnnotation::asXMLElementInternal(document, element);
+      }
+
+      OriginalMetadataAnnotation::metadata_type&
+      OriginalMetadataAnnotation::getMetadata ()
+      {
+        return metadata;
+      }
+
+      const OriginalMetadataAnnotation::metadata_type&
+      OriginalMetadataAnnotation::getMetadata () const
+      {
+        return metadata;
+      }
+
+      void
+      OriginalMetadataAnnotation::setMetadata (const metadata_type& metadata)
+      {
+        this->metadata = metadata;
+
+        xerces::Platform xmlplat;
+
+        xerces::dom::Document Value_document(ome::xerces::dom::createEmptyDocument("wrapped"));
+        xerces::dom::Element Value_root = Value_document.getDocumentElement();
+
+        xerces::dom::Element keyElement =
+          Value_document.createElement("Key");
+        keyElement.setTextContent(metadata.first);
+        xerces::dom::Element valueElement =
+          Value_document.createElement("Value");
+        valueElement.setTextContent(metadata.second);
+
+        xerces::dom::Element originalMetadata =
+          Value_document.createElement("OriginalMetadata");
+        originalMetadata.appendChild(keyElement);
+        originalMetadata.appendChild(valueElement);
+        Value_root.appendChild(originalMetadata);
+
+        std::string textvalue;
+        ome::xerces::dom::writeNode(originalMetadata, textvalue);
+        setValue(textvalue);
+
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -132,7 +132,7 @@ namespace ome
             std::vector<xerces::dom::Element> OriginalMetadataValue_nodeList = getChildrenByTagName(XMLValue_nodeList.at(0), "OriginalMetadata");
             if (OriginalMetadataValue_nodeList.size() > 1)
               {
-                format fmt("Value node list size %1% != 1");
+                format fmt("OriginalMetadata node list size %1% != 1");
                 fmt % OriginalMetadataValue_nodeList.size();
                 throw ModelException(fmt.str());
               }
@@ -141,7 +141,7 @@ namespace ome
                 std::vector<xerces::dom::Element> Key_nodeList = getChildrenByTagName(OriginalMetadataValue_nodeList.at(0), "Key");
                 if (Key_nodeList.size() > 1)
                   {
-                    format fmt("Key node list size %1% != 1");
+                    format fmt("OriginalMetadata Key node list size %1% != 1");
                     fmt % Key_nodeList.size();
                     throw ModelException(fmt.str());
                   }
@@ -152,7 +152,7 @@ namespace ome
                 std::vector<xerces::dom::Element> Value_nodeList = getChildrenByTagName(OriginalMetadataValue_nodeList.at(0), "Value");
                 if (Value_nodeList.size() > 1)
                   {
-                    format fmt("Value node list size %1% != 1");
+                    format fmt("OriginalMetadata Value node list size %1% != 1");
                     fmt % Value_nodeList.size();
                     throw ModelException(fmt.str());
                   }

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
@@ -1,0 +1,175 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2006 - 2013 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
+#define OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
+
+#include <string>
+#include <utility>
+
+#include <ome/compat/memory.h>
+
+#include <ome/xerces/dom/Document.h>
+#include <ome/xerces/dom/Element.h>
+#include <ome/xerces/dom/Node.h>
+#include <ome/xerces/dom/NodeList.h>
+
+#include <ome/xml/model/XMLAnnotation.h>
+
+namespace ome
+{
+  namespace xml
+  {
+    namespace model
+    {
+
+      // Forward declarations.
+      class OMEModel;
+
+      /**
+       * OriginalMetadataAnnotation model object.
+       */
+      class OriginalMetadataAnnotation : public XMLAnnotation
+      {
+      public:
+        /// Type of original annotation.
+        typedef std::pair<std::string, std::string> metadata_type;
+
+      private:
+        /// Original metadata key-value pair.
+        metadata_type metadata;
+
+      public:
+        /// Default constructor.
+        OriginalMetadataAnnotation ();
+
+        /**
+         * Copy constructor.
+         *
+         * @param copy the object to copy.
+         */
+        OriginalMetadataAnnotation (const OriginalMetadataAnnotation& copy);
+
+        /**
+         * Construct from original metadata key and value.
+         *
+         * @param map the map to copy.
+         */
+        OriginalMetadataAnnotation (const metadata_type& map);
+
+        /**
+         * Construct a OriginalMetadataAnnotation recursively from an XML DOM tree.
+         *
+         * @param element root of the XML DOM tree to from which to
+         * construct the model object graph.
+         * @param model handler for the OME model used to track
+         * instances and references seen during the update.
+         * @throws EnumerationException if there is an error
+         * instantiating an enumeration during model object creation.
+         */
+        OriginalMetadataAnnotation (xerces::dom::Element& element, ::ome::xml::model::OMEModel& model);
+
+        /// Destructor.
+        virtual
+        ~OriginalMetadataAnnotation ();
+
+        // Documented in superclass.
+        const std::string&
+        elementName() const;
+
+        // Documented in superclass.
+        bool
+        validElementName(const std::string& name) const;
+
+        /// @copydoc ome::xml::model::OMEModelObject::update
+        virtual void
+        update(const xerces::dom::Element&  element,
+               ::ome::xml::model::OMEModel& model);
+
+      public:
+        /// @copydoc ome::xml::model::OMEModelObject::link
+        bool
+        link (std::shared_ptr<Reference>&                          reference,
+              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+
+        /**
+         * Get the key-value pair mappings.
+         *
+         * @returns the map.
+         */
+        metadata_type&
+        getMetadata ();
+
+        /**
+         * Get the key-value pair mappings.
+         *
+         * @returns the map.
+         */
+        const metadata_type&
+        getMetadata () const;
+
+        /**
+         * Set the key-value pair mappings.
+         *
+         * @param map the map to set.
+         */
+        void
+        setMetadata (const metadata_type& map);
+
+        /// @copydoc ome::xml::model::OMEModelObject::asXMLElement
+        virtual xerces::dom::Element
+        asXMLElement (xerces::dom::Document& document) const;
+
+      protected:
+        // Documented in base class.
+        virtual xerces::dom::Element
+        asXMLElementInternal (xerces::dom::Document& document,
+                              xerces::dom::Element&  element) const;
+      };
+
+    }
+  }
+}
+
+#endif // OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/xml/model/detail/Parse.h
+++ b/cpp/lib/ome/xml/model/detail/Parse.h
@@ -122,6 +122,14 @@ namespace ome
             parse_value_fail(text, klass, property);
         }
 
+    // Disable -Wunused-parameter temporarily.  We can't comment out
+    // the names since they are needed for docstrings when used
+    // inline.
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
         /**
          * Parse a string value.
          *
@@ -140,6 +148,10 @@ namespace ome
         {
           value = text;
         }
+
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
 
         /**
          * Parse an arbitrary value.

--- a/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -411,7 +411,6 @@ namespace ome
            * Increment the constrained value by one.  If the new value
            * fails the constraint check, this will cause an error.
            *
-           * @param value the value to compute the modulus with.
            * @returns the new value.
            */
           inline ConstrainedNumeric&
@@ -426,7 +425,6 @@ namespace ome
            * Decrement the constrained value by one.  If the new value
            * fails the constraint check, this will cause an error.
            *
-           * @param value the value to compute the modulus with.
            * @returns the new value.
            */
           inline ConstrainedNumeric&

--- a/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -127,7 +127,9 @@ namespace ome
                                            boost::dividable2<ConstrainedNumeric<N, C, E>, N,
                                            boost::dividable<ConstrainedNumeric<N, C, E>,
                                            boost::multipliable2<ConstrainedNumeric<N, C, E>, N,
-                                           boost::multipliable<ConstrainedNumeric<N, C, E> > > > > > > > > > > > >
+                                           boost::multipliable<ConstrainedNumeric<N, C, E>,
+                                           boost::incrementable<ConstrainedNumeric<N, C, E>,
+                                           boost::decrementable<ConstrainedNumeric<N, C, E> > > > > > > > > > > > > > >
         {
         public:
           /// The type to constrain.
@@ -401,6 +403,36 @@ namespace ome
           operator%= (const value_type& value)
           {
             this->value %= value;
+            check();
+            return *this;
+          }
+
+          /**
+           * Increment the constrained value by one.  If the new value
+           * fails the constraint check, this will cause an error.
+           *
+           * @param value the value to compute the modulus with.
+           * @returns the new value.
+           */
+          inline ConstrainedNumeric&
+          operator++ ()
+          {
+            ++this->value;
+            check();
+            return *this;
+          }
+
+          /**
+           * Decrement the constrained value by one.  If the new value
+           * fails the constraint check, this will cause an error.
+           *
+           * @param value the value to compute the modulus with.
+           * @returns the new value.
+           */
+          inline ConstrainedNumeric&
+          operator-- ()
+          {
+            --this->value;
             check();
             return *this;
           }

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -495,7 +495,7 @@ TEST_P(FormatReaderTest, SubresolutionUnflattenedCoreMetadata)
 TEST_P(FormatReaderTest, DefaultLUT)
 {
   VariantPixelBuffer buf;
-  EXPECT_THROW(r.getLookupTable(buf), std::runtime_error);
+  EXPECT_THROW(r.getLookupTable(buf, 0U), std::runtime_error);
 }
 
 TEST_P(FormatReaderTest, FlatLUT)
@@ -503,7 +503,7 @@ TEST_P(FormatReaderTest, FlatLUT)
   r.setId("flat");
 
   VariantPixelBuffer buf;
-  EXPECT_THROW(r.getLookupTable(buf), std::runtime_error);
+  EXPECT_THROW(r.getLookupTable(buf, 0U), std::runtime_error);
 }
 
 TEST_P(FormatReaderTest, DefaultSeries)

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -97,10 +97,7 @@ namespace
   ReaderProperties
   test_properties()
   {
-    ReaderProperties p;
-
-    p.name = "TestReader";
-    p.description = "Reader for unit testing";
+    ReaderProperties p("TestReader", "Reader for unit testing");
     p.suffixes.push_back("test");
     p.compression_suffixes.push_back("gz");
     p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
@@ -185,7 +182,7 @@ protected:
   }
 
   void
-  initFile(const std::string& id)
+  initFile(const boost::filesystem::path& id)
   {
     ::ome::bioformats::detail::FormatReader::initFile(id);
 
@@ -234,7 +231,7 @@ protected:
 
 public:
   bool
-  isUsedFile(const std::string& file)
+  isUsedFile(const boost::filesystem::path& file)
   {
     return ::ome::bioformats::detail::FormatReader::isUsedFile(file);
   }
@@ -307,9 +304,17 @@ TEST_P(FormatReaderTest, IsThisType)
   EXPECT_FALSE(r.isThisType("invalid.file", true));
   EXPECT_FALSE(r.isThisType("invalid.file", false));
 
+  EXPECT_FALSE(r.isThisType("invalid.file.gz"));
+  EXPECT_FALSE(r.isThisType("invalid.file.gz", true));
+  EXPECT_FALSE(r.isThisType("invalid.file.gz", false));
+
   EXPECT_TRUE(r.isThisType("valid.test"));
   EXPECT_TRUE(r.isThisType("valid.test", true));
   EXPECT_TRUE(r.isThisType("valid.test", false));
+
+  EXPECT_TRUE(r.isThisType("valid.test.gz"));
+  EXPECT_TRUE(r.isThisType("valid.test.gz", true));
+  EXPECT_TRUE(r.isThisType("valid.test.gz", false));
 
   EXPECT_FALSE(r.isThisType(reinterpret_cast<uint8_t *>(&*icontent.begin()),
                             reinterpret_cast<uint8_t *>(&*icontent.end())));

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -289,8 +289,8 @@ TEST_P(FormatReaderTest, ReaderProperties)
   r.setId("test");
   ASSERT_EQ(props.name, r.getFormat());
   ASSERT_EQ(props.description, r.getFormatDescription());
-  ASSERT_EQ(props.suffixes, r.getSuffixes());
-  ASSERT_EQ(props.compression_suffixes, r.getCompressionSuffixes());
+  ASSERT_TRUE(props.suffixes == r.getSuffixes());
+  ASSERT_TRUE(props.compression_suffixes == r.getCompressionSuffixes());
 }
 
 TEST_P(FormatReaderTest, IsThisType)

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -334,8 +334,8 @@ TEST_P(FormatWriterTest, WriterProperties)
   w.setId("output.test");
   ASSERT_EQ(props.name, w.getFormat());
   ASSERT_EQ(props.description, w.getFormatDescription());
-  ASSERT_EQ(props.suffixes, w.getSuffixes());
-  ASSERT_EQ(props.compression_suffixes, w.getCompressionSuffixes());
+  ASSERT_TRUE(props.suffixes == w.getSuffixes());
+  ASSERT_TRUE(props.compression_suffixes == w.getCompressionSuffixes());
   ASSERT_EQ(props.compression_types, w.getCompressionTypes());
   ASSERT_EQ(props.stacks, w.canDoStacks());
 }

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -165,10 +165,7 @@ namespace
   WriterProperties
   test_properties()
   {
-    WriterProperties p;
-
-    p.name = "TestWriter";
-    p.description = "Writer for unit testing";
+    WriterProperties p("TestWriter", "Writer for unit testing");
     p.suffixes.push_back("test");
     p.compression_suffixes.push_back("gz");
 

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -283,7 +283,7 @@ private:
 
 public:
   void
-  setId(const std::string& id)
+  setId(const boost::filesystem::path& id)
   {
     if (!currentId)
       {

--- a/cpp/test/ome-xml/constrained-numeric.h
+++ b/cpp/test/ome-xml/constrained-numeric.h
@@ -62,7 +62,9 @@ enum operation
     DIVIDE,
     DIVIDE_ASSIGN,
     MODULO,
-    MODULO_ASSIGN
+    MODULO_ASSIGN,
+    INCREMENT,
+    DECREMENT
   };
 
 template <typename T>
@@ -235,6 +237,20 @@ struct OperationModuloAssign
 {
   T eval(T lhs,                      T rhs) { return lhs %= rhs; }
   T eval(T lhs, typename T::value_type rhs) { return lhs %= rhs; }
+};
+
+template<typename T>
+struct OperationIncrement
+{
+  T eval(T lhs,                      T /* rhs */) { return ++lhs; }
+  T eval(T lhs, typename T::value_type /* rhs */) { return ++lhs; }
+};
+
+template<typename T>
+struct OperationDecrement
+{
+  T eval(T lhs,                      T /* rhs */) { return --lhs; }
+  T eval(T lhs, typename T::value_type /* rhs */) { return --lhs; }
 };
 
 template<typename Operation, typename Test>
@@ -507,6 +523,24 @@ TYPED_TEST_P(NumericTest, OperatorModuloAssign)
       operation_test<OperationModuloAssign<TypeParam> >(*this, *i);
 }
 
+TYPED_TEST_P(NumericTest, OperatorIncrement)
+{
+  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
+       i != this->ops.end();
+       ++i)
+    if (i->op == INCREMENT)
+      operation_test<OperationIncrement<TypeParam> >(*this, *i);
+}
+
+TYPED_TEST_P(NumericTest, OperatorDecrement)
+{
+  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
+       i != this->ops.end();
+       ++i)
+    if (i->op == DECREMENT)
+      operation_test<OperationDecrement<TypeParam> >(*this, *i);
+}
+
 REGISTER_TYPED_TEST_CASE_P(NumericTest,
                            DefaultConstruct,
                            Stream,
@@ -525,7 +559,9 @@ REGISTER_TYPED_TEST_CASE_P(NumericTest,
                            OperatorDivide,
                            OperatorDivideAssign,
                            OperatorModulo,
-                           OperatorModuloAssign);
+                           OperatorModuloAssign,
+                           OperatorIncrement,
+                           OperatorDecrement);
 
 #endif // TEST_CONSTRAINED_NUMERIC_H
 

--- a/cpp/test/ome-xml/non-negative-float.cpp
+++ b/cpp/test/ome-xml/non-negative-float.cpp
@@ -98,7 +98,8 @@ struct CompareGreaterOrEqual<NonNegativeFloat>
 };
 
 
-// Floating point types don't implement modulo, so make it a no-op.
+// Floating point types don't implement modulo, increment or
+// decrement, so make them a no-op.
 template<>
 struct OperationModulo<NonNegativeFloat>
 {
@@ -108,6 +109,20 @@ struct OperationModulo<NonNegativeFloat>
 
 template<>
 struct OperationModuloAssign<NonNegativeFloat>
+{
+  NonNegativeFloat eval(NonNegativeFloat lhs,             NonNegativeFloat /* rhs */) { return lhs; }
+  NonNegativeFloat eval(NonNegativeFloat lhs, NonNegativeFloat::value_type /* rhs */) { return lhs; }
+};
+
+template<>
+struct OperationIncrement<NonNegativeFloat>
+{
+  NonNegativeFloat eval(NonNegativeFloat lhs,             NonNegativeFloat /* rhs */) { return lhs; }
+  NonNegativeFloat eval(NonNegativeFloat lhs, NonNegativeFloat::value_type /* rhs */) { return lhs; }
+};
+
+template<>
+struct OperationDecrement<NonNegativeFloat>
 {
   NonNegativeFloat eval(NonNegativeFloat lhs,             NonNegativeFloat /* rhs */) { return lhs; }
   NonNegativeFloat eval(NonNegativeFloat lhs, NonNegativeFloat::value_type /* rhs */) { return lhs; }

--- a/cpp/test/ome-xml/non-negative-integer.cpp
+++ b/cpp/test/ome-xml/non-negative-integer.cpp
@@ -126,7 +126,14 @@ namespace
       {   43,   43,          0, MODULO,           true,  false, false},
       {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
       {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    true,  false, false}
+      {   43,   43,          0, MODULO_ASSIGN,    true,  false, false},
+
+      {  33,     0,         34, INCREMENT,        true,  false, false},
+      {  33,     0,         33, INCREMENT,        false, false, false},
+      {   0,     0,          1, INCREMENT,        true,  false, false},
+      {  33,     0,         32, DECREMENT,        true,  false, false},
+      {  33,     0,         33, DECREMENT,        false, false, false},
+      {   0,     0,          0, DECREMENT,        false, true,  false}
     };
 
 }

--- a/cpp/test/ome-xml/non-negative-long.cpp
+++ b/cpp/test/ome-xml/non-negative-long.cpp
@@ -127,7 +127,14 @@ namespace
       {   43,   43,          0, MODULO,           true,  false, false},
       {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
       {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    true,  false, false}
+      {   43,   43,          0, MODULO_ASSIGN,    true,  false, false},
+
+      {  33,     0,         34, INCREMENT,        true,  false, false},
+      {  33,     0,         33, INCREMENT,        false, false, false},
+      {   0,     0,          1, INCREMENT,        true,  false, false},
+      {  33,     0,         32, DECREMENT,        true,  false, false},
+      {  33,     0,         33, DECREMENT,        false, false, false},
+      {   0,     0,          0, DECREMENT,        false, true,  false}
     };
 
 }

--- a/cpp/test/ome-xml/percent-fraction.cpp
+++ b/cpp/test/ome-xml/percent-fraction.cpp
@@ -97,7 +97,8 @@ struct CompareGreaterOrEqual<PercentFraction>
   { return lhs > static_cast<PercentFraction::value_type>(rhs) - 0.05F; }
 };
 
-// Floating point types don't implement modulo, so make it a no-op.
+// Floating point types don't implement modulo, increment or
+// decrement, so make them a no-op.
 template<>
 struct OperationModulo<PercentFraction>
 {
@@ -107,6 +108,20 @@ struct OperationModulo<PercentFraction>
 
 template<>
 struct OperationModuloAssign<PercentFraction>
+{
+  PercentFraction eval(PercentFraction lhs,             PercentFraction /* rhs */) { return lhs; }
+  PercentFraction eval(PercentFraction lhs, PercentFraction::value_type /* rhs */) { return lhs; }
+};
+
+template<>
+struct OperationIncrement<PercentFraction>
+{
+  PercentFraction eval(PercentFraction lhs,             PercentFraction /* rhs */) { return lhs; }
+  PercentFraction eval(PercentFraction lhs, PercentFraction::value_type /* rhs */) { return lhs; }
+};
+
+template<>
+struct OperationDecrement<PercentFraction>
 {
   PercentFraction eval(PercentFraction lhs,             PercentFraction /* rhs */) { return lhs; }
   PercentFraction eval(PercentFraction lhs, PercentFraction::value_type /* rhs */) { return lhs; }

--- a/cpp/test/ome-xml/positive-float.cpp
+++ b/cpp/test/ome-xml/positive-float.cpp
@@ -98,7 +98,8 @@ struct CompareGreaterOrEqual<PositiveFloat>
 };
 
 
-// Floating point types don't implement modulo, so make it a no-op.
+// Floating point types don't implement modulo, increment or
+// decrement, so make them a no-op.
 template<>
 struct OperationModulo<PositiveFloat>
 {
@@ -108,6 +109,20 @@ struct OperationModulo<PositiveFloat>
 
 template<>
 struct OperationModuloAssign<PositiveFloat>
+{
+  PositiveFloat eval(PositiveFloat lhs,             PositiveFloat /* rhs */) { return lhs; }
+  PositiveFloat eval(PositiveFloat lhs, PositiveFloat::value_type /* rhs */) { return lhs; }
+};
+
+template<>
+struct OperationIncrement<PositiveFloat>
+{
+  PositiveFloat eval(PositiveFloat lhs,             PositiveFloat /* rhs */) { return lhs; }
+  PositiveFloat eval(PositiveFloat lhs, PositiveFloat::value_type /* rhs */) { return lhs; }
+};
+
+template<>
+struct OperationDecrement<PositiveFloat>
 {
   PositiveFloat eval(PositiveFloat lhs,             PositiveFloat /* rhs */) { return lhs; }
   PositiveFloat eval(PositiveFloat lhs, PositiveFloat::value_type /* rhs */) { return lhs; }

--- a/cpp/test/ome-xml/positive-integer.cpp
+++ b/cpp/test/ome-xml/positive-integer.cpp
@@ -124,7 +124,14 @@ namespace
       {   43,   43,          0, MODULO,           false, true,  false},
       {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
       {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    false, true,  false}
+      {   43,   43,          0, MODULO_ASSIGN,    false, true,  false},
+
+      {  33,     1,         34, INCREMENT,        true,  false, false},
+      {  33,     1,         33, INCREMENT,        false, false, false},
+      {   1,     1,          2, INCREMENT,        true,  false, false},
+      {  33,     1,         32, DECREMENT,        true,  false, false},
+      {  33,     1,         33, DECREMENT,        false, false, false},
+      {   1,     1,          0, DECREMENT,        false, true,  false}
     };
 
 }

--- a/cpp/test/ome-xml/positive-long.cpp
+++ b/cpp/test/ome-xml/positive-long.cpp
@@ -125,7 +125,14 @@ namespace
       {   43,   43,          0, MODULO,           false, true,  false},
       {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
       {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    false, true,  false}
+      {   43,   43,          0, MODULO_ASSIGN,    false, true,  false},
+
+      {  33,     1,         34, INCREMENT,        true,  false, false},
+      {  33,     1,         33, INCREMENT,        false, false, false},
+      {   1,     1,          2, INCREMENT,        true,  false, false},
+      {  33,     1,         32, DECREMENT,        true,  false, false},
+      {  33,     1,         33, DECREMENT,        false, false, false},
+      {   1,     1,          0, DECREMENT,        false, true,  false}
     };
 
 }


### PR DESCRIPTION
Primarily metadata-related fixes, but includes a number of additional assorted fixes and API improvements.  The main change is to the generated model and metadatastore code, to enforce the safe use of shared and weak references.  Where the Java code would have thrown an NPE, here it segfaults the program, so this adds strict checking and will throw an exception if a bad reference is encountered (either null or bad weak refs).  This is what the internal `safe_fetch` function templates do.  They check the validity of the pointer and then return it back to the caller.  This approach was necessary due to the way the templates generate and chain multiple calls together.

--no-rebase

--------

Testing: Should be handled by the unit tests and travis.

When the OME-TIFF reader is added, it will test most of these changes fairly extensively.  You could try applying my cpp-ome-tiffreader branch on top and reading an OME-TIFF with showinf.  However, this isn't yet ready for testing and so will currently not work correctly (but will be completed very soon).