### PR TITLE
TillVision: throw a more informative exception when the .vws file is missing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
@@ -207,11 +207,16 @@ public class TillVisionReader extends FormatReader {
       else if (vwsFile.isDirectory()) {
         parent = pst.getParentFile();
         String[] list = parent.list(true);
+        boolean foundVWS = false;
         for (String f : list) {
           if (checkSuffix(f, "vws")) {
             id = new Location(parent, f).getAbsolutePath();
+            foundVWS = true;
             break;
           }
+        }
+        if (!foundVWS) {
+          throw new FormatException("Could not find .vws file.");
         }
       }
       else throw new FormatException("Could not find .vws file.");


### PR DESCRIPTION
This throws an exception indicating that the .vws file could not be found, instead of attempting to parse the .pst file as a .vws file.  .pst files cannot be read alone, as they are just pixels - an accompanying .vws file is expected and required.

/cc @joshmoore, @dietzc
See also https://github.com/scifio/scifio-bf-compat/issues/11