### PR TITLE
ND2: fix RGB channel splitting

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1046,6 +1046,7 @@ public class NativeND2Reader extends FormatReader {
       if (getSizeZ() * getSizeT() * (split ? 1 : getSizeC()) <
         imageOffsets.size() / getSeriesCount())
       {
+        split = getSizeC() > 1;
         int count = imageOffsets.size() / getSeriesCount();
         if (!split && count >= getSizeC()) {
           count /= getSizeC();


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/12725.  To test, verify that the file from QA 10425 has 10 Z sections and 3 channels, just like in NIS Elements Viewer (version 4.20).  For two of the channels, only one Z section will have non-zero data.

I would expect all builds to remain green.