### PR TITLE
Fix Python files to be PEP8 1.6.0 compliant

### DIFF
--- a/components/xsd-fu/ez_setup.py
+++ b/components/xsd-fu/ez_setup.py
@@ -13,7 +13,15 @@ the appropriate options to ``use_setuptools()``.
 
 This file can also be run as a script to install or upgrade setuptools.
 """
+
 import sys
+import os
+
+try:
+    from hashlib import md5
+except ImportError:
+    from md5 import md5
+
 DEFAULT_VERSION = "0.6c11"
 DEFAULT_URL = ("http://pypi.python.org/packages/%s/s/setuptools/"
                % sys.version[:3])
@@ -62,13 +70,6 @@ md5_data = {
     'setuptools-0.6c9-py2.5.egg': 'fe67c3e5a17b12c0e7c541b7ea43a8e6',
     'setuptools-0.6c9-py2.6.egg': 'ca37b1ff16fa2ede6e19383e7b59245a',
 }
-
-import sys
-import os
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
 
 
 def _validate_md5(egg_name, data):

--- a/components/xsd-fu/python/ome/modeltools/generateds.py
+++ b/components/xsd-fu/python/ome/modeltools/generateds.py
@@ -7,13 +7,12 @@ import logging
 # The generateDS package and our generateds module
 # collide on case-insensitive file systems.
 import generateDS.generateDS
-XschemaHandler = generateDS.generateDS.XschemaHandler
-set_type_constants = generateDS.generateDS.set_type_constants
-
 from ome.modeltools.exceptions import ModelProcessingError
 from xml import sax
-
 from ome.modeltools.model import OMEModel
+
+XschemaHandler = generateDS.generateDS.XschemaHandler
+set_type_constants = generateDS.generateDS.set_type_constants
 
 
 def parse(opts):

--- a/components/xsd-fu/setup.py
+++ b/components/xsd-fu/setup.py
@@ -15,15 +15,16 @@ import glob
 import sys
 import os
 
+from ez_setup import use_setuptools
+from setuptools import setup, find_packages
+
 ov = os.environ.get("BF_VERSION", "unknown")
 
 for tools in glob.glob("tempTOFIX/setuptools*.egg"):
     if tools.find(".".join(map(str, sys.version_info[0:2]))) > 0:
         sys.path.insert(0, tools)
 
-from ez_setup import use_setuptools
 use_setuptools(to_dir='tempTOFIX')
-from setuptools import setup, find_packages
 
 if os.path.exists("target"):
     packages = find_packages("target")+[""]


### PR DESCRIPTION
With the latest release of PEP8, `import` needs to be at top-level. The number of Python files is reasonable in the Bio-Formats code base so we can open a quick fix PR. Arguably we could also impose the `pep8` version used by Travis.

To test this PR, check Travis remains green.
--no-rebase