### PR TITLE
Removing all references to OME FAQs

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -884,9 +884,8 @@ public abstract class FormatReader extends FormatHandler
       throw new FormatException("Image plane too large. Only 2GB of data can " +
         "be extracted at one time. You can workaround the problem by opening " +
         "the plane in tiles; for further details, see: " +
-        "http://www.openmicroscopy.org/site/support/faq/bio-formats/" +
-        "i-see-an-outofmemory-or-negativearraysize-error-message-when-" +
-        "attempting-to-open-an-svs-or-jpeg-2000-file.-what-does-this-mean", e);
+        "http://www.openmicroscopy.org/site/support/bio-formats/about/" +
+        "bug-reporting.html", e);
     }
     return openBytes(no, newBuffer, x, y, w, h);
   }

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -885,7 +885,7 @@ public abstract class FormatReader extends FormatHandler
         "be extracted at one time. You can workaround the problem by opening " +
         "the plane in tiles; for further details, see: " +
         "http://www.openmicroscopy.org/site/support/bio-formats/about/" +
-        "bug-reporting.html", e);
+        "bug-reporting.html#common-issues-to-check", e);
     }
     return openBytes(no, newBuffer, x, y, w, h);
   }

--- a/docs/sphinx/about/index.txt
+++ b/docs/sphinx/about/index.txt
@@ -96,18 +96,17 @@ metadata, original metadata, and OME metadata.
 Help
 ----
 
-For help, see the
-`Bio-Formats <http://www.openmicroscopy.org/site/support/faq/bio-formats>`_,
-`File Formats <http://www.openmicroscopy.org/site/support/faq/file-formats>`_
-and `OME-XML and OME-TIFF 
-<http://www.openmicroscopy.org/site/support/faq/ome-xml-and-ome-tiff>`_
-sections of the `OME FAQ <http://www.openmicroscopy.org/site/support/faq>`_ 
-for answers to some common questions. Please `contact us 
-<http://www.openmicroscopy.org/site/community/mailing-lists>`__ if
-you have any questions or problems with Bio-Formats.
+There is a :doc:`guide for reporting bugs here <bug-reporting>`.
 
-There is a :doc:`guide 
-for reporting bugs here <bug-reporting>`.
+For help relating to opening images in ImageJ or FIJI or when using the
+command line tools, refer to the :doc:`users documentation </users/index>`.
+You can also find tips on common issues with specific formats on the
+pages linked from the :doc:`supported formats table </supported-formats>`.
+
+Please `contact us 
+<http://www.openmicroscopy.org/site/community/mailing-lists>`__ if
+you have any questions or problems with Bio-Formats not addressed by referring
+to the documentation.
 
 Other places where questions are commonly asked and/or bugs are reported
 include:
@@ -123,11 +122,6 @@ include:
    (searchable using google with 'site:lists.openmicroscopy.org.uk')
 -  `ImageJ mailing list (for ImageJ/Fiji
    issues) <http://imagej.1557.n6.nabble.com/>`_
-
-For help relating to opening images in ImageJ or FIJI or when using the
-command line tools, refer to the :doc:`users documentation </users/index>`.
-You can also find tips on common issues with specific formats on the
-pages linked from the :doc:`supported formats table </supported-formats>`.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -191,7 +191,6 @@ extlinks = {
     'legacy_plone' : (oo_site_root + '/support/legacy/%s', ''),
     'about_plone' : (oo_site_root + '/about/%s', ''),
     'team_plone' : (oo_site_root + '/team/%s', ''),
-    'faq_plone' : (oo_site_root + '/support/faq/%s', ''),
     'omerodoc' : (omerodoc_uri + '/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     # Downloads
@@ -386,8 +385,7 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ['http://www.openmicroscopy.org/site/support/faq',]
 
 import urllib
 brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
-linkcheck_ignore.extend(urllib.urlopen(brokenfiles_url).read().splitlines())
+linkcheck_ignore = urllib.urlopen(brokenfiles_url).read().splitlines()


### PR DESCRIPTION
See https://trello.com/c/3uqvWhlq/240-faq-issues-needing-moved-to-docs-plone - The FAQs are being deleted from the website for 5.1 as part of a general clean-up.

I grepped so hopefully haven't missed any links in the rest of the codebase.