### PR TITLE
C++: Add OME-TIFF reader

### DIFF
--- a/components/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/components/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -30,7 +30,8 @@
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 {% end %}\
@@ -55,7 +56,8 @@
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 {% end %}\
@@ -77,7 +79,8 @@
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_name_string(indexes)});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 {% end %}\
@@ -99,7 +102,8 @@
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}();
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 {% end %}\
@@ -126,7 +130,8 @@
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
+        throw MetadataException("AggregateMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "no delegate MetadataStore implementation");
       }
 {% end source %}\
 {% end %}\
@@ -148,7 +153,8 @@
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
+        throw MetadataException("AggregateMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "no delegate MetadataStore implementation");
       }
 {% end source %}\
 {% end %}\
@@ -170,7 +176,8 @@
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
+        throw MetadataException("AggregateMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "no delegate MetadataStore implementation");
       }
 {% end source %}\
 {% end %}\
@@ -266,6 +273,7 @@
 
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/meta/Metadata.h>
+#include <ome/xml/meta/MetadataException.h>
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
 #include <ome/xml/meta/AggregateMetadata.h>
@@ -352,7 +360,7 @@ namespace ome
          * @copydoc MetadataStore::getRoot()
          * @note Unsupported by AggregateMetadata, which will throw an
          * exception if called.
-         * @throws RuntimeException Always.
+         * @throws MetadataException always.
          */
         std::shared_ptr<MetadataRoot>&
         getRoot();
@@ -361,7 +369,8 @@ namespace ome
       std::shared_ptr<MetadataRoot>&
       AggregateMetadata::getRoot()
       {
-        throw std::runtime_error("getRoot() unsupported by AggregateMetadata.");
+        throw MetadataException("AggregateMetadata", "getRoot",
+                                "unsupported");
       }
 {% end source %}\
 
@@ -370,7 +379,7 @@ namespace ome
          * @copydoc MetadataStore::setRoot()
          * @note Unsupported by AggregateMetadata, which will throw an
          * exception if called.
-         * @throws RuntimeException Always.
+         * @throws MetadataException always.
          */
         void
         setRoot(std::shared_ptr<MetadataRoot>& root);
@@ -379,7 +388,8 @@ namespace ome
       void
       AggregateMetadata::setRoot(std::shared_ptr<MetadataRoot>& /* root */)
       {
-        throw std::runtime_error("setRoot unsupported by AggregateMetadata.");
+        throw MetadataException("AggregateMetadata", "setRoot",
+                                "unsupported");
       }
 {% end source %}\
 
@@ -404,7 +414,8 @@ namespace ome
             if (retrieve)
               return retrieve->getPixelsBinDataCount(imageIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getPixelsBinDataCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -425,7 +436,8 @@ namespace ome
             if (retrieve)
               return retrieve->getBooleanAnnotationAnnotationCount(booleanAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getBooleanAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -446,7 +458,8 @@ namespace ome
             if (retrieve)
               return retrieve->getCommentAnnotationAnnotationCount(commentAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getCommentAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -467,7 +480,8 @@ namespace ome
             if (retrieve)
               return retrieve->getDoubleAnnotationAnnotationCount(doubleAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getDoubleAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -488,7 +502,8 @@ namespace ome
             if (retrieve)
               return retrieve->getFileAnnotationAnnotationCount(fileAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getFileAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -509,7 +524,8 @@ namespace ome
             if (retrieve)
               return retrieve->getListAnnotationAnnotationCount(listAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getListAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -530,7 +546,8 @@ namespace ome
             if (retrieve)
               return retrieve->getLongAnnotationAnnotationCount(longAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getLongAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -551,7 +568,8 @@ namespace ome
             if (retrieve)
               return retrieve->getTagAnnotationAnnotationCount(tagAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getTagAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -572,7 +590,8 @@ namespace ome
             if (retrieve)
               return retrieve->getTermAnnotationAnnotationCount(termAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getTermAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -593,7 +612,8 @@ namespace ome
             if (retrieve)
               return retrieve->getTimestampAnnotationAnnotationCount(timestampAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getTimestampAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -614,7 +634,8 @@ namespace ome
             if (retrieve)
               return retrieve->getXMLAnnotationAnnotationCount(xmlAnnotationIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getXMLAnnotationAnnotationCount",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -638,7 +659,8 @@ namespace ome
               return retrieve->getLightSourceType(instrumentIndex,
                                                   lightSourceIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getLightSourceType",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -661,7 +683,8 @@ namespace ome
             if (retrieve)
               return retrieve->getShapeType(roiIndex, shapeIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getShapeType",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -693,7 +716,8 @@ namespace ome
             if (store)
               store->set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
+        throw MetadataException("AggregateMetadata", "set${o.name}Value",
+                                "no delegate MetadataStore implementation");
       }
 {% end source %}\
 
@@ -713,7 +737,8 @@ namespace ome
             if (retrieve)
               return retrieve->get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "get${o.name}Value",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -755,7 +780,8 @@ ${counter(k, o, v)}\
             if (retrieve)
               return retrieve->getPixelsBinDataBigEndian(imageIndex, binDataIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getPixelsBinDataBigEndian",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -780,7 +806,8 @@ ${counter(k, o, v)}\
             if (retrieve)
               return retrieve->getUUID();
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataRetrieve implementation");
+        throw MetadataException("AggregateMetadata", "getUUID",
+                                "no delegate MetadataRetrieve implementation");
       }
 {% end source %}\
 
@@ -885,7 +912,8 @@ ${getter(k, o, prop, v)}\
             if (store)
               store->setPixelsBinDataBigEndian(bigEndian, imageIndex, binDataIndex);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
+        throw MetadataException("AggregateMetadata", "setPixelsBinDataBigEndian",
+                                "no delegate MetadataStore implementation");
       }
 {% end source %}\
 
@@ -910,7 +938,8 @@ ${getter(k, o, prop, v)}\
             if (store)
               store->setUUID(uuid);
           }
-        throw std::runtime_error("AggregateMetadata: No delegate MetadataStore implementation");
+        throw MetadataException("AggregateMetadata", "setUUID",
+                                "no delegate MetadataStore implementation");
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/components/xsd-fu/templates-cpp/DummyMetadata.template
@@ -23,7 +23,8 @@
       BaseMetadata::index_type
       DummyMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string_dummy(indexes[:-1])}) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count",
+                                "intentionally not implemented");
       }
 {% end source %}\
 {% end %}\
@@ -66,7 +67,8 @@
 {% end %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "intentionally not implemented");
       }
 {% end source %}\
 {% end %}\
@@ -201,6 +203,7 @@
 #define ${fu.GUARD}
 
 #include <ome/xml/meta/Metadata.h>
+#include <ome/xml/meta/MetadataException.h>
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
 #include <ome/xml/meta/DummyMetadata.h>
@@ -270,7 +273,8 @@ namespace ome
       std::shared_ptr<MetadataRoot>&
       DummyMetadata::getRoot()
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getRoot",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -299,7 +303,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getPixelsBinDataCount(index_type /* imageIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getPixelsBinDataCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -312,7 +317,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getBooleanAnnotationAnnotationCount(index_type /* booleanAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getBooleanAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -325,7 +331,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getCommentAnnotationAnnotationCount(index_type /* commentAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getCommentAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -338,7 +345,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getDoubleAnnotationAnnotationCount(index_type /* doubleAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getDoubleAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -351,7 +359,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getFileAnnotationAnnotationCount(index_type /* fileAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getFileAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -364,7 +373,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getListAnnotationAnnotationCount(index_type /* listAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getListAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -377,7 +387,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getLongAnnotationAnnotationCount(index_type /* longAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getLongAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -390,7 +401,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getTagAnnotationAnnotationCount(index_type /* tagAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getTagAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -403,7 +415,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getTermAnnotationAnnotationCount(index_type /* termAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getTermAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -416,7 +429,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getTimestampAnnotationAnnotationCount(index_type /* timestampAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getTimestampAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -429,7 +443,8 @@ namespace ome
       BaseMetadata::index_type
       DummyMetadata::getXMLAnnotationAnnotationCount(index_type /* xmlAnnotationIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getXMLAnnotationAnnotationCount",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -444,7 +459,8 @@ namespace ome
       DummyMetadata::getLightSourceType(index_type /* instrumentIndex */,
                                         index_type /* lightSourceIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getLightSourceType",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -459,7 +475,8 @@ namespace ome
       DummyMetadata::getShapeType(index_type /* roiIndex */,
                                   index_type /* shapeIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getShapeType",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -495,7 +512,8 @@ namespace ome
       ${o.langBaseType}
       DummyMetadata::get${o.name}Value(${indexes_string_dummy(indexes[o.name].items()[0][1])}) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "get${o.name}Value",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -529,7 +547,8 @@ ${counter(k, o, v)}\
       DummyMetadata::getPixelsBinDataBigEndian(index_type /* imageIndex */,
                                                index_type /* binDataIndex */) const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getPixelsBinDataBigEndian",
+                                "intentionally not implemented");
       }
 {% end source %}\
 
@@ -546,7 +565,8 @@ ${counter(k, o, v)}\
       const std::string&
       DummyMetadata::getUUID() const
       {
-        throw std::runtime_error("DummyMetadata: No metadata methods implemented");
+        throw MetadataException("DummyMetadata", "getUUID",
+                                "intentionally not implemented");
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -85,7 +85,8 @@
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
-        throw(std::runtime_error("Internal metadata store inconsistency: null object"));
+        throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "Internal metadata store inconsistency: null object");
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract proprietary
@@ -93,7 +94,8 @@
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
-        throw(std::runtime_error("Internal metadata store inconsistency: null object"));
+        throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "Internal metadata store inconsistency: null object");
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract proprietary and not a reference
@@ -103,7 +105,8 @@
         if (ret)
           return *ret;
 {% if prop.maxOccurs != 1 or prop.defaultXsdValue is None %}\
-        throw(std::runtime_error("Internal metadata store inconsistency: null annotation"));
+        throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "Internal metadata store inconsistency: null object");
 {% end %}\
 {% if prop.maxOccurs == 1 and prop.defaultXsdValue is not None %}\
 {% if prop.langType == 'std::string' or prop.isEnumeration %}\
@@ -124,15 +127,16 @@
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
-        throw(std::runtime_error("Internal metadata store inconsistency: null annotation"));
+        throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "Internal metadata store inconsistency: null annotation");
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
         std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
-        /// @todo: Need an exception for store inconsistency.
-        throw(std::runtime_error("Internal metadata store inconsistency: null annotation"));
+        throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "Internal metadata store inconsistency: null annotation");
 {% end %}\
 {% otherwise %}\
         // ${prop.name} is not a reference
@@ -140,7 +144,8 @@
         ${prop.retType[' const']} ret = ${safe_accessor(['root']+accessor(obj.name, parent, prop))}->get${prop.methodName}();
         if (ret)
           return *ret;
-        throw(std::runtime_error("Internal metadata store inconsistency: null annotation"));
+        throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                "Internal metadata store inconsistency: null object");
 {% end %}\
 {% if prop.minOccurs == 1 %}\
         return ${safe_accessor(['root']+accessor(obj.name, parent, prop))}->get${prop.methodName}();
@@ -244,7 +249,8 @@
 {% end %}\
         std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
-          throw(std::runtime_error("Internal metadata store inconsistency: "));
+          throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                  "Internal metadata store inconsistency: null object");
 
 {% if not prop.isShared %}\
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
@@ -299,7 +305,8 @@
 {% end %}\
         std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
-          throw(std::runtime_error("Internal metadata store inconsistency: "));
+          throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
+                                  "Internal metadata store inconsistency: null object");
 
 {% if not prop.isShared %}\
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
@@ -422,6 +429,7 @@ ${customContent[obj.name][prop.name]}
 #define ${fu.GUARD}
 
 #include <ome/xml/meta/Metadata.h>
+#include <ome/xml/meta/MetadataException.h>
 #include <ome/xml/meta/OMEXMLMetadataRoot.h>
 #include <ome/xml/model/detail/OMEModel.h>
 
@@ -446,7 +454,8 @@ namespace
   safe_fetch(std::shared_ptr<T> ptr)
   {
     if (!ptr)
-      throw(std::runtime_error("Internal metadata store inconsistency: "));
+      throw ome::xml::meta::MetadataException("OMEXMLMetadata", "safe_fetch",
+                                              "Internal metadata store inconsistency: null object");
     return ptr;
   }
 
@@ -457,7 +466,8 @@ namespace
   {
     std::shared_ptr<T> shared(ptr.lock());
     if (!shared)
-      throw(std::runtime_error("Internal metadata store inconsistency: "));
+      throw ome::xml::meta::MetadataException("OMEXMLMetadata", "safe_fetch",
+                                              "Internal metadata store inconsistency: null weak reference");
     return shared;
   }
 
@@ -568,7 +578,8 @@ namespace ome
           std::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
 
         if (!newroot)
-          throw std::logic_error("OMEXMLMetadata root must be of type OMEXMLMetadataRoot");
+          throw MetadataException("OMEXMLMetadata", "setRoot",
+                                  "root must be of type OMEXMLMetadataRoot");
 
         this->root = newroot;
         this->genericRoot = std::static_pointer_cast<MetadataRoot>(this->root);
@@ -920,7 +931,8 @@ ${counter(k, o, v)}\
         if (uuid)
           return *root->getUUID();
         else
-          throw(std::runtime_error("Internal metadata store inconsistency: UUID is null"));
+          throw MetadataException("OMEXMLMetadata", "getUUID",
+                                  "Internal metadata store inconsistency: null object");
       }
 {% end source %}\
 

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -472,7 +472,7 @@ namespace
              const char * const method)
   {
     if (!ptr)
-      throw ome::xml::meta::MetadataException("OMEXMLMetadata", "safe_fetch",
+      throw ome::xml::meta::MetadataException("OMEXMLMetadata", method,
                                               "Internal metadata store inconsistency: null object");
     return ptr;
   }
@@ -485,7 +485,7 @@ namespace
   {
     std::shared_ptr<T> shared(ptr.lock());
     if (!shared)
-      throw ome::xml::meta::MetadataException("OMEXMLMetadata", "safe_fetch",
+      throw ome::xml::meta::MetadataException("OMEXMLMetadata", method,
                                               "Internal metadata store inconsistency: null weak reference");
     return shared;
   }
@@ -494,7 +494,7 @@ namespace
   template<typename T>
   T
   safe_fetch(T                  value,
-             const char * const method)
+             const char * const /* method */)
   {
     return value;
   }

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -17,20 +17,20 @@
 {% end debug %}\
         // Documented in base class.
         index_type
-        get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])}) const;
+        ${getCounterMethod(is_multi_path[o.name], parent, obj.name)}(${indexes_string(indexes[:-1])}) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       OMEXMLMetadata::index_type
-      OMEXMLMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])}) const
+      OMEXMLMetadata::${getCounterMethod(is_multi_path[o.name], parent, obj.name)}(${indexes_string(indexes[:-1])}) const
       {
         // Parents: ${repr(parents[obj.name])}
 {% if obj.isReference %}\
         // ${obj.name} is a reference
-        return ${safe_accessor(['root']+accessor(obj.name, parent, obj.name)[:-1] + ["sizeOfLinked%sList()" % obj.name.replace('Ref', '')])};
+        return ${safe_accessor(['root']+accessor(obj.name, parent, obj.name)[:-1] + ["sizeOfLinked%sList()" % obj.name.replace('Ref', '')], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
 {% end %}\
 {% if not obj.isReference %}\
         // ${obj.name} is not a reference
-        return ${safe_accessor(['root']+accessor(obj.name, parent, obj.name)[:-1] + ["sizeOf%sList()" % obj.name.replace('Ref', '')])};
+        return ${safe_accessor(['root']+accessor(obj.name, parent, obj.name)[:-1] + ["sizeOf%sList()" % obj.name.replace('Ref', '')], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
 {% end %}\
       }
 {% end source %}\
@@ -42,33 +42,33 @@
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         ${prop.metadataStoreRetType}
-        get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)}, ${index_string(prop.name)}) const;
+        ${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}(${indexes_string(indexes)}, ${index_string(prop.name)}) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       ${prop.metadataStoreRetType}
-      OMEXMLMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)}, ${index_string(prop.name)}) const
+OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}(${indexes_string(indexes)}, ${index_string(prop.name)}) const
 {% end source %}\
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         ${prop.metadataStoreRetType}
-        get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)}) const;
+        ${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}(${indexes_string(indexes)}) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       ${prop.metadataStoreRetType}
-      OMEXMLMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)}) const
+      OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}(${indexes_string(indexes)}) const
 {% end source %}\
 {% end %}\
 {% otherwise %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         ${prop.metadataStoreRetType}
-        get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}() const;
+        ${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}() const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       ${prop.metadataStoreRetType}
-      OMEXMLMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}() const
+      OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}() const
 {% end source %}\
 {% end %}\
 {% end %}\
@@ -81,7 +81,7 @@
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
         // DUMMYLINE
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -90,7 +90,7 @@
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract proprietary
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -99,7 +99,7 @@
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract proprietary and not a reference
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -123,7 +123,7 @@
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -132,7 +132,7 @@
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop))}->getLinked${prop.methodName}().lock());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -141,14 +141,14 @@
 {% otherwise %}\
         // ${prop.name} is not a reference
 {% if prop.minOccurs == 0 %}\
-        ${prop.retType[' const']} ret = ${safe_accessor(['root']+accessor(obj.name, parent, prop))}->get${prop.methodName}();
+        ${prop.retType[' const']} ret = ${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->get${prop.methodName}();
         if (ret)
           return *ret;
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                 "Internal metadata store inconsistency: null object");
 {% end %}\
 {% if prop.minOccurs == 1 %}\
-        return ${safe_accessor(['root']+accessor(obj.name, parent, prop))}->get${prop.methodName}();
+        return ${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->get${prop.methodName}();
 {% end %}\
 {% end %}\
 {% end %}\
@@ -184,11 +184,11 @@
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.metadataStoreArgType} ${prop.argumentName});
+        ${setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}(${prop.metadataStoreArgType} ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      OMEXMLMetadata::set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.metadataStoreArgType} ${prop.argumentName})
+      OMEXMLMetadata::${setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name)}(${prop.metadataStoreArgType} ${prop.argumentName})
 {% end source %}\
 {% end %}\
 {% end %}\
@@ -200,7 +200,7 @@
         // ${prop.name} is abstract proprietary and is a reference
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1])}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
         std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
@@ -266,8 +266,7 @@
         // ${prop.name} is reference and occurs more than once
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject
-          (std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop))}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
         std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
@@ -365,17 +364,35 @@ ${customContent[obj.name][prop.name]}
                         raise Exception("Zero KEYS No accessor for: name:%s parent:%s prop:%s === %s" % (name, parent, prop, results))
                 return results[parent]
 
-        def safe_accessor(calls):
+        def safe_accessor(calls, method):
                 ret = None
                 if len(calls) == 1:
-                        ret = "safe_fetch(%s)" % calls[0]
+                       ret = "safe_fetch(%s, \"%s [%s]\")" % (calls[0], method, calls[0])
                 else:
                         for call in range(len(calls)):
                                 if call == 0:
-                                        ret = "safe_fetch(%s)" % (calls[call])
+                                        ret = "safe_fetch(%s, \"%s [%s]\")" % (calls[call], method, calls[call])
                                 else:
-                                        ret = "safe_fetch(%s->%s)" % (ret, calls[call])
+                                        ret = "safe_fetch(%s->%s, \"%s [%s]\")" % (ret, calls[call], method, calls[call])
                 return ret
+
+        def getCounterMethod(multipath, parent, name):
+                if multipath:
+                        return "get%s%sCount" % (parent, name)
+                else:
+                        return "get%sCount" % (name)
+
+        def getPropMethod(multipath, parent, name, prop):
+                if multipath:
+                        return "get%s%s%s" % (parent, name, prop)
+                else:
+                        return "get%s%s" % (name, prop)
+
+        def setPropMethod(multipath, parent, name, prop):
+                if multipath:
+                        return "set%s%s%s" % (parent, name, prop)
+                else:
+                        return "set%s%s" % (name, prop)
 %}\
 \
 \
@@ -451,7 +468,8 @@ namespace
   // Throw an exception if a pointer is invalid.
   template<typename T>
   std::shared_ptr<T>
-  safe_fetch(std::shared_ptr<T> ptr)
+  safe_fetch(std::shared_ptr<T> ptr,
+             const char * const method)
   {
     if (!ptr)
       throw ome::xml::meta::MetadataException("OMEXMLMetadata", "safe_fetch",
@@ -462,7 +480,8 @@ namespace
   // Throw an exception if a pointer is invalid.
   template<typename T>
   std::shared_ptr<T>
-  safe_fetch(std::weak_ptr<T> ptr)
+  safe_fetch(std::weak_ptr<T>   ptr,
+             const char * const method)
   {
     std::shared_ptr<T> shared(ptr.lock());
     if (!shared)
@@ -474,7 +493,8 @@ namespace
   // Pass through for value types.
   template<typename T>
   T
-  safe_fetch(T value)
+  safe_fetch(T                  value,
+             const char * const method)
   {
     return value;
   }
@@ -649,7 +669,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getPixelsBinDataCount(index_type imageIndex) const
       {
-        return safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->sizeOfBinDataList();
+        const char * const image_method("getPixelsBinDataCount [getImage]");
+        const char * const pixels_method("getPixelsBinDataCount [getPixels]");
+        return safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->sizeOfBinDataList();
       }
 {% end source %}\
 
@@ -662,7 +684,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getBooleanAnnotationAnnotationCount(index_type booleanAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getBooleanAnnotation(booleanAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getBooleanAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getBooleanAnnotationAnnotationCount [getBooleanAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getBooleanAnnotation(booleanAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -675,7 +699,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getCommentAnnotationAnnotationCount(index_type commentAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getCommentAnnotation(commentAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getCommentAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getCommentAnnotationAnnotationCount [getCommentAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getCommentAnnotation(commentAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -688,7 +714,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getDoubleAnnotationAnnotationCount(index_type doubleAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getDoubleAnnotation(doubleAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getDoubleAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getDoubleAnnotationAnnotationCount [getDoubleAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getDoubleAnnotation(doubleAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -701,7 +729,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getFileAnnotationAnnotationCount(index_type fileAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getFileAnnotation(fileAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getFileAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getFileAnnotationAnnotationCount [getFileAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getFileAnnotation(fileAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -714,7 +744,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getListAnnotationAnnotationCount(index_type listAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getListAnnotation(listAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getListAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getListAnnotationAnnotationCount [getListAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getListAnnotation(listAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -727,7 +759,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getLongAnnotationAnnotationCount(index_type longAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getLongAnnotation(longAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getLongAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getLongAnnotationAnnotationCount [getLongAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getLongAnnotation(longAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -740,7 +774,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getTagAnnotationAnnotationCount(index_type tagAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getTagAnnotation(tagAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getTagAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getTagAnnotationAnnotationCount [getTagAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTagAnnotation(tagAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -753,7 +789,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getTermAnnotationAnnotationCount(index_type termAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getTermAnnotation(termAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getTermAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getTermAnnotationAnnotationCount [getTermAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTermAnnotation(termAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -766,7 +804,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getTimestampAnnotationAnnotationCount(index_type timestampAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getTimestampAnnotation(timestampAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getTimestampAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getTimestampAnnotationAnnotationCount [getTimestampAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTimestampAnnotation(timestampAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -779,7 +819,9 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::getXMLAnnotationAnnotationCount(index_type xmlAnnotationIndex) const
       {
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations())->getXMLAnnotation(xmlAnnotationIndex))->sizeOfLinkedAnnotationList();
+        const char * const sa_method("getXMLAnnotationAnnotationCount [getStructuredAnnotations]");
+        const char * const annotation_method("getXMLAnnotationAnnotationCount [getXMLAnnotation]");
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getXMLAnnotation(xmlAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -794,7 +836,8 @@ namespace ome
       OMEXMLMetadata::getLightSourceType(index_type instrumentIndex,
                                          index_type lightSourceIndex) const
       {
-        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex))->getLightSource(lightSourceIndex);
+        const char * const instrument_method("getLightSourceType [getInstrument]");
+        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex), instrument_method)->getLightSource(lightSourceIndex);
         return o->getLightSourceType();
       }
 {% end source %}\
@@ -810,7 +853,10 @@ namespace ome
       OMEXMLMetadata::getShapeType(index_type roiIndex,
                                    index_type shapeIndex) const
       {
-        return safe_fetch(safe_fetch(safe_fetch(root->getROI(roiIndex))->getUnion())->getShape(shapeIndex))->getShapeType();
+        const char * const roi_method("getShapeType [getROI]");
+        const char * const union_method("getShapeType [getUnion]");
+        const char * const shape_method("getShapeType [getShape]");
+        return safe_fetch(safe_fetch(safe_fetch(root->getROI(roiIndex), roi_method)->getUnion(), union_method)->getShape(shapeIndex), shape_method)->getShapeType();
       }
 {% end source %}\
 {% if fu.SOURCE_TYPE == "header" %}\
@@ -873,7 +919,11 @@ namespace ome
       ${o.langBaseType}
       OMEXMLMetadata::get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])}) const
       {
-        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->getTiffData(tiffDataIndex))->getUUID())->getValue();
+        const char * const image_method("get${o.name}Value [getImage]");
+        const char * const pixels_method("get${o.name}Value [getPixels]");
+        const char * const tiffdata_method("get${o.name}Value [getTiffData]");
+        const char * const uuid_method("get${o.name}Value [getUUID]");
+        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getTiffData(tiffDataIndex), tiffdata_method)->getUUID(), uuid_method)->getValue();
       }
 {% end source %}\
 
@@ -903,14 +953,18 @@ ${counter(k, o, v)}\
       OMEXMLMetadata::getPixelsBinDataBigEndian(index_type imageIndex,
                                                 index_type binDataIndex) const
       {
-        std::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->getBigEndian();
+        const char * const image_method("getPixelsBinDataBigEndian [getImage]");
+        const char * const pixels_method("getPixelsBinDataBigEndian [getPixels]");
+        const char * const bindata_method("getPixelsBinDataBigEndian [getBinData]");
+
+        std::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getBigEndian();
 
         if (bigEndian) { // not null
           return *bigEndian;
         }
 
         // Fall back to BinData
-        return safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex))->getPixels())->getBinData(binDataIndex))->getBigEndian();
+        return safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getBinData(binDataIndex), bindata_method)->getBigEndian();
       }
 {% end source %}\
 

--- a/cpp/bin/showinf/ImageInfo.cpp
+++ b/cpp/bin/showinf/ImageInfo.cpp
@@ -262,8 +262,8 @@ namespace showinf
               {
                 std::cout << '\t' << i->first << ": " << i->second << '\n';
               }
+            stream << '\n';
           }
-        stream << '\n';
       }
 
     try

--- a/cpp/bin/showinf/ImageInfo.cpp
+++ b/cpp/bin/showinf/ImageInfo.cpp
@@ -36,6 +36,7 @@
  */
 
 #include <ome/bioformats/in/TIFFReader.h>
+#include <ome/bioformats/in/OMETIFFReader.h>
 
 #include <ome/xerces/Platform.h>
 #include <ome/xerces/dom/Document.h>
@@ -83,7 +84,7 @@ namespace showinf
   ImageInfo::testRead(std::ostream& stream)
   {
     if (!reader)
-      reader = std::make_shared<in::TIFFReader>();
+      reader = std::make_shared<in::OMETIFFReader>();
 
     preInit(stream);
 

--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -92,10 +92,12 @@ set(OME_BIOFORMATS_DETAIL_HEADERS
 
 set(OME_BIOFORMATS_IN_SOURCES
     in/MinimalTIFFReader.cpp
+    in/OMETIFFReader.cpp
     in/TIFFReader.cpp)
 
 set(OME_BIOFORMATS_IN_HEADERS
     in/MinimalTIFFReader.h
+    in/OMETIFFReader.h
     in/TIFFReader.h)
 
 set(OME_BIOFORMATS_TIFF_SOURCES

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -39,6 +39,7 @@
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
+#include <boost/range/size.hpp>
 
 #include <ome/bioformats/FormatTools.h>
 
@@ -267,7 +268,7 @@ namespace ome
               };
             static const std::vector<std::string> non_graphics_domains
               (domain_strings(non_graphics_enums,
-                              non_graphics_enums + (sizeof(non_graphics_enums) / sizeof(non_graphics_enums[0]))));
+                              non_graphics_enums + boost::size(non_graphics_enums)));
             return non_graphics_domains;
           }
           break;
@@ -288,7 +289,7 @@ namespace ome
               };
             static const std::vector<std::string> non_hcs_domains
               (domain_strings(non_hcs_enums,
-                              non_hcs_enums + (sizeof(non_hcs_enums) / sizeof(non_hcs_enums[0]))));
+                              non_hcs_enums + boost::size(non_hcs_enums)));
             return non_hcs_domains;
           }
           break;
@@ -309,7 +310,7 @@ namespace ome
               };
             static const std::vector<std::string> non_special_domains
               (domain_strings(non_special_enums,
-                              non_special_enums + (sizeof(non_special_enums) / sizeof(non_special_enums[0]))));
+                              non_special_enums + boost::size(non_special_enums)));
             return non_special_domains;
           }
           break;
@@ -332,7 +333,7 @@ namespace ome
               };
             static const std::vector<std::string> all_domains
               (domain_strings(all_enums,
-                              all_enums + (sizeof(all_enums) / sizeof(all_enums[0]))));
+                              all_enums + boost::size(all_enums)));
             return all_domains;
           }
           break;
@@ -344,7 +345,7 @@ namespace ome
               };
             static const std::vector<std::string> hcs_only_domains
               (domain_strings(hcs_only_enums,
-                              hcs_only_enums + (sizeof(hcs_only_enums) / sizeof(hcs_only_enums[0]))));
+                              hcs_only_enums + boost::size(hcs_only_enums)));
             return hcs_only_domains;
           }
           break;

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -336,6 +336,18 @@ namespace ome
             return all_domains;
           }
           break;
+        case HCS_ONLY_DOMAINS:
+          {
+            const Domain hcs_only_enums[] =
+              {
+                HCS_DOMAIN
+              };
+            static const std::vector<std::string> hcs_only_domains
+              (domain_strings(hcs_only_enums,
+                              hcs_only_enums + (sizeof(hcs_only_enums) / sizeof(hcs_only_enums[0]))));
+            return hcs_only_domains;
+          }
+          break;
         }
 
       // Fallback if enum is unknown.

--- a/cpp/lib/ome/bioformats/FormatTools.h
+++ b/cpp/lib/ome/bioformats/FormatTools.h
@@ -76,7 +76,8 @@ namespace ome
         NON_GRAPHICS_DOMAINS,
         NON_HCS_DOMAINS,
         NON_SPECIAL_DOMAINS,
-        ALL_DOMAINS
+        ALL_DOMAINS,
+        HCS_ONLY_DOMAINS
       };
 
     /**

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -702,6 +702,59 @@ namespace ome
       return map;
     }
 
+    void
+    fillOriginalMetadata(::ome::xml::meta::OMEXMLMetadata& omexml,
+                         const MetadataMap&                metadata)
+    {
+      omexml.resolveReferences();
+
+      if (metadata.empty())
+        return;
+
+      MetadataMap flat(metadata.flatten());
+
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      if (root)
+        {
+          std::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
+          if (!sa)
+            sa = std::make_shared<StructuredAnnotations>();
+          OMEXMLMetadata::index_type annotationIndex = sa->sizeOfXMLAnnotationList();
+          OMEXMLMetadata::index_type idIndex = sa->sizeOfXMLAnnotationList();
+
+          std::set<std::string> ids;
+          for (OMEXMLMetadata::index_type i = 0; i < annotationIndex; ++i)
+            {
+              // Already in metadata store
+              ids.insert(omexml.getXMLAnnotationID(i));
+            }
+
+          for (MetadataMap::const_iterator i = flat.begin();
+               i != flat.end();
+               ++i, ++annotationIndex)
+            {
+              std::string id;
+              do
+                {
+                  id = createID("Annotation", idIndex);
+                  ++idIndex;
+                }
+              while (ids.find(id) != ids.end());
+
+              std::ostringstream value;
+              boost::apply_visitor(::ome::bioformats::detail::MetadataMapValueTypeOStreamVisitor(value), i->second);
+
+              std::shared_ptr<OriginalMetadataAnnotation> orig(std::make_shared<OriginalMetadataAnnotation>());
+              orig->setID(id);
+              orig->setMetadata(OriginalMetadataAnnotation::metadata_type(i->first, value.str()));
+              std::shared_ptr<XMLAnnotation> xmlorig(std::static_pointer_cast<XMLAnnotation>(orig));
+              sa->addXMLAnnotation(xmlorig);
+            }
+
+          root->setStructuredAnnotations(sa);
+        }
+    }
+
     std::string
     getModelVersion()
     {

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -650,12 +650,16 @@ namespace ome
                   // Fall back to parsing by hand.
                   try
                     {
+                      std::string wrappedValue("<wrapped>");
+                      wrappedValue += annotation->getValue();
+                      wrappedValue += "</wrapped>";
+
                       xerces::Platform xmlplat;
                       xerces::dom::ParseParameters params;
                       params.validationScheme = xercesc::XercesDOMParser::Val_Never;
-                      xerces::dom::Document doc(ome::xerces::dom::createDocument(annotation->getValue()));
+                      xerces::dom::Document doc(ome::xerces::dom::createDocument(wrappedValue));
 
-                      std::vector<xerces::dom::Element> OriginalMetadataValue_nodeList = ome::xml::model::detail::OMEModelObject::getChildrenByTagName(doc, "OriginalMetadata");
+                      std::vector<xerces::dom::Element> OriginalMetadataValue_nodeList = ome::xml::model::detail::OMEModelObject::getChildrenByTagName(doc.getDocumentElement(), "OriginalMetadata");
                       if (OriginalMetadataValue_nodeList.size() > 1)
                         {
                           format fmt("Value node list size %1% != 1");

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -351,6 +351,16 @@ namespace ome
     getOriginalMetadata(::ome::xml::meta::OMEXMLMetadata& omexml);
 
     /**
+     * Create OriginalMetadataAnnotations from MetadataMap.
+     *
+     * @param omexml the OME-XML metadata store.
+     * @param metadata the original metadata.
+     */
+    void
+    fillOriginalMetadata(::ome::xml::meta::OMEXMLMetadata& omexml,
+                         const MetadataMap&                metadata);
+
+    /**
      * Check if default creation date is enabled.
      *
      * @returns @c true if enabled, @c false otherwise.

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -47,6 +47,7 @@
 #include <ome/compat/string.h>
 
 #include <ome/bioformats/FormatTools.h>
+#include <ome/bioformats/MetadataTools.h>
 #include <ome/bioformats/PixelBuffer.h>
 #include <ome/bioformats/PixelProperties.h>
 #include <ome/bioformats/VariantPixelBuffer.h>
@@ -1358,10 +1359,7 @@ namespace ome
                         }
                     }
 
-                    /**
-                     * @todo Implement populateOriginalMetadata.  Requires bits of MetadataTools and OMEXMLServiceImpl.
-                     */
-                    // populateOriginalMetadata(store, allMetadata.flatten());
+                    fillOriginalMetadata(*store, allMetadata);
                   }
 
                 setSeries(0);

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -38,6 +38,7 @@
 #include <cassert>
 
 #include <boost/format.hpp>
+#include <boost/range/size.hpp>
 
 #include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/FormatTools.h>
@@ -71,7 +72,7 @@ namespace ome
                              "Baseline Tagged Image File Format");
 
           p.suffixes = std::vector<boost::filesystem::path>(suffixes,
-                                                            suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
+                                                            suffixes + boost::size(suffixes));
           p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
           p.metadata_levels.insert(MetadataOptions::METADATA_NO_OVERLAYS);
           p.metadata_levels.insert(MetadataOptions::METADATA_ALL);
@@ -82,7 +83,7 @@ namespace ome
         const ReaderProperties props(tiff_properties());
 
         std::vector<std::string> companion_suffixes(companion_suffixes_array,
-                                                    companion_suffixes_array + (sizeof(companion_suffixes_array) / sizeof(companion_suffixes_array[0])));
+                                                    companion_suffixes_array + boost::size(companion_suffixes_array));
 
       }
 

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -1,0 +1,1419 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <algorithm>
+#include <iterator>
+#include <map>
+#include <set>
+
+#include <ome/bioformats/FormatException.h>
+#include <ome/bioformats/FormatTools.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/in/OMETIFFReader.h>
+#include <ome/bioformats/tiff/IFD.h>
+#include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Tags.h>
+#include <ome/bioformats/tiff/Field.h>
+
+#include <ome/xml/meta/OMEXMLMetadata.h>
+#include <ome/xml/meta/BaseMetadata.h>
+#include <ome/xml/meta/Convert.h>
+
+namespace fs = boost::filesystem;
+using boost::filesystem::path;
+using ome::compat::canonical;
+
+using ome::bioformats::detail::ReaderProperties;
+using ome::bioformats::tiff::TIFF;
+using ome::bioformats::tiff::IFD;
+
+typedef ome::xml::meta::BaseMetadata::index_type index_type;
+using namespace ome::xml::model::primitives;
+using namespace ome::xml::model::enums;
+
+namespace
+{
+
+  struct get_file : public std::unary_function<std::map<std::string, path>::value_type, path>
+  {
+    path
+    operator() (const std::map<std::string, path>::value_type& value) const
+    {
+      return value.second;
+    }
+  };
+
+}
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace in
+    {
+
+      namespace
+      {
+
+        const char *suffixes[] = {"ome.tif", "ome.tiff", };
+        const char *companion_suffixes_array[] = {"companion.ome"};
+
+        ReaderProperties
+        tiff_properties()
+        {
+          ReaderProperties p("OME-TIFF",
+                             "Open Microscopy Environment TIFF");
+
+          p.suffixes = std::vector<boost::filesystem::path>(suffixes,
+                                                            suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
+          p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
+          p.metadata_levels.insert(MetadataOptions::METADATA_NO_OVERLAYS);
+          p.metadata_levels.insert(MetadataOptions::METADATA_ALL);
+
+          return p;
+        }
+
+        const ReaderProperties props(tiff_properties());
+
+        std::vector<path> companion_suffixes(companion_suffixes_array,
+                                             companion_suffixes_array + (sizeof(companion_suffixes_array) / sizeof(companion_suffixes_array[0])));
+
+        void
+        getComment(const TIFF&  tiff,
+                   std::string& omexml)
+        {
+          try
+            {
+              std::shared_ptr<tiff::IFD> ifd (tiff.getDirectoryByIndex(0));
+              if (ifd)
+                ifd->getField(ome::bioformats::tiff::IMAGEDESCRIPTION).get(omexml);
+              else
+                throw tiff::Exception("No TIFF IFDs found");
+            }
+          catch (const tiff::Exception& /* e */)
+            {
+              throw FormatException("No TIFF ImageDescription found");
+            }
+        }
+
+        class OMETIFFPlane
+        {
+        public:
+          /// Status of the file associated with this plane.
+          enum Status
+            {
+              UNKNOWN, ///< Not known.
+              PRESENT, ///< File exists.
+              ABSENT   ///< File is missing.
+            };
+
+          /// File containing this plane.
+          path id;
+          /// IFD index.
+          dimension_size_type ifd;
+          /// Certainty flag, for dealing with unspecified NumPlanes.
+          bool certain;
+          /// File status.
+          Status status;
+
+          OMETIFFPlane():
+            id(),
+            ifd(),
+            certain(false),
+            status(UNKNOWN)
+          {
+          }
+
+          OMETIFFPlane(const std::string& id):
+            id(id),
+            ifd(),
+            certain(false),
+            status(UNKNOWN)
+          {
+          }
+        };
+
+        class OMETIFFMetadata : public CoreMetadata
+        {
+        public:
+          /// Tile width.
+          dimension_size_type tileWidth;
+          /// Tile width.
+          dimension_size_type tileHeight;
+          /// Per-plane data.
+          std::vector<OMETIFFPlane> tiffPlanes;
+
+          OMETIFFMetadata():
+            CoreMetadata(),
+            tileWidth(),
+            tileHeight(),
+            tiffPlanes()
+          {}
+
+          OMETIFFMetadata(const OMETIFFMetadata& copy):
+            CoreMetadata(copy),
+            tileWidth(copy.tileWidth),
+            tileHeight(copy.tileHeight),
+            tiffPlanes(copy.tiffPlanes)
+          {}
+
+        };
+
+      }
+
+      OMETIFFReader::OMETIFFReader():
+        detail::FormatReader(props),
+        files(),
+        tiffs(),
+        metadataFile(),
+        usedFiles(),
+        hasSPW(false)
+      {
+        this->suffixNecessary = false;
+        this->suffixSufficient = false;
+        this->domains = getDomainCollection(NON_GRAPHICS_DOMAINS);
+        this->companionFiles = true;
+        this->datasetDescription = "One or more .ome.tiff files";
+      }
+
+      OMETIFFReader::~OMETIFFReader()
+      {
+      }
+
+      void
+      OMETIFFReader::close(bool fileOnly)
+      {
+        /// @todo
+
+        if (!fileOnly)
+          {
+            files.clear();
+            hasSPW = false;
+            usedFiles.clear();
+            metadataFile.clear();
+          }
+        tiffs.clear(); // Closes all open TIFFs.
+
+        detail::FormatReader::close(fileOnly);
+      }
+
+      bool
+      OMETIFFReader::isSingleFile(const boost::filesystem::path& id) const
+      {
+        if (checkSuffix(id, companion_suffixes))
+          return false;
+
+        std::shared_ptr<tiff::TIFF> tiff = TIFF::open(id, "r");
+
+        if (!tiff)
+          {
+            boost::format fmt("Failed to open ‘%1%’");
+            fmt % id.native();
+            throw FormatException(fmt.str());
+          }
+
+        std::string omexml;
+        getComment(*tiff, omexml);
+
+        std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+
+        dimension_size_type nImages = 0U;
+        for (dimension_size_type i = 0U;
+             i < meta->getImageCount();
+             ++i)
+          {
+            dimension_size_type nChannels = meta->getChannelCount(i);
+            if (!nChannels)
+              nChannels = 1;
+            ome::xml::model::primitives::PositiveInteger z(meta->getPixelsSizeZ(i));
+            ome::xml::model::primitives::PositiveInteger t(meta->getPixelsSizeT(i));
+
+            nImages += static_cast<dimension_size_type>(z) * static_cast<dimension_size_type>(t) * nChannels;
+          }
+
+        dimension_size_type nIFD = tiff->directoryCount();
+
+        return nImages > 0 && nImages <= nIFD;
+      }
+
+      bool
+      OMETIFFReader::isThisType(const boost::filesystem::path& name,
+                                bool                           open) const
+      {
+        if (checkSuffix(name, companion_suffixes))
+          return true;
+
+        return detail::FormatReader::isThisType(name, open);
+      }
+
+      bool
+      OMETIFFReader::isFilenameThisTypeImpl(const boost::filesystem::path& name) const
+      {
+        std::shared_ptr<tiff::TIFF> tiff = TIFF::open(name, "r");
+
+        if (!tiff)
+          {
+            boost::format fmt("Failed to open ‘%1%’");
+            fmt % name.native();
+            throw FormatException(fmt.str());
+          }
+
+        std::string omexml;
+        getComment(*tiff, omexml);
+
+        // Basic sanity check before parsing.
+        if (omexml.size() == 0 || omexml[0] != '<' || omexml[omexml.size()-1] != '>')
+          return false;
+
+        try
+          {
+            std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+
+            std::string metadataFile = meta->getBinaryOnlyMetadataFile();
+            if (!metadataFile.empty())
+              return true;
+
+            for (::ome::xml::meta::Metadata::index_type i = 0;
+                 i < meta->getImageCount();
+                 ++i)
+              {
+                verifyMinimum(*meta, i);
+              }
+            return meta->getImageCount() > 0;
+          }
+        catch (const std::exception& /* e */)
+          {
+            return false;
+          }
+      }
+
+      const std::shared_ptr<const tiff::IFD>
+      OMETIFFReader::ifdAtIndex(dimension_size_type no) const
+      {
+        std::shared_ptr<const IFD> ifd;
+
+        const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
+
+        if (no < ometa.tiffPlanes.size())
+          {
+            const OMETIFFPlane& plane(ometa.tiffPlanes.at(no));
+            const std::shared_ptr<const TIFF> tiff(getTIFF(plane.id));
+            if (tiff)
+              ifd = std::shared_ptr<const IFD>(tiff->getDirectoryByIndex(plane.ifd));
+          }
+
+        if (!ifd)
+          {
+            boost::format fmt("Failed to open IFD ‘%1%’");
+            fmt % no;
+            throw FormatException(fmt.str());
+          }
+
+        return ifd;
+      }
+
+      const std::vector<std::string>&
+      OMETIFFReader::getDomains() const
+      {
+        assertId(currentId, true);
+        return getDomainCollection(hasSPW ? HCS_ONLY_DOMAINS : NON_GRAPHICS_DOMAINS); 
+      }
+
+      const std::vector<boost::filesystem::path>
+      OMETIFFReader::getSeriesUsedFiles(bool noPixels) const
+      {
+        assertId(currentId, true);
+
+        std::set<boost::filesystem::path> fileSet;
+
+        if (!noPixels)
+          {
+            if (!metadataFile.empty())
+              fileSet.insert(metadataFile);
+
+            const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
+
+            for(std::vector<OMETIFFPlane>::const_iterator i = ometa.tiffPlanes.begin();
+                i != ometa.tiffPlanes.end();
+                ++i)
+              {
+                if (!i->id.empty())
+                  fileSet.insert(i->id);
+              }
+          }
+
+        return std::vector<boost::filesystem::path>(fileSet.begin(), fileSet.end());
+      }
+
+      FormatReader::FileGroupOption
+      OMETIFFReader::fileGroupOption(const std::string& id)
+      {
+        FileGroupOption group = CAN_GROUP;
+
+        try
+          {
+            if (!isSingleFile(id))
+              group = MUST_GROUP;
+          }
+        catch (const std::exception& /* e */)
+          {
+          }
+
+        return group;
+      }
+
+      dimension_size_type
+      OMETIFFReader::getOptimalTileWidth() const
+      {
+        assertId(currentId, true);
+
+        const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
+
+        return ometa.tileWidth;
+      }
+
+      dimension_size_type
+      OMETIFFReader::getOptimalTileHeight() const
+      {
+        assertId(currentId, true);
+
+        const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
+
+        return ometa.tileHeight;
+      }
+
+      void
+      OMETIFFReader::initFile(const boost::filesystem::path& id)
+      {
+        detail::FormatReader::initFile(id);
+        path dir(id.parent_path());
+
+        if (checkSuffix(id, companion_suffixes))
+          {
+            // This is a companion file.  Read the metadata, get the
+            // TIFF for the TiffData for the first image, and then
+            // recurse with this file as the id.
+            std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(id));
+            path firstTIFF(path(meta->getUUIDFileName(0, 0)));
+            initFile(canonical(firstTIFF, dir));
+            return;
+          }
+
+        // Cache and use this TIFF.
+        addTIFF(id);
+        const std::shared_ptr<const TIFF> tiff(getTIFF(id));
+
+        // Get the OME-XML from the first TIFF, and create OME-XML
+        // metadata from it.
+        std::string omexml;
+        getComment(*tiff, omexml);
+        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
+
+        // Is there an associated binary-only metadata file?
+        try
+          {
+            metadataFile = canonical(path(meta->getBinaryOnlyMetadataFile()), dir);
+            if (!metadataFile.empty() && boost::filesystem::exists(metadataFile))
+              meta = createOMEXMLMetadata(metadataFile);
+          }
+        catch (const std::exception& /* e */)
+          {
+            /// @todo Log.
+            metadataFile.clear();
+          }
+
+        // Is this a screen/plate?
+        try
+          {
+            this->hasSPW = meta->getPlateCount() > 0U;
+          }
+        catch (const std::exception& /* e */)
+          {
+          }
+
+        // Clean up any invalid metadata.
+        cleanMetadata(*meta);
+
+        // Retrieve original metadata.
+        metadata = getOriginalMetadata(*meta);
+
+        if (!meta->getRoot())
+          throw FormatException("Could not parse OME-XML from TIFF ImageDescription");
+
+        // Save image timestamps for later use.
+        std::vector<boost::optional<Timestamp> > acquiredDates(meta->getImageCount());
+        getAcquisitionDates(*meta, acquiredDates);
+
+        // Get UUID for the first file.
+        boost::optional<std::string> currentUUID;
+        try
+          {
+            currentUUID = meta->getUUID();
+          }
+        catch (const std::exception& /* e */)
+          {
+            // null UUID.
+          }
+
+        // Transfer OME-XML metadata to metadata store for reader.
+        convert(*meta, *metadataStore);
+
+        // Create CoreMetadata for each image.
+        index_type seriesCount = meta->getImageCount();
+        core.clear();
+        core.reserve(seriesCount);
+        for (index_type i = 0; i < seriesCount; ++i)
+          core.push_back(std::make_shared<OMETIFFMetadata>());
+
+        // UUID → file mapping and used files.
+        findUsedFiles(*meta, id, dir, currentUUID);
+
+        // Process TiffData elements.
+        for (index_type series = 0; series < seriesCount; ++series)
+          {
+            std::shared_ptr<OMETIFFMetadata> coreMeta(std::dynamic_pointer_cast<OMETIFFMetadata>(core.at(series)));
+            assert(coreMeta); // Should never be null.
+            std::clog << "Image[" << series << "] {\n  id = " << meta->getImageID(series) << '\n';
+
+            DimensionOrder order(meta->getPixelsDimensionOrder(series));
+
+            boost::optional<dimension_size_type> samples;
+            if (meta->getChannelCount(series) > 0)
+              {
+                try
+                  {
+                    PositiveInteger samplesPerPixel = meta->getChannelSamplesPerPixel(series, 0);
+                    samples = samplesPerPixel;
+                  }
+                catch (const std::exception& /* e */)
+                  {
+                  }
+              }
+            dimension_size_type tiffSamples = seriesFileSamplesPerPixel(*meta, series);
+
+            bool adjustedSamples = false;
+            if (!samples || *samples != tiffSamples)
+              {
+                boost::format fmt("SamplesPerPixel mismatch: OME=%1%, TIFF=%2%");
+                fmt % (samples ? *samples : 0) % tiffSamples;
+                std::clog << fmt.str() << '\n';
+
+                samples = tiffSamples;
+                adjustedSamples = true;
+              }
+
+            if (adjustedSamples && meta->getChannelCount(series) <= 1)
+              adjustedSamples = false;
+
+            PositiveInteger effSizeC = meta->getPixelsSizeC(series);
+            if (!adjustedSamples && !(effSizeC % *samples))
+              effSizeC /= static_cast<PositiveInteger::value_type>(*samples);
+
+            PositiveInteger sizeT = meta->getPixelsSizeT(series);
+            PositiveInteger sizeZ = meta->getPixelsSizeZ(series);
+            PositiveInteger num = effSizeC * sizeT * sizeZ;
+
+            coreMeta->tiffPlanes.resize(num);
+            index_type tiffDataCount = meta->getTiffDataCount(series);
+            boost::optional<NonNegativeInteger> zIndexStart;
+            boost::optional<NonNegativeInteger> tIndexStart;
+            boost::optional<NonNegativeInteger> cIndexStart;
+
+            seriesIndexStart(*meta, series,
+                             zIndexStart, tIndexStart, cIndexStart);
+
+            for (index_type td = 0; td < tiffDataCount; ++td)
+              {
+                std::clog << "  TiffData[" << td << "] {\n";
+
+                boost::optional<NonNegativeInteger> tdIFD;
+                NonNegativeInteger numPlanes = 0;
+                NonNegativeInteger firstZ = 0;
+                NonNegativeInteger firstT = 0;
+                NonNegativeInteger firstC = 0;
+
+                if (!getTiffDataValues(*meta, series, td,
+                                       tdIFD, numPlanes,
+                                       firstZ, firstT, firstC))
+                  break;
+
+                // Note: some writers index FirstC, FirstZ, and FirstT from 1.
+                // Subtract index start to correct for this.
+                if (cIndexStart && firstC >= *cIndexStart)
+                  firstC -= *cIndexStart;
+                if (zIndexStart && firstZ >= *zIndexStart)
+                  firstZ -= *zIndexStart;
+                if (tIndexStart && firstT >= *tIndexStart)
+                  firstT -= *tIndexStart;
+
+                if (firstZ >= static_cast<PositiveInteger::value_type>(sizeZ) ||
+                    firstC >= static_cast<PositiveInteger::value_type>(effSizeC) ||
+                    firstT >= static_cast<PositiveInteger::value_type>(sizeT))
+                  {
+                    boost::format fmt("Found invalid TiffData: Z=%1%, C=%2%, T=%3%");
+                    fmt % firstZ % firstC % firstT;
+                    std::clog << fmt.str() << '\n';
+                    break;
+                  }
+
+                dimension_size_type index = ome::bioformats::getIndex(order,
+                                                                      sizeZ, effSizeC, sizeT,
+                                                                      num,
+                                                                      firstZ, firstC, firstT);
+
+                // get reader object for this filename.
+                boost::optional<path> filename;
+                boost::optional<std::string> uuid;
+                try
+                  {
+                    filename = path(meta->getUUIDFileName(series, td));
+                  }
+                catch (const std::exception& e)
+                  {
+                    std::clog << "Ignoring null UUID object when retrieving filename.\n";
+                  }
+                try
+                  {
+                    uuid = meta->getUUIDValue(series, td);
+                  }
+                catch (const std::exception& e)
+                  {
+                    std::clog << "Ignoring null UUID object when retrieving value.\n";
+                  }
+
+                if (!filename)
+                  {
+                    if (!uuid)
+                      {
+                        filename = id;
+                      }
+                    else
+                      {
+                        std::map<std::string, path>::const_iterator i(files.find(*uuid));
+                        if (i != files.end())
+                          filename = i->second;
+                      }
+                  }
+                else
+                  {
+                    // All the other cases will already have a canonical path.
+                    filename = canonical(*filename, dir);
+                  }
+
+                addTIFF(*filename);
+
+                bool exists = true;
+                if (!fs::exists(*filename))
+                  {
+                    // If an absolute filename, try using a relative
+                    // name.  Old versions of the Java OMETiffWriter
+                    // wrote an absolute path to UUID.FileName, which
+                    // causes problems if the file is moved to a
+                    // different directory.
+                    path relative(dir / (*filename).filename());
+                    if (fs::exists(relative))
+                      {
+                        filename = relative;
+                      }
+                    else
+                      {
+                        filename = id;
+                        exists = usedFiles.size() == 1;
+                      }
+                  }
+
+                // Fill plane index → IFD mapping
+                for (dimension_size_type q = 0;
+                     q < static_cast<dimension_size_type>(numPlanes);
+                     ++q)
+                  {
+                    dimension_size_type no = index + q;
+                    OMETIFFPlane& plane(coreMeta->tiffPlanes.at(no));
+                    plane.id = *filename;
+                    plane.ifd = static_cast<dimension_size_type>(*tdIFD) + q;
+                    plane.certain = true;
+                    plane.status = exists ? OMETIFFPlane::PRESENT : OMETIFFPlane::ABSENT;
+
+                    std::clog << "    Plane[" << no
+                              << "]: file=" << plane.id.native()
+                              << ", IFD=" << plane.ifd << '\n';
+                  }
+                if (numPlanes == 0)
+                  {
+                    // Unknown number of planes (default value); fill down
+                    for (dimension_size_type no = index + 1;
+                         no < static_cast<dimension_size_type>(num);
+                         ++no)
+                      {
+                        OMETIFFPlane& plane(coreMeta->tiffPlanes.at(no));
+                        if (plane.certain)
+                          break;
+                        OMETIFFPlane& previousPlane(coreMeta->tiffPlanes.at(no - 1));
+                        plane.id = *filename;
+                        plane.ifd = previousPlane.ifd + 1;
+                        plane.status = exists ? OMETIFFPlane::PRESENT : OMETIFFPlane::ABSENT;
+
+                        std::clog << "    Plane[" << no
+                                  << "]: FILLED\n";
+                      }
+                  }
+                std::clog << "  }\n";
+              }
+
+            // DEBUG
+            for (dimension_size_type q = 0;
+                 q < static_cast<dimension_size_type>(num);
+                 ++q)
+              {
+                OMETIFFPlane& plane(coreMeta->tiffPlanes.at(q));
+
+                std::clog << "    CHECK Plane[" << q
+                          << "]: file=" << plane.id.native()
+                          << ", IFD=" << plane.ifd << '\n';
+              }
+
+            // Clear any unset planes.
+            for (std::vector<OMETIFFPlane>::iterator plane = coreMeta->tiffPlanes.begin();
+                 plane != coreMeta->tiffPlanes.end();
+                 ++plane)
+              {
+                if (plane->status != OMETIFFPlane::UNKNOWN)
+                  continue;
+                plane->id.clear();
+                plane->ifd = 0;
+
+                std::clog << "    Plane[" << plane - coreMeta->tiffPlanes.begin()
+                          << "]: CLEARED\n";
+              }
+
+            if (!core.at(series))
+              continue;
+
+            // Verify all planes are available.
+            for (dimension_size_type no = 0;
+                 no < static_cast<dimension_size_type>(num);
+                 ++no)
+              {
+                OMETIFFPlane& plane(coreMeta->tiffPlanes.at(no));
+
+                std::clog << "  Verify Plane[" << no
+                          << "]: file=" << plane.id.native()
+                          << ", IFD=" << plane.ifd << '\n';
+
+                if (plane.id.empty())
+                  {
+                    std::clog << "Image ID: " << meta->getImageID(series)
+                              << " missing plane #" << no << '\n';
+
+                    // Fallback if broken.
+                    dimension_size_type nIFD = tiff->directoryCount();
+
+                    coreMeta->tiffPlanes.clear();
+                    coreMeta->tiffPlanes.resize(nIFD);
+                    for (dimension_size_type p = 0; p < nIFD; ++p)
+                      {
+                        OMETIFFPlane& plane(coreMeta->tiffPlanes.at(p));
+                        plane.id = id;
+                        plane.ifd = p;
+                      }
+                    break;
+                  }
+              }
+
+            std::clog << "}\n";
+
+            // Fill CoreMetadata.
+            try
+              {
+
+                for (std::vector<OMETIFFPlane>::iterator i = coreMeta->tiffPlanes.begin();
+                     i != coreMeta->tiffPlanes.end();
+                     ++i)
+                  {
+                    // What exactly are we checking for here?  That
+                    // it's a valid TIFF?  Why the fallback to currentId?
+                  }
+
+                const OMETIFFPlane& plane(coreMeta->tiffPlanes.at(0));
+                const std::shared_ptr<const tiff::TIFF> ptiff(getTIFF(plane.id));
+                const std::shared_ptr<const tiff::IFD> pifd(ptiff->getDirectoryByIndex(plane.ifd));
+                const tiff::TileInfo tinfo(pifd->getTileInfo());
+
+                uint32_t tiffWidth = pifd->getImageWidth();
+                uint32_t tiffHeight = pifd->getImageHeight();
+                ome::xml::model::enums::PixelType tiffPixelType = pifd->getPixelType();
+                tiff::PhotometricInterpretation photometric = pifd->getPhotometricInterpretation();
+
+                coreMeta->tileWidth = tinfo.tileWidth();
+                coreMeta->tileHeight = tinfo.tileHeight();
+                coreMeta->sizeX = meta->getPixelsSizeX(series);
+                coreMeta->sizeY = meta->getPixelsSizeY(series);
+                coreMeta->sizeZ = meta->getPixelsSizeZ(series);
+                coreMeta->sizeT = meta->getPixelsSizeT(series);
+                coreMeta->sizeC = meta->getPixelsSizeC(series);
+                coreMeta->pixelType = meta->getPixelsType(series);
+                coreMeta->imageCount = num;
+                coreMeta->dimensionOrder = meta->getPixelsDimensionOrder(series);
+                coreMeta->orderCertain = true;
+                // libtiff converts to the native endianess transparently
+#ifdef BOOST_BIG_ENDIAN
+                coreMeta->littleEndian = false;
+#else // Little endian
+                coreMeta->littleEndian = true;
+#endif
+                coreMeta->interleaved = false;
+                coreMeta->indexed = false;
+                if (photometric == tiff::PALETTE)
+                  {
+                    try
+                      {
+                        std::array<std::vector<uint16_t>, 3> cmap;
+                        pifd->getField(ome::bioformats::tiff::COLORMAP).get(cmap);
+                        coreMeta->indexed = true;
+                      }
+                    catch (const tiff::Exception&)
+                      {
+                      }
+                  }
+                coreMeta->metadataComplete = true;
+                coreMeta->bitsPerPixel = bitsPerPixel(coreMeta->pixelType);
+                try
+                  {
+                    pixel_size_type bpp =
+                      static_cast<pixel_size_type>(meta->getPixelsSignificantBits(series));
+                    if (bpp <= coreMeta->bitsPerPixel)
+                      {
+                        coreMeta->bitsPerPixel = bpp;
+                      }
+                    else
+                      {
+                        boost::format fmt("BitsPerPixel out of range: OME=%1%, MAX=%2%");
+                        fmt % bpp % coreMeta->bitsPerPixel;
+                        std::clog << fmt.str() << '\n';
+                      }
+                  }
+                catch (const std::exception&)
+                  {
+                  }
+                coreMeta->rgb = (*samples > 1) || photometric == tiff::RGB;
+                if ((*samples != coreMeta->sizeC &&
+                     (*samples % coreMeta->sizeC) != 0U &&
+                     (coreMeta->sizeC % *samples) != 0U) ||
+                    coreMeta->sizeC == 1U ||
+                    adjustedSamples)
+                  coreMeta->sizeC *= *samples;
+
+                if (coreMeta->sizeX != tiffWidth)
+                  {
+                    boost::format fmt("SizeX mismatch: OME=%1%, TIFF=%2%");
+                    fmt % coreMeta->sizeX % tiffWidth;
+                    std::clog << fmt.str() << '\n';
+                  }
+                if (coreMeta->sizeY != tiffHeight)
+                  {
+                    boost::format fmt("SizeY mismatch: OME=%1%, TIFF=%2%");
+                    fmt % coreMeta->sizeY % tiffHeight;
+                    std::clog << fmt.str() << '\n';
+                  }
+                if (coreMeta->pixelType != tiffPixelType)
+                  {
+                    boost::format fmt("PixelType mismatch: OME=%1%, TIFF=%2%");
+                    fmt % coreMeta->pixelType % tiffPixelType;
+                    std::clog << fmt.str() << '\n';
+                  }
+                if (meta->getPixelsBinDataCount(series) > 1U)
+                  {
+                    std::clog << "Ignoring invalid BinData elements in OME-TIFF Pixels element\n";
+                  }
+
+                fixOMEROMetadata(*meta, series);
+                fixDimensions(series);
+              }
+            catch (const std::exception& e)
+              {
+                boost::format fmt("Incomplete Pixels metadata: %1%");
+                fmt % e.what();
+                throw FormatException(fmt.str());
+              }
+          }
+
+        for (coremetadata_list_type::iterator i = core.begin();
+             i != core.end();
+             ++i)
+          {
+            try
+              {
+                (*i)->moduloZ = getModuloAlongZ(*meta, std::distance(core.begin(), i));
+              }
+            catch (const std::exception&)
+              {
+              }
+            try
+              {
+                (*i)->moduloT = getModuloAlongT(*meta, std::distance(core.begin(), i));
+              }
+            catch (const std::exception&)
+              {
+              }
+            try
+              {
+                (*i)->moduloC = getModuloAlongC(*meta, std::distance(core.begin(), i));
+              }
+            catch (const std::exception&)
+              {
+              }
+          }
+
+        // Remove null CoreMetadata entries.
+        std::remove(core.begin(), core.end(), std::shared_ptr<OMETIFFMetadata>());
+
+        if (getImageCount() == 1U)
+          {
+            std::shared_ptr<CoreMetadata>& ms0 = core.at(0);
+            ms0->sizeZ = 1U;
+            if (!ms0->rgb)
+              ms0->sizeC = 1U;
+            ms0->sizeT = 1U;
+          }
+
+        fillMetadata(*metadataStore, *this, false, false);
+
+        for (std::vector<boost::optional<Timestamp> >::const_iterator ts = acquiredDates.begin();
+             ts != acquiredDates.end();
+             ++ts)
+          {
+            index_type series = std::distance<std::vector<boost::optional<Timestamp> >::const_iterator>(acquiredDates.begin(), ts);
+            if (*ts)
+              {
+                try
+                  {
+                    metadataStore->setImageAcquisitionDate(**ts, series);
+                  }
+                catch (const std::exception& e)
+                  {
+                    boost::format fmt("Failed to set Image AcquisitionDate for series %1%: %2%");
+                    fmt % series % e.what();
+                    std::clog << fmt.str();
+                  }
+              }
+          }
+
+        metadataStore = getMetadataStoreForConversion();
+      }
+
+      void
+      OMETIFFReader::findUsedFiles(const ome::xml::meta::OMEXMLMetadata& meta,
+                                   const boost::filesystem::path&        currentId,
+                                   const boost::filesystem::path&        currentDir,
+                                   const boost::optional<std::string>&   currentUUID)
+      {
+        index_type seriesCount = meta.getImageCount();
+        for (index_type series = 0; series < seriesCount; ++series)
+          {
+            index_type tiffDataCount = meta.getTiffDataCount(series);
+            for (index_type td = 0; td < tiffDataCount; ++td)
+              {
+                std::string uuid;
+                path filename;
+                try
+                  {
+                    uuid = meta.getUUIDValue(series, td);
+                  }
+                catch (const std::exception& /* e */)
+                  {
+                  }
+                if (uuid.empty())
+                  {
+                    // No UUID means that TiffData element refers to this
+                    // file.
+                    filename = currentId;
+                  }
+                else
+                  {
+                    path uuidFilename;
+                    try
+                      {
+                        uuidFilename = meta.getUUIDFileName(series, td);
+                      }
+                    catch (const std::exception& /* e */)
+                      {
+                      }
+                    if (fs::exists(uuidFilename))
+                      {
+                        filename = canonical(uuidFilename, currentDir);
+                      }
+                    else
+                      {
+                        if (currentUUID && (uuid == *currentUUID || (*currentUUID).empty()))
+                          {
+                            // UUID references this file
+                            filename = currentId;
+                          }
+                        else
+                          {
+                            boost::format fmt("Unmatched filename for UUID ‘%1%’");
+                            fmt % uuid;
+                            throw FormatException(fmt.str());
+                          }
+                      }
+                  }
+
+                std::map<std::string, path>::const_iterator existing = files.find(uuid);
+                if (existing == files.end())
+                  files.insert(std::make_pair(uuid, filename));
+                else if (existing->second != filename)
+                  {
+                    boost::format fmt("Inconsistent UUID filenames ‘%1%’ and ‘%2%’");
+                    fmt % existing->second.native() % filename.native();
+                    throw FormatException(fmt.str());
+                  }
+              }
+          }
+
+        // Build list of used files.
+        {
+          std::set<path> fileSet;
+          std::transform(files.begin(), files.end(),
+                         std::inserter(fileSet, fileSet.begin()), get_file());
+          usedFiles.assign(fileSet.begin(), fileSet.end());
+        }
+      }
+
+      void
+      OMETIFFReader::getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                  meta,
+                                         std::vector<boost::optional<ome::xml::model::primitives::Timestamp> >& timestamps)
+      {
+        for (index_type i = 0; i < meta.getImageCount(); ++i)
+          {
+            boost::optional<Timestamp> ts;
+            try
+              {
+                meta.getImageAcquisitionDate(i);
+              }
+            catch (const std::exception& /* e */)
+              {
+                // null timestamp.
+              }
+            timestamps.push_back(ts);
+          }
+      }
+
+      void
+      OMETIFFReader::cleanMetadata(ome::xml::meta::OMEXMLMetadata& meta)
+      {
+        index_type imageCount = meta.getImageCount();
+        for (index_type i = 0; i < imageCount; ++i)
+          {
+            PositiveInteger sizeC = meta.getPixelsSizeC(i);
+            removeChannels(meta, i, sizeC);
+          }
+      }
+
+
+      dimension_size_type
+      OMETIFFReader::seriesFileSamplesPerPixel(const ome::xml::meta::OMEXMLMetadata&    meta,
+                                               ome::xml::meta::BaseMetadata::index_type series)
+      {
+        index_type tiffDataCount = meta.getTiffDataCount(series);
+        index_type td = 0;
+        boost::optional<NonNegativeInteger> ifdIndex = 0;
+        for (td = 0; td < tiffDataCount; ++td)
+          {
+            boost::optional<NonNegativeInteger> tdIFD;
+            try
+              {
+                ifdIndex = meta.getTiffDataIFD(series, td);
+              }
+            catch (const std::exception& e)
+              {
+              }
+            if (ifdIndex)
+              break; // Found an IFD.
+          }
+        if (!ifdIndex)
+          {
+            // Fallback to use the first IFD
+            ifdIndex = 0;
+            td = 0;
+          }
+
+        std::string uuid;
+        try
+          {
+            uuid = meta.getUUIDValue(series, td);
+          }
+        catch (const std::exception& /* e */)
+          {
+          }
+
+        path filename;
+        file_map::const_iterator i = files.find(uuid);
+        if (i != files.end())
+          filename = i->second;
+        else
+          filename = *currentId;
+
+        const std::shared_ptr<const tiff::TIFF> tiff(getTIFF(filename));
+        const std::shared_ptr<const tiff::IFD> ifd(tiff->getDirectoryByIndex(*ifdIndex));
+
+        return ifd->getSamplesPerPixel();
+      }
+
+      void
+      OMETIFFReader::seriesIndexStart(const ome::xml::meta::OMEXMLMetadata&                             meta,
+                                      ome::xml::meta::BaseMetadata::index_type                          series,
+                                      boost::optional<ome::xml::model::primitives::NonNegativeInteger>& zIndexStart,
+                                      boost::optional<ome::xml::model::primitives::NonNegativeInteger>& tIndexStart,
+                                      boost::optional<ome::xml::model::primitives::NonNegativeInteger>& cIndexStart)
+      {
+        // Pre-scan TiffData indices to see if any are indexed from 1.
+        index_type tiffDataCount = meta.getTiffDataCount(series);
+        for (index_type td = 0; td < tiffDataCount; ++td)
+          {
+            NonNegativeInteger firstC = 0;
+            try
+              {
+                firstC = meta.getTiffDataFirstC(series, td);
+              }
+            catch (const std::exception& e)
+              {
+              }
+            if (!cIndexStart)
+              cIndexStart = firstC;
+            else
+              cIndexStart = std::min(*cIndexStart, firstC);
+
+            NonNegativeInteger firstZ = 0;
+            try
+              {
+                firstZ = meta.getTiffDataFirstC(series, td);
+              }
+            catch (const std::exception& e)
+              {
+              }
+            if (!zIndexStart)
+              zIndexStart = firstZ;
+            else
+              zIndexStart = std::min(*zIndexStart, firstZ);
+
+            NonNegativeInteger firstT = 0;
+            try
+              {
+                firstT = meta.getTiffDataFirstT(series, td);
+              }
+            catch (const std::exception& e)
+              {
+              }
+            if (!tIndexStart)
+              tIndexStart = firstT;
+            else
+              tIndexStart = std::min(*tIndexStart, firstT);
+          }
+      }
+
+      bool
+      OMETIFFReader::getTiffDataValues(const ome::xml::meta::OMEXMLMetadata&                             meta,
+                                       ome::xml::meta::BaseMetadata::index_type                          series,
+                                       ome::xml::meta::BaseMetadata::index_type                          tiffData,
+                                       boost::optional<ome::xml::model::primitives::NonNegativeInteger>& tdIFD,
+                                       ome::xml::model::primitives::NonNegativeInteger&                  numPlanes,
+                                       ome::xml::model::primitives::NonNegativeInteger&                  firstZ,
+                                       ome::xml::model::primitives::NonNegativeInteger&                  firstT,
+                                       ome::xml::model::primitives::NonNegativeInteger&                  firstC)
+      {
+        bool valid = true;
+
+        try
+          {
+            tdIFD = meta.getTiffDataIFD(series, tiffData);
+          }
+        catch (const std::exception& e)
+          {
+          }
+
+        try
+          {
+            numPlanes = meta.getTiffDataPlaneCount(series, tiffData);
+          }
+        catch (const std::exception& e)
+          {
+            if (tdIFD)
+              numPlanes = 1;
+          }
+
+        if (numPlanes == 0)
+          {
+            core.at(series) = std::shared_ptr<OMETIFFMetadata>();
+            valid = false;
+          }
+
+        if (!tdIFD)
+          tdIFD = 0; // Start at first IFD in file if unspecified.
+
+        try
+          {
+            firstC = meta.getTiffDataFirstC(series, tiffData);
+          }
+        catch (const std::exception& e)
+          {
+          }
+
+        try
+          {
+            firstT = meta.getTiffDataFirstT(series, tiffData);
+          }
+        catch (const std::exception& e)
+          {
+          }
+
+        try
+          {
+            firstZ = meta.getTiffDataFirstZ(series, tiffData);
+          }
+        catch (const std::exception& e)
+          {
+          }
+
+        return valid;
+      }
+
+      void
+      OMETIFFReader::fixOMEROMetadata(ome::xml::meta::OMEXMLMetadata&          meta,
+                                      ome::xml::meta::BaseMetadata::index_type series)
+      {
+        // Hackish workaround for files exported by OMERO
+        // having an incorrect dimension order.
+        {
+          std::string uuidFileName;
+          try
+            {
+              if (meta.getTiffDataCount(series) > 0)
+                uuidFileName = meta.getUUIDFileName(series, 0);
+            }
+          catch (const std::exception& e)
+            {
+            }
+          if (meta.getChannelCount(series) > 0)
+            {
+              try
+                {
+                  // Will throw if null.
+                  std::string channelName(meta.getChannelName(series, 0));
+                  std::shared_ptr<CoreMetadata> coreMeta(core.at(series));
+                  if (meta.getTiffDataCount(series) > 0 &&
+                      files.find("__omero_export") == files.end() &&
+                      coreMeta)
+                    coreMeta->dimensionOrder = ome::xml::model::enums::DimensionOrder("XYZCT");
+                }
+              catch (const std::exception& e)
+                {
+                }
+            }
+        }
+      }
+
+      void
+      OMETIFFReader::fixDimensions(ome::xml::meta::BaseMetadata::index_type series)
+      {
+        std::shared_ptr<CoreMetadata> coreMeta(core.at(series));
+        if (coreMeta)
+          {
+
+            if (coreMeta->sizeZ * coreMeta->sizeT * coreMeta->sizeC > coreMeta->imageCount &&
+                !coreMeta->rgb)
+              {
+                if (coreMeta->sizeZ == coreMeta->imageCount)
+                  {
+                    coreMeta->sizeT = 1U;
+                    coreMeta->sizeC = 1U;
+                  }
+                else if (coreMeta->sizeT == coreMeta->imageCount)
+                  {
+                    coreMeta->sizeZ = 1U;
+                    coreMeta->sizeC = 1U;
+                  }
+                else if (coreMeta->sizeC == coreMeta->imageCount)
+                  {
+                    coreMeta->sizeZ = 1U;
+                    coreMeta->sizeT = 1U;
+                  }
+                else
+                  {
+                    coreMeta->sizeZ = 1U;
+                    coreMeta->sizeT = coreMeta->imageCount;
+                    coreMeta->sizeC = 1U;
+                  }
+              }
+          }
+      }
+
+      void
+      OMETIFFReader::getLookupTable(VariantPixelBuffer& buf,
+                                    dimension_size_type no) const
+      {
+        assertId(currentId, true);
+
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+
+        try
+          {
+            ifd->readLookupTable(buf);
+          }
+        catch (const std::exception& e)
+          {
+            boost::format fmt("Failed to get lookup table:");
+            fmt % e.what();
+            throw FormatException(fmt.str());
+          }
+      }
+
+      void
+      OMETIFFReader::openBytesImpl(dimension_size_type no,
+                                   VariantPixelBuffer& buf,
+                                   dimension_size_type x,
+                                   dimension_size_type y,
+                                   dimension_size_type w,
+                                   dimension_size_type h) const
+      {
+        assertId(currentId, true);
+
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+
+        if (isRGB())
+          {
+            // Copy the desired subchannel into the destination buffer.
+            VariantPixelBuffer tmp;
+            ifd->readImage(tmp, x, y, w, h);
+
+            dimension_size_type S = no % getSizeC();
+            detail::CopySubchannelVisitor v(buf, S);
+            boost::apply_visitor(v, tmp.vbuffer());
+          }
+        else
+          ifd->readImage(buf, x, y, w, h);
+      }
+
+      void
+      OMETIFFReader::addTIFF(const boost::filesystem::path& tiff)
+      {
+        tiffs.insert(std::make_pair(tiff, std::shared_ptr<tiff::TIFF>()));
+      }
+
+      const std::shared_ptr<const ome::bioformats::tiff::TIFF>
+      OMETIFFReader::getTIFF(const boost::filesystem::path& tiff) const
+      {
+        tiff_map::iterator i = tiffs.find(tiff);
+        if (!i->second)
+          i->second = tiff::TIFF::open(i->first, "r");
+
+        if (!i->second)
+          {
+            boost::format fmt("Failed to open ‘%1%’");
+            fmt % i->first.native();
+            throw FormatException(fmt.str());
+          }
+
+        return i->second;
+      }
+
+      void
+      OMETIFFReader::closeTIFF(const boost::filesystem::path& tiff)
+      {
+        tiff_map::iterator i = tiffs.find(tiff);
+        if (i->second)
+          {
+            i->second->close();
+            i->second = std::shared_ptr<ome::bioformats::tiff::TIFF>();
+          }
+      }
+
+      std::shared_ptr<ome::xml::meta::MetadataStore>
+      OMETIFFReader::getMetadataStoreForConversion()
+      {
+        SaveSeries sentry(*this);
+
+        std::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
+
+        if (store)
+          {
+            for (dimension_size_type i = 0; i < getSeriesCount(); ++i)
+              {
+                setSeries(i);
+                store->setPixelsBinDataBigEndian(!isLittleEndian(), i, 0);
+              }
+          }
+
+        return store;
+      }
+
+      std::shared_ptr<ome::xml::meta::MetadataStore>
+      OMETIFFReader::getMetadataStoreForDisplay()
+      {
+        std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omexml;
+        std::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
+
+        if (store)
+          {
+            omexml = std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(store);
+            if (omexml)
+              {
+                removeBinData(*omexml);
+                for (dimension_size_type i = 0;
+                     i < getSeriesCount();
+                     ++i)
+                  {
+                    try
+                      {
+                        if (omexml->getTiffDataCount(i) == 0)
+                          addMetadataOnly(*omexml, i);
+                      }
+                    catch (const std::exception& e)
+                      {
+                        boost::format fmt("Failed to add MetadataOnly for series %1%: %2%");
+                        fmt % i % e.what();
+                        std::clog << fmt.str();
+                      }
+                  }
+              }
+          }
+
+        return omexml;
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -40,6 +40,8 @@
 #include <map>
 #include <set>
 
+#include <boost/range/size.hpp>
+
 #include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/FormatTools.h>
 #include <ome/bioformats/MetadataTools.h>
@@ -99,7 +101,7 @@ namespace ome
                              "Open Microscopy Environment TIFF");
 
           p.suffixes = std::vector<boost::filesystem::path>(suffixes,
-                                                            suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
+                                                            suffixes + boost::size(suffixes));
           p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
           p.metadata_levels.insert(MetadataOptions::METADATA_NO_OVERLAYS);
           p.metadata_levels.insert(MetadataOptions::METADATA_ALL);
@@ -110,7 +112,7 @@ namespace ome
         const ReaderProperties props(tiff_properties());
 
         std::vector<path> companion_suffixes(companion_suffixes_array,
-                                             companion_suffixes_array + (sizeof(companion_suffixes_array) / sizeof(companion_suffixes_array[0])));
+                                             companion_suffixes_array + boost::size(companion_suffixes_array));
 
         void
         getComment(const TIFF&  tiff,

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -696,18 +696,6 @@ namespace ome
                 std::clog << "  }\n";
               }
 
-            // DEBUG
-            for (dimension_size_type q = 0;
-                 q < static_cast<dimension_size_type>(num);
-                 ++q)
-              {
-                OMETIFFPlane& plane(coreMeta->tiffPlanes.at(q));
-
-                std::clog << "    CHECK Plane[" << q
-                          << "]: file=" << plane.id.native()
-                          << ", IFD=" << plane.ifd << '\n';
-              }
-
             // Clear any unset planes.
             for (std::vector<OMETIFFPlane>::iterator plane = coreMeta->tiffPlanes.begin();
                  plane != coreMeta->tiffPlanes.end();

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -492,7 +492,7 @@ namespace ome
           }
 
         // Transfer OME-XML metadata to metadata store for reader.
-        convert(*meta, *metadataStore);
+        convert(*meta, *metadataStore, true);
 
         // Create CoreMetadata for each image.
         index_type seriesCount = meta->getImageCount();

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -1,0 +1,357 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_IN_OMETIFFREADER_H
+#define OME_BIOFORMATS_IN_OMETIFFREADER_H
+
+#include <ome/bioformats/in/MinimalTIFFReader.h>
+#include <ome/bioformats/tiff/ImageJMetadata.h>
+
+#include <ome/xml/meta/BaseMetadata.h>
+
+namespace ome
+{
+
+  namespace xml
+  {
+    namespace meta
+    {
+      class OMEXMLMetadata;
+    }
+  }
+
+  namespace bioformats
+  {
+    namespace in
+    {
+
+      /**
+       * TIFF reader with support for ImageJ extensions.
+       */
+      class OMETIFFReader : public ::ome::bioformats::detail::FormatReader
+      {
+        using detail::FormatReader::isThisType;
+
+      protected:
+        /// Map UUID to filename.
+        typedef std::map<std::string, boost::filesystem::path> file_map;
+
+        /// Map filename to open TIFF handle.
+        typedef std::map<boost::filesystem::path, std::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
+
+        /// UUID to filename mapping.
+        file_map files;
+
+        // Mutable to allow opening TIFFs when const.
+        /// Open TIFF files
+        mutable tiff_map tiffs;
+
+        /// Metadata file.
+        boost::filesystem::path metadataFile;
+
+        /// Used files.
+        std::vector<boost::filesystem::path> usedFiles;
+
+        /// Has screen-plate-well metadata.
+        bool hasSPW;
+
+      public:
+        /// Constructor.
+        OMETIFFReader();
+
+        /// Destructor.
+        virtual
+        ~OMETIFFReader();
+
+        // Documented in superclass.
+        bool
+        isSingleFile(const boost::filesystem::path& id) const;
+
+        // Documented in superclass.
+        bool
+        isThisType(const boost::filesystem::path& name,
+                   bool                           open) const;
+
+      protected:
+        // Documented in superclass.
+        bool
+        isFilenameThisTypeImpl(const boost::filesystem::path& name) const;
+
+        // Documented in superclass.
+        void
+        getLookupTable(VariantPixelBuffer& buf,
+                       dimension_size_type no) const;
+
+        // Documented in superclass.
+        void
+        openBytesImpl(dimension_size_type no,
+                      VariantPixelBuffer& buf,
+                      dimension_size_type x,
+                      dimension_size_type y,
+                      dimension_size_type w,
+                      dimension_size_type h) const;
+
+        /**
+         * Get the IFD index for a plane in the current series.
+         *
+         * @param no the image index within the file.
+         * @returns the IFD index.
+         * @throws FormatException if out of range.
+         */
+        const std::shared_ptr<const tiff::IFD>
+        ifdAtIndex(dimension_size_type no) const;
+
+        /**
+         * Add a TIFF file to the internal TIFF map.
+         *
+         * @param tiff the TIFF file to add.
+         */
+        void
+        addTIFF(const boost::filesystem::path& tiff);
+
+        /**
+         * Get a an open TIFF file from the internal TIFF map.
+         *
+         * If the file does not exist in the map, the file will be
+         * added to the internal map first.  If the file is not
+         * currently open it will be opened.
+         *
+         * @param tiff the TIFF file to get.
+         * @returns the open TIFF.
+         * @throws FormatException if invalid.
+         */
+        const std::shared_ptr<const ome::bioformats::tiff::TIFF>
+        getTIFF(const boost::filesystem::path& tiff) const;
+
+        /**
+         * Close an open TIFF file from the internal TIFF map.
+         *
+         * If the file is currently open, it will be closed.
+         *
+         * @param tiff the TIFF file to add.
+         */
+        void
+        closeTIFF(const boost::filesystem::path& tiff);
+
+      public:
+        // Documented in superclass.
+        void
+        close(bool fileOnly = false);
+
+        const std::vector<std::string>&
+        getDomains() const;
+
+        // Documented in superclass.
+        const std::vector<boost::filesystem::path>
+        getSeriesUsedFiles(bool noPixels) const;
+
+        // Documented in superclass.
+        FormatReader::FileGroupOption
+        fileGroupOption(const std::string& id);
+
+        // Documented in superclass.
+        dimension_size_type
+        getOptimalTileWidth() const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getOptimalTileHeight() const;
+
+        // Documented in superclass.
+        void
+        initFile(const boost::filesystem::path& id);
+
+      private:
+        /**
+         * Get UUID to file associations and used files.
+         *
+         * Updates both the files map and the used files list.
+         *
+         * @param meta the metadata store to use.
+         * @param currentId the current file.
+         * @param currentDir the current directory.
+         * @param currentUUID the current UUID (if any).
+         */
+        void
+        findUsedFiles(const ome::xml::meta::OMEXMLMetadata& meta,
+                      const boost::filesystem::path&        currentId,
+                      const boost::filesystem::path&        currentDir,
+                      const boost::optional<std::string>&   currentUUID);
+
+        /**
+         * Get acquisition dates for each image.
+         *
+         * If no date was specified for the image, the timestamp will
+         * be unset.
+         *
+         * @param meta the metadata store to use.
+         * @param timestamps the acquisition dates, indexed by image.
+         */
+        void
+        getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                  meta,
+                            std::vector<boost::optional<ome::xml::model::primitives::Timestamp> >& timestamps);
+
+        /**
+         * Clean up OME-XML metadata.
+         *
+         * Remove invalid channels.
+         *
+         * @param meta the metadata store to clean up.
+         */
+        void
+        cleanMetadata(ome::xml::meta::OMEXMLMetadata& meta);
+
+        /**
+         * Get the samples per pixel from the first IFD for a series.
+         *
+         * @param meta the metadata store to query.
+         * @param series the series to check.
+         * @returns the samples per pixel.
+         */
+        dimension_size_type
+        seriesFileSamplesPerPixel(const ome::xml::meta::OMEXMLMetadata&    meta,
+                                  ome::xml::meta::BaseMetadata::index_type series);
+
+        /**
+         * Get starting index for each dimension.
+         *
+         * This is to cater for files which have been incorrectly
+         * written, where the starting index is not zero.
+         *
+         * @param meta the metadata store to query.
+         * @param series the series to check.
+         * @param zIndexStart the Z starting index.
+         * @param tIndexStart the T starting index.
+         * @param cIndexStart the C starting index.
+         */
+        void
+        seriesIndexStart(const ome::xml::meta::OMEXMLMetadata&                             meta,
+                         ome::xml::meta::BaseMetadata::index_type                          series,
+                         boost::optional<ome::xml::model::primitives::NonNegativeInteger>& zIndexStart,
+                         boost::optional<ome::xml::model::primitives::NonNegativeInteger>& tIndexStart,
+                         boost::optional<ome::xml::model::primitives::NonNegativeInteger>& cIndexStart);
+
+        /**
+         * Get values from a TiffData element.
+         *
+         * @param meta the metadata store to query.
+         * @param series the series to check.
+         * @param tiffData the TiffData index to check.
+         * @param tdIFD the starting IFD.
+         * @param numPlanes the number of planes.
+         * @param firstZ the first Z plane.
+         * @param firstT the first T plane.
+         * @param firstC the first C plane.
+         * @returns @c true if read successfully, @c false otherwise.
+         */
+        bool
+        getTiffDataValues(const ome::xml::meta::OMEXMLMetadata&                             meta,
+                          ome::xml::meta::BaseMetadata::index_type                          series,
+                          ome::xml::meta::BaseMetadata::index_type                          tiffData,
+                          boost::optional<ome::xml::model::primitives::NonNegativeInteger>& tdIFD,
+                          ome::xml::model::primitives::NonNegativeInteger&                  numPlanes,
+                          ome::xml::model::primitives::NonNegativeInteger&                  firstZ,
+                          ome::xml::model::primitives::NonNegativeInteger&                  firstT,
+                          ome::xml::model::primitives::NonNegativeInteger&                  firstC);
+
+        /**
+         * Fix invalid OMERO OME-TIFF metadata.
+         *
+         * OMERO has in the past written OME-TIFF with incorrect
+         * DimensionOrder.  Attempt to identify such data and reset
+         * the dimension order to XYZCT.
+         *
+         * @param meta the metadata store to query.
+         * @param series the series to correct.
+         */
+        void
+        fixOMEROMetadata(ome::xml::meta::OMEXMLMetadata&          meta,
+                         ome::xml::meta::BaseMetadata::index_type series);
+
+        /**
+         * Attempt to correct logically inconsistent dimensions.
+         *
+         * If the product of SizeZ, SizeT and SizeC is not equal to
+         * the total image count, attempt to correct it by finding the
+         * dimension equal to the image count, and setting all other
+         * dimension sizes to 1.  If a match isn't found, fall back to
+         * setting SizeT to the image count.
+         *
+         * @param series the series to correct.
+         */
+        void
+        fixDimensions(ome::xml::meta::BaseMetadata::index_type series);
+
+      public:
+        /**
+         * Get a MetadataStore suitable for writing.
+         *
+         * @note This will be suitable for use with FormatWriter, but
+         * will likely not generate valid OME-XML due to the
+         * likelihood of containing both BinData and TiffData
+         * elements.
+         *
+         * @returns the metadata store.
+         */
+        std::shared_ptr< ome::xml::meta::MetadataStore>
+        getMetadataStoreForConversion();
+
+        /**
+         * Get a MetadataStore suitable for display.
+         *
+         * @note This will not be suitable for use with FormatWriter
+         * due to not containing required BinData BigEndian
+         * attributes.
+         *
+         * @returns the metadata store.
+         */
+        std::shared_ptr< ome::xml::meta::MetadataStore>
+        getMetadataStoreForDisplay();
+      };
+
+
+    }
+  }
+}
+
+#endif // OME_BIOFORMATS_IN_OMETIFFREADER_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -35,6 +35,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/in/TIFFReader.h>
 #include <ome/bioformats/tiff/IFD.h>
@@ -64,7 +66,7 @@ namespace ome
         {
           ReaderProperties p("TIFF", "Tagged Image File Format");
           p.suffixes = std::vector<boost::filesystem::path>(suffixes,
-                                                            suffixes + (sizeof(suffixes) / sizeof(suffixes[0])));
+                                                            suffixes + boost::size(suffixes));
           p.metadata_levels.insert(MetadataOptions::METADATA_MINIMUM);
           p.metadata_levels.insert(MetadataOptions::METADATA_NO_OVERLAYS);
           p.metadata_levels.insert(MetadataOptions::METADATA_ALL);
@@ -75,7 +77,7 @@ namespace ome
         const ReaderProperties props(tiff_properties());
 
         std::vector<boost::filesystem::path> companion_suffixes(companion_suffixes_array,
-                                                                companion_suffixes_array + (sizeof(companion_suffixes_array) / sizeof(companion_suffixes_array[0])));
+                                                                companion_suffixes_array + boost::size(companion_suffixes_array));
 
       }
 

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -106,6 +106,8 @@ namespace ome
       public:
         /// The libtiff file handle.
         ::TIFF *tiff;
+        /// The number of IFDs.
+        directory_index_type directoryCount;
 
         /**
          * The constructor.
@@ -117,7 +119,8 @@ namespace ome
          */
         Impl(const boost::filesystem::path& filename,
              const std::string&             mode):
-          tiff()
+          tiff(),
+          directoryCount(0)
         {
           Sentry sentry;
 
@@ -221,6 +224,20 @@ namespace ome
       TIFF::operator bool ()
       {
         return impl && impl->tiff;
+      }
+
+      directory_index_type
+      TIFF::directoryCount() const
+      {
+        if (!impl->directoryCount)
+          {
+            directory_index_type nIFD = 0U;
+            for (const_iterator i = begin();
+                 i != end();
+                 ++i, ++nIFD);
+            impl->directoryCount = nIFD;
+          }
+        return impl->directoryCount;
       }
 
       std::shared_ptr<IFD>

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -39,6 +39,8 @@
 #include <cmath>
 #include <cstdarg>
 
+#include <boost/range/size.hpp>
+
 #include <ome/bioformats/tiff/TIFF.h>
 #include <ome/bioformats/tiff/IFD.h>
 #include <ome/bioformats/tiff/Sentry.h>
@@ -345,11 +347,11 @@ namespace ome
         Sentry sentry;
 
 # if TIFF_HAVE_MERGEFIELDINFO_RETURN
-        int e = TIFFMergeFieldInfo(tiffraw, ImageJFieldInfo, sizeof(ImageJFieldInfo)/sizeof(ImageJFieldInfo[0]));
+        int e = TIFFMergeFieldInfo(tiffraw, ImageJFieldInfo, boost::size(ImageJFieldInfo));
         if (e)
           sentry.error();
 # else // !TIFF_HAVE_MERGEFIELDINFO_RETURN
-        TIFFMergeFieldInfo(tiffraw, ImageJFieldInfo, sizeof(ImageJFieldInfo)/sizeof(ImageJFieldInfo[0]));
+        TIFFMergeFieldInfo(tiffraw, ImageJFieldInfo, boost::size(ImageJFieldInfo));
 #endif // TIFF_HAVE_MERGEFIELDINFO_RETURN
 #endif // TIFF_HAVE_MERGEFIELDINFO
       }

--- a/cpp/lib/ome/bioformats/tiff/TIFF.h
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.h
@@ -212,6 +212,14 @@ namespace ome
         operator bool ();
 
         /**
+         * Get the total number of IFDs.
+         *
+         * @returns the IFD count.
+         */
+        directory_index_type
+        directoryCount() const;
+
+        /**
          * Get an IFD by its index.
          *
          * @param index the directory index.

--- a/cpp/lib/ome/compat/module.cpp
+++ b/cpp/lib/ome/compat/module.cpp
@@ -37,6 +37,7 @@
  */
 
 #include <boost/format.hpp>
+#include <boost/range/size.hpp>
 
 #include <ome/compat/filesystem.h>
 #include <ome/compat/module.h>
@@ -130,7 +131,7 @@ namespace
     };
 
   path_map internalpaths(paths,
-                         paths + (sizeof(paths) / sizeof(paths[0])));
+                         paths + boost::size(paths));
 }
 
 #endif // OME_HAVE_DLADDR

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -52,6 +52,7 @@ foreach(hdr ${model_headers})
 endforeach(hdr)
 
 set(OME_XML_STATIC_SOURCES
+  meta/MetadataException.cpp
   meta/OMEXMLMetadataRoot.cpp
   meta/Convert.cpp
   model/Catalog.cpp
@@ -77,6 +78,7 @@ set(OME_XML_META_PRIVATE_STATIC_HEADERS
 set(OME_XML_META_STATIC_HEADERS
     meta/BaseMetadata.h
     meta/Metadata.h
+    meta/MetadataException.h
     meta/MetadataRoot.h
     meta/OMEXMLMetadataRoot.h)
 

--- a/cpp/lib/ome/xml/meta/Convert.cpp
+++ b/cpp/lib/ome/xml/meta/Convert.cpp
@@ -1449,6 +1449,22 @@ namespace ome
         converter();
       }
 
+      void
+      convert(MetadataRetrieve& src,
+              MetadataStore&    dest,
+              bool              skip)
+      {
+        MetadataStore *src_store(dynamic_cast<MetadataStore *>(&src));
+        if (typeid(src) == typeid(dest) && src_store && skip)
+          {
+            dest.setRoot(src_store->getRoot());
+          }
+        else
+          {
+            convert(src, dest);
+          }
+      }
+
     }
   }
 }

--- a/cpp/lib/ome/xml/meta/Convert.cpp
+++ b/cpp/lib/ome/xml/meta/Convert.cpp
@@ -112,6 +112,105 @@ namespace
     }
 
     /**
+     * Safely get a count value (no arguments).
+     *
+     * @param get a getter method from MetadataRetrieve.
+     * @returns the count value, or zero if the getter threw an exception.
+     */
+    template<typename T>
+    T
+    count(T (MetadataRetrieve::* get)() const) const
+    {
+      T value = 0U;
+      try
+        {
+          value = (src.*get)();
+        }
+      catch (const std::runtime_error& /* e */)
+        {
+        }
+      return value;
+    }
+
+    /**
+     * Safely get a count value (one index argument).
+     *
+     * @param get a getter method from MetadataRetrieve.
+     * @param param getter parameter.
+     * @returns the count value, or zero if the getter threw an exception.
+     */
+    template<typename T, typename P>
+    T
+    count(T (MetadataRetrieve::* get)(P param) const,
+          P                      param) const
+    {
+      T value = 0U;
+      try
+        {
+          value = (src.*get)(param);
+        }
+      catch (const std::runtime_error& /* e */)
+        {
+        }
+      return value;
+    }
+
+    /**
+     * Safely get a count value (two index arguments).
+     *
+     * @param get a getter method from MetadataRetrieve.
+     * @param param1 getter parameter 1.
+     * @param param2 getter parameter 2.
+     * @returns the count value, or zero if the getter threw an exception.
+     */
+    template<typename T, typename P>
+    T
+    count(T (MetadataRetrieve::* get)(P param1,
+                                      P param2) const,
+          P                      param1,
+          P                      param2) const
+    {
+      T value = 0U;
+      try
+        {
+          value = (src.*get)(param1, param2);
+        }
+      catch (const std::runtime_error& /* e */)
+        {
+        }
+      return value;
+    }
+
+    /**
+     * Safely get a count value (three index arguments).
+     *
+     * @param get a getter method from MetadataRetrieve.
+     * @param param1 getter parameter 1.
+     * @param param2 getter parameter 2.
+     * @param param3 getter parameter 3.
+     * @returns the count value, or zero if the getter threw an exception.
+     */
+    template<typename T, typename P>
+    T
+    count(T (MetadataRetrieve::* get)(P param1,
+                                      P param2,
+                                      P param3) const,
+          P                      param1,
+          P                      param2,
+          P                      param3) const
+    {
+      T value = 0U;
+      try
+        {
+          value = (src.*get)(param1, param2, param3);
+        }
+      catch (const std::runtime_error& /* e */)
+        {
+        }
+      return value;
+    }
+
+    /**
      * Transfer a single metadata value (no arguments).
      *
      * @param get a getter method from MetadataRetrieve.
@@ -141,6 +240,7 @@ namespace
      *
      * @param get a getter method from MetadataRetrieve.
      * @param set a setter method from MetadataStore.
+     * @param param getter and setter parameter.
      * @returns @c true if the transfer succeeded, @c false if an
      * exception was thrown.
      */
@@ -148,7 +248,7 @@ namespace
     bool
     transfer(T    (MetadataRetrieve::* get)(P param) const,
              void (MetadataStore::*    set)(T value, P param),
-             P                                param)
+             P                         param)
     {
       bool ok = true;
       try
@@ -168,6 +268,8 @@ namespace
      *
      * @param get a getter method from MetadataRetrieve.
      * @param set a setter method from MetadataStore.
+     * @param param1 getter and setter parameter 1.
+     * @param param2 getter and setter parameter 2.
      * @returns @c true if the transfer succeeded, @c false if an
      * exception was thrown.
      */
@@ -199,6 +301,9 @@ namespace
      *
      * @param get a getter method from MetadataRetrieve.
      * @param set a setter method from MetadataStore.
+     * @param param1 getter and setter parameter 1.
+     * @param param2 getter and setter parameter 2.
+     * @param param3 getter and setter parameter 3.
      * @returns @c true if the transfer succeeded, @c false if an
      * exception was thrown.
      */
@@ -233,6 +338,10 @@ namespace
      *
      * @param get a getter method from MetadataRetrieve.
      * @param set a setter method from MetadataStore.
+     * @param param1 getter and setter parameter 1.
+     * @param param2 getter and setter parameter 2.
+     * @param param3 getter and setter parameter 3.
+     * @param param4 getter and setter parameter 4.
      * @returns @c true if the transfer succeeded, @c false if an
      * exception was thrown.
      */
@@ -269,7 +378,7 @@ namespace
     void
     convertBooleanAnnotations()
     {
-      index_type booleanAnnotationCount(src.getBooleanAnnotationCount());
+      index_type booleanAnnotationCount(count(&MR::getBooleanAnnotationCount));
       for (index_type i = 0; i < booleanAnnotationCount; ++i)
         {
           if (transfer(&MR::getBooleanAnnotationID,          &MS::setBooleanAnnotationID,          i))
@@ -279,7 +388,7 @@ namespace
               transfer(&MR::getBooleanAnnotationValue,       &MS::setBooleanAnnotationValue,       i);
               transfer(&MR::getBooleanAnnotationAnnotator,   &MS::setBooleanAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getBooleanAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getBooleanAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getBooleanAnnotationAnnotationRef, &MS::setBooleanAnnotationAnnotationRef, i, a);
             }
@@ -290,7 +399,7 @@ namespace
     void
     convertCommentAnnotations()
     {
-      index_type commentAnnotationCount(src.getCommentAnnotationCount());
+      index_type commentAnnotationCount(count(&MR::getCommentAnnotationCount));
       for (index_type i = 0; i < commentAnnotationCount; ++i)
         {
           if (transfer(&MR::getCommentAnnotationID,          &MS::setCommentAnnotationID,          i))
@@ -300,7 +409,7 @@ namespace
               transfer(&MR::getCommentAnnotationValue,       &MS::setCommentAnnotationValue,       i);
               transfer(&MR::getCommentAnnotationAnnotator,   &MS::setCommentAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getCommentAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getCommentAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getCommentAnnotationAnnotationRef, &MS::setCommentAnnotationAnnotationRef, i, a);
             }
@@ -311,7 +420,7 @@ namespace
     void
     convertDatasets()
     {
-      index_type datasets(src.getDatasetCount());
+      index_type datasets(count(&MR::getDatasetCount));
       for (index_type i = 0; i < datasets; ++i)
         {
           if (transfer(&MR::getDatasetID,                   &MS::setDatasetID,                   i))
@@ -321,11 +430,11 @@ namespace
               transfer(&MR::getDatasetExperimenterRef,      &MS::setDatasetExperimenterRef,      i);
               transfer(&MR::getDatasetName,                 &MS::setDatasetName,                 i);
 
-              index_type imageRefCount(src.getDatasetImageRefCount(i));
+              index_type imageRefCount(count(&MR::getDatasetImageRefCount, i));
               for (index_type q = 0; q < imageRefCount; ++q)
                 transfer(&MR::getDatasetImageRef, &MS::setDatasetImageRef, i, q);
 
-              index_type annotationRefCount = src.getDatasetAnnotationRefCount(i);
+              index_type annotationRefCount = count(&MR::getDatasetAnnotationRefCount, i);
               for (index_type q = 0; q < annotationRefCount; ++q)
                 transfer(&MR::getDatasetAnnotationRef, &MS::setDatasetAnnotationRef, i, q);
             }
@@ -336,7 +445,7 @@ namespace
     void
     convertDoubleAnnotations()
     {
-      index_type doubleAnnotationCount(src.getDoubleAnnotationCount());
+      index_type doubleAnnotationCount(count(&MR::getDoubleAnnotationCount));
       for (index_type i = 0; i < doubleAnnotationCount; ++i)
         {
           if (transfer(&MR::getDoubleAnnotationID,          &MS::setDoubleAnnotationID,          i))
@@ -346,7 +455,7 @@ namespace
               transfer(&MR::getDoubleAnnotationValue,       &MS::setDoubleAnnotationValue,       i);
               transfer(&MR::getDoubleAnnotationAnnotator,   &MS::setDoubleAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getDoubleAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getDoubleAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getDoubleAnnotationAnnotationRef, &MS::setDoubleAnnotationAnnotationRef, i, a);
             }
@@ -357,7 +466,7 @@ namespace
     void
     convertExperiments()
     {
-      index_type experimentCount(src.getExperimentCount());
+      index_type experimentCount(count(&MR::getExperimentCount));
       for (index_type i = 0; i < experimentCount; ++i)
         {
           if (transfer(&MR::getExperimentID,              &MS::setExperimentID,              i))
@@ -367,7 +476,7 @@ namespace
               transfer(&MR::getExperimentExperimenterRef, &MS::setExperimentExperimenterRef, i);
               transfer(&MR::getExperimentType,            &MS::setExperimentType,            i);
 
-              index_type microbeamCount(src.getMicrobeamManipulationCount(i));
+              index_type microbeamCount(count(&MR::getMicrobeamManipulationCount, i));
               for (index_type q = 0; q < microbeamCount; ++q)
                 {
                   if (transfer(&MR::getMicrobeamManipulationID,              &MS::setMicrobeamManipulationID,              i, q))
@@ -376,7 +485,7 @@ namespace
                       transfer(&MR::getMicrobeamManipulationExperimenterRef, &MS::setMicrobeamManipulationExperimenterRef, i, q);
                       transfer(&MR::getMicrobeamManipulationType,            &MS::setMicrobeamManipulationType,            i, q);
 
-                      index_type lightSourceCount(src.getMicrobeamManipulationLightSourceSettingsCount(i, q));
+                      index_type lightSourceCount(count(&MR::getMicrobeamManipulationLightSourceSettingsCount, i, q));
                       for (index_type p = 0; p < lightSourceCount; ++p)
                         {
                           transfer(&MR::getMicrobeamManipulationLightSourceSettingsID,          &MS::setMicrobeamManipulationLightSourceSettingsID,          i, q, p);
@@ -384,7 +493,7 @@ namespace
                           transfer(&MR::getMicrobeamManipulationLightSourceSettingsWavelength,  &MS::setMicrobeamManipulationLightSourceSettingsWavelength,  i, q, p);
                         }
 
-                      index_type roiRefCount(src.getMicrobeamManipulationROIRefCount(i, q));
+                      index_type roiRefCount(count(&MR::getMicrobeamManipulationROIRefCount, i, q));
                       for (index_type p = 0; p < roiRefCount; ++p)
                         transfer(&MR::getMicrobeamManipulationROIRef, &MS::setMicrobeamManipulationROIRef, i, q, p);
                     }
@@ -397,7 +506,7 @@ namespace
     void
     convertExperimenters()
     {
-      index_type experimenterCount(src.getExperimenterCount());
+      index_type experimenterCount(count(&MR::getExperimenterCount));
       for (index_type i = 0; i < experimenterCount; ++i)
         {
           if (transfer(&MR::getExperimenterID,          &MS::setExperimenterID,          i))
@@ -409,7 +518,7 @@ namespace
               transfer(&MR::getExperimenterMiddleName,  &MS::setExperimenterMiddleName,  i);
               transfer(&MR::getExperimenterUserName,    &MS::setExperimenterUserName,    i);
 
-              index_type annotationRefCount(src.getExperimenterAnnotationRefCount(i));
+              index_type annotationRefCount(count(&MR::getExperimenterAnnotationRefCount, i));
               for (index_type q = 0; q < annotationRefCount; ++q)
                 transfer(&MR::getExperimenterAnnotationRef, &MS::setExperimenterAnnotationRef, i, q);
             }
@@ -420,7 +529,7 @@ namespace
     void
     convertExperimenterGroups()
     {
-      index_type experimenterGroupCount(src.getExperimenterGroupCount());
+      index_type experimenterGroupCount(count(&MR::getExperimenterGroupCount));
       for (index_type i = 0; i < experimenterGroupCount; ++i)
         {
           if (transfer(&MR::getExperimenterGroupID,          &MS::setExperimenterGroupID,          i))
@@ -428,15 +537,15 @@ namespace
               transfer(&MR::getExperimenterGroupDescription, &MS::setExperimenterGroupDescription, i);
               transfer(&MR::getExperimenterGroupName,        &MS::setExperimenterGroupName,        i);
 
-              index_type annotationRefCount(src.getExperimenterGroupAnnotationRefCount(i));
+              index_type annotationRefCount(count(&MR::getExperimenterGroupAnnotationRefCount, i));
               for (index_type q = 0; q < annotationRefCount; ++q)
                 transfer(&MR::getExperimenterGroupAnnotationRef, &MS::setExperimenterGroupAnnotationRef, i, q);
 
-              index_type experimenterRefCount(src.getExperimenterGroupExperimenterRefCount(i));
+              index_type experimenterRefCount(count(&MR::getExperimenterGroupExperimenterRefCount, i));
               for (index_type q = 0; q < experimenterRefCount; ++q)
                 transfer(&MR::getExperimenterGroupExperimenterRef, &MS::setExperimenterGroupExperimenterRef, i, q);
 
-              index_type leaderCount(src.getLeaderCount(i));
+              index_type leaderCount(count(&MR::getLeaderCount, i));
               for (index_type q = 0; q < leaderCount; ++q)
                 transfer(&MR::getExperimenterGroupLeader, &MS::setExperimenterGroupLeader, i, q);
             }
@@ -447,7 +556,7 @@ namespace
     void
     convertFileAnnotations()
     {
-      index_type fileAnnotationCount(src.getFileAnnotationCount());
+      index_type fileAnnotationCount(count(&MR::getFileAnnotationCount));
       for (index_type i = 0; i < fileAnnotationCount; ++i)
         {
           if (transfer(&MR::getFileAnnotationID,          &MS::setFileAnnotationID,          i))
@@ -459,7 +568,7 @@ namespace
               transfer(&MR::getBinaryFileMIMEType,        &MS::setBinaryFileMIMEType,        i);
               transfer(&MR::getBinaryFileSize,            &MS::setBinaryFileSize,            i);
 
-              index_type annotationRefCount(src.getFileAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getFileAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getFileAnnotationAnnotationRef, &MS::setFileAnnotationAnnotationRef, i, a);
             }
@@ -470,7 +579,7 @@ namespace
     void
     convertImages()
     {
-      index_type imageCount(src.getImageCount());
+      index_type imageCount(count(&MR::getImageCount));
       for (index_type i = 0; i < imageCount; ++i)
         {
           if (transfer(&MR::getImageID,                       &MS::setImageID,                       i))
@@ -517,19 +626,19 @@ namespace
               transfer(&MR::getPixelsInterleaved,     &MS::setPixelsInterleaved,     i);
               transfer(&MR::getPixelsSignificantBits, &MS::setPixelsSignificantBits, i);
 
-              index_type binDataCount(src.getPixelsBinDataCount(i));
+              index_type binDataCount(count(&MR::getPixelsBinDataCount, i));
               for (index_type q = 0; q < binDataCount; ++q)
                 transfer(&MR::getPixelsBinDataBigEndian, &MS::setPixelsBinDataBigEndian, i, q);
 
-              index_type pixelsAnnotationRefCount(src.getPixelsAnnotationRefCount(i));
+              index_type pixelsAnnotationRefCount(count(&MR::getPixelsAnnotationRefCount, i));
               for (index_type q = 0; q < pixelsAnnotationRefCount; ++q)
                 transfer(&MR::getPixelsAnnotationRef, &MS::setPixelsAnnotationRef, i, q);
 
-              index_type imageAnnotationRefCount(src.getImageAnnotationRefCount(i));
+              index_type imageAnnotationRefCount(count(&MR::getImageAnnotationRefCount, i));
               for (index_type q = 0; q < imageAnnotationRefCount; ++q)
                 transfer(&MR::getImageAnnotationRef, &MS::setImageAnnotationRef, i, q);
 
-              index_type channelCount(src.getChannelCount(i));
+              index_type channelCount(count(&MR::getChannelCount, i));
               for (index_type c = 0; c < channelCount; ++c)
                 {
                   if (transfer(&MR::getChannelID,                   &MS::setChannelID,                   i, c))
@@ -567,21 +676,21 @@ namespace
                           transfer(&MR::getChannelLightSourceSettingsWavelength,  &MS::setChannelLightSourceSettingsWavelength,  i, c);
                         }
 
-                      index_type channelAnnotationRefCount(src.getChannelAnnotationRefCount(i, c));
+                      index_type channelAnnotationRefCount(count(&MR::getChannelAnnotationRefCount, i, c));
                       for (index_type q = 0; q < channelAnnotationRefCount; ++q)
                         transfer(&MR::getChannelAnnotationRef, &MS::setChannelAnnotationRef, i, c, q);
 
-                      index_type emFilterRefCount(src.getLightPathEmissionFilterRefCount(i, c));
+                      index_type emFilterRefCount(count(&MR::getLightPathEmissionFilterRefCount, i, c));
                       for (index_type q = 0; q < emFilterRefCount; ++q)
                         transfer(&MR::getLightPathEmissionFilterRef, &MS::setLightPathEmissionFilterRef, i, c, q);
 
-                      index_type exFilterRefCount(src.getLightPathExcitationFilterRefCount(i, c));
+                      index_type exFilterRefCount(count(&MR::getLightPathExcitationFilterRefCount, i, c));
                       for (index_type q = 0; q < exFilterRefCount; ++q)
                         transfer(&MR::getLightPathExcitationFilterRef, &MS::setLightPathExcitationFilterRef, i, c, q);
                     }
                 }
 
-              index_type planeCount(src.getPlaneCount(i));
+              index_type planeCount(count(&MR::getPlaneCount, i));
               for (index_type p = 0; p < planeCount; ++p)
                 {
                   transfer(&MR::getPlaneDeltaT,       &MS::setPlaneDeltaT,       i, p);
@@ -594,20 +703,20 @@ namespace
                   transfer(&MR::getPlaneTheT,         &MS::setPlaneTheT,         i, p);
                   transfer(&MR::getPlaneTheC,         &MS::setPlaneTheC,         i, p);
 
-                  index_type planeAnnotationRefCount(src.getPlaneAnnotationRefCount(i, p));
+                  index_type planeAnnotationRefCount(count(&MR::getPlaneAnnotationRefCount, i, p));
                   for (index_type q = 0; q < planeAnnotationRefCount; ++q)
                     transfer(&MR::getPlaneAnnotationRef, &MS::setPlaneAnnotationRef, i, p, q);
                 }
 
-              index_type microbeamCount(src.getMicrobeamManipulationRefCount(i));
+              index_type microbeamCount(count(&MR::getMicrobeamManipulationRefCount, i));
               for (index_type q = 0; q < microbeamCount; ++q)
                 transfer(&MR::getImageMicrobeamManipulationRef, &MS::setImageMicrobeamManipulationRef, i, q);
 
-              index_type roiRefCount(src.getImageROIRefCount(i));
+              index_type roiRefCount(count(&MR::getImageROIRefCount, i));
               for (index_type q = 0; q < roiRefCount; ++q)
                 transfer(&MR::getImageROIRef, &MS::setImageROIRef, i, q);
 
-              index_type tiffDataCount(src.getTiffDataCount(i));
+              index_type tiffDataCount(count(&MR::getTiffDataCount, i));
               for (index_type q = 0; q < tiffDataCount; ++q)
                 {
                   transfer(&MR::getUUIDValue,          &MS::setUUIDValue,          i, q);
@@ -630,7 +739,7 @@ namespace
     void
     convertLightSources(index_type instrumentIndex)
     {
-      index_type lightSourceCount(src.getLightSourceCount(instrumentIndex));
+      index_type lightSourceCount(count(&MR::getLightSourceCount, instrumentIndex));
 
       for (index_type lightSource = 0; lightSource < lightSourceCount; ++lightSource)
         {
@@ -699,7 +808,7 @@ namespace
     void
     convertInstruments()
     {
-      index_type instrumentCount(src.getInstrumentCount());
+      index_type instrumentCount(count(&MR::getInstrumentCount));
       for (index_type i = 0; i < instrumentCount; ++i)
         {
           if (transfer(&MR::getInstrumentID,           &MS::setInstrumentID,           i))
@@ -710,7 +819,7 @@ namespace
               transfer(&MR::getMicroscopeSerialNumber, &MS::setMicroscopeSerialNumber, i);
               transfer(&MR::getMicroscopeType,         &MS::setMicroscopeType,         i);
 
-              index_type detectorCount(src.getDetectorCount(i));
+              index_type detectorCount(count(&MR::getDetectorCount, i));
               for (index_type q = 0; q < detectorCount; ++q)
                 {
                   if (transfer(&MR::getDetectorID,                &MS::setDetectorID,                i, q))
@@ -728,7 +837,7 @@ namespace
                     }
                 }
 
-              index_type dichroicCount(src.getDichroicCount(i));
+              index_type dichroicCount(count(&MR::getDichroicCount, i));
               for (index_type q = 0; q < dichroicCount; ++q)
                 {
                   if (transfer(&MR::getDichroicID,           &MS::setDichroicID,           i, q))
@@ -740,7 +849,7 @@ namespace
                     }
                 }
 
-              index_type filterCount(src.getFilterCount(i));
+              index_type filterCount(count(&MR::getFilterCount, i));
               for (index_type q = 0; q < filterCount; ++q)
                 {
                   if (transfer(&MR::getFilterID,                          &MS::setFilterID,                          i, q))
@@ -759,7 +868,7 @@ namespace
                     }
                 }
 
-              index_type objectiveCount(src.getObjectiveCount(i));
+              index_type objectiveCount(count(&MR::getObjectiveCount, i));
               for (index_type q = 0; q < objectiveCount; ++q)
                 {
                   if (transfer(&MR::getObjectiveID,                      &MS::setObjectiveID,                      i, q))
@@ -778,7 +887,7 @@ namespace
                     }
                 }
 
-              index_type filterSetCount(src.getFilterSetCount(i));
+              index_type filterSetCount(count(&MR::getFilterSetCount, i));
               for (index_type q = 0; q < filterSetCount; ++q)
                 {
                   if (transfer(&MR::getFilterSetID,           &MS::setFilterSetID,           i, q))
@@ -789,11 +898,11 @@ namespace
                       transfer(&MR::getFilterSetModel,        &MS::setFilterSetModel,        i, q);
                       transfer(&MR::getFilterSetSerialNumber, &MS::setFilterSetSerialNumber, i, q);
 
-                      index_type emFilterCount(src.getFilterSetEmissionFilterRefCount(i, q));
+                      index_type emFilterCount(count(&MR::getFilterSetEmissionFilterRefCount, i, q));
                       for (index_type f = 0; f < emFilterCount; ++f)
                         transfer(&MR::getFilterSetEmissionFilterRef, &MS::setFilterSetEmissionFilterRef, i, q, f);
 
-                      index_type exFilterCount(src.getFilterSetExcitationFilterRefCount(i, q));
+                      index_type exFilterCount(count(&MR::getFilterSetExcitationFilterRefCount, i, q));
                       for (index_type f = 0; f < exFilterCount; ++f)
                         transfer(&MR::getFilterSetExcitationFilterRef, &MS::setFilterSetExcitationFilterRef, i, q, f);
                     }
@@ -808,7 +917,7 @@ namespace
     void
     convertListAnnotations()
     {
-      index_type listAnnotationCount(src.getListAnnotationCount());
+      index_type listAnnotationCount(count(&MR::getListAnnotationCount));
       for (index_type i = 0; i < listAnnotationCount; ++i)
         {
           if (transfer(&MR::getListAnnotationID,          &MS::setListAnnotationID,          i))
@@ -817,7 +926,7 @@ namespace
               transfer(&MR::getListAnnotationNamespace,   &MS::setListAnnotationNamespace,   i);
               transfer(&MR::getListAnnotationAnnotator,   &MS::setListAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getListAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getListAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getListAnnotationAnnotationRef, &MS::setListAnnotationAnnotationRef, i, a);
             }
@@ -828,7 +937,7 @@ namespace
     void
     convertLongAnnotations()
     {
-      index_type longAnnotationCount(src.getLongAnnotationCount());
+      index_type longAnnotationCount(count(&MR::getLongAnnotationCount));
       for (index_type i = 0; i < longAnnotationCount; ++i)
         {
           if (transfer(&MR::getLongAnnotationID,          &MS::setLongAnnotationID,          i))
@@ -838,7 +947,7 @@ namespace
               transfer(&MR::getLongAnnotationValue,       &MS::setLongAnnotationValue,       i);
               transfer(&MR::getLongAnnotationAnnotator,   &MS::setLongAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getLongAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getLongAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getLongAnnotationAnnotationRef, &MS::setLongAnnotationAnnotationRef, i, a);
             }
@@ -849,7 +958,7 @@ namespace
     void
     convertPlates()
     {
-      index_type plateCount(src.getPlateCount());
+      index_type plateCount(count(&MR::getPlateCount));
       for (index_type i = 0; i < plateCount; ++i)
         {
           if (transfer(&MR::getPlateID,                     &MS::setPlateID,                     i))
@@ -866,7 +975,7 @@ namespace
               transfer(&MR::getPlateWellOriginX,            &MS::setPlateWellOriginX,            i);
               transfer(&MR::getPlateWellOriginY,            &MS::setPlateWellOriginY,            i);
 
-              index_type wellCount(src.getWellCount(i));
+              index_type wellCount(count(&MR::getWellCount, i));
               for (index_type q = 0; q < wellCount; ++q)
                 {
                   if (transfer(&MR::getWellID,                  &MS::setWellID,                  i, q))
@@ -879,11 +988,11 @@ namespace
                       transfer(&MR::getWellRow,                 &MS::setWellRow,                 i, q);
                       transfer(&MR::getWellType,                &MS::setWellType,                i, q);
 
-                      index_type wellAnnotationRefCount(src.getWellAnnotationRefCount(i, q));
+                      index_type wellAnnotationRefCount(count(&MR::getWellAnnotationRefCount, i, q));
                       for (index_type a = 0; a < wellAnnotationRefCount; ++a)
                         transfer(&MR::getWellAnnotationRef, &MS::setWellAnnotationRef, i, q, a);
 
-                      index_type wellSampleCount(src.getWellSampleCount(i, q));
+                      index_type wellSampleCount(count(&MR::getWellSampleCount, i, q));
                       for (index_type w = 0; w < wellSampleCount; ++w)
                         {
                           if (transfer(&MR::getWellSampleID,        &MS::setWellSampleID,        i, q, w))
@@ -895,14 +1004,14 @@ namespace
                               transfer(&MR::getWellSampleTimepoint, &MS::setWellSampleTimepoint, i, q, w);
                             }
 
-                          index_type wellSampleAnnotationRefCount(src.getWellSampleAnnotationRefCount(i, q, w));
+                          index_type wellSampleAnnotationRefCount(count(&MR::getWellSampleAnnotationRefCount, i, q, w));
                           for (index_type s = 0; s < wellSampleAnnotationRefCount; ++s)
                             transfer(&MR::getWellSampleAnnotationRef, &MS::setWellSampleAnnotationRef, i, q, w, s);
                         }
                     }
                 }
 
-              index_type plateAcquisitionCount(src.getPlateAcquisitionCount(i));
+              index_type plateAcquisitionCount(count(&MR::getPlateAcquisitionCount, i));
               for (index_type q = 0; q < plateAcquisitionCount; ++q)
                 {
                   if (transfer(&MR::getPlateAcquisitionID,                &MS::setPlateAcquisitionID,                i, q))
@@ -913,17 +1022,17 @@ namespace
                       transfer(&MR::getPlateAcquisitionName,              &MS::setPlateAcquisitionName,              i, q);
                       transfer(&MR::getPlateAcquisitionStartTime,         &MS::setPlateAcquisitionStartTime,         i, q);
 
-                      index_type plateAcquisitionAnnotationRefCount(src.getPlateAcquisitionAnnotationRefCount(i, q));
+                      index_type plateAcquisitionAnnotationRefCount(count(&MR::getPlateAcquisitionAnnotationRefCount, i, q));
                       for (index_type a = 0; a < plateAcquisitionAnnotationRefCount; ++a)
                         transfer(&MR::getPlateAcquisitionAnnotationRef, &MS::setPlateAcquisitionAnnotationRef, i, q, a);
 
-                      index_type wellSampleRefCount(src.getWellSampleRefCount(i, q));
+                      index_type wellSampleRefCount(count(&MR::getWellSampleRefCount, i, q));
                       for (index_type w = 0; w < wellSampleRefCount; ++w)
                         transfer(&MR::getPlateAcquisitionWellSampleRef, &MS::setPlateAcquisitionWellSampleRef, i, q, w);
                     }
                 }
 
-              index_type plateAnnotationRefCount(src.getPlateAnnotationRefCount(i));
+              index_type plateAnnotationRefCount(count(&MR::getPlateAnnotationRefCount, i));
               for (index_type q = 0; q < plateAnnotationRefCount; ++q)
                 transfer(&MR::getPlateAnnotationRef, &MS::setPlateAnnotationRef, i, q);
             }
@@ -934,7 +1043,7 @@ namespace
     void
     convertProjects()
     {
-      index_type projectCount(src.getProjectCount());
+      index_type projectCount(count(&MR::getProjectCount));
       for (index_type i = 0; i < projectCount; ++i)
         {
           if (transfer(&MR::getProjectID,                   &MS::setProjectID,                   i))
@@ -944,11 +1053,11 @@ namespace
               transfer(&MR::getProjectExperimenterRef,      &MS::setProjectExperimenterRef,      i);
               transfer(&MR::getProjectName,                 &MS::setProjectName,                 i);
 
-              index_type annotationRefCount(src.getProjectAnnotationRefCount(i));
+              index_type annotationRefCount(count(&MR::getProjectAnnotationRefCount, i));
               for (index_type q = 0; q < annotationRefCount; ++q)
                 transfer(&MR::getProjectAnnotationRef, &MS::setProjectAnnotationRef, i, q);
 
-              index_type datasetRefCount(src.getDatasetRefCount(i));
+              index_type datasetRefCount(count(&MR::getDatasetRefCount, i));
               for (index_type q = 0; q < datasetRefCount; ++q)
                 transfer(&MR::getProjectDatasetRef, &MS::setProjectDatasetRef, i, q);
             }
@@ -959,7 +1068,7 @@ namespace
     void
     convertROIs()
     {
-      index_type roiCount(src.getROICount());
+      index_type roiCount(count(&MR::getROICount));
       for (index_type i = 0; i < roiCount; ++i)
         {
           if (transfer(&MR::getROIID,          &MS::setROIID,          i))
@@ -968,7 +1077,7 @@ namespace
               transfer(&MR::getROIDescription, &MS::setROIDescription, i);
               transfer(&MR::getROINamespace,   &MS::setROINamespace,   i);
 
-              index_type shapeCount(src.getShapeCount(i));
+              index_type shapeCount(count(&MR::getShapeCount, i));
               for (index_type q = 0; q < shapeCount; ++q)
                 {
                   std::string type = src.getShapeType(i, q);
@@ -1177,7 +1286,7 @@ namespace
                     }
                 }
 
-              index_type annotationRefCount(src.getROIAnnotationRefCount(i));
+              index_type annotationRefCount(count(&MR::getROIAnnotationRefCount, i));
               for (index_type q = 0; q < annotationRefCount; ++q)
                 transfer(&MR::getROIAnnotationRef, &MS::setROIAnnotationRef, i, q);
             }
@@ -1188,7 +1297,7 @@ namespace
     void
     convertScreens()
     {
-      index_type screenCount(src.getScreenCount());
+      index_type screenCount(count(&MR::getScreenCount));
       for (index_type i = 0; i < screenCount; ++i)
         {
           if (transfer(&MR::getScreenID,                    &MS::setScreenID,                    i))
@@ -1201,15 +1310,15 @@ namespace
               transfer(&MR::getScreenReagentSetIdentifier,  &MS::setScreenReagentSetIdentifier,  i);
               transfer(&MR::getScreenType,                  &MS::setScreenType,                  i);
 
-              index_type plateRefCount(src.getPlateRefCount(i));
+              index_type plateRefCount(count(&MR::getPlateRefCount, i));
               for (index_type q = 0; q < plateRefCount; ++q)
                 transfer(&MR::getScreenPlateRef, &MS::setScreenPlateRef, i, q);
 
-              index_type annotationRefCount(src.getScreenAnnotationRefCount(i));
+              index_type annotationRefCount(count(&MR::getScreenAnnotationRefCount, i));
               for (index_type q = 0; q < annotationRefCount; ++q)
                 transfer(&MR::getScreenAnnotationRef, &MS::setScreenAnnotationRef, i, q);
 
-              index_type reagentCount(src.getReagentCount(i));
+              index_type reagentCount(count(&MR::getReagentCount, i));
               for (index_type q = 0; q < reagentCount; ++q)
                 {
                   if (transfer(&MR::getReagentID,                &MS::setReagentID,                i, q))
@@ -1218,7 +1327,7 @@ namespace
                       transfer(&MR::getReagentName,              &MS::setReagentName,              i, q);
                       transfer(&MR::getReagentReagentIdentifier, &MS::setReagentReagentIdentifier, i, q);
 
-                      index_type reagentAnnotationRefCount(src.getReagentAnnotationRefCount(i, q));
+                      index_type reagentAnnotationRefCount(count(&MR::getReagentAnnotationRefCount, i, q));
                       for (index_type r = 0; r < reagentAnnotationRefCount; ++r)
                         transfer(&MR::getReagentAnnotationRef, &MS::setReagentAnnotationRef, i, q, r);
                     }
@@ -1231,7 +1340,7 @@ namespace
     void
     convertTagAnnotations()
     {
-      index_type tagAnnotationCount(src.getTagAnnotationCount());
+      index_type tagAnnotationCount(count(&MR::getTagAnnotationCount));
       for (index_type i = 0; i < tagAnnotationCount; ++i)
         {
           if (transfer(&MR::getTagAnnotationID,          &MS::setTagAnnotationID,          i))
@@ -1241,7 +1350,7 @@ namespace
               transfer(&MR::getTagAnnotationValue,       &MS::setTagAnnotationValue,       i);
               transfer(&MR::getTagAnnotationAnnotator,   &MS::setTagAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getTagAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getTagAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getTagAnnotationAnnotationRef, &MS::setTagAnnotationAnnotationRef, i, a);
             }
@@ -1252,7 +1361,7 @@ namespace
     void
     convertTermAnnotations()
     {
-      index_type termAnnotationCount(src.getTermAnnotationCount());
+      index_type termAnnotationCount(count(&MR::getTermAnnotationCount));
       for (index_type i = 0; i < termAnnotationCount; ++i)
         {
           if (transfer(&MR::getTermAnnotationID,          &MS::setTermAnnotationID,          i))
@@ -1262,7 +1371,7 @@ namespace
               transfer(&MR::getTermAnnotationValue,       &MS::setTermAnnotationValue,       i);
               transfer(&MR::getTermAnnotationAnnotator,   &MS::setTermAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getTermAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getTermAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getTermAnnotationAnnotationRef, &MS::setTermAnnotationAnnotationRef, i, a);
             }
@@ -1273,7 +1382,7 @@ namespace
     void
     convertTimestampAnnotations()
     {
-      index_type timestampAnnotationCount(src.getTimestampAnnotationCount());
+      index_type timestampAnnotationCount(count(&MR::getTimestampAnnotationCount));
       for (index_type i = 0; i < timestampAnnotationCount; ++i)
         {
           if (transfer(&MR::getTimestampAnnotationID,          &MS::setTimestampAnnotationID,          i))
@@ -1283,7 +1392,7 @@ namespace
               transfer(&MR::getTimestampAnnotationValue,       &MS::setTimestampAnnotationValue,       i);
               transfer(&MR::getTimestampAnnotationAnnotator,   &MS::setTimestampAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getTimestampAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getTimestampAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getTimestampAnnotationAnnotationRef, &MS::setTimestampAnnotationAnnotationRef, i, a);
             }
@@ -1294,7 +1403,7 @@ namespace
     void
     convertXMLAnnotations()
     {
-      index_type xmlAnnotationCount(src.getXMLAnnotationCount());
+      index_type xmlAnnotationCount(count(&MR::getXMLAnnotationCount));
       for (index_type i = 0; i < xmlAnnotationCount; ++i)
         {
           if (transfer(&MR::getXMLAnnotationID,          &MS::setXMLAnnotationID,          i))
@@ -1304,7 +1413,7 @@ namespace
               transfer(&MR::getXMLAnnotationValue,       &MS::setXMLAnnotationValue,       i);
               transfer(&MR::getXMLAnnotationAnnotator,   &MS::setXMLAnnotationAnnotator,   i);
 
-              index_type annotationRefCount(src.getXMLAnnotationAnnotationCount(i));
+              index_type annotationRefCount(count(&MR::getXMLAnnotationAnnotationCount, i));
               for (index_type a = 0; a < annotationRefCount; ++a)
                 transfer(&MR::getXMLAnnotationAnnotationRef,&MS::setXMLAnnotationAnnotationRef, i, a);
             }
@@ -1336,8 +1445,8 @@ namespace ome
       convert(const MetadataRetrieve& src,
               MetadataStore&          dest)
       {
-        MetadataConverter convert(src, dest);
-        convert();
+        MetadataConverter converter(src, dest);
+        converter();
       }
 
     }

--- a/cpp/lib/ome/xml/meta/Convert.h
+++ b/cpp/lib/ome/xml/meta/Convert.h
@@ -56,10 +56,32 @@ namespace ome
        *
        * @param src the source object.
        * @param dest the destination object.
+       * type; dest will take ownership of the root object.
        */
       void
       convert(const MetadataRetrieve& src,
               MetadataStore&          dest);
+
+      /**
+       * A utility class containing a method for piping a source
+       * MetadataRetrieve object into a destination MetadataStore.
+       *
+       * This allows conversion between two different storage media.
+       *
+       * @note Only skip if it is acceptable and safe for the
+       * destination object to take ownership of the source metadata
+       * root object.
+       *
+       * @param src the source object.
+       * @param dest the destination object.
+       * @param skip if @c true, skip deep copy if src and dest are of
+       * the same, else if @c false always deep copy.
+       * type; dest will take ownership of the root object.
+       */
+      void
+      convert(MetadataRetrieve& src,
+              MetadataStore&    dest,
+              bool              skip);
 
     }
   }

--- a/cpp/lib/ome/xml/meta/MetadataException.cpp
+++ b/cpp/lib/ome/xml/meta/MetadataException.cpp
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <boost/format.hpp>
+
+#include <ome/xml/meta/MetadataException.h>
+
+namespace
+{
+
+  std::string
+  format_message(const std::string& type,
+                 const std::string& method,
+                 const std::string& msg)
+  {
+    boost::format fmt("%1%::%2%: %3%");
+    fmt % type % method % msg;
+    return fmt.str();
+  }
+
+}
+
+namespace ome
+{
+  namespace xml
+  {
+    namespace meta
+    {
+
+      MetadataException::MetadataException (const std::string& what):
+        std::runtime_error(what)
+      {
+      }
+
+      MetadataException::MetadataException (const std::string& type,
+                                            const std::string& method,
+                                            const std::string& msg):
+        std::runtime_error(format_message(type, method, msg))
+      {
+      }
+
+      MetadataException::~MetadataException () throw()
+      {
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/xml/meta/MetadataException.h
+++ b/cpp/lib/ome/xml/meta/MetadataException.h
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_XML_META_METADATAEXCEPTION_H
+#define OME_XML_META_METADATAEXCEPTION_H
+
+#include <stdexcept>
+
+namespace ome
+{
+  namespace xml
+  {
+    namespace meta
+    {
+
+      /**
+       * Exception thrown for metadata consistency and validity errors.
+       */
+      class MetadataException : public std::runtime_error
+      {
+      public:
+        /**
+         * Constructor.
+         *
+         * @param what the exception message.
+         */
+        explicit
+        MetadataException (const std::string& what);
+
+        /**
+         * Constructor.
+         *
+         * @param type the MetadataStore or Retrieve type.
+         * @param method the MetadataStore or Retrieve method.
+         * @param msg the exception message.
+         */
+        explicit
+        MetadataException (const std::string& type,
+                           const std::string& method,
+                           const std::string& msg);
+
+        /// Destructor.
+        virtual
+        ~MetadataException () throw();
+      };
+
+    }
+  }
+}
+
+#endif // OME_XML_META_METADATAEXCEPTION_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -49,6 +49,7 @@
 #include <ome/test/config.h>
 
 #include <boost/filesystem/operations.hpp>
+#include <boost/range/size.hpp>
 
 #include <ome/test/test.h>
 
@@ -634,7 +635,7 @@ TEST_P(FormatReaderTest, FlatSeries)
     { 0, 1, 20, 80, 21, 81, 100, 101, 123, 72, 128, 159 };
 
   for (unsigned int i = 0;
-       i < sizeof(coords)/sizeof(coords[0]);
+       i < boost::size(coords);
        ++i)
     {
       const dim coord(static_cast<dim>(coords[i]));
@@ -648,7 +649,7 @@ TEST_P(FormatReaderTest, FlatSeries)
     }
 
   for (unsigned int i = 0;
-       i < sizeof(modcoords)/sizeof(modcoords[0]);
+       i < boost::size(modcoords);
        ++i)
     {
       const moddim coord(static_cast<moddim>(modcoords[i]));

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -38,6 +38,8 @@
 
 #include <stdexcept>
 
+#include <boost/range/size.hpp>
+
 #include <ome/bioformats/FormatWriter.h>
 #include <ome/bioformats/MetadataTools.h>
 #include <ome/bioformats/VariantPixelBuffer.h>
@@ -157,10 +159,10 @@ namespace
     };
 
   std::set<ome::xml::model::enums::PixelType> default_pixel_types(init_pt,
-                                                                  init_pt + (sizeof(init_pt) / sizeof(init_pt[0])));
+                                                                  init_pt + boost::size(init_pt));
 
   std::set<ome::xml::model::enums::PixelType> advanced_pixel_types(init_adv_pt,
-                                                                   init_adv_pt + (sizeof(init_adv_pt) / sizeof(init_adv_pt[0])));
+                                                                   init_adv_pt + boost::size(init_adv_pt));
 
   WriterProperties
   test_properties()

--- a/cpp/test/ome-xml/non-negative-float.cpp
+++ b/cpp/test/ome-xml/non-negative-float.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/NonNegativeFloat.h>
 
 #include "constrained-numeric.h"
@@ -213,12 +215,12 @@ namespace
 template<>
 const std::vector<NumericTest<NonNegativeFloat>::test_str>
 NumericTest<NonNegativeFloat>::strings(init_strings,
-                                       init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                       init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<NonNegativeFloat>::test_op>
 NumericTest<NonNegativeFloat>::ops(init_ops,
-                                   init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+                                   init_ops + boost::size(init_ops));
 
 template<>
 const NonNegativeFloat::value_type NumericTest<NonNegativeFloat>::error(0.0005);

--- a/cpp/test/ome-xml/non-negative-integer.cpp
+++ b/cpp/test/ome-xml/non-negative-integer.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/NonNegativeInteger.h>
 
 #include "constrained-numeric.h"
@@ -141,12 +143,12 @@ namespace
 template<>
 const std::vector<NumericTest<NonNegativeInteger>::test_str>
 NumericTest<NonNegativeInteger>::strings(init_strings,
-                                         init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                         init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<NonNegativeInteger>::test_op>
 NumericTest<NonNegativeInteger>::ops(init_ops,
-                                     init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+                                     init_ops + boost::size(init_ops));
 
 template<>
 const NonNegativeInteger::value_type NumericTest<NonNegativeInteger>::error(0);

--- a/cpp/test/ome-xml/non-negative-long.cpp
+++ b/cpp/test/ome-xml/non-negative-long.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/NonNegativeLong.h>
 
 #include "constrained-numeric.h"
@@ -142,12 +144,12 @@ namespace
 template<>
 const std::vector<NumericTest<NonNegativeLong>::test_str>
 NumericTest<NonNegativeLong>::strings(init_strings,
-                                      init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                      init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<NonNegativeLong>::test_op>
 NumericTest<NonNegativeLong>::ops(init_ops,
-                                  init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+                                  init_ops + boost::size(init_ops));
 
 template<>
 const NonNegativeLong::value_type NumericTest<NonNegativeLong>::error(0);

--- a/cpp/test/ome-xml/percent-fraction.cpp
+++ b/cpp/test/ome-xml/percent-fraction.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/PercentFraction.h>
 
 #include "constrained-numeric.h"
@@ -221,12 +223,12 @@ namespace
 template<>
 const std::vector<NumericTest<PercentFraction>::test_str>
 NumericTest<PercentFraction>::strings(init_strings,
-                                      init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                      init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<PercentFraction>::test_op>
 NumericTest<PercentFraction>::ops(init_ops,
-                                  init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+                                  init_ops + boost::size(init_ops));
 
 template<>
 const PercentFraction::value_type NumericTest<PercentFraction>::error(0.0005F);

--- a/cpp/test/ome-xml/positive-float.cpp
+++ b/cpp/test/ome-xml/positive-float.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/PositiveFloat.h>
 
 #include "constrained-numeric.h"
@@ -213,12 +215,12 @@ namespace
 template<>
 const std::vector<NumericTest<PositiveFloat>::test_str>
 NumericTest<PositiveFloat>::strings(init_strings,
-                                    init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                    init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<PositiveFloat>::test_op>
 NumericTest<PositiveFloat>::ops(init_ops,
-                                init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+                                init_ops + boost::size(init_ops));
 
 template<>
 const PositiveFloat::value_type NumericTest<PositiveFloat>::error(0.0005);

--- a/cpp/test/ome-xml/positive-integer.cpp
+++ b/cpp/test/ome-xml/positive-integer.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/PositiveInteger.h>
 
 #include "constrained-numeric.h"
@@ -139,12 +141,12 @@ namespace
 template<>
 const std::vector<NumericTest<PositiveInteger>::test_str>
 NumericTest<PositiveInteger>::strings(init_strings,
-                                      init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                      init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<PositiveInteger>::test_op>
 NumericTest<PositiveInteger>::ops(init_ops,
-                                  init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+                                  init_ops + boost::size(init_ops));
 
 template<>
 const PositiveInteger::value_type NumericTest<PositiveInteger>::error(0);

--- a/cpp/test/ome-xml/positive-long.cpp
+++ b/cpp/test/ome-xml/positive-long.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
 #include <ome/xml/model/primitives/PositiveLong.h>
 
 #include "constrained-numeric.h"
@@ -140,7 +142,7 @@ namespace
 template<>
 const std::vector<NumericTest<PositiveLong>::test_str>
 NumericTest<PositiveLong>::strings(init_strings,
-                                   init_strings + (sizeof(init_strings) / sizeof(init_strings[0])));
+                                   init_strings + boost::size(init_strings));
 
 template<>
 const std::vector<NumericTest<PositiveLong>::test_op>


### PR DESCRIPTION
Initial work to add OME-TIFF read support.  Note that the reader will not be fully functional with this PR, and will certainly need additional work.  Known broken: Some multi-file data.

All the workarounds for broken files should be the same as the Java code but aren't testable without sample data which is broken.  The most notable difference code-wise is that the large 2D array in the reader is moved to a per-series vector in the core metadata, but is functionally the same.

Note to aid testing and validation, I deliberately made it print debug info by default for now.  This will be disabled for the release.

--no-rebase

--------

Testing: You can run `showinf` with an OME-TIFF using the 2013-06 schema.  You can make one using the 5.0.8 bfconvert, e.g. `tools/bfconvert Beta\ Catenin.lif BetaCatenin.ome.tiff`.  To run it, do:

```
./bf ./cpp/bin/showinf/showinf BetaCatenin.ome.tiff 2>&1 | less
```

You should see it scan all the IFDs and print output which matches the Java showinf for the same image.  The IFD numbers must match exactly.  However, it's likely to break on some images and it doesn't include the original metadata for some reason.  Does it pick up Modulo annotations in FLIM data?

Note pixel data viewing isn't testable with showinf, so can't be tested with this PR alone.