### PR TITLE
Gatan 32

### DIFF
--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -526,20 +526,9 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   public String readString(int n) throws IOException {
     int avail = available();
     if (n > avail) n = avail;
-    byte[] bytes = new byte[n];
-    readFully(bytes);
-    StringBuffer newString = new StringBuffer();
-    for (byte b : bytes) {
-        int v = b & 0xff;
-        if (v > 0x7f) {
-          newString.append(Character.toChars(v));
-        }
-        else {
-          newString.append((char) b);
-        }
-      }
-    String s = newString.toString();
-    return new String(s.getBytes(encoding), encoding);
+    byte[] b = new byte[n];
+    readFully(b);
+    return new String(b, encoding);
   }
 
   /** Read eight input bytes and return a long value. */

--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -529,21 +529,21 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
    * @throws IOException Thrown if an error occurred while reading the data.
    */
   public String readByteToString(int n) throws IOException {
-      n = (int) Math.min(available(), n);
-      byte[] bytes = new byte[n];
-      readFully(bytes);
-      StringBuffer newString = new StringBuffer();
-      for (byte b : bytes) {
-          int v = b & 0xff;
-          if (v > 0x7f) {
-              newString.append(Character.toChars(v));
-          }
-          else {
-              newString.append((char) b);
-          }
-      }
-      String s = newString.toString();
-      return new String(s.getBytes(encoding), encoding);
+    n = (int) Math.min(available(), n);
+    byte[] bytes = new byte[n];
+    readFully(bytes);
+    StringBuffer newString = new StringBuffer();
+    for (byte b : bytes) {
+        int v = b & 0xff;
+        if (v > 0x7f) {
+            newString.append(Character.toChars(v));
+        }
+        else {
+            newString.append((char) b);
+        }
+    }
+    String s = newString.toString();
+    return new String(s.getBytes(encoding), encoding);
   }
 
   /** Read a string of up to length n. */

--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -37,8 +37,6 @@ import java.io.DataInput;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -520,6 +518,32 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   public String readCString() throws IOException {
     String line = findString("\0");
     return line.length() == 0 ? null : line;
+  }
+
+  /**
+   * Reads a byte array of the given length byte by byte. Returns a string
+   * using the set encoding.
+   *
+   * @param n The length of the array.
+   * @return See above
+   * @throws IOException Thrown if an error occurred while reading the data.
+   */
+  public String readByteToString(int n) throws IOException {
+      n = (int) Math.min(available(), n);
+      byte[] bytes = new byte[n];
+      readFully(bytes);
+      StringBuffer newString = new StringBuffer();
+      for (byte b : bytes) {
+          int v = b & 0xff;
+          if (v > 0x7f) {
+              newString.append(Character.toChars(v));
+          }
+          else {
+              newString.append((char) b);
+          }
+      }
+      String s = newString.toString();
+      return new String(s.getBytes(encoding), encoding);
   }
 
   /** Read a string of up to length n. */

--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -526,9 +526,20 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
   public String readString(int n) throws IOException {
     int avail = available();
     if (n > avail) n = avail;
-    byte[] b = new byte[n];
-    readFully(b);
-    return new String(b, encoding);
+    byte[] bytes = new byte[n];
+    readFully(bytes);
+    StringBuffer newString = new StringBuffer();
+    for (byte b : bytes) {
+        int v = b & 0xff;
+        if (v > 0x7f) {
+          newString.append(Character.toChars(v));
+        }
+        else {
+          newString.append((char) b);
+        }
+      }
+    String s = newString.toString();
+    return new String(s.getBytes(encoding), encoding);
   }
 
   /** Read eight input bytes and return a long value. */

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -26,14 +26,12 @@
 package loci.formats.in;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.text.Collator;
 import java.util.Vector;
 
 import com.google.common.base.Charsets;
 
 import loci.common.Constants;
-import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -334,7 +334,7 @@ public class GatanReader extends FormatReader {
       String value = null;
 
       if (type == VALUE) {
-        labelString = readString(length);
+        labelString = in.readByteToString(length);
         skipPadding();
         skipPadding();
         int skip = in.readInt(); // equal to '%%%%' / 623191333
@@ -378,7 +378,7 @@ public class GatanReader extends FormatReader {
             }
             else {
               if (dataType == 10) in.skipBytes(length);
-              else value = in.readString(length * 2);
+              else value = in.readByteToString(length * 2);
             }
           }
           else LOGGER.warn("dataType mismatch: {}", dataType);
@@ -457,7 +457,7 @@ public class GatanReader extends FormatReader {
         }
       }
       else if (type == GROUP) {
-        labelString = readString(length);
+        labelString = in.readByteToString(length);
         in.skipBytes(2);
         skipPadding();
         skipPadding();
@@ -577,25 +577,6 @@ public class GatanReader extends FormatReader {
     if (version == 4) {
       in.skipBytes(4);
     }
-  }
-
-  private String readString(int length) throws IOException {
-    byte[] bytes = new byte[(int) Math.min(in.available(), length)];
-    in.readFully(bytes);
-
-    StringBuffer newString = new StringBuffer();
-    
-    for (byte b : bytes) {
-      int v = b & 0xff;
-      if (v > 0x7f) {
-        newString.append(Character.toChars(v));
-      }
-      else {
-        newString.append((char) b);
-      }
-    }
-    String s = newString.toString();
-    return new String(s.getBytes(Charsets.UTF_8), Charsets.UTF_8);
   }
 
   private Double correctForUnits(Double value, String units) {

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -580,11 +580,11 @@ public class GatanReader extends FormatReader {
     Double newValue = value;
     Collator c = Collator.getInstance();
     if (units != null) {
-        if (c.compare("nm", units) == 0) {
-            newValue /= 1000;
-          } else if (c.compare("um", units) != 0 && c.compare("µm", units) != 0) {
-            LOGGER.warn("Not adjusting for unknown units: {}", units);
-          }
+      if (c.compare("nm", units) == 0) {
+        newValue /= 1000;
+      } else if (c.compare("um", units) != 0 && c.compare("µm", units) != 0) {
+        LOGGER.warn("Not adjusting for unknown units: {}", units);
+      }
     }
     return newValue;
   }

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -579,13 +579,13 @@ public class GatanReader extends FormatReader {
   private Double correctForUnits(Double value, String units) {
     Double newValue = value;
     Collator c = Collator.getInstance();
-    if ("nm".equals(units)) {
-      newValue /= 1000;
+    if (units != null) {
+        if (c.compare("nm", units) == 0) {
+            newValue /= 1000;
+          } else if (c.compare("um", units) != 0 && c.compare("µm", units) != 0) {
+            LOGGER.warn("Not adjusting for unknown units: {}", units);
+          }
     }
-    else if (units != null && !"um".equals(units) && c.compare("µm", units) != 0) {
-      LOGGER.warn("Not adjusting for unknown units: {}", units);
-    }
-
     return newValue;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -379,7 +379,7 @@ public class GatanReader extends FormatReader {
             }
             else {
               if (dataType == 10) in.skipBytes(length);
-              else value = DataTools.stripString(in.readString(length * 2));
+              else value = in.readString(length * 2);
             }
           }
           else LOGGER.warn("dataType mismatch: {}", dataType);

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -37,7 +37,6 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
-import ome.xml.model.primitives.PositiveFloat;
 
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Length;

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -26,7 +26,10 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Vector;
+
+import com.google.common.base.Charsets;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -37,7 +40,6 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
-
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
@@ -583,6 +585,7 @@ public class GatanReader extends FormatReader {
     in.readFully(bytes);
 
     StringBuffer newString = new StringBuffer();
+    
     for (byte b : bytes) {
       int v = b & 0xff;
       if (v > 0x7f) {
@@ -592,7 +595,8 @@ public class GatanReader extends FormatReader {
         newString.append((char) b);
       }
     }
-    return newString.toString();
+    String s = newString.toString();
+    return new String(s.getBytes(Charsets.UTF_8), Charsets.UTF_8);
   }
 
   private Double correctForUnits(Double value, String units) {

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.text.Collator;
 import java.util.Vector;
 
 import com.google.common.base.Charsets;
@@ -601,10 +602,11 @@ public class GatanReader extends FormatReader {
 
   private Double correctForUnits(Double value, String units) {
     Double newValue = value;
+    Collator c = Collator.getInstance();
     if ("nm".equals(units)) {
       newValue /= 1000;
     }
-    else if (!"um".equals(units) && !"µm".equals(units) && units != null) {
+    else if (units != null && !"um".equals(units) && c.compare("µm", units) != 0) {
       LOGGER.warn("Not adjusting for unknown units: {}", units);
     }
 

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -28,9 +28,6 @@ package loci.formats.in;
 import java.io.IOException;
 import java.text.Collator;
 import java.util.Vector;
-
-import com.google.common.base.Charsets;
-
 import loci.common.Constants;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;


### PR DESCRIPTION
Problem reported by @bramalingam 
Fix issues with metadata reading 
To test: use ```from_skyking/gatan/chip/Nanogold-1.dm3 ```

Metadata to check using either  ```showinf``` or ImageJ

Emission Current (�A): 0.0 before
Emission Current (µA): 0.0 after
Units: �m before
Units: µm after

Using ```showinf``` make sure you do no have displayed 
Populating metadata
Not adjusting for unknown units: µm
Not adjusting for unknown units: µm

To check that the values are correctly read you can use the ImageJ plugin http://rsb.info.nih.gov/ij/plugins/DM3_Reader.html (Thanks @melissalinkert for tip)
This should already be installed under Plugins>Input-Output

Other readers might be affected but we will need to find good testing files
