### PR TITLE
J2K image reader memory leak fix from jai-imageio-core

### DIFF
--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
@@ -603,6 +603,7 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
     }
 
     //Implemented to fix Memory Leak in JAI Sun Impl
+    @Override
     public void dispose(){
         if(iis != null){
             try {

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/jpeg2000/J2KImageReader.java
@@ -602,6 +602,20 @@ public class J2KImageReader extends ImageReader implements MsgLogger {
         return null;
     }
 
+    //Implemented to fix Memory Leak in JAI Sun Impl
+    public void dispose(){
+        if(iis != null){
+            try {
+                iis.close();
+            } catch (IOException e) {
+                // XXX Ignore
+            }
+        }
+        imageMetadata = null;
+        hd = null;
+        readState = null;
+    }
+
     // --- Begin jj2000.j2k.util.MsgLogger implementation ---
     public void flush() {
         // Do nothing.


### PR DESCRIPTION
see https://github.com/jai-imageio/jai-imageio-core/pull/2

--no-rebase