### PR TITLE
Updating DeltaVision link (rebased onto dev_5_0)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -471,7 +471,7 @@ reader = CellVoyagerReader.java
 
 [DeltaVision]
 extensions = .dv, .r3d
-owner = `Applied Precision <http://www.api.com/>`_
+owner = `GE Healthcare (formerly Applied Precision) <http://www.gelifesciences.com/webapp/wcs/stores/servlet/catalog/en/GELifeSciences-UK/brands/deltavision/>`_
 bsd = no
 export = no
 software = `DeltaVision Opener plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/track/delta.html>`_
@@ -491,9 +491,6 @@ notes = - The Deltavision format is based on the Medical Research Council (MRC) 
   * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
   * `SVI Huygens <http://svi.nl/>`_ \n
   * `Image-Pro Plus <http://www.mediacy.com/>`_ \n
-\n
-.. seealso:: \n
-  `DeltaVision system description <http://api.com/deltavision.asp>`_
 
 [DICOM]
 extensions = .dcm, .dicom

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -475,7 +475,6 @@ owner = `GE Healthcare (formerly Applied Precision) <http://www.gelifesciences.c
 bsd = no
 export = no
 software = `DeltaVision Opener plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/track/delta.html>`_
-samples = `Applied Precision Datasets <http://www.api.com/downloads/software/softworxexplorer2.0/SampleImages.zip>`_
 weHave = * a DV specification document (v2.10 or newer, in HTML) \n
 * numerous DV datasets
 pixelsRating = Outstanding


### PR DESCRIPTION


This is the same as gh-1585 but rebased onto dev_5_0.

----

See https://github.com/openmicroscopy/bioformats/issues/1581

This is the UK redirect with prettier graphics 

I've also removed the extra link as the main one goes to the equivalent page.

                    