### PR TITLE
Call dispose() on each created J2KImageReader

### DIFF
--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -148,7 +148,9 @@ public class JAIIIOServiceImpl extends AbstractService
     if (options.resolution != null) {
       param.setResolution(options.resolution.intValue());
     }
-    return reader.read(0, param);
+    BufferedImage image = reader.read(0, param);
+    reader.dispose();
+    return image;
   }
 
   /* @see JAIIIOService#readImage(InputStream) */
@@ -171,7 +173,9 @@ public class JAIIIOServiceImpl extends AbstractService
     if (options.resolution != null) {
       param.setResolution(options.resolution.intValue());
     }
-    return reader.readRaster(0, param);
+    Raster raster = reader.readRaster(0, param);
+    reader.dispose();
+    return raster;
   }
 
   /* @see JAIIIOService#readRaster(InputStream) */


### PR DESCRIPTION
See gh-1596.  This was less work than I expected; I think I checked all of the places where JAIImageIOServiceImpl is used to make sure this won't cause a problem, but it's especially important to make sure the builds remain green before merging.

No other testing should be necessary.