### PR TITLE
LSM reader

### DIFF
--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -534,13 +534,12 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     readFully(bytes);
     StringBuffer newString = new StringBuffer();
     for (byte b : bytes) {
-        int v = b & 0xff;
-        if (v > 0x7f) {
-            newString.append(Character.toChars(v));
-        }
-        else {
-            newString.append((char) b);
-        }
+      int v = b & 0xff;
+      if (v > 0x7f) {
+          newString.append(Character.toChars(v));
+      } else {
+          newString.append((char) b);
+      }
     }
     String s = newString.toString();
     return new String(s.getBytes(encoding), encoding);

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -2134,7 +2134,7 @@ public class ZeissLSMReader extends FormatReader {
       case TYPE_RATIONAL:
         return new Double(in.readDouble());
       case TYPE_ASCII:
-        String s = in.readString(dataSize).trim();
+        String s = in.readByteToString(dataSize).trim();
         StringBuffer sb = new StringBuffer();
         for (int i=0; i<s.length(); i++) {
           if (s.charAt(i) >= 10) sb.append(s.charAt(i));

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -53,9 +53,6 @@ import loci.formats.tiff.TiffCompression;
 import loci.formats.tiff.TiffConstants;
 import loci.formats.tiff.TiffParser;
 import ome.xml.model.primitives.Color;
-import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.PositiveFloat;
-import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;


### PR DESCRIPTION
Fix reading of string

To test this PR:
 * run ```showinf``` on the ````test_images_good/zeiss-lsm-martin/01-01.lsm```

Without PR:
 *  Track ID Condensor Aperture #1: �

With PR
 * Track ID Condensor Aperture #1: ß

Make sure you do not see any �

--no-rebase

