### PR TITLE
Be safe and create the artifacts folder in store-version

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -1047,6 +1047,7 @@ Type "ant -p" for a list of targets.
   </target>
 
   <target name="store-version" description="store version information in a property file" depends="release-version">
+    <mkdir dir="${artifact.dir}"/>
     <delete file="${artifact.dir}/bioformats.properties"/>
     <propertyfile file="${artifact.dir}/bioformats.properties">
       <entry key="release.shortversion" value="${release.shortversion}"/>


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/3487#issuecomment-74871610

This should allow the `release-src` target to work from a completely clean OMERO/Bio-Formats repositories.

--no-rebase