### PR TITLE
Prevent NPE in FV1000Reader when reading channel wavelengths

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -515,9 +515,11 @@ public class FV1000Reader extends FormatReader {
         channel.name = guiChannel.get("CH Name");
         channel.dyeName = guiChannel.get("DyeName");
         channel.emissionFilter = guiChannel.get("EmissionDM Name");
-        channel.emWave = new Double(guiChannel.get("EmissionWavelength"));
+        String emWave = guiChannel.get("EmissionWavelength");
+        if (emWave != null) channel.emWave = new Double(emWave);
         channel.excitationFilter = guiChannel.get("ExcitationDM Name");
-        channel.exWave = new Double(guiChannel.get("ExcitationWavelength"));
+        String exWave = guiChannel.get("ExcitationWavelength");
+        if (emWave != null) channel.exWave = new Double(exWave);
         channels.add(channel);
         index++;
         guiChannel = f.getTable("GUI Channel " + index + " Parameters");


### PR DESCRIPTION
Fixes NullPointerException from the files uploaded in https://www.openmicroscopy.org/qa2/qa/feedback/10517/.

Note the uploaded samples does not contain the supporting TIFF files so BIo-Formats will fail while trying to access the `.oif.file` folder but the reader should not fail while reading the metadata.