### PR TITLE
cpp: compat: Don't import types into std namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - BUILD=maven
   - BUILD=cpp
   - BUILD=cppwrap
+  - BUILD=flake8
   - BUILD=sphinx
   - BUILD=ant
 
@@ -24,13 +25,13 @@ before_install:
   - if [[ $BUILD != 'sphinx' ]]; then sudo apt-get install -qq python-genshi; fi
   - if [[ $BUILD == 'cpp' ]] || [[ $BUILD == 'cppwrap' ]]; then sudo apt-get install -qq build-essential cmake libboost1.48-all-dev; fi
   - if [[ $BUILD == 'cpp' ]]; then sudo apt-get install -qq libgtest-dev libxerces-c-dev libtiff4-dev doxygen graphviz graphicsmagick; fi
-  - if [[ $BUILD == 'sphinx' ]]; then sudo pip install flake8 pep8==1.6.2 Sphinx; fi
+  - if [[ $BUILD == 'sphinx' ]] || [[ $BUILD == 'flake8' ]]; then sudo pip install flake8 pep8==1.6.2 Sphinx; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo fc-cache -rsfv; fi
 
 install:
-  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx' ]]; then git fetch --tags; fi
+  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx' ]] && [[ $BUILD != 'flake8' ]]; then git fetch --tags; fi
   - if [[ $BUILD == 'maven' ]]; then mvn install -DskipTests=true; fi
 
 script:
@@ -38,6 +39,10 @@ script:
 
 matrix:
   exclude:
+    - jdk: oraclejdk8
+      env: BUILD=flake8
+    - jdk: oraclejdk7
+      env: BUILD=flake8
     - jdk: oraclejdk8
       env: BUILD=sphinx
     - jdk: oraclejdk7

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -439,11 +439,11 @@ class OMEModelProperty(OMEModelEntity):
                 itype = self.langTypeNS
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = "std::shared_ptr<%s>&" % ns_sep
+                    itype = "ome::compat::shared_ptr<%s>&" % ns_sep
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.isReference or self.isBackReference:
-                itype = "std::weak_ptr<%s>&" % ns_sep
+                itype = "ome::compat::weak_ptr<%s>&" % ns_sep
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -451,11 +451,11 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = "std::shared_ptr<%s>&" % ns_sep
+                    itype = "ome::compat::shared_ptr<%s>&" % ns_sep
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::vector<std::shared_ptr<%s> >&" % ns_sep
+                itype = "std::vector<ome::compat::shared_ptr<%s> >&" % ns_sep
 
         return itype
     argType = property(_get_argType, doc="""The property's argument type.""")
@@ -481,14 +481,14 @@ class OMEModelProperty(OMEModelEntity):
                 itype = {' const': self.langTypeNS}
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = {' const': "const std::shared_ptr<%s>" % ns_sep,
-                             '':       "std::shared_ptr<%s>" % ns_sep}
+                    itype = {' const': "const ome::compat::shared_ptr<%s>" % ns_sep,
+                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "const std::weak_ptr<%s>" % ns_sep,
-                         '':       "std::weak_ptr<%s>" % ns_sep}
+                itype = {' const': "const ome::compat::weak_ptr<%s>" % ns_sep,
+                         '':       "ome::compat::weak_ptr<%s>" % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -496,14 +496,14 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = {' const': "const std::shared_ptr<%s>" % ns_sep,
-                             '':       "std::shared_ptr<%s>" % ns_sep}
+                    itype = {' const': "const ome::compat::shared_ptr<%s>" % ns_sep,
+                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = {' const': "const std::vector<std::shared_ptr<%s> >"
+                itype = {' const': "const std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep,
-                         '':      "std::vector<std::shared_ptr<%s> >"
+                         '':      "std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -531,7 +531,7 @@ class OMEModelProperty(OMEModelEntity):
                     not self.isChoice):
                 itype = self.argType()
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::shared_ptr<%s>&" % ns_sep
+                itype = "ome::compat::shared_ptr<%s>&" % ns_sep
 
         return itype
     elementArgType = property(
@@ -568,8 +568,8 @@ class OMEModelProperty(OMEModelEntity):
                 itype = self.argType()
             elif (self.maxOccurs > 1 and
                   not self.parent.isAbstractProprietary):
-                itype = {' const': "const std::shared_ptr<%s>&" % ns_sep,
-                         '':      "std::shared_ptr<%s>&" % ns_sep}
+                itype = {' const': "const ome::compat::shared_ptr<%s>&" % ns_sep,
+                         '':      "ome::compat::shared_ptr<%s>&" % ns_sep}
 
         return itype
     elementRetType = property(
@@ -600,14 +600,14 @@ class OMEModelProperty(OMEModelEntity):
                 itype = {' const': self.langTypeNS}
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = {' const': "std::shared_ptr<const %s>" % ns_sep,
-                             '':       "std::shared_ptr<%s>" % ns_sep}
+                    itype = {' const': "ome::compat::shared_ptr<const %s>" % ns_sep,
+                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "std::shared_ptr<const %s>" % ns_sep,
-                         '':       "std::shared_ptr<%s>" % ns_sep}
+                itype = {' const': "ome::compat::shared_ptr<const %s>" % ns_sep,
+                         '':       "ome::compat::shared_ptr<%s>" % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -615,16 +615,16 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = {' const': "std::shared_ptr<const %s>" % ns_sep,
-                             '':       "std::shared_ptr<%s>" % ns_sep}
+                    itype = {' const': "ome::compat::shared_ptr<const %s>" % ns_sep,
+                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif (self.maxOccurs > 1 and
                     not self.parent.isAbstractProprietary):
-                itype = {' const': "const std::vector<std::shared_ptr<%s> >"
+                itype = {' const': "const std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep,
-                         '':      "std::vector<std::shared_ptr<%s> >"
+                         '':      "std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -694,14 +694,14 @@ class OMEModelProperty(OMEModelEntity):
                     self.unitsCompanion.instanceVariableType)
             elif self.isReference and self.maxOccurs > 1:
                 itype = ("OMEModelObject::indexed_container"
-                         "<%s, std::weak_ptr>::type") % ns_sep
+                         "<%s, ome::compat::weak_ptr>::type") % ns_sep
             elif self.isReference:
-                itype = "std::weak_ptr<%s>" % ns_sep
+                itype = "ome::compat::weak_ptr<%s>" % ns_sep
             elif self.isBackReference and self.maxOccurs > 1:
                 itype = ("OMEModelObject::indexed_container"
-                         "<%s, std::weak_ptr>::type") % ns_sep
+                         "<%s, ome::compat::weak_ptr>::type") % ns_sep
             elif self.isBackReference:
-                itype = "std::weak_ptr<%s>" % ns_sep
+                itype = "ome::compat::weak_ptr<%s>" % ns_sep
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -709,11 +709,11 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = "std::shared_ptr<%s>" % ns_sep
+                    itype = "ome::compat::shared_ptr<%s>" % ns_sep
                 else:
                     itype = self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::vector<std::shared_ptr<%s> >" % ns_sep
+                itype = "std::vector<ome::compat::shared_ptr<%s> >" % ns_sep
 
         return itype
     instanceVariableType = property(
@@ -749,7 +749,7 @@ class OMEModelProperty(OMEModelEntity):
                 if self.isEnumeration:
                     if self.minOccurs == 0:
                         idefault = (
-                            "std::shared_ptr<%s>(new %s(%s::%s))"
+                            "ome::compat::shared_ptr<%s>(new %s(%s::%s))"
                             % (ns_sep, self.langTypeNS, self.langTypeNS,
                                self.defaultValue.upper()))
                     else:

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -481,8 +481,10 @@ class OMEModelProperty(OMEModelEntity):
                 itype = {' const': self.langTypeNS}
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = {' const': "const ome::compat::shared_ptr<%s>" % ns_sep,
-                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
+                    itype = {' const': "const ome::compat::shared_ptr<%s>"
+                             % ns_sep,
+                             '':       "ome::compat::shared_ptr<%s>"
+                             % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
@@ -496,14 +498,20 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = {' const': "const ome::compat::shared_ptr<%s>" % ns_sep,
-                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
+                    itype = {' const':
+                             "const ome::compat::shared_ptr<%s>"
+                             % ns_sep,
+                             '':
+                             "ome::compat::shared_ptr<%s>"
+                             % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = {' const': "const std::vector<ome::compat::shared_ptr<%s> >"
+                itype = {' const':
+                         "const std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep,
-                         '':      "std::vector<ome::compat::shared_ptr<%s> >"
+                         '':
+                         "std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -568,8 +576,10 @@ class OMEModelProperty(OMEModelEntity):
                 itype = self.argType()
             elif (self.maxOccurs > 1 and
                   not self.parent.isAbstractProprietary):
-                itype = {' const': "const ome::compat::shared_ptr<%s>&" % ns_sep,
-                         '':      "ome::compat::shared_ptr<%s>&" % ns_sep}
+                itype = {' const': "const ome::compat::shared_ptr<%s>&"
+                         % ns_sep,
+                         '':       "ome::compat::shared_ptr<%s>&"
+                         % ns_sep}
 
         return itype
     elementRetType = property(
@@ -600,14 +610,20 @@ class OMEModelProperty(OMEModelEntity):
                 itype = {' const': self.langTypeNS}
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = {' const': "ome::compat::shared_ptr<const %s>" % ns_sep,
-                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
+                    itype = {' const':
+                             "ome::compat::shared_ptr<const %s>" %
+                             ns_sep,
+                             '':
+                             "ome::compat::shared_ptr<%s>" %
+                             ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "ome::compat::shared_ptr<const %s>" % ns_sep,
-                         '':       "ome::compat::shared_ptr<%s>" % ns_sep}
+                itype = {' const': "ome::compat::shared_ptr<const %s>"
+                         % ns_sep,
+                         '':       "ome::compat::shared_ptr<%s>"
+                         % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -615,16 +631,20 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = {' const': "ome::compat::shared_ptr<const %s>" % ns_sep,
-                             '':       "ome::compat::shared_ptr<%s>" % ns_sep}
+                    itype = {' const': "ome::compat::shared_ptr<const %s>"
+                             % ns_sep,
+                             '': "ome::compat::shared_ptr<%s>"
+                             % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif (self.maxOccurs > 1 and
                     not self.parent.isAbstractProprietary):
-                itype = {' const': "const std::vector<ome::compat::shared_ptr<%s> >"
+                itype = {' const':
+                         "const std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep,
-                         '':      "std::vector<ome::compat::shared_ptr<%s> >"
+                         '':
+                         "std::vector<ome::compat::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype

--- a/components/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/components/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -25,7 +25,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             /// TODO: No handling of -1 as for Java.  Callee must throw.
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
@@ -52,7 +52,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -75,7 +75,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_name_string(indexes)});
           }
@@ -98,7 +98,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}();
           }
@@ -126,7 +126,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -149,7 +149,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)});
           }
@@ -172,7 +172,7 @@
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName});
           }
@@ -302,7 +302,7 @@ namespace ome
       {
       public:
         /// A list of MetadataStore and MetadataRetrieve instances.
-        typedef std::vector<std::shared_ptr<BaseMetadata> > delegate_list_type;
+        typedef std::vector<ome::compat::shared_ptr<BaseMetadata> > delegate_list_type;
 
       private:
         /** The active metadata store delegates. */
@@ -348,7 +348,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->createRoot();
           }
@@ -362,11 +362,11 @@ namespace ome
          * exception if called.
          * @throws MetadataException always.
          */
-        std::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataRoot>&
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>&
       AggregateMetadata::getRoot()
       {
         throw MetadataException("AggregateMetadata", "getRoot",
@@ -382,11 +382,11 @@ namespace ome
          * @throws MetadataException always.
          */
         void
-        setRoot(std::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      AggregateMetadata::setRoot(std::shared_ptr<MetadataRoot>& /* root */)
+      AggregateMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& /* root */)
       {
         throw MetadataException("AggregateMetadata", "setRoot",
                                 "unsupported");
@@ -410,7 +410,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getPixelsBinDataCount(imageIndex);
           }
@@ -432,7 +432,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getBooleanAnnotationAnnotationCount(booleanAnnotationIndex);
           }
@@ -454,7 +454,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getCommentAnnotationAnnotationCount(commentAnnotationIndex);
           }
@@ -476,7 +476,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getDoubleAnnotationAnnotationCount(doubleAnnotationIndex);
           }
@@ -498,7 +498,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getFileAnnotationAnnotationCount(fileAnnotationIndex);
           }
@@ -520,7 +520,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getListAnnotationAnnotationCount(listAnnotationIndex);
           }
@@ -542,7 +542,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getLongAnnotationAnnotationCount(longAnnotationIndex);
           }
@@ -564,7 +564,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTagAnnotationAnnotationCount(tagAnnotationIndex);
           }
@@ -586,7 +586,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTermAnnotationAnnotationCount(termAnnotationIndex);
           }
@@ -608,7 +608,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTimestampAnnotationAnnotationCount(timestampAnnotationIndex);
           }
@@ -630,7 +630,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getXMLAnnotationAnnotationCount(xmlAnnotationIndex);
           }
@@ -654,7 +654,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getLightSourceType(instrumentIndex,
                                                   lightSourceIndex);
@@ -679,7 +679,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getShapeType(roiIndex, shapeIndex);
           }
@@ -712,7 +712,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -733,7 +733,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -776,7 +776,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getPixelsBinDataBigEndian(imageIndex, binDataIndex);
           }
@@ -802,7 +802,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getUUID();
           }
@@ -908,7 +908,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setPixelsBinDataBigEndian(bigEndian, imageIndex, binDataIndex);
           }
@@ -934,7 +934,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setUUID(uuid);
           }

--- a/components/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/components/xsd-fu/templates-cpp/DummyMetadata.template
@@ -266,11 +266,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        std::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataRoot>&
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>&
       DummyMetadata::getRoot()
       {
         throw MetadataException("DummyMetadata", "getRoot",
@@ -281,11 +281,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setRoot(std::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      DummyMetadata::setRoot(std::shared_ptr<MetadataRoot>& /* root */)
+      DummyMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& /* root */)
       {
       }
 {% end source %}\

--- a/components/xsd-fu/templates-cpp/FilterMetadata.template
+++ b/components/xsd-fu/templates-cpp/FilterMetadata.template
@@ -187,7 +187,7 @@ namespace ome
       {
       private:
         /// The wrapped metadata store.
-	std::shared_ptr<MetadataStore> store;
+	ome::compat::shared_ptr<MetadataStore> store;
         /// Is filtering enabled?
 	bool filter;
 
@@ -199,11 +199,11 @@ namespace ome
          * @param filter @c true to enable filtering, @c false to
          * disable.
          */
-        FilterMetadata(std::shared_ptr<MetadataStore>& store,
+        FilterMetadata(ome::compat::shared_ptr<MetadataStore>& store,
                        bool filter);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      FilterMetadata::FilterMetadata(std::shared_ptr<MetadataStore>& store,
+      FilterMetadata::FilterMetadata(ome::compat::shared_ptr<MetadataStore>& store,
                                      bool filter):
         store(store),
         filter(filter)
@@ -237,11 +237,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        std::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataRoot>&
 	getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>&
       FilterMetadata::getRoot()
       {
         return store->getRoot();
@@ -251,11 +251,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
 	void
-        setRoot(std::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      FilterMetadata::setRoot(std::shared_ptr<MetadataRoot>& root)
+      FilterMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& root)
       {
         store->setRoot(root);
       }

--- a/components/xsd-fu/templates-cpp/MetadataStore.template
+++ b/components/xsd-fu/templates-cpp/MetadataStore.template
@@ -220,7 +220,7 @@ namespace ome
          *
          * @todo should this be a reference or shared_ptr?
          */
-        virtual std::shared_ptr<MetadataRoot>&
+        virtual ome::compat::shared_ptr<MetadataRoot>&
         getRoot() = 0;
 
         /**
@@ -234,7 +234,7 @@ namespace ome
          * @todo should this be a reference or shared_ptr?
          */
         virtual void
-        setRoot(std::shared_ptr<MetadataRoot>& root) = 0;
+        setRoot(ome::compat::shared_ptr<MetadataRoot>& root) = 0;
 
 {% if debug %}\
         // -- Entity storage (manual definitions) --

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -81,7 +81,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
         // DUMMYLINE
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -90,7 +90,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract proprietary
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -99,7 +99,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract proprietary and not a reference
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -123,7 +123,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -132,7 +132,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
+        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -198,10 +198,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${prop.name} is abstract proprietary and is a reference
-        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
+        ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
-        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
         // ${parent} is abstract proprietary
@@ -212,42 +212,42 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when v['level'] == 2 %}\
 {% if i == 0 %}\
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${obj.langTypeNS}>());
+            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${obj.langTypeNS}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
-        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        ome::compat::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -256,7 +256,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(ome::compat::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -264,10 +264,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
+        ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
-        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
 {% end %}\
@@ -277,32 +277,32 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
-        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        ome::compat::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -311,7 +311,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(ome::compat::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -467,8 +467,8 @@ namespace
 
   // Throw an exception if a pointer is invalid.
   template<typename T>
-  std::shared_ptr<T>
-  safe_fetch(std::shared_ptr<T> ptr,
+  ome::compat::shared_ptr<T>
+  safe_fetch(ome::compat::shared_ptr<T> ptr,
              const char * const method)
   {
     if (!ptr)
@@ -479,11 +479,11 @@ namespace
 
   // Throw an exception if a pointer is invalid.
   template<typename T>
-  std::shared_ptr<T>
-  safe_fetch(std::weak_ptr<T>   ptr,
+  ome::compat::shared_ptr<T>
+  safe_fetch(ome::compat::weak_ptr<T>   ptr,
              const char * const method)
   {
-    std::shared_ptr<T> shared(ptr.lock());
+    ome::compat::shared_ptr<T> shared(ptr.lock());
     if (!shared)
       throw ome::xml::meta::MetadataException("OMEXMLMetadata", method,
                                               "Internal metadata store inconsistency: null weak reference");
@@ -520,11 +520,11 @@ namespace ome
       {
       private:
         /// OME-XML root node.
-        std::shared_ptr<OMEXMLMetadataRoot> root; // OME
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> root; // OME
         /// Generic root node.
-        std::shared_ptr<MetadataRoot> genericRoot; // OME
+        ome::compat::shared_ptr<MetadataRoot> genericRoot; // OME
         /// OME-XML model.
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModel> model;
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModel> model;
 
       public:
 {% end header %}\
@@ -561,18 +561,18 @@ namespace ome
       void
       OMEXMLMetadata::createRoot()
       {
-        std::shared_ptr<MetadataRoot> newroot(std::make_shared<OMEXMLMetadataRoot>());
+        ome::compat::shared_ptr<MetadataRoot> newroot(ome::compat::make_shared<OMEXMLMetadataRoot>());
         setRoot(newroot);
       }
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        std::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataRoot>&
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>&
       OMEXMLMetadata::getRoot()
       {
         return this->genericRoot;
@@ -588,22 +588,22 @@ namespace ome
          * @copydoc ::${lang.metadata_package}::MetadataStore::setRoot()
          */
         void
-        setRoot(std::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      OMEXMLMetadata::setRoot(std::shared_ptr<MetadataRoot>& root)
+      OMEXMLMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& root)
       {
-        std::shared_ptr<OMEXMLMetadataRoot> newroot =
-          std::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> newroot =
+          ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
 
         if (!newroot)
           throw MetadataException("OMEXMLMetadata", "setRoot",
                                   "root must be of type OMEXMLMetadataRoot");
 
         this->root = newroot;
-        this->genericRoot = std::static_pointer_cast<MetadataRoot>(this->root);
-        model = std::make_shared< ::${lang.omexml_model_package}::detail::OMEModel>();
+        this->genericRoot = ome::compat::static_pointer_cast<MetadataRoot>(this->root);
+        model = ome::compat::make_shared< ::${lang.omexml_model_package}::detail::OMEModel>();
       }
 {% end source %}\
 
@@ -837,7 +837,7 @@ namespace ome
                                          index_type lightSourceIndex) const
       {
         const char * const instrument_method("getLightSourceType [getInstrument]");
-        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex), instrument_method)->getLightSource(lightSourceIndex);
+        ome::compat::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex), instrument_method)->getLightSource(lightSourceIndex);
         return o->getLightSourceType();
       }
 {% end source %}\
@@ -884,28 +884,28 @@ namespace ome
       {
         if (root->sizeOfImageList() == imageIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
+            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         if (o2->sizeOfTiffDataList() == tiffDataIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared< ::${lang.omexml_model_package}::TiffData>());
+            ome::compat::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(ome::compat::make_shared< ::${lang.omexml_model_package}::TiffData>());
             o2->addTiffData(newTiffData);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
         if (!o3->getUUID()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(std::make_shared< ::${lang.omexml_model_package}::UUID>());
+            ome::compat::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(ome::compat::make_shared< ::${lang.omexml_model_package}::UUID>());
             o3->setUUID(newUUID);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
         o4->setValue(value);
       }
 {% end source %}\
@@ -957,7 +957,7 @@ ${counter(k, o, v)}\
         const char * const pixels_method("getPixelsBinDataBigEndian [getPixels]");
         const char * const bindata_method("getPixelsBinDataBigEndian [getBinData]");
 
-        std::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getBigEndian();
+        ome::compat::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getBigEndian();
 
         if (bigEndian) { // not null
           return *bigEndian;
@@ -981,7 +981,7 @@ ${counter(k, o, v)}\
       const std::string&
       OMEXMLMetadata::getUUID() const
       {
-        std::shared_ptr<const std::string> uuid = root->getUUID();
+        ome::compat::shared_ptr<const std::string> uuid = root->getUUID();
         if (uuid)
           return *root->getUUID();
         else
@@ -1092,17 +1092,17 @@ ${getter(k, o, prop, v)}\
         // Type is not a reference
         if (root->sizeOfImageList() == imageIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
+            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
-        std::shared_ptr<bool> newBool(std::make_shared<bool>(bigEndian));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        ome::compat::shared_ptr<bool> newBool(ome::compat::make_shared<bool>(bigEndian));
         o2->setBigEndian(newBool);
       }
 {% end source %}\
@@ -1120,7 +1120,7 @@ ${getter(k, o, prop, v)}\
       void
       OMEXMLMetadata::setUUID(const std::string& uuid)
       {
-        std::shared_ptr<std::string> newString(std::make_shared<std::string>(uuid));
+        ome::compat::shared_ptr<std::string> newString(ome::compat::make_shared<std::string>(uuid));
         root->setUUID(newString);
       }
 {% end source %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -282,16 +282,16 @@ namespace ome
          *
          * @returns a new model object.
          */
-        static std::shared_ptr< ${klass.name}>
+        static ome::compat::shared_ptr< ${klass.name}>
         create(const xerces::dom::Element& element,
                ${lang.omexml_model_package}::OMEModel& model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr< ${klass.name}>
+      ome::compat::shared_ptr< ${klass.name}>
       ${klass.name}::create(const xerces::dom::Element& element,
                               ${lang.omexml_model_package}::OMEModel& model)
       {
-        std::shared_ptr< ${klass.name}> newinstance(std::make_shared< ${klass.name}>());
+        ome::compat::shared_ptr< ${klass.name}> newinstance(ome::compat::make_shared< ${klass.name}>());
         newinstance->update(element, model);
         return newinstance;
       }
@@ -397,10 +397,10 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            std::shared_ptr<${prop.name}> rcptr(std::make_shared< ${prop.name}>());
+            ome::compat::shared_ptr<${prop.name}> rcptr(ome::compat::make_shared< ${prop.name}>());
             rcptr->setID(elem->getAttribute("ID"));
-            std::shared_ptr<Reference> rptr(std::static_pointer_cast<Reference>(rcptr));
-            std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+            ome::compat::shared_ptr<Reference> rptr(ome::compat::static_pointer_cast<Reference>(rcptr));
+            ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(ome::compat::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
             model.addReference(optr, rptr);
           }
 {% end %}\
@@ -426,7 +426,7 @@ ${customUpdatePropertyContent[prop.name]}
              set${prop.methodName}(element.getAttribute("${prop.name}"));
 {% end %}\
              // Adding this model object to the model handler
-             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+             ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(ome::compat::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
              model.addModelObject(getID(), thisptr);
            }
 {% end %}\
@@ -437,7 +437,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Attribute property which is an enumeration ${prop.name}
 {% if prop.minOccurs == 0 %}\
             std::string text(element.getAttribute("${prop.name}"));
-            ${prop.instanceVariableType} nattr(std::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} nattr(ome::compat::make_shared< ${prop.langTypeNS}>(text));
             set${prop.methodName}(nattr);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -473,7 +473,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Element property ${prop.name} which is complex (has sub-elements)
 {% if prop.minOccurs == 0 or (not lang.hasPrimitiveType(prop.langType) and not prop.isEnumeration) %}\
             xerces::dom::Element elem(${prop.name}_nodeList.at(0));
-            // While std::make_shared<> works, here,
+            // While ome::compat::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
             ${prop.instanceVariableType} p(${prop.langTypeNS}::create(elem, model));
 {% end %}\
@@ -487,7 +487,7 @@ ${customUpdatePropertyContent[prop.name]}
             // sub-elements)
             std::string text(${prop.name}_nodeList.at(0).getTextContent());
 {% if prop.minOccurs == 0 %}\
-            ${prop.instanceVariableType} ns(std::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} ns(ome::compat::make_shared< ${prop.langTypeNS}>(text));
             set${prop.methodName}(ns);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -521,10 +521,10 @@ ${customUpdatePropertyContent[prop.name]}
                  inner_elem != ${inner_prop.name}_nodeList.end();
                  ++inner_elem)
                    {
-                     // While std::make_shared<> works, here,
+                     // While ome::compat::make_shared<> works, here,
                      // boost::make_shared<> does not, so use new
                      // directly.
-                     std::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
+                     ome::compat::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
                      object->update(*inner_elem, model);
                      add${prop.methodName}(object);
                    }
@@ -540,9 +540,9 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            // While std::make_shared<> works, here,
+            // While ome::compat::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
-            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
+            ome::compat::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -556,7 +556,7 @@ ${customUpdatePropertyContent[prop.name]}
              ++elem)
           {
             std::string text(element.getTextContent());
-            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
+            ome::compat::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -576,13 +576,13 @@ ${customUpdatePropertyContent[prop.name]}
 
         /// @copydoc ${lang.omexml_model_package}::OMEModelObject::link
         bool
-        link (std::shared_ptr<Reference>& reference,
-              std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
+        link (ome::compat::shared_ptr<Reference>& reference,
+              ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::link (std::shared_ptr<Reference>& reference,
-                           std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
+      ${klass.name}::link (ome::compat::shared_ptr<Reference>& reference,
+                           ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
       {
         if (${klass.parentName}::link(reference, object))
           {
@@ -590,18 +590,18 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
-        if (std::dynamic_pointer_cast<${prop.name}>(reference))
+        if (ome::compat::dynamic_pointer_cast<${prop.name}>(reference))
           {
             /// @todo This bit is silly; why do we have two dynamic_casts here.
-            std::shared_ptr<${prop.langTypeNS}> o_casted = std::dynamic_pointer_cast<${prop.langTypeNS}>(object);
+            ome::compat::shared_ptr<${prop.langTypeNS}> o_casted = ome::compat::dynamic_pointer_cast<${prop.langTypeNS}>(object);
             if (o_casted)
               {
 {% if not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-                o_casted->link${klass.type}(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+                o_casted->link${klass.type}(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-                o_casted->link${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+                o_casted->link${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
 {% end %}\
 {% end %}\
 {% if prop.maxOccurs > 1 %}\
@@ -612,7 +612,7 @@ ${customUpdatePropertyContent[prop.name]}
                   }
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
-                typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
+                typedef OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::nth_index<1>::type container_set_type;
                 container_set_type::iterator it(${prop.instanceVariableName}.get<1>().find(o_casted));
                 if (it != this->${prop.instanceVariableName}.get<1>().end())
                   {
@@ -715,11 +715,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a weak pointer to the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        const std::weak_ptr<${prop.langTypeNS}>&
+        const ome::compat::weak_ptr<${prop.langTypeNS}>&
         getLinked${prop.methodName} (${prop.instanceVariableType}::size_type index) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const std::weak_ptr<${prop.langTypeNS}>&
+      const ome::compat::weak_ptr<${prop.langTypeNS}>&
       ${klass.name}::getLinked${prop.methodName} (${prop.instanceVariableType}::size_type index) const
       {
         return ${prop.instanceVariableName}.at(index);
@@ -737,21 +737,21 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a weak pointer to the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        const std::weak_ptr<${prop.langTypeNS}>&
+        const ome::compat::weak_ptr<${prop.langTypeNS}>&
         setLinked${prop.methodName} (${prop.instanceVariableType}::size_type index,
-                                     const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+                                     const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const std::weak_ptr<${prop.langTypeNS}>&
+      const ome::compat::weak_ptr<${prop.langTypeNS}>&
       ${klass.name}::setLinked${prop.methodName}(${prop.instanceVariableType}::size_type index,
-                                                 const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+                                                 const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isReference and not prop.isBackReference %}\
         return this->${prop.instanceVariableName}.at(index) = ${prop.argumentName};
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
         ${prop.instanceVariableType}::iterator it(${prop.instanceVariableName}.iterator_to(${prop.instanceVariableName}.at(index)));
-        const std::weak_ptr<${prop.langTypeNS}> wp(${prop.argumentName});
+        const ome::compat::weak_ptr<${prop.langTypeNS}> wp(${prop.argumentName});
         ${prop.instanceVariableName}.replace(it, wp);
         return *it;
 {% end %}\
@@ -770,18 +770,18 @@ ${customUpdatePropertyContent[prop.name]}
          * Is this an artifact of the Java API?
          */
         bool
-        link${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        link${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::link${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::link${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->link${klass.type}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->link${klass.type}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->link${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->link${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% end %}\
 {% if not prop.isReference and not prop.isBackReference %}\
@@ -792,11 +792,11 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
-        typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
+        typedef OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::nth_index<1>::type container_set_type;
         container_set_type::iterator it(${prop.instanceVariableName}.get<1>().find(${prop.argumentName}));
         if (it == this->${prop.instanceVariableName}.get<1>().end())
           {
-            std::pair<OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::iterator, bool> res(this->${prop.instanceVariableName}.push_back(std::weak_ptr<${prop.langTypeNS}>(${prop.argumentName})));
+            std::pair<OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::iterator, bool> res(this->${prop.instanceVariableName}.push_back(ome::compat::weak_ptr<${prop.langTypeNS}>(${prop.argumentName})));
             return res.second;
           }
 {% end %}\
@@ -821,18 +821,18 @@ ${customUpdatePropertyContent[prop.name]}
          * aren't preventing duplicates on insertion.
          */
         bool
-        unlink${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        unlink${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::unlink${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::unlink${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->unlink${klass.type}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->unlink${klass.type}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->unlink${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->unlink${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% end %}\
         bool found = false;
@@ -878,11 +878,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @param ${prop.argumentName} the ${prop.methodName} to link.
          */
         void
-        link${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        link${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::link${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::link${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
         this->${prop.instanceVariableName} = ${prop.argumentName};
       }
@@ -899,15 +899,15 @@ ${customUpdatePropertyContent[prop.name]}
          * internally.
          */
         void
-        unlink${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        unlink${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::unlink${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::unlink${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
-        if (std::shared_ptr<${prop.langTypeNS}>(this->${prop.instanceVariableName}) == ${prop.argumentName})
+        if (ome::compat::shared_ptr<${prop.langTypeNS}>(this->${prop.instanceVariableName}) == ${prop.argumentName})
           {
-            this->${prop.instanceVariableName} = std::shared_ptr<${prop.langTypeNS}>();
+            this->${prop.instanceVariableName} = ome::compat::shared_ptr<${prop.langTypeNS}>();
           }
       }
 {% end source %}\
@@ -1029,7 +1029,7 @@ ${customUpdatePropertyContent[prop.name]}
                                             ${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
-        std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+        ome::compat::weak_ptr<${klass.type}> self(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
         ${prop.argumentName}->set${klass.type}(self);
 {% end %}\
 {% if not prop.isReference and not prop.isBackReference %}\
@@ -1059,7 +1059,7 @@ ${customUpdatePropertyContent[prop.name]}
       ${klass.name}::add${prop.methodName} (${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
-        std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+        ome::compat::weak_ptr<${klass.type}> self(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
         ${prop.argumentName}->set${klass.type}(self);
 {% end %}\
         ${prop.instanceVariableName}.push_back(${prop.argumentName});
@@ -1255,8 +1255,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 // shared_ptr, but keep compatible with the rest of
                 // the API to allow consistency for future
                 // refactoring.
-                std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
-                std::shared_ptr<${prop.langTypeNS}> is(i->lock());
+                ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
+                ome::compat::shared_ptr<${prop.langTypeNS}> is(i->lock());
                 if (is)
                   {
                     o->setID(is->getID());
@@ -1272,8 +1272,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
             // Note that this doesn't strictly need to be a
             // shared_ptr, but keep compatible with the rest of the
             // API to allow consistency for future refactoring.
-            std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
-            std::shared_ptr<${prop.langTypeNS}> sv(${prop.instanceVariableName}.lock());
+            ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
+            ome::compat::shared_ptr<${prop.langTypeNS}> sv(${prop.instanceVariableName}.lock());
             if (sv)
               {
                 o->setID(sv->getID());

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_MapAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_MapAnnotation_update_Value.template
@@ -20,6 +20,6 @@ if (Value_nodeList.size() > 1)
            map.insert(::${lang.omexml_model_package}::MapPairs::map_type::value_type(e.getAttribute("K"),
                                                                       e.getTextContent()));
        }
-     std::shared_ptr< ::${lang.omexml_model_package}::MapPairs> mapPairs(std::make_shared< ::${lang.omexml_model_package}::MapPairs>(map));
+     ome::compat::shared_ptr< ::${lang.omexml_model_package}::MapPairs> mapPairs(ome::compat::make_shared< ::${lang.omexml_model_package}::MapPairs>(map));
      setValue(mapPairs);
    }

--- a/cpp/bin/showinf/ImageInfo.cpp
+++ b/cpp/bin/showinf/ImageInfo.cpp
@@ -75,7 +75,7 @@ namespace showinf
   }
 
   void
-  ImageInfo::setReader(std::shared_ptr<FormatReader>& reader)
+  ImageInfo::setReader(ome::compat::shared_ptr<FormatReader>& reader)
   {
     this->reader = reader;
   }
@@ -84,7 +84,7 @@ namespace showinf
   ImageInfo::testRead(std::ostream& stream)
   {
     if (!reader)
-      reader = std::make_shared<in::OMETIFFReader>();
+      reader = ome::compat::make_shared<in::OMETIFFReader>();
 
     preInit(stream);
 
@@ -107,12 +107,12 @@ namespace showinf
     if (opts.showomexml)
       {
         reader->setOriginalMetadataPopulated(opts.showsa);
-        std::shared_ptr<ome::xml::meta::MetadataStore> store(std::make_shared<ome::xml::meta::OMEXMLMetadata>());
+        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store(ome::compat::make_shared<ome::xml::meta::OMEXMLMetadata>());
         reader->setMetadataStore(store);
       }
 
     /// @todo ImageReader format detection.
-    std::shared_ptr<ome::bioformats::detail::FormatReader> detail = std::dynamic_pointer_cast<ome::bioformats::detail::FormatReader>(reader);
+    ome::compat::shared_ptr<ome::bioformats::detail::FormatReader> detail = ome::compat::dynamic_pointer_cast<ome::bioformats::detail::FormatReader>(reader);
     if (detail)
       stream << "Using reader: " << detail->getFormat()
              << " (" << detail->getFormatDescription() << ")\n";
@@ -268,8 +268,8 @@ namespace showinf
 
     try
       {
-        std::shared_ptr<ome::xml::meta::MetadataStore> ms(reader->getMetadataStore());
-        std::shared_ptr<ome::xml::meta::MetadataRetrieve> mr(std::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(ms));
+        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> ms(reader->getMetadataStore());
+        ome::compat::shared_ptr<ome::xml::meta::MetadataRetrieve> mr(ome::compat::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(ms));
       }
     catch (const std::exception& e)
       {
@@ -278,7 +278,7 @@ namespace showinf
 
     if (opts.showomexml)
       {
-        std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omemeta(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(reader->getMetadataStore()));
+        ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> omemeta(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(reader->getMetadataStore()));
         if (omemeta)
           {
             ome::xerces::Platform xmlplat;

--- a/cpp/bin/showinf/ImageInfo.h
+++ b/cpp/bin/showinf/ImageInfo.h
@@ -67,7 +67,7 @@ namespace showinf
     virtual ~ImageInfo ();
 
     void
-    setReader(std::shared_ptr<ome::bioformats::FormatReader>& reader);
+    setReader(ome::compat::shared_ptr<ome::bioformats::FormatReader>& reader);
 
     void
     testRead(std::ostream& stream);
@@ -115,7 +115,7 @@ namespace showinf
     /// Command-line options.
     options opts;
     /// FormatReader instance.
-    std::shared_ptr<ome::bioformats::FormatReader> reader;
+    ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
   };
 
 }

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -233,11 +233,11 @@ int main() { uint16_t test(134); }
 
 check_cxx_source_compiles("
 #include <memory>
-struct foo : public std::enable_shared_from_this<foo>
+struct foo : public ome::compat::enable_shared_from_this<foo>
 {
         foo() {}
 };
-int main() { std::shared_ptr<foo> f(new foo()); }
+int main() { ome::compat::shared_ptr<foo> f(new foo()); }
 " OME_HAVE_MEMORY)
 
 check_cxx_source_compiles("

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -919,7 +919,7 @@ namespace ome
        * @returns a const reference to the core metadata.
        */
       virtual
-      const std::vector<std::shared_ptr<CoreMetadata> >&
+      const std::vector<ome::compat::shared_ptr<CoreMetadata> >&
       getCoreMetadataList() const = 0;
 
       /**
@@ -953,7 +953,7 @@ namespace ome
        */
       virtual
       void
-      setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store) = 0;
+      setMetadataStore(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>& store) = 0;
 
       /**
        * Get the current metadata store for this reader.
@@ -961,7 +961,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
       getMetadataStore() const = 0;
 
       /**
@@ -970,7 +970,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
       getMetadataStore() = 0;
 
       /**
@@ -982,7 +982,7 @@ namespace ome
        * @returns a list of readers.
        */
       virtual
-      std::vector<std::shared_ptr<FormatReader> >
+      std::vector<ome::compat::shared_ptr<FormatReader> >
       getUnderlyingReaders() const = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -257,7 +257,7 @@ namespace ome
        */
       virtual
       void
-      setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve) = 0;
+      setMetadataRetrieve(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve) = 0;
 
       /**
        * Get the current metadata store for this writer.
@@ -265,7 +265,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       getMetadataRetrieve() const = 0;
 
       /**
@@ -274,7 +274,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       getMetadataRetrieve() = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -161,20 +161,20 @@ namespace ome
       return fmt.str();
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::xerces::dom::Document& document)
     {
       ome::xerces::dom::Element docroot(document.getDocumentElement());
 
-      std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+      ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
       ome::xml::model::detail::OMEModel model;
-      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
+      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
       root->update(docroot, model);
 
       return meta;
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file)
     {
       // Parse OME-XML into DOM Document.
@@ -194,7 +194,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text)
     {
       // Parse OME-XML into DOM Document.
@@ -215,7 +215,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream)
     {
       // Parse OME-XML into DOM Document.
@@ -236,41 +236,41 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane,
                          bool                doImageName)
     {
-      std::shared_ptr<OMEXMLMetadata> metadata(std::make_shared<OMEXMLMetadata>());
-      std::shared_ptr<MetadataStore> store(std::static_pointer_cast<MetadataStore>(metadata));
+      ome::compat::shared_ptr<OMEXMLMetadata> metadata(ome::compat::make_shared<OMEXMLMetadata>());
+      ome::compat::shared_ptr<MetadataStore> store(ome::compat::static_pointer_cast<MetadataStore>(metadata));
       fillMetadata(*store, reader, doPlane, doImageName);
       return metadata;
     }
 
-    std::shared_ptr< ::ome::xml::meta::MetadataRoot>
+    ome::compat::shared_ptr< ::ome::xml::meta::MetadataRoot>
     createOMEXMLRoot(const std::string& document)
     {
       /// @todo Implement model transforms.
 
-      std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(createOMEXMLMetadata(document)));
-      return meta ? meta->getRoot() : std::shared_ptr< ::ome::xml::meta::MetadataRoot>();
+      ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(createOMEXMLMetadata(document)));
+      return meta ? meta->getRoot() : ome::compat::shared_ptr< ::ome::xml::meta::MetadataRoot>();
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-    getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    getOMEXMLMetadata(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
     {
-      std::shared_ptr<OMEXMLMetadata> ret;
+      ome::compat::shared_ptr<OMEXMLMetadata> ret;
 
       if (retrieve)
         {
-          std::shared_ptr<OMEXMLMetadata> omexml(std::dynamic_pointer_cast<OMEXMLMetadata>(retrieve));
+          ome::compat::shared_ptr<OMEXMLMetadata> omexml(ome::compat::dynamic_pointer_cast<OMEXMLMetadata>(retrieve));
           if (omexml)
             {
               ret = omexml;
             }
           else
             {
-              ret = std::shared_ptr<OMEXMLMetadata>(std::make_shared<OMEXMLMetadata>());
+              ret = ome::compat::shared_ptr<OMEXMLMetadata>(ome::compat::make_shared<OMEXMLMetadata>());
               ome::xml::meta::convert(*retrieve, *ret);
             }
         }
@@ -405,17 +405,17 @@ namespace ome
     {
       if (resolve)
         omexml.resolveReferences();
-      std::shared_ptr<MetadataRoot> root(omexml.getRoot());
-      std::shared_ptr<OMEXMLMetadataRoot> omexmlroot(std::dynamic_pointer_cast<OMEXMLMetadataRoot>(root));
+      ome::compat::shared_ptr<MetadataRoot> root(omexml.getRoot());
+      ome::compat::shared_ptr<OMEXMLMetadataRoot> omexmlroot(ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root));
       if (omexmlroot)
         {
-          std::shared_ptr<Image> image = omexmlroot->getImage(series);
+          ome::compat::shared_ptr<Image> image = omexmlroot->getImage(series);
           if (image)
             {
-              std::shared_ptr<Pixels> pixels = image->getPixels();
+              ome::compat::shared_ptr<Pixels> pixels = image->getPixels();
               if (pixels)
                 {
-                  std::shared_ptr<MetadataOnly> meta(std::make_shared<MetadataOnly>());
+                  ome::compat::shared_ptr<MetadataOnly> meta(ome::compat::make_shared<MetadataOnly>());
                   pixels->setMetadataOnly(meta);
                 }
             }
@@ -451,12 +451,12 @@ namespace ome
       // @todo Implement Modulo retrieval.
       ::ome::xml::meta::OMEXMLMetadata& momexml(const_cast< ::ome::xml::meta::OMEXMLMetadata&>(omexml));
 
-      std::shared_ptr<OMEXMLMetadataRoot> root =
-        std::dynamic_pointer_cast<OMEXMLMetadataRoot>(momexml.getRoot());
+      ome::compat::shared_ptr<OMEXMLMetadataRoot> root =
+        ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(momexml.getRoot());
       if (!root) // Should never occur
         throw std::logic_error("OMEXMLMetadata does not have an OMEXMLMetadataRoot");
 
-      std::shared_ptr< ::ome::xml::model::Image> mimage(root->getImage(image));
+      ome::compat::shared_ptr< ::ome::xml::model::Image> mimage(root->getImage(image));
       if (!mimage)
         throw std::runtime_error("Image does not exist in OMEXMLMetadata");
 
@@ -464,8 +464,8 @@ namespace ome
            i < mimage->sizeOfLinkedAnnotationList();
            ++i)
         {
-          std::shared_ptr< ::ome::xml::model::Annotation> annotation(mimage->getLinkedAnnotation(i));
-          std::shared_ptr< ::ome::xml::model::XMLAnnotation> xmlannotation(std::dynamic_pointer_cast< ::ome::xml::model::XMLAnnotation>(annotation));
+          ome::compat::shared_ptr< ::ome::xml::model::Annotation> annotation(mimage->getLinkedAnnotation(i));
+          ome::compat::shared_ptr< ::ome::xml::model::XMLAnnotation> xmlannotation(ome::compat::dynamic_pointer_cast< ::ome::xml::model::XMLAnnotation>(annotation));
           if (xmlannotation)
             {
               try
@@ -570,27 +570,27 @@ namespace ome
     removeBinData(::ome::xml::meta::OMEXMLMetadata& omexml)
     {
       omexml.resolveReferences();
-      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          std::vector<std::shared_ptr<ome::xml::model::Image> >& images(root->getImageList());
-          for(std::vector<std::shared_ptr<ome::xml::model::Image> >::const_iterator image = images.begin();
+          std::vector<ome::compat::shared_ptr<ome::xml::model::Image> >& images(root->getImageList());
+          for(std::vector<ome::compat::shared_ptr<ome::xml::model::Image> >::const_iterator image = images.begin();
               image != images.end();
               ++image)
             {
-              std::shared_ptr<ome::xml::model::Pixels> pixels((*image)->getPixels());
+              ome::compat::shared_ptr<ome::xml::model::Pixels> pixels((*image)->getPixels());
               if (pixels)
                 {
                   // Note a copy not a reference to avoid iterator
                   // invalidation during removal.
-                  std::vector<std::shared_ptr<ome::xml::model::BinData> > binData(pixels->getBinDataList());
-                  for (std::vector<std::shared_ptr<ome::xml::model::BinData> >::iterator bin = binData.begin();
+                  std::vector<ome::compat::shared_ptr<ome::xml::model::BinData> > binData(pixels->getBinDataList());
+                  for (std::vector<ome::compat::shared_ptr<ome::xml::model::BinData> >::iterator bin = binData.begin();
                    bin != binData.end();
                        ++bin)
                     {
                       pixels->removeBinData(*bin);
                     }
-                  std::shared_ptr<ome::xml::model::MetadataOnly> metadataOnly;
+                  ome::compat::shared_ptr<ome::xml::model::MetadataOnly> metadataOnly;
                   pixels->setMetadataOnly(metadataOnly);
                 }
             }
@@ -603,19 +603,19 @@ namespace ome
                    dimension_size_type               sizeC)
     {
       omexml.resolveReferences();
-      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          std::shared_ptr<ome::xml::model::Image>& imageref(root->getImage(image));
+          ome::compat::shared_ptr<ome::xml::model::Image>& imageref(root->getImage(image));
           if (image)
             {
-              std::shared_ptr<ome::xml::model::Pixels> pixels(imageref->getPixels());
+              ome::compat::shared_ptr<ome::xml::model::Pixels> pixels(imageref->getPixels());
               if (pixels)
                 {
-                  std::vector<std::shared_ptr<ome::xml::model::Channel> > channels(pixels->getChannelList());
+                  std::vector<ome::compat::shared_ptr<ome::xml::model::Channel> > channels(pixels->getChannelList());
                   for (Metadata::index_type c = 0U; c < channels.size(); ++c)
                     {
-                      std::shared_ptr<ome::xml::model::Channel> channel(channels.at(c));
+                      ome::compat::shared_ptr<ome::xml::model::Channel> channel(channels.at(c));
                       if (channel->getID().empty() || c >= sizeC)
                         pixels->removeChannel(channel);
                     }
@@ -629,17 +629,17 @@ namespace ome
     {
       MetadataMap map;
 
-      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          std::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
+          ome::compat::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
           if (sa)
             {
               for (OMEXMLMetadata::index_type i = 0; i < sa->sizeOfXMLAnnotationList(); ++i)
                 {
                   // Check if this is an OriginalMetadataAnnotation object.
-                  std::shared_ptr<XMLAnnotation> annotation(sa->getXMLAnnotation(i));
-                  std::shared_ptr<OriginalMetadataAnnotation> original(std::dynamic_pointer_cast<OriginalMetadataAnnotation>(annotation));
+                  ome::compat::shared_ptr<XMLAnnotation> annotation(sa->getXMLAnnotation(i));
+                  ome::compat::shared_ptr<OriginalMetadataAnnotation> original(ome::compat::dynamic_pointer_cast<OriginalMetadataAnnotation>(annotation));
                   if (original)
                     {
                       const OriginalMetadataAnnotation::metadata_type kv(original->getMetadata());
@@ -717,12 +717,12 @@ namespace ome
 
       MetadataMap flat(metadata.flatten());
 
-      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          std::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
+          ome::compat::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
           if (!sa)
-            sa = std::make_shared<StructuredAnnotations>();
+            sa = ome::compat::make_shared<StructuredAnnotations>();
           OMEXMLMetadata::index_type annotationIndex = sa->sizeOfXMLAnnotationList();
           OMEXMLMetadata::index_type idIndex = sa->sizeOfXMLAnnotationList();
 
@@ -748,10 +748,10 @@ namespace ome
               std::ostringstream value;
               boost::apply_visitor(::ome::bioformats::detail::MetadataMapValueTypeOStreamVisitor(value), i->second);
 
-              std::shared_ptr<OriginalMetadataAnnotation> orig(std::make_shared<OriginalMetadataAnnotation>());
+              ome::compat::shared_ptr<OriginalMetadataAnnotation> orig(ome::compat::make_shared<OriginalMetadataAnnotation>());
               orig->setID(id);
               orig->setMetadata(OriginalMetadataAnnotation::metadata_type(i->first, value.str()));
-              std::shared_ptr<XMLAnnotation> xmlorig(std::static_pointer_cast<XMLAnnotation>(orig));
+              ome::compat::shared_ptr<XMLAnnotation> xmlorig(ome::compat::static_pointer_cast<XMLAnnotation>(orig));
               sa->addXMLAnnotation(xmlorig);
             }
 

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -121,7 +121,7 @@ namespace ome
      * @param document the XML document.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::xerces::dom::Document& document);
 
     /**
@@ -130,7 +130,7 @@ namespace ome
      * @param file the XML file.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file);
 
     /**
@@ -139,7 +139,7 @@ namespace ome
      * @param text the XML string.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text);
 
     /**
@@ -148,7 +148,7 @@ namespace ome
      * @param stream the XML input stream.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream);
 
     /**
@@ -159,7 +159,7 @@ namespace ome
      * @param doImageName set image name if @c true.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane = false,
                          bool                doImageName = true);
@@ -171,7 +171,7 @@ namespace ome
      * @param document the XML document source.
      * @returns the OME-XML metadata root.
      */
-    std::shared_ptr< ::ome::xml::meta::MetadataRoot>
+    ome::compat::shared_ptr< ::ome::xml::meta::MetadataRoot>
     createOMEXMLRoot(const std::string& document);
 
     /**
@@ -182,8 +182,8 @@ namespace ome
      * @param retrieve the metadata to use.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-    getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
+    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    getOMEXMLMetadata(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
 
     /**
      * Get OME-XML document from OME-XML metadata.

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -257,8 +257,8 @@ namespace ome
        */
       explicit PixelBuffer():
         PixelBufferBase(::ome::xml::model::enums::PixelType::UINT8, ENDIAN_NATIVE),
-        multiarray(std::shared_ptr<array_type>(new array_type(boost::extents[1][1][1][1][1][1][1][1][1],
-                                                              PixelBufferBase::default_storage_order())))
+        multiarray(ome::compat::shared_ptr<array_type>(new array_type(boost::extents[1][1][1][1][1][1][1][1][1],
+                                                                      PixelBufferBase::default_storage_order())))
       {}
 
       /**
@@ -279,7 +279,7 @@ namespace ome
                   EndianType                          endiantype = ENDIAN_NATIVE,
                   const storage_order_type&           storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(std::shared_ptr<array_type>(new array_type(extents, storage)))
+        multiarray(ome::compat::shared_ptr<array_type>(new array_type(extents, storage)))
       {}
 
       /**
@@ -304,7 +304,7 @@ namespace ome
                   EndianType                           endiantype = ENDIAN_NATIVE,
                   const storage_order_type&            storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(std::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, extents, storage)))
+        multiarray(ome::compat::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, extents, storage)))
       {}
 
       /**
@@ -324,7 +324,7 @@ namespace ome
                   EndianType                          endiantype = ENDIAN_NATIVE,
                   const storage_order_type&           storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(std::shared_ptr<array_type>(new array_type(range, storage)))
+        multiarray(ome::compat::shared_ptr<array_type>(new array_type(range, storage)))
       {}
 
       /**
@@ -348,7 +348,7 @@ namespace ome
                   EndianType                           endiantype = ENDIAN_NATIVE,
                   const storage_order_type&            storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(std::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, range, storage)))
+        multiarray(ome::compat::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, range, storage)))
       {}
 
       /**
@@ -452,7 +452,7 @@ namespace ome
       bool
       managed() const
       {
-        return (boost::get<std::shared_ptr<array_type> >(&multiarray) != 0);
+        return (boost::get<ome::compat::shared_ptr<array_type> >(&multiarray) != 0);
       }
 
       /**
@@ -818,8 +818,8 @@ namespace ome
        * also permits efficient shallow copying in the absence of a
        * C++11 move constructor for @c MultiArray types.
        */
-      boost::variant<std::shared_ptr<array_type>,
-                     std::shared_ptr<array_ref_type> > multiarray;
+      boost::variant<ome::compat::shared_ptr<array_type>,
+                     ome::compat::shared_ptr<array_ref_type> > multiarray;
     };
 
     namespace detail

--- a/cpp/lib/ome/bioformats/TileCache.h
+++ b/cpp/lib/ome/bioformats/TileCache.h
@@ -62,7 +62,7 @@ namespace ome
       /// Tile index type.
       typedef dimension_size_type key_type;
       /// Tile buffer type.
-      typedef std::shared_ptr<TileBuffer> value_type;
+      typedef ome::compat::shared_ptr<TileBuffer> value_type;
 
       /// Constructor.
       TileCache();

--- a/cpp/lib/ome/bioformats/TileCoverage.cpp
+++ b/cpp/lib/ome/bioformats/TileCoverage.cpp
@@ -194,7 +194,7 @@ namespace ome
     };
 
     TileCoverage::TileCoverage():
-      impl(std::shared_ptr<Impl>(new Impl()))
+      impl(ome::compat::shared_ptr<Impl>(new Impl()))
     {
     }
 

--- a/cpp/lib/ome/bioformats/TileCoverage.h
+++ b/cpp/lib/ome/bioformats/TileCoverage.h
@@ -147,7 +147,7 @@ namespace ome
     protected:
       class Impl;
       /// Private implementation details.
-      std::shared_ptr<Impl> impl;
+      ome::compat::shared_ptr<Impl> impl;
     };
 
   }

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
@@ -276,7 +276,7 @@ namespace
         >::value,
       void
       >::type
-    operator() (std::shared_ptr<PixelBuffer<typename PixelProperties<P>::std_type> >& lhs) const
+    operator() (ome::compat::shared_ptr<PixelBuffer<typename PixelProperties<P>::std_type> >& lhs) const
     {
       if (!lhs)
         throw std::runtime_error("Null pixel type");

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -112,7 +112,7 @@ namespace ome
       struct make_buffer
       {
         /// Buffer type.
-        typedef std::shared_ptr<PixelBuffer<typename T::std_type> > type;
+        typedef ome::compat::shared_ptr<PixelBuffer<typename T::std_type> > type;
       };
 
       /// Aggregate view of all buffer types.
@@ -212,7 +212,7 @@ namespace ome
        */
       template<typename T>
       explicit
-      VariantPixelBuffer(std::shared_ptr<PixelBuffer<T> >& buffer):
+      VariantPixelBuffer(ome::compat::shared_ptr<PixelBuffer<T> >& buffer):
         buffer(buffer)
       {
       }
@@ -262,7 +262,7 @@ namespace ome
                  const storage_order_type&           storage,
                  ::ome::xml::model::enums::PixelType pixeltype)
       {
-        return std::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(extents, pixeltype, ENDIAN_NATIVE, storage));
+        return ome::compat::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(extents, pixeltype, ENDIAN_NATIVE, storage));
       }
 
       /**
@@ -282,7 +282,7 @@ namespace ome
                  const storage_order_type&           storage,
                  ::ome::xml::model::enums::PixelType pixeltype)
       {
-        return std::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(range, pixeltype, ENDIAN_NATIVE, storage));
+        return ome::compat::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(range, pixeltype, ENDIAN_NATIVE, storage));
       }
 
       // No switch default to avoid -Wunreachable-code errors.
@@ -706,7 +706,7 @@ namespace ome
          * @throws if the PixelBuffer is null.
          */
         PixelBuffer<T>&
-        operator() (std::shared_ptr<PixelBuffer<T> >& v) const
+        operator() (ome::compat::shared_ptr<PixelBuffer<T> >& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
@@ -739,7 +739,7 @@ namespace ome
          * @throws if the PixelBuffer is null.
          */
         const PixelBuffer<T>&
-        operator() (const std::shared_ptr<PixelBuffer<T> >& v) const
+        operator() (const ome::compat::shared_ptr<PixelBuffer<T> >& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
@@ -786,7 +786,7 @@ namespace ome
          * @throws if the PixelBuffer is null or the PixelBuffer's data array is null.
          */
         void
-        operator() (std::shared_ptr<PixelBuffer<typename std::iterator_traits<InputIterator>::value_type> >& v) const
+        operator() (ome::compat::shared_ptr<PixelBuffer<typename std::iterator_traits<InputIterator>::value_type> >& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -96,7 +96,7 @@ namespace ome
         indexedAsRGB(false),
         group(true),
         domains(),
-        metadataStore(std::make_shared<DummyMetadata>()),
+        metadataStore(ome::compat::make_shared<DummyMetadata>()),
         metadataOptions()
       {
         assertId(currentId, false);
@@ -157,7 +157,7 @@ namespace ome
         metadata.clear();
 
         core.clear();
-        core.push_back(std::make_shared<CoreMetadata>());
+        core.push_back(ome::compat::make_shared<CoreMetadata>());
 
         // reinitialize the MetadataStore
         // NB: critical for metadata conversion to work properly!
@@ -387,12 +387,12 @@ namespace ome
         boost::apply_visitor(v, dest.vbuffer());
       }
 
-      std::shared_ptr< ::ome::xml::meta::MetadataStore>
+      ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>
       FormatReader::makeFilterMetadata()
       {
-        // While std::make_shared<> works, here, boost::make_shared<>
+        // While ome::compat::make_shared<> works, here, boost::make_shared<>
         // does not, so use new directly.
-        return std::shared_ptr< ::ome::xml::meta::MetadataStore>
+        return ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>
           (new FilterMetadata(getMetadataStore(), isMetadataFiltered()));
       }
 
@@ -765,7 +765,7 @@ namespace ome
       FormatReader::close(bool fileOnly)
       {
         if (in)
-          in = std::shared_ptr<std::istream>(); // set to null.
+          in = ome::compat::shared_ptr<std::istream>(); // set to null.
         if (!fileOnly)
           {
             currentId = boost::none;
@@ -1031,7 +1031,7 @@ namespace ome
         return getCoreMetadata(getCoreIndex()).seriesMetadata;
       }
 
-      const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&
+      const std::vector<ome::compat::shared_ptr< ::ome::bioformats::CoreMetadata> >&
       FormatReader::getCoreMetadataList() const
       {
         assertId(currentId, true);
@@ -1052,7 +1052,7 @@ namespace ome
       }
 
       void
-      FormatReader::setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store)
+      FormatReader::setMetadataStore(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>& store)
       {
         assertId(currentId, false);
 
@@ -1062,22 +1062,22 @@ namespace ome
         metadataStore = store;
       }
 
-      const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
       FormatReader::getMetadataStore() const
       {
         return metadataStore;
       }
 
-      std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
       FormatReader::getMetadataStore()
       {
         return metadataStore;
       }
 
-      std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >
+      std::vector<ome::compat::shared_ptr< ::ome::bioformats::FormatReader> >
       FormatReader::getUnderlyingReaders() const
       {
-        return std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >();
+        return std::vector<ome::compat::shared_ptr< ::ome::bioformats::FormatReader> >();
       }
 
       bool
@@ -1322,8 +1322,8 @@ namespace ome
               }
             initFile(canonicalID);
 
-            const std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
-              std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());
+            const ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
+              ome::compat::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());
             if(store)
               {
                 if(saveOriginalMetadata)

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -111,7 +111,7 @@ namespace ome
       {
       protected:
         /// List type for storing CoreMetadata.
-        typedef std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> > coremetadata_list_type;
+        typedef std::vector<ome::compat::shared_ptr< ::ome::bioformats::CoreMetadata> > coremetadata_list_type;
 
         /// Reader properties specific to the derived file format.
         const ReaderProperties& readerProperties;
@@ -120,7 +120,7 @@ namespace ome
         boost::optional<boost::filesystem::path> currentId;
 
         /// Current input.
-        std::shared_ptr<std::istream> in;
+        ome::compat::shared_ptr<std::istream> in;
 
         /// Mapping of metadata key/value pairs.
         ::ome::bioformats::MetadataMap metadata;
@@ -196,7 +196,7 @@ namespace ome
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataStore() prevent "null" access.
          */
-        std::shared_ptr< ::ome::xml::meta::MetadataStore> metadataStore;
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore> metadataStore;
 
         /// Metadata parsing options.
         MetadataOptions metadataOptions;
@@ -301,7 +301,7 @@ namespace ome
          * @returns a FilterMetadata instance.
          */
         virtual
-        std::shared_ptr< ::ome::xml::meta::MetadataStore>
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>
         makeFilterMetadata();
 
         /**
@@ -672,7 +672,7 @@ namespace ome
         getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.
-        const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&
+        const std::vector<ome::compat::shared_ptr< ::ome::bioformats::CoreMetadata> >&
         getCoreMetadataList() const;
 
         // Documented in superclass.
@@ -685,18 +685,18 @@ namespace ome
 
         // Documented in superclass.
         void
-        setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store);
+        setMetadataStore(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>& store);
 
         // Documented in superclass.
-        const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+        const ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
         getMetadataStore() const;
 
         // Documented in superclass.
-        std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
         getMetadataStore();
 
         // Documented in superclass.
-        std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >
+        std::vector<ome::compat::shared_ptr< ::ome::bioformats::FormatReader> >
         getUnderlyingReaders() const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -83,7 +83,7 @@ namespace ome
         compression(boost::none),
         sequential(false),
         framesPerSecond(0),
-        metadataRetrieve(std::make_shared<DummyMetadata>())
+        metadataRetrieve(ome::compat::make_shared<DummyMetadata>())
       {
         assertId(currentId, false);
       }
@@ -98,11 +98,11 @@ namespace ome
         if (!currentId || id != currentId.get())
           {
             if (out)
-              out = std::shared_ptr<std::ostream>();
+              out = ome::compat::shared_ptr<std::ostream>();
 
             SaveSeries sentry(*this);
 
-            std::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
+            ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
 
             for (dimension_size_type  s = 0;
                  s < mr->getImageCount();
@@ -124,7 +124,7 @@ namespace ome
       FormatWriter::close(bool fileOnly)
       {
         if (out)
-          out = std::shared_ptr<std::ostream>(); // set to null.
+          out = ome::compat::shared_ptr<std::ostream>(); // set to null.
         if (!fileOnly)
           {
             currentId = boost::none;
@@ -261,7 +261,7 @@ namespace ome
       }
 
       void
-      FormatWriter::setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
+      FormatWriter::setMetadataRetrieve(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
       {
         assertId(currentId, false);
 
@@ -271,13 +271,13 @@ namespace ome
         metadataRetrieve = retrieve;
       }
 
-      const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       FormatWriter::getMetadataRetrieve() const
       {
         return metadataRetrieve;
       }
 
-      std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       FormatWriter::getMetadataRetrieve()
       {
         return metadataRetrieve;

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -116,7 +116,7 @@ namespace ome
         boost::optional<boost::filesystem::path> currentId;
 
         /// Current output.
-        std::shared_ptr<std::ostream> out;
+        ome::compat::shared_ptr<std::ostream> out;
 
         /// Current series.
         mutable dimension_size_type series;
@@ -134,7 +134,7 @@ namespace ome
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataRetrieve() prevent "null" access.
          */
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
 
       protected:
         /// Constructor.
@@ -190,14 +190,14 @@ namespace ome
 
         // Documented in superclass.
         void
-        setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
+        setMetadataRetrieve(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
 
         // Documented in superclass.
-        const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+        const ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve() const;
 
         // Documented in superclass.
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve();
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -113,7 +113,7 @@ namespace ome
         return static_cast<bool>(TIFF::open(name, "r"));
       }
 
-      const std::shared_ptr<const tiff::IFD>
+      const ome::compat::shared_ptr<const tiff::IFD>
       MinimalTIFFReader::ifdAtIndex(dimension_size_type no) const
       {
         dimension_size_type series = getSeries();
@@ -142,7 +142,7 @@ namespace ome
             throw FormatException(fmt.str());
           }
 
-        const std::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
+        const ome::compat::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
         return ifd;
       }
 
@@ -198,8 +198,8 @@ namespace ome
       {
         core.clear();
 
-        std::shared_ptr<const tiff::IFD> prev_ifd;
-        std::shared_ptr<CoreMetadata> prev_core;
+        ome::compat::shared_ptr<const tiff::IFD> prev_ifd;
+        ome::compat::shared_ptr<CoreMetadata> prev_core;
 
         dimension_size_type current_ifd = 0U;
 
@@ -234,7 +234,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
 
         try
           {
@@ -258,7 +258,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
 
         if (isRGB())
           {
@@ -274,13 +274,13 @@ namespace ome
           ifd->readImage(buf, x, y, w, h);
       }
 
-      std::shared_ptr<ome::bioformats::tiff::TIFF>
+      ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
       MinimalTIFFReader::getTIFF()
       {
         return tiff;
       }
 
-      const std::shared_ptr<ome::bioformats::tiff::TIFF>
+      const ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
       MinimalTIFFReader::getTIFF() const
       {
         return tiff;

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -70,7 +70,7 @@ namespace ome
         typedef std::vector<std::pair<dimension_size_type, dimension_size_type> > series_ifd_map_type;
 
         /// Underlying TIFF file.
-        std::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
+        ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
 
         /// Mapping between series index and start and end IFD as a half-open range.
         series_ifd_map_type series_ifd_map;
@@ -109,7 +109,7 @@ namespace ome
          * @returns the IFD index.
          * @throws FormatException if out of range.
          */
-        const std::shared_ptr<const tiff::IFD>
+        const ome::compat::shared_ptr<const tiff::IFD>
         ifdAtIndex(dimension_size_type no) const;
 
       public:
@@ -140,7 +140,7 @@ namespace ome
          *
          * @returns a reference to the TIFF file.
          */
-        std::shared_ptr<ome::bioformats::tiff::TIFF>
+        ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
         getTIFF();
 
         /**
@@ -150,7 +150,7 @@ namespace ome
          *
          * @returns a reference to the TIFF file.
          */
-        const std::shared_ptr<ome::bioformats::tiff::TIFF>
+        const ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
         getTIFF() const;
       };
 

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -120,7 +120,7 @@ namespace ome
         {
           try
             {
-              std::shared_ptr<tiff::IFD> ifd (tiff.getDirectoryByIndex(0));
+              ome::compat::shared_ptr<tiff::IFD> ifd (tiff.getDirectoryByIndex(0));
               if (ifd)
                 ifd->getField(ome::bioformats::tiff::IMAGEDESCRIPTION).get(omexml);
               else
@@ -239,7 +239,7 @@ namespace ome
         if (checkSuffix(id, companion_suffixes))
           return false;
 
-        std::shared_ptr<tiff::TIFF> tiff = TIFF::open(id, "r");
+        ome::compat::shared_ptr<tiff::TIFF> tiff = TIFF::open(id, "r");
 
         if (!tiff)
           {
@@ -251,7 +251,7 @@ namespace ome
         std::string omexml;
         getComment(*tiff, omexml);
 
-        std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+        ome::compat::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
 
         dimension_size_type nImages = 0U;
         for (dimension_size_type i = 0U;
@@ -285,7 +285,7 @@ namespace ome
       bool
       OMETIFFReader::isFilenameThisTypeImpl(const boost::filesystem::path& name) const
       {
-        std::shared_ptr<tiff::TIFF> tiff = TIFF::open(name, "r");
+        ome::compat::shared_ptr<tiff::TIFF> tiff = TIFF::open(name, "r");
 
         if (!tiff)
           {
@@ -303,7 +303,7 @@ namespace ome
 
         try
           {
-            std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+            ome::compat::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
 
             std::string metadataFile = meta->getBinaryOnlyMetadataFile();
             if (!metadataFile.empty())
@@ -323,19 +323,19 @@ namespace ome
           }
       }
 
-      const std::shared_ptr<const tiff::IFD>
+      const ome::compat::shared_ptr<const tiff::IFD>
       OMETIFFReader::ifdAtIndex(dimension_size_type no) const
       {
-        std::shared_ptr<const IFD> ifd;
+        ome::compat::shared_ptr<const IFD> ifd;
 
         const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
 
         if (no < ometa.tiffPlanes.size())
           {
             const OMETIFFPlane& plane(ometa.tiffPlanes.at(no));
-            const std::shared_ptr<const TIFF> tiff(getTIFF(plane.id));
+            const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(plane.id));
             if (tiff)
-              ifd = std::shared_ptr<const IFD>(tiff->getDirectoryByIndex(plane.ifd));
+              ifd = ome::compat::shared_ptr<const IFD>(tiff->getDirectoryByIndex(plane.ifd));
           }
 
         if (!ifd)
@@ -429,7 +429,7 @@ namespace ome
             // This is a companion file.  Read the metadata, get the
             // TIFF for the TiffData for the first image, and then
             // recurse with this file as the id.
-            std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(id));
+            ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(id));
             path firstTIFF(path(meta->getUUIDFileName(0, 0)));
             initFile(canonical(firstTIFF, dir));
             return;
@@ -437,13 +437,13 @@ namespace ome
 
         // Cache and use this TIFF.
         addTIFF(id);
-        const std::shared_ptr<const TIFF> tiff(getTIFF(id));
+        const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(id));
 
         // Get the OME-XML from the first TIFF, and create OME-XML
         // metadata from it.
         std::string omexml;
         getComment(*tiff, omexml);
-        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
+        ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
 
         // Is there an associated binary-only metadata file?
         try
@@ -499,7 +499,7 @@ namespace ome
         core.clear();
         core.reserve(seriesCount);
         for (index_type i = 0; i < seriesCount; ++i)
-          core.push_back(std::make_shared<OMETIFFMetadata>());
+          core.push_back(ome::compat::make_shared<OMETIFFMetadata>());
 
         // UUID → file mapping and used files.
         findUsedFiles(*meta, id, dir, currentUUID);
@@ -507,7 +507,7 @@ namespace ome
         // Process TiffData elements.
         for (index_type series = 0; series < seriesCount; ++series)
           {
-            std::shared_ptr<OMETIFFMetadata> coreMeta(std::dynamic_pointer_cast<OMETIFFMetadata>(core.at(series)));
+            ome::compat::shared_ptr<OMETIFFMetadata> coreMeta(ome::compat::dynamic_pointer_cast<OMETIFFMetadata>(core.at(series)));
             assert(coreMeta); // Should never be null.
             std::clog << "Image[" << series << "] {\n  id = " << meta->getImageID(series) << '\n';
 
@@ -759,8 +759,8 @@ namespace ome
                   }
 
                 const OMETIFFPlane& plane(coreMeta->tiffPlanes.at(0));
-                const std::shared_ptr<const tiff::TIFF> ptiff(getTIFF(plane.id));
-                const std::shared_ptr<const tiff::IFD> pifd(ptiff->getDirectoryByIndex(plane.ifd));
+                const ome::compat::shared_ptr<const tiff::TIFF> ptiff(getTIFF(plane.id));
+                const ome::compat::shared_ptr<const tiff::IFD> pifd(ptiff->getDirectoryByIndex(plane.ifd));
                 const tiff::TileInfo tinfo(pifd->getTileInfo());
 
                 uint32_t tiffWidth = pifd->getImageWidth();
@@ -889,11 +889,11 @@ namespace ome
           }
 
         // Remove null CoreMetadata entries.
-        std::remove(core.begin(), core.end(), std::shared_ptr<OMETIFFMetadata>());
+        std::remove(core.begin(), core.end(), ome::compat::shared_ptr<OMETIFFMetadata>());
 
         if (getImageCount() == 1U)
           {
-            std::shared_ptr<CoreMetadata>& ms0 = core.at(0);
+            ome::compat::shared_ptr<CoreMetadata>& ms0 = core.at(0);
             ms0->sizeZ = 1U;
             if (!ms0->rgb)
               ms0->sizeC = 1U;
@@ -1077,8 +1077,8 @@ namespace ome
         else
           filename = *currentId;
 
-        const std::shared_ptr<const tiff::TIFF> tiff(getTIFF(filename));
-        const std::shared_ptr<const tiff::IFD> ifd(tiff->getDirectoryByIndex(*ifdIndex));
+        const ome::compat::shared_ptr<const tiff::TIFF> tiff(getTIFF(filename));
+        const ome::compat::shared_ptr<const tiff::IFD> ifd(tiff->getDirectoryByIndex(*ifdIndex));
 
         return ifd->getSamplesPerPixel();
       }
@@ -1167,7 +1167,7 @@ namespace ome
 
         if (numPlanes == 0)
           {
-            core.at(series) = std::shared_ptr<OMETIFFMetadata>();
+            core.at(series) = ome::compat::shared_ptr<OMETIFFMetadata>();
             valid = false;
           }
 
@@ -1223,7 +1223,7 @@ namespace ome
                 {
                   // Will throw if null.
                   std::string channelName(meta.getChannelName(series, 0));
-                  std::shared_ptr<CoreMetadata> coreMeta(core.at(series));
+                  ome::compat::shared_ptr<CoreMetadata> coreMeta(core.at(series));
                   if (meta.getTiffDataCount(series) > 0 &&
                       files.find("__omero_export") == files.end() &&
                       coreMeta)
@@ -1239,7 +1239,7 @@ namespace ome
       void
       OMETIFFReader::fixDimensions(ome::xml::meta::BaseMetadata::index_type series)
       {
-        std::shared_ptr<CoreMetadata> coreMeta(core.at(series));
+        ome::compat::shared_ptr<CoreMetadata> coreMeta(core.at(series));
         if (coreMeta)
           {
 
@@ -1277,7 +1277,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
 
         try
           {
@@ -1301,7 +1301,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
 
         if (isRGB())
           {
@@ -1320,10 +1320,10 @@ namespace ome
       void
       OMETIFFReader::addTIFF(const boost::filesystem::path& tiff)
       {
-        tiffs.insert(std::make_pair(tiff, std::shared_ptr<tiff::TIFF>()));
+        tiffs.insert(std::make_pair(tiff, ome::compat::shared_ptr<tiff::TIFF>()));
       }
 
-      const std::shared_ptr<const ome::bioformats::tiff::TIFF>
+      const ome::compat::shared_ptr<const ome::bioformats::tiff::TIFF>
       OMETIFFReader::getTIFF(const boost::filesystem::path& tiff) const
       {
         tiff_map::iterator i = tiffs.find(tiff);
@@ -1347,16 +1347,16 @@ namespace ome
         if (i->second)
           {
             i->second->close();
-            i->second = std::shared_ptr<ome::bioformats::tiff::TIFF>();
+            i->second = ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>();
           }
       }
 
-      std::shared_ptr<ome::xml::meta::MetadataStore>
+      ome::compat::shared_ptr<ome::xml::meta::MetadataStore>
       OMETIFFReader::getMetadataStoreForConversion()
       {
         SaveSeries sentry(*this);
 
-        std::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
+        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
 
         if (store)
           {
@@ -1370,15 +1370,15 @@ namespace ome
         return store;
       }
 
-      std::shared_ptr<ome::xml::meta::MetadataStore>
+      ome::compat::shared_ptr<ome::xml::meta::MetadataStore>
       OMETIFFReader::getMetadataStoreForDisplay()
       {
-        std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omexml;
-        std::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
+        ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> omexml;
+        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
 
         if (store)
           {
-            omexml = std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(store);
+            omexml = ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(store);
             if (omexml)
               {
                 removeBinData(*omexml);

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -71,7 +71,7 @@ namespace ome
         typedef std::map<std::string, boost::filesystem::path> file_map;
 
         /// Map filename to open TIFF handle.
-        typedef std::map<boost::filesystem::path, std::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
+        typedef std::map<boost::filesystem::path, ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
 
         /// UUID to filename mapping.
         file_map files;
@@ -132,7 +132,7 @@ namespace ome
          * @returns the IFD index.
          * @throws FormatException if out of range.
          */
-        const std::shared_ptr<const tiff::IFD>
+        const ome::compat::shared_ptr<const tiff::IFD>
         ifdAtIndex(dimension_size_type no) const;
 
         /**
@@ -154,7 +154,7 @@ namespace ome
          * @returns the open TIFF.
          * @throws FormatException if invalid.
          */
-        const std::shared_ptr<const ome::bioformats::tiff::TIFF>
+        const ome::compat::shared_ptr<const ome::bioformats::tiff::TIFF>
         getTIFF(const boost::filesystem::path& tiff) const;
 
         /**
@@ -327,7 +327,7 @@ namespace ome
          *
          * @returns the metadata store.
          */
-        std::shared_ptr< ome::xml::meta::MetadataStore>
+        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
         getMetadataStoreForConversion();
 
         /**
@@ -339,7 +339,7 @@ namespace ome
          *
          * @returns the metadata store.
          */
-        std::shared_ptr< ome::xml::meta::MetadataStore>
+        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
         getMetadataStoreForDisplay();
       };
 

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -101,7 +101,7 @@ namespace ome
       void
       TIFFReader::readIFDs()
       {
-        std::shared_ptr<IFD> ifd0 = *(tiff->begin());
+        ome::compat::shared_ptr<IFD> ifd0 = *(tiff->begin());
 
         if (ifd0)
           {
@@ -111,7 +111,7 @@ namespace ome
               {
                 tiff::ImageJMetadata ijmeta(*ifd0);
 
-                std::shared_ptr<CoreMetadata> ijm(tiff::makeCoreMetadata(*ifd0));
+                ome::compat::shared_ptr<CoreMetadata> ijm(tiff::makeCoreMetadata(*ifd0));
 
                 ijm->sizeZ = ijmeta.slices;
                 ijm->sizeT = ijmeta.frames;

--- a/cpp/lib/ome/bioformats/tiff/Field.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Field.cpp
@@ -116,7 +116,7 @@ namespace ome
       {
       public:
         /// Weak reference to the parent IFD.
-        std::weak_ptr<IFD>  ifd;
+        ome::compat::weak_ptr<IFD>  ifd;
         /// The tag being wrapped.
         tag_type            tag;
         /// Field information for this tag.
@@ -128,8 +128,8 @@ namespace ome
          * @param ifd the directory the field belongs to.
          * @param tag the tag identifying this field.
          */
-        Impl(std::shared_ptr<IFD>& ifd,
-             tag_type              tag):
+        Impl(ome::compat::shared_ptr<IFD>& ifd,
+             tag_type                      tag):
           ifd(ifd),
           tag(tag),
           fieldinfo()
@@ -146,10 +146,10 @@ namespace ome
          *
          * @returns the directory.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         getIFD() const
         {
-          std::shared_ptr<IFD> sifd = std::shared_ptr<IFD>(ifd);
+          ome::compat::shared_ptr<IFD> sifd = ome::compat::shared_ptr<IFD>(ifd);
           if (!sifd)
             throw Exception("Field reference to IFD no longer valid");
 
@@ -236,9 +236,9 @@ namespace ome
         }
       };
 
-      FieldBase::FieldBase(std::shared_ptr<IFD> ifd,
-                           tag_type             tag):
-        impl(std::shared_ptr<Impl>(new Impl(ifd, tag)))
+      FieldBase::FieldBase(ome::compat::shared_ptr<IFD> ifd,
+                           tag_type                     tag):
+        impl(ome::compat::shared_ptr<Impl>(new Impl(ifd, tag)))
       {
       }
 
@@ -340,7 +340,7 @@ namespace ome
         return impl->tag;
       }
 
-      std::shared_ptr<IFD>
+      ome::compat::shared_ptr<IFD>
       FieldBase::getIFD() const
       {
         return impl->getIFD();
@@ -351,100 +351,100 @@ namespace ome
 
         template<typename T>
         void
-        generic_get1(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* readcount */,
-                     T& value)
+        generic_get1(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* readcount */,
+                     T&                           value)
         {
           ifd->getRawField(tag, &value);
         }
 
         template<typename T>
         void
-        generic_set1(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* writecount */,
-                     const T& value)
+        generic_set1(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* writecount */,
+                     const T&                     value)
         {
           ifd->setRawField(tag, value);
         }
 
         template<typename T>
         void
-        generic_get2(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* readcount */,
-                     T& value)
+        generic_get2(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* readcount */,
+                     T&                           value)
         {
           ifd->getRawField(tag, &value[0], &value[1]);
         }
 
         template<typename T>
         void
-        generic_set2(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* writecount */,
-                     const T& value)
+        generic_set2(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* writecount */,
+                     const T&                     value)
         {
           ifd->setRawField(tag, value[0], value[1]);
         }
 
         template<typename T>
         void
-        generic_get3(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* readcount */,
-                     T& value)
+        generic_get3(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* readcount */,
+                     T&                           value)
         {
           ifd->getRawField(tag, &value[0], &value[1], &value[2]);
         }
 
         template<typename T>
         void
-        generic_set3(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* writecount */,
-                     const T& value)
+        generic_set3(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* writecount */,
+                     const T&                     value)
         {
           ifd->setRawField(tag, value[0], value[1], value[2]);
         }
 
         template<typename T>
         void
-        generic_get6(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* readcount */,
-                     T& value)
+        generic_get6(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* readcount */,
+                     T&                           value)
         {
           ifd->getRawField(tag, &value[0], &value[1], &value[2], &value[3], &value[4], &value[5]);
         }
 
         template<typename T>
         void
-        generic_set6(std::shared_ptr<IFD> ifd,
-                     tag_type tag,
-                     bool /* passcount */,
-                     int /* writecount */,
-                     const T& value)
+        generic_set6(ome::compat::shared_ptr<IFD> ifd,
+                     tag_type                     tag,
+                     bool                         /* passcount */,
+                     int                          /* writecount */,
+                     const T&                     value)
         {
           ifd->setRawField(tag, value[0], value[1], value[2], value[3], value[4], value[5]);
         }
 
         template<typename T>
         void
-        generic_enum16_get1(std::shared_ptr<IFD> ifd,
-                            tag_type tag,
-                            Type type,
-                            bool passcount,
-                            int readcount,
-                            T& value)
+        generic_enum16_get1(ome::compat::shared_ptr<IFD> ifd,
+                            tag_type                     tag,
+                            Type                         type,
+                            bool                         passcount,
+                            int                          readcount,
+                            T&                           value)
         {
 #if defined(TIFF_HAVE_FIELD) || defined(TIFF_HAVE_FIELDINFO)
           if (type != TYPE_SHORT &&
@@ -460,12 +460,12 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_set1(std::shared_ptr<IFD> ifd,
-                            tag_type tag,
-                            Type type,
-                            bool passcount,
-                            int writecount,
-                            const T& value)
+        generic_enum16_set1(ome::compat::shared_ptr<IFD> ifd,
+                            tag_type                     tag,
+                            Type                         type,
+                            bool                         passcount,
+                            int                          writecount,
+                            const T&                     value)
         {
 #if defined(TIFF_HAVE_FIELD) || defined(TIFF_HAVE_FIELDINFO)
           if (type != TYPE_SHORT &&
@@ -480,10 +480,10 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_get1(std::shared_ptr<IFD> ifd,
-                           tag_type tag,
-                           int readcount,
-                           T& value)
+        generic_array_get1(ome::compat::shared_ptr<IFD> ifd,
+                           tag_type                     tag,
+                           int                          readcount,
+                           T&                           value)
         {
           // Special case:
           if (tag == TIFFTAG_IMAGEJ_META_DATA_BYTE_COUNTS ||
@@ -560,10 +560,10 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_set1(std::shared_ptr<IFD> ifd,
-                           tag_type tag,
-                           int writecount,
-                           const T& value)
+        generic_array_set1(ome::compat::shared_ptr<IFD> ifd,
+                           tag_type                     tag,
+                           int                          writecount,
+                           const T&                     value)
         {
           if (writecount == TIFF_SPP)
             {
@@ -594,10 +594,10 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_get3(std::shared_ptr<IFD> ifd,
-                           tag_type tag,
-                           int readcount,
-                           T& value)
+        generic_array_get3(ome::compat::shared_ptr<IFD> ifd,
+                           tag_type                     tag,
+                           int                          readcount,
+                           T&                           value)
         {
           bool limit = false; // Special case for TIFFTAG_TRANSFERFUNCTION which can used 1 or 3 vectors.
           typename T::value_type::value_type *valueptr0, *valueptr1, *valueptr2;
@@ -657,10 +657,10 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_set3(std::shared_ptr<IFD> ifd,
-                           tag_type tag,
-                           int writecount,
-                           const T& value)
+        generic_array_set3(ome::compat::shared_ptr<IFD> ifd,
+                           tag_type                     tag,
+                           int                          writecount,
+                           const T&                     value)
         {
           if (value[0].size() != value[1].size() ||
               value[0].size() != value[2].size())
@@ -710,10 +710,10 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_array_get1(std::shared_ptr<IFD> ifd,
-                                  tag_type tag,
-                                  int readcount,
-                                  T& value)
+        generic_enum16_array_get1(ome::compat::shared_ptr<IFD> ifd,
+                                  tag_type                     tag,
+                                  int                          readcount,
+                                  T&                           value)
         {
           std::vector<uint16_t> v;
           generic_array_get1(ifd, tag, readcount, v);
@@ -726,10 +726,10 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_array_set1(std::shared_ptr<IFD> ifd,
-                                  tag_type tag,
-                                  int writecount,
-                                  const T& value)
+        generic_enum16_array_set1(ome::compat::shared_ptr<IFD> ifd,
+                                  tag_type                     tag,
+                                  int                          writecount,
+                                  const T&                     value)
         {
           std::vector<uint16_t> v;
           for(typename T::const_iterator i = value.begin();

--- a/cpp/lib/ome/bioformats/tiff/Field.h
+++ b/cpp/lib/ome/bioformats/tiff/Field.h
@@ -66,8 +66,8 @@ namespace ome
          * @param ifd the directory the field belongs to.
          * @param tag the tag identifying this field.
          */
-        FieldBase(std::shared_ptr<IFD> ifd,
-                  tag_type             tag);
+        FieldBase(ome::compat::shared_ptr<IFD> ifd,
+                  tag_type                     tag);
 
       public:
         /// Destructor.
@@ -141,13 +141,13 @@ namespace ome
          *
          * @returns the directory.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         getIFD() const;
 
       protected:
         class Impl;
         /// Private implementation details.
-        std::shared_ptr<Impl> impl;
+        ome::compat::shared_ptr<Impl> impl;
       };
 
       /**
@@ -171,8 +171,8 @@ namespace ome
          * @param ifd the directory the field belongs to.
          * @param tag the tag identifying this field.
          */
-        Field(std::shared_ptr<IFD> ifd,
-              tag_category         tag):
+        Field(ome::compat::shared_ptr<IFD> ifd,
+              tag_category                 tag):
           FieldBase(ifd, getWrappedTag(tag)),
           tag(tag)
         {}

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -144,12 +144,12 @@ namespace
 
     template<typename T>
     void
-    transfer(std::shared_ptr<T>& buffer,
-             typename T::indices_type& destidx,
-             const TileBuffer& tilebuf,
-             PlaneRegion& rfull,
-             PlaneRegion& rclip,
-             uint16_t copysamples)
+    transfer(ome::compat::shared_ptr<T>& buffer,
+             typename T::indices_type&   destidx,
+             const TileBuffer&           tilebuf,
+             PlaneRegion&                rfull,
+             PlaneRegion&                rclip,
+             uint16_t                    copysamples)
     {
       if (rclip.w == rfull.w &&
           rclip.x == region.x &&
@@ -194,12 +194,12 @@ namespace
 
     // Special case for BIT
     void
-    transfer(std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
-             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type& destidx,
-             const TileBuffer& tilebuf,
-             PlaneRegion& rfull,
-             PlaneRegion& rclip,
-             uint16_t copysamples)
+    transfer(ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
+             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&             destidx,
+             const TileBuffer&                                                                 tilebuf,
+             PlaneRegion&                                                                      rfull,
+             PlaneRegion&                                                                      rclip,
+             uint16_t                                                                          copysamples)
     {
       // Unpack bits from buffer.
 
@@ -238,18 +238,18 @@ namespace
 
     template<typename T>
     dimension_size_type
-    expected_read(const std::shared_ptr<T>& /* buffer */,
-                  const PlaneRegion& rclip,
-                  uint16_t copysamples) const
+    expected_read(const ome::compat::shared_ptr<T>& /* buffer */,
+                  const PlaneRegion&                rclip,
+                  uint16_t                          copysamples) const
     {
       return rclip.w * rclip.h * copysamples * sizeof(typename T::value_type);
     }
 
     // Special case for BIT
     dimension_size_type
-    expected_read(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& /* buffer */,
-                  const PlaneRegion& rclip,
-                  uint16_t copysamples) const
+    expected_read(const ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& /* buffer */,
+                  const PlaneRegion&                                                                      rclip,
+                  uint16_t                                                                                copysamples) const
     {
       dimension_size_type expectedread = rclip.w;
 
@@ -263,9 +263,9 @@ namespace
 
     template<typename T>
     void
-    operator()(std::shared_ptr<T>& buffer)
+    operator()(ome::compat::shared_ptr<T>& buffer)
     {
-      std::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
+      ome::compat::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
       ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
 
@@ -349,7 +349,7 @@ namespace
     void
     flush()
     {
-      std::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
+      ome::compat::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
       ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
       PlaneRegion rimage(0, 0, ifd.getImageWidth(), ifd.getImageHeight());
@@ -392,12 +392,12 @@ namespace
 
     template<typename T>
     void
-    transfer(const std::shared_ptr<T>& buffer,
-             typename T::indices_type& srcidx,
-             TileBuffer& tilebuf,
-             PlaneRegion& rfull,
-             PlaneRegion& rclip,
-             uint16_t copysamples)
+    transfer(const ome::compat::shared_ptr<T>& buffer,
+             typename T::indices_type&         srcidx,
+             TileBuffer&                       tilebuf,
+             PlaneRegion&                      rfull,
+             PlaneRegion&                      rclip,
+             uint16_t                          copysamples)
     {
       if (rclip.w == rfull.w &&
           rclip.x == region.x &&
@@ -446,12 +446,12 @@ namespace
 
     // Special case for BIT
     void
-    transfer(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
-             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type& srcidx,
-             TileBuffer& tilebuf,
-             PlaneRegion& rfull,
-             PlaneRegion& rclip,
-             uint16_t copysamples)
+    transfer(const ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
+             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&                   srcidx,
+             TileBuffer&                                                                             tilebuf,
+             PlaneRegion&                                                                            rfull,
+             PlaneRegion&                                                                            rclip,
+             uint16_t                                                                                copysamples)
     {
       // Pack bits into buffer.
 
@@ -492,7 +492,7 @@ namespace
 
     template<typename T>
     void
-    operator()(const std::shared_ptr<T>& buffer)
+    operator()(const ome::compat::shared_ptr<T>& buffer)
     {
       uint16_t samples = ifd.getSamplesPerPixel();
       PlanarConfiguration planarconfig = ifd.getPlanarConfiguration();
@@ -520,7 +520,7 @@ namespace
           // Note boost::make_shared makes arguments const, so can't use
           // here.
           if (!tilecache.find(tile))
-            tilecache.insert(tile, std::shared_ptr<TileBuffer>(new TileBuffer(tileinfo.bufferSize())));
+            tilecache.insert(tile, ome::compat::shared_ptr<TileBuffer>(new TileBuffer(tileinfo.bufferSize())));
           assert(tilecache.find(tile));
           TileBuffer& tilebuf = *tilecache.find(tile);
 
@@ -556,13 +556,13 @@ namespace ome
         class IFDConcrete : public IFD
         {
         public:
-          IFDConcrete(std::shared_ptr<TIFF>& tiff,
+          IFDConcrete(ome::compat::shared_ptr<TIFF>& tiff,
                       offset_type            offset):
             IFD(tiff, offset)
           {
           }
 
-          IFDConcrete(std::shared_ptr<TIFF>& tiff):
+          IFDConcrete(ome::compat::shared_ptr<TIFF>& tiff):
             IFD(tiff, 0)
           {
           }
@@ -582,7 +582,7 @@ namespace ome
       {
       public:
         /// Reference to the parent TIFF.
-        std::shared_ptr<TIFF> tiff;
+        ome::compat::shared_ptr<TIFF> tiff;
         /// Offset of this IFD.
         offset_type offset;
         /// Tile coverage cache (used when writing).
@@ -616,8 +616,8 @@ namespace ome
          * @param tiff the parent TIFF.
          * @param offset the IFD offset.
          */
-        Impl(std::shared_ptr<TIFF>& tiff,
-             offset_type            offset):
+        Impl(ome::compat::shared_ptr<TIFF>& tiff,
+             offset_type                    offset):
           tiff(tiff),
           offset(offset),
           coverage(),
@@ -647,18 +647,18 @@ namespace ome
         operator= (const Impl&);
       };
 
-      IFD::IFD(std::shared_ptr<TIFF>& tiff,
-               offset_type            offset):
+      IFD::IFD(ome::compat::shared_ptr<TIFF>& tiff,
+               offset_type                    offset):
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        impl(std::shared_ptr<Impl>(new Impl(tiff, offset)))
+        impl(ome::compat::shared_ptr<Impl>(new Impl(tiff, offset)))
       {
       }
 
-      IFD::IFD(std::shared_ptr<TIFF>& tiff):
+      IFD::IFD(ome::compat::shared_ptr<TIFF>& tiff):
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        impl(std::shared_ptr<Impl>(new Impl(tiff, 0)))
+        impl(ome::compat::shared_ptr<Impl>(new Impl(tiff, 0)))
       {
       }
 
@@ -666,9 +666,9 @@ namespace ome
       {
       }
 
-      std::shared_ptr<IFD>
-      IFD::openIndex(std::shared_ptr<TIFF>& tiff,
-                     directory_index_type   index)
+      ome::compat::shared_ptr<IFD>
+      IFD::openIndex(ome::compat::shared_ptr<TIFF>& tiff,
+                     directory_index_type           index)
       {
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
@@ -682,27 +682,27 @@ namespace ome
         return openOffset(tiff, static_cast<uint64_t>(TIFFCurrentDirOffset(tiffraw)));
       }
 
-      std::shared_ptr<IFD>
-      IFD::openOffset(std::shared_ptr<TIFF>& tiff,
-                      offset_type            offset)
+      ome::compat::shared_ptr<IFD>
+      IFD::openOffset(ome::compat::shared_ptr<TIFF>& tiff,
+                      offset_type                    offset)
       {
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        return std::shared_ptr<IFD>(new IFDConcrete(tiff, offset));
+        return ome::compat::shared_ptr<IFD>(new IFDConcrete(tiff, offset));
       }
 
-      std::shared_ptr<IFD>
-      IFD::current(std::shared_ptr<TIFF>& tiff)
+      ome::compat::shared_ptr<IFD>
+      IFD::current(ome::compat::shared_ptr<TIFF>& tiff)
       {
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        return std::shared_ptr<IFD>(new IFDConcrete(tiff));
+        return ome::compat::shared_ptr<IFD>(new IFDConcrete(tiff));
       }
 
       void
       IFD::makeCurrent() const
       {
-        std::shared_ptr<TIFF>& tiff = getTIFF();
+        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -719,7 +719,7 @@ namespace ome
           }
       }
 
-      std::shared_ptr<TIFF>&
+      ome::compat::shared_ptr<TIFF>&
       IFD::getTIFF() const
       {
         return impl->tiff;
@@ -735,7 +735,7 @@ namespace ome
       IFD::getRawField(tag_type tag,
                        ...) const
       {
-        std::shared_ptr<TIFF>& tiff = getTIFF();
+        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -756,7 +756,7 @@ namespace ome
       IFD::setRawField(tag_type tag,
                        ...)
       {
-        std::shared_ptr<TIFF>& tiff = getTIFF();
+        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -1226,8 +1226,8 @@ namespace ome
 
         buf.setBuffer(shape, PixelType::UINT16, order_planar);
 
-        std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > uint16_buffer
-          (boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > >(buf.vbuffer()));
+        ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > uint16_buffer
+          (boost::get<ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > >(buf.vbuffer()));
         assert(uint16_buffer);
 
         for (VariantPixelBuffer::size_type s = 0U; s < shape[DIM_SUBCHANNEL]; ++s)
@@ -1300,12 +1300,12 @@ namespace ome
         boost::apply_visitor(v, source.vbuffer());
       }
 
-      std::shared_ptr<IFD>
+      ome::compat::shared_ptr<IFD>
       IFD::next() const
       {
-        std::shared_ptr<IFD> ret;
+        ome::compat::shared_ptr<IFD> ret;
 
-        std::shared_ptr<TIFF>& tiff = getTIFF();
+        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -1324,7 +1324,7 @@ namespace ome
       bool
       IFD::last() const
       {
-        std::shared_ptr<TIFF>& tiff = getTIFF();
+        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -1414,10 +1414,10 @@ namespace ome
 
       }
 
-      std::shared_ptr<CoreMetadata>
+      ome::compat::shared_ptr<CoreMetadata>
       makeCoreMetadata(const IFD& ifd)
       {
-        std::shared_ptr<CoreMetadata> m(std::make_shared<CoreMetadata>());
+        ome::compat::shared_ptr<CoreMetadata> m(ome::compat::make_shared<CoreMetadata>());
 
         m->dimensionOrder = ome::xml::model::enums::DimensionOrder::XYCZT;
         m->sizeX = ifd.getImageWidth();

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -68,20 +68,20 @@ namespace ome
        *
        * An IFD represents a subfile within a TIFF.
        */
-      class IFD : public std::enable_shared_from_this<IFD>
+      class IFD : public ome::compat::enable_shared_from_this<IFD>
       {
       private:
         class Impl;
         /// Private implementation details.
-        std::shared_ptr<Impl> impl;
+        ome::compat::shared_ptr<Impl> impl;
 
       protected:
         /// Constructor (not public).
-        IFD(std::shared_ptr<TIFF>& tiff,
-            offset_type            offset);
+        IFD(ome::compat::shared_ptr<TIFF>& tiff,
+            offset_type                    offset);
 
         /// Constructor (not public).
-        IFD(std::shared_ptr<TIFF>& tiff);
+        IFD(ome::compat::shared_ptr<TIFF>& tiff);
 
       private:
         /// Copy constructor (deleted).
@@ -102,9 +102,9 @@ namespace ome
          * @param index the directory index.
          * @returns the open IFD.
          */
-        static std::shared_ptr<IFD>
-        openIndex(std::shared_ptr<TIFF>& tiff,
-                  directory_index_type   index);
+        static ome::compat::shared_ptr<IFD>
+        openIndex(ome::compat::shared_ptr<TIFF>& tiff,
+                  directory_index_type           index);
 
         /**
          * Open an IFD.
@@ -113,9 +113,9 @@ namespace ome
          * @param offset the directory offset.
          * @returns the open IFD.
          */
-        static std::shared_ptr<IFD>
-        openOffset(std::shared_ptr<TIFF>& tiff,
-                   offset_type            offset);
+        static ome::compat::shared_ptr<IFD>
+        openOffset(ome::compat::shared_ptr<TIFF>& tiff,
+                   offset_type                    offset);
 
         /**
          * Get the current IFD.
@@ -123,15 +123,15 @@ namespace ome
          * @param tiff the source TIFF.
          * @returns the open IFD.
          */
-        static std::shared_ptr<IFD>
-        current(std::shared_ptr<TIFF>& tiff);
+        static ome::compat::shared_ptr<IFD>
+        current(ome::compat::shared_ptr<TIFF>& tiff);
 
         /**
          * Get the source TIFF this descriptor belongs to.
          *
          * @returns the source TIFF.
          */
-        std::shared_ptr<TIFF>&
+        ome::compat::shared_ptr<TIFF>&
         getTIFF() const;
 
         /**
@@ -487,7 +487,7 @@ namespace ome
          *
          * @returns the next directory, or null if this is the last directory.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         next() const;
 
         /**
@@ -505,7 +505,7 @@ namespace ome
        * @param ifd the IFD to use.
        * @returns the CoreMetadata.
        */
-      std::shared_ptr<CoreMetadata>
+      ome::compat::shared_ptr<CoreMetadata>
       makeCoreMetadata(const IFD& ifd);
 
     }

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -184,7 +184,7 @@ namespace ome
       // Note boost::make_shared can't be used here.
       TIFF::TIFF(const boost::filesystem::path& filename,
                  const std::string&             mode):
-        impl(std::shared_ptr<Impl>(new Impl(filename, mode)))
+        impl(ome::compat::shared_ptr<Impl>(new Impl(filename, mode)))
       {
         registerImageJTags();
       }
@@ -199,15 +199,15 @@ namespace ome
         return reinterpret_cast<wrapped_type *>(impl->tiff);
       }
 
-      std::shared_ptr<TIFF>
+      ome::compat::shared_ptr<TIFF>
       TIFF::open(const boost::filesystem::path& filename,
                  const std::string& mode)
       {
-        std::shared_ptr<TIFF> ret;
+        ome::compat::shared_ptr<TIFF> ret;
         try
           {
             // Note boost::make_shared can't be used here.
-            ret = std::shared_ptr<TIFF>(new TIFFConcrete(filename, mode));
+            ret = ome::compat::shared_ptr<TIFF>(new TIFFConcrete(filename, mode));
           }
         catch (const std::exception& e)
           {
@@ -242,7 +242,7 @@ namespace ome
         return impl->directoryCount;
       }
 
-      std::shared_ptr<IFD>
+      ome::compat::shared_ptr<IFD>
       TIFF::getDirectoryByIndex(directory_index_type index) const
       {
         Sentry sentry;
@@ -250,11 +250,11 @@ namespace ome
         if (!TIFFSetDirectory(impl->tiff, index))
           sentry.error();
 
-        std::shared_ptr<TIFF> t(std::const_pointer_cast<TIFF>(shared_from_this()));
+        ome::compat::shared_ptr<TIFF> t(ome::compat::const_pointer_cast<TIFF>(shared_from_this()));
         return IFD::openIndex(t, index);
       }
 
-      std::shared_ptr<IFD>
+      ome::compat::shared_ptr<IFD>
       TIFF::getDirectoryByOffset(offset_type offset) const
       {
         Sentry sentry;
@@ -267,14 +267,14 @@ namespace ome
           sentry.error();
 #endif // TIFF_HAVE_BIGTIFF
 
-        std::shared_ptr<TIFF> t(std::const_pointer_cast<TIFF>(shared_from_this()));
+        ome::compat::shared_ptr<TIFF> t(ome::compat::const_pointer_cast<TIFF>(shared_from_this()));
         return IFD::openOffset(t, offset);
       }
 
-      std::shared_ptr<IFD>
+      ome::compat::shared_ptr<IFD>
       TIFF::getCurrentDirectory() const
       {
-        std::shared_ptr<TIFF> t(std::const_pointer_cast<TIFF>(shared_from_this()));
+        ome::compat::shared_ptr<TIFF> t(ome::compat::const_pointer_cast<TIFF>(shared_from_this()));
         return IFD::current(t);
       }
 
@@ -290,14 +290,14 @@ namespace ome
       TIFF::iterator
       TIFF::begin()
       {
-        std::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
+        ome::compat::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
         return iterator(ifd);
       }
 
       TIFF::const_iterator
       TIFF::begin() const
       {
-        std::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
+        ome::compat::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
         return const_iterator(ifd);
       }
 

--- a/cpp/lib/ome/bioformats/tiff/TIFF.h
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.h
@@ -65,7 +65,7 @@ namespace ome
        */
       template<typename Value>
       class IFDIterator : public boost::iterator_facade<IFDIterator<Value>,
-                                                        std::shared_ptr<Value>,
+                                                        ome::compat::shared_ptr<Value>,
                                                         boost::forward_traversal_tag>
       {
       public:
@@ -85,7 +85,7 @@ namespace ome
          *
          * @param ifd the descriptor to point to.
          */
-        IFDIterator(std::shared_ptr<IFD>& ifd):
+        IFDIterator(ome::compat::shared_ptr<IFD>& ifd):
           pos(ifd)
         {}
 
@@ -105,7 +105,7 @@ namespace ome
          * It's mutable to allow const and non-const access to the
          * underlying descriptor via const and non-const iterators.
          */
-        mutable std::shared_ptr<Value> pos;
+        mutable ome::compat::shared_ptr<Value> pos;
 
         friend class boost::iterator_core_access;
         template <class> friend class IFDIterator;
@@ -137,7 +137,7 @@ namespace ome
          *
          * @returns a reference to currently referenced descriptor.
          */
-        std::shared_ptr<Value>&
+        ome::compat::shared_ptr<Value>&
         dereference() const
         {
           return pos;
@@ -152,13 +152,13 @@ namespace ome
        * instance.  This instance may be used to get IFD instances and
        * then access to image metadata and pixel data.
        */
-      class TIFF : public std::enable_shared_from_this<TIFF>
+      class TIFF : public ome::compat::enable_shared_from_this<TIFF>
       {
       private:
         class Impl;
         class wrapped_type;
         /// Private implementation details.
-        std::shared_ptr<Impl> impl;
+        ome::compat::shared_ptr<Impl> impl;
 
       protected:
         /// Constructor (non-public).
@@ -189,7 +189,7 @@ namespace ome
          * @returns the the open TIFF.
          * @throws an Exception on failure.
          */
-        static std::shared_ptr<TIFF>
+        static ome::compat::shared_ptr<TIFF>
         open(const boost::filesystem::path& filename,
              const std::string&             mode);
 
@@ -227,7 +227,7 @@ namespace ome
          * @throws an Exception if the index is invalid or could not
          * be accessed.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         getDirectoryByIndex(directory_index_type index) const;
 
         /**
@@ -238,7 +238,7 @@ namespace ome
          * @throws an Exception if the offset is invalid or could not
          * be accessed.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         getDirectoryByOffset(offset_type offset) const;
 
         /**
@@ -247,7 +247,7 @@ namespace ome
          * @returns the IFD.
          * @throws an Exception if the IFD could not be accessed.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         getCurrentDirectory() const;
 
         /**

--- a/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
@@ -63,7 +63,7 @@ namespace ome
       {
       public:
         /// Weak reference to the parent IFD.
-        std::weak_ptr<IFD>  ifd;
+        ome::compat::weak_ptr<IFD>  ifd;
         /// Whether the image is chunky or planar.
         TileType type;
         /// Width of a tile.
@@ -90,7 +90,7 @@ namespace ome
          *
          * @param ifd the directory the tile belongs to.
          */
-        Impl(std::shared_ptr<IFD>& ifd):
+        Impl(ome::compat::shared_ptr<IFD>& ifd):
           ifd(ifd),
           tilewidth(),
           tileheight(),
@@ -147,10 +147,10 @@ namespace ome
          *
          * @returns the directory.
          */
-        std::shared_ptr<IFD>
+        ome::compat::shared_ptr<IFD>
         getIFD() const
         {
-          std::shared_ptr<IFD> sifd = std::shared_ptr<IFD>(ifd);
+          ome::compat::shared_ptr<IFD> sifd = ome::compat::shared_ptr<IFD>(ifd);
           if (!sifd)
             throw Exception("TileInfo reference to IFD no longer valid");
 
@@ -173,8 +173,8 @@ namespace ome
         }
       };
 
-      TileInfo::TileInfo(std::shared_ptr<IFD> ifd):
-        impl(std::shared_ptr<Impl>(new Impl(ifd)))
+      TileInfo::TileInfo(ome::compat::shared_ptr<IFD> ifd):
+        impl(ome::compat::shared_ptr<Impl>(new Impl(ifd)))
       {
       }
 

--- a/cpp/lib/ome/bioformats/tiff/TileInfo.h
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.h
@@ -68,7 +68,7 @@ namespace ome
          *
          * @param ifd the directory the tile belongs to.
          */
-        TileInfo(std::shared_ptr<IFD> ifd);
+        TileInfo(ome::compat::shared_ptr<IFD> ifd);
 
       public:
         /// Destructor.
@@ -227,7 +227,7 @@ namespace ome
       protected:
         class Impl;
         /// Private implementation details.
-        std::shared_ptr<Impl> impl;
+        ome::compat::shared_ptr<Impl> impl;
       };
 
     }

--- a/cpp/lib/ome/compat/memory.h
+++ b/cpp/lib/ome/compat/memory.h
@@ -104,7 +104,10 @@ namespace boost
 
 } // namespace boost
 # endif
-namespace std {
+namespace ome
+{
+  namespace compat
+  {
     using boost::shared_ptr;
     using boost::weak_ptr;
     using boost::static_pointer_cast;
@@ -113,6 +116,7 @@ namespace std {
     using boost::enable_shared_from_this;
     using boost::make_shared;
     using boost::owner_less;
+  }
 }
 # else
 #  error A shared_ptr implementation is not available

--- a/cpp/lib/ome/compat/regex.h
+++ b/cpp/lib/ome/compat/regex.h
@@ -52,25 +52,45 @@
 
 # ifdef OME_HAVE_REGEX
 #  include <regex>
+namespace ome
+{
+  namespace compat
+  {
+    using std::regex;
+    using std::regex_error;
+    using std::regex_match;
+    using std::regex_search;
+    using std::cmatch;
+    using std::smatch;
+  }
+}
 # elif OME_HAVE_TR1_REGEX
 #  include <tr1/regex.hpp>
-namespace std {
-  using std::tr1::regex;
-  using std::tr1::regex_error;
-  using std::tr1::regex_match;
-  using std::tr1::regex_search;
-  using std::tr1::cmatch;
-  using std::tr1::smatch;
+namespace ome
+{
+  namespace compat
+  {
+    using std::tr1::regex;
+    using std::tr1::regex_error;
+    using std::tr1::regex_match;
+    using std::tr1::regex_search;
+    using std::tr1::cmatch;
+    using std::tr1::smatch;
+  }
 }
 # elif OME_HAVE_BOOST_REGEX
 #  include <boost/regex.hpp>
-namespace std {
-  using boost::regex;
-  using boost::regex_error;
-  using boost::regex_match;
-  using boost::regex_search;
-  using boost::cmatch;
-  using boost::smatch;
+namespace ome
+{
+  namespace compat
+  {
+    using boost::regex;
+    using boost::regex_error;
+    using boost::regex_match;
+    using boost::regex_search;
+    using boost::cmatch;
+    using boost::smatch;
+  }
 }
 # else
 #  error An regex implementation is not available

--- a/cpp/lib/ome/compat/tuple.h
+++ b/cpp/lib/ome/compat/tuple.h
@@ -52,17 +52,33 @@
 
 # ifdef OME_HAVE_TUPLE
 #  include <tuple>
+namespace ome
+{
+  namespace compat
+  {
+    using std::tuple;
+    using std::get;
+  }
+}
 # elif OME_HAVE_TR1_TUPLE
 #  include <tr1/tuple>
-namespace std {
-  using tr1::tuple;
-  using tr1::get;
+namespace ome
+{
+  namespace compat
+  {
+    using std::tr1::tuple;
+    using std::tr1::get;
+  }
 }
 # elif OME_HAVE_BOOST_TUPLE
 #  include <boost/tuple/tuple.hpp>
-namespace std {
-  using boost::tuple;
-  using boost::get;
+namespace ome
+{
+  namespace compat
+  {
+    using boost::tuple;
+    using boost::get;
+  }
 }
 # else
 #  error A tuple implementation is not available

--- a/cpp/lib/ome/xerces/EntityResolver.cpp
+++ b/cpp/lib/ome/xerces/EntityResolver.cpp
@@ -211,7 +211,7 @@ namespace ome
                               if (e.hasAttribute("uri") && e.hasAttribute("name"))
                                 {
                                   boost::filesystem::path newid(currentdir / static_cast<std::string>(e.getAttribute("uri")));
-                                  registration.push_back(std::shared_ptr<AutoRegisterEntity>(new AutoRegisterEntity(static_cast<std::string>(e.getAttribute("name")),
+                                  registration.push_back(ome::compat::shared_ptr<AutoRegisterEntity>(new AutoRegisterEntity(static_cast<std::string>(e.getAttribute("name")),
                                                                                                                     ome::compat::canonical(newid))));
                                 }
                             }

--- a/cpp/lib/ome/xerces/EntityResolver.h
+++ b/cpp/lib/ome/xerces/EntityResolver.h
@@ -181,7 +181,7 @@ namespace ome
         operator= (const AutoRegisterCatalog&);
 
         /// Registered entities from this catalog.
-        std::vector<std::shared_ptr<AutoRegisterEntity> > registration;
+        std::vector<ome::compat::shared_ptr<AutoRegisterEntity> > registration;
       };
 
     public:
@@ -214,7 +214,7 @@ namespace ome
 
       private:
         /// Automatic registration.
-        std::shared_ptr<AutoRegisterEntity> registration;
+        ome::compat::shared_ptr<AutoRegisterEntity> registration;
       };
 
       /**
@@ -239,7 +239,7 @@ namespace ome
 
       private:
         /// Automatic registration.
-        std::shared_ptr<AutoRegisterCatalog> registration;
+        ome::compat::shared_ptr<AutoRegisterCatalog> registration;
       };
 
       friend class RegisterEntity;

--- a/cpp/lib/ome/xerces/dom/Base.h
+++ b/cpp/lib/ome/xerces/dom/Base.h
@@ -94,8 +94,8 @@ namespace ome
         Base(base_element_type *wrapped,
              Deleter            del):
           base(wrapped ?
-               std::shared_ptr<base_element_type>(wrapped, del) :
-               std::shared_ptr<base_element_type>())
+               ome::compat::shared_ptr<base_element_type>(wrapped, del) :
+               ome::compat::shared_ptr<base_element_type>())
         {}
 
         /**
@@ -106,8 +106,8 @@ namespace ome
         explicit
         Base(base_element_type *wrapped):
           base(wrapped ?
-               std::shared_ptr<base_element_type>(wrapped, &ome::xerces::dom::detail::unmanaged<base_element_type>) :
-               std::shared_ptr<base_element_type>())
+               ome::compat::shared_ptr<base_element_type>(wrapped, &ome::xerces::dom::detail::unmanaged<base_element_type>) :
+               ome::compat::shared_ptr<base_element_type>())
         {}
 
         /// Destructor.
@@ -160,7 +160,7 @@ namespace ome
         reset()
         {
           base.reset();
-          std::shared_ptr<base_element_type> n;
+          ome::compat::shared_ptr<base_element_type> n;
           assign(n);
         }
 
@@ -198,7 +198,7 @@ namespace ome
          */
         virtual
         void
-        assign(std::shared_ptr<base_element_type>& wrapped)
+        assign(ome::compat::shared_ptr<base_element_type>& wrapped)
         {
           base = wrapped;
         }
@@ -225,7 +225,7 @@ namespace ome
 
       private:
         /// Wrapped reference.
-        std::shared_ptr<base_element_type> base;
+        ome::compat::shared_ptr<base_element_type> base;
       };
 
     }

--- a/cpp/lib/ome/xerces/dom/NodeList.cpp
+++ b/cpp/lib/ome/xerces/dom/NodeList.cpp
@@ -56,7 +56,7 @@ namespace ome
                                     size_type             index):
         index(index),
         xmlnodelist(xmlnodelist),
-        xmlnode(std::shared_ptr<Node>(new Node(xmlnodelist->item(index), false)))
+        xmlnode(ome::compat::shared_ptr<Node>(new Node(xmlnodelist->item(index), false)))
       {}
 
       NodeList::iterator::iterator (const iterator& rhs):

--- a/cpp/lib/ome/xerces/dom/NodeList.h
+++ b/cpp/lib/ome/xerces/dom/NodeList.h
@@ -164,7 +164,7 @@ namespace ome
           /// List being iterated over.
           xercesc::DOMNodeList *xmlnodelist;
           /// Node at current position.
-          std::shared_ptr<Node> xmlnode;
+          ome::compat::shared_ptr<Node> xmlnode;
         };
 
         /**

--- a/cpp/lib/ome/xerces/dom/Wrapper.h
+++ b/cpp/lib/ome/xerces/dom/Wrapper.h
@@ -110,11 +110,11 @@ namespace ome
           parent_type(),
           wrapped()
         {
-          std::shared_ptr<base_element_type> pbase;
+          ome::compat::shared_ptr<base_element_type> pbase;
           if (base)
-            pbase = std::shared_ptr<base_element_type>(base, del);
+            pbase = ome::compat::shared_ptr<base_element_type>(base, del);
           else
-            pbase = std::shared_ptr<base_element_type>();
+            pbase = ome::compat::shared_ptr<base_element_type>();
           assign(pbase);
         }
 
@@ -128,11 +128,11 @@ namespace ome
           parent_type(),
           wrapped()
         {
-          std::shared_ptr<base_element_type> pbase;
+          ome::compat::shared_ptr<base_element_type> pbase;
           if (base)
-            pbase = std::shared_ptr<base_element_type>(base, &ome::xerces::dom::detail::unmanaged<base_element_type>);
+            pbase = ome::compat::shared_ptr<base_element_type>(base, &ome::xerces::dom::detail::unmanaged<base_element_type>);
           else
-            pbase = std::shared_ptr<base_element_type>();
+            pbase = ome::compat::shared_ptr<base_element_type>();
           assign(pbase);
         }
 
@@ -188,7 +188,7 @@ namespace ome
          */
         virtual
         void
-        assign(std::shared_ptr<base_element_type>& wrapped)
+        assign(ome::compat::shared_ptr<base_element_type>& wrapped)
         {
           this->wrapped = this->template assign_check<element_type>(wrapped.get());
           parent_type::assign(wrapped);

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -135,8 +135,8 @@ namespace ome
       }
 
       bool
-      MapPairs::link (std::shared_ptr<Reference>&                          reference,
-                      std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      MapPairs::link (ome::compat::shared_ptr<Reference>&                          reference,
+                      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
       {
         if (detail::OMEModelObject::link(reference, object))
           {

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -128,8 +128,8 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (std::shared_ptr<Reference>&                          reference,
-              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+        link (ome::compat::shared_ptr<Reference>&                          reference,
+              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/cpp/lib/ome/xml/model/OMEModel.h
+++ b/cpp/lib/ome/xml/model/OMEModel.h
@@ -63,11 +63,11 @@ namespace ome
       {
       public:
         /// A list of Reference objects.
-        typedef std::vector<std::shared_ptr<Reference> > reference_list_type;
+        typedef std::vector<ome::compat::shared_ptr<Reference> > reference_list_type;
         /// A map of string model object identifiers to model objects.
-        typedef std::map<std::string, std::shared_ptr<OMEModelObject> > object_map_type;
+        typedef std::map<std::string, ome::compat::shared_ptr<OMEModelObject> > object_map_type;
         /// A map of model objects to list of Reference objects.
-        typedef std::map<std::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
+        typedef std::map<ome::compat::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
         /// Size type for reference map.
         typedef reference_map_type::size_type size_type;
 
@@ -105,9 +105,9 @@ namespace ome
          * Should it be possible to insert null objects?
          */
         virtual
-        std::shared_ptr<OMEModelObject>
-        addModelObject (const std::string&               id,
-                        std::shared_ptr<OMEModelObject>& object) = 0;
+        ome::compat::shared_ptr<OMEModelObject>
+        addModelObject (const std::string&                       id,
+                        ome::compat::shared_ptr<OMEModelObject>& object) = 0;
 
         /**
          * Remove a model object from the model.
@@ -118,7 +118,7 @@ namespace ome
          * not exist.
          */
         virtual
-        std::shared_ptr<OMEModelObject>
+        ome::compat::shared_ptr<OMEModelObject>
         removeModelObject (const std::string& id) = 0;
 
         /**
@@ -132,7 +132,7 @@ namespace ome
          * @todo: Would a const reference be better for the return?
          */
         virtual
-        std::shared_ptr<OMEModelObject>
+        ome::compat::shared_ptr<OMEModelObject>
         getModelObject (const std::string& id) const = 0;
 
         /**
@@ -161,8 +161,8 @@ namespace ome
          */
         virtual
         bool
-        addReference (std::shared_ptr<OMEModelObject>& a,
-                      std::shared_ptr<Reference>&      b) = 0;
+        addReference (ome::compat::shared_ptr<OMEModelObject>& a,
+                      ome::compat::shared_ptr<Reference>&      b) = 0;
 
         /**
          * Retrieve all references from the model.

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -74,7 +74,7 @@ namespace ome
        * could just be Object, since it's really an
        * ome::xml::model::Object.
        */
-      class OMEModelObject : public std::enable_shared_from_this<OMEModelObject>
+      class OMEModelObject : public ome::compat::enable_shared_from_this<OMEModelObject>
       {
       protected:
         /**
@@ -89,7 +89,7 @@ namespace ome
             Ptr<T>, // value type
             boost::multi_index::indexed_by<
               boost::multi_index::random_access<>, // insertion order
-              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, std::owner_less<Ptr<T> >  > // sorted order
+              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, ome::compat::owner_less<Ptr<T> > > // sorted order
               >
             > type;
         };
@@ -186,8 +186,8 @@ namespace ome
          * to all generated model objects implementing this interface.
          */
         virtual bool
-        link (std::shared_ptr<Reference>&      reference,
-              std::shared_ptr<OMEModelObject>& object) = 0;
+        link (ome::compat::shared_ptr<Reference>&      reference,
+              ome::compat::shared_ptr<OMEModelObject>& object) = 0;
 
         /**
          * Get the XML namespace for this model object.

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -165,8 +165,8 @@ namespace ome
     }
 
       bool
-      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
-                      std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      OriginalMetadataAnnotation::link (ome::compat::shared_ptr<Reference>&                          reference,
+                                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
       {
         if (XMLAnnotation::link(reference, object))
           {
@@ -185,7 +185,7 @@ namespace ome
 
       xerces::dom::Element
       OriginalMetadataAnnotation::asXMLElementInternal (xerces::dom::Document& document,
-                                      xerces::dom::Element&  element) const
+                                                        xerces::dom::Element&  element) const
       {
 
         return XMLAnnotation::asXMLElementInternal(document, element);

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
@@ -124,8 +124,8 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (std::shared_ptr<Reference>&                          reference,
-              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+        link (ome::compat::shared_ptr<Reference>&                          reference,
+              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/cpp/lib/ome/xml/model/detail/OMEModel.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.cpp
@@ -64,12 +64,12 @@ namespace ome
         {
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::addModelObject(const std::string&                                   id,
-                                 std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                                 ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
         {
           // Don't store references.
-          if (std::dynamic_pointer_cast<Reference>(object))
+          if (ome::compat::dynamic_pointer_cast<Reference>(object))
             return object;
 
           object_map_type::iterator i = modelObjects.find(id);
@@ -81,10 +81,10 @@ namespace ome
           return object;
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::removeModelObject(const std::string& id)
         {
-          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -96,10 +96,10 @@ namespace ome
           return ret;
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::getModelObject(const std::string& id) const
         {
-          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::const_iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -115,8 +115,8 @@ namespace ome
         }
 
         bool
-        OMEModel::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                                    std::shared_ptr<Reference>&                      b)
+        OMEModel::addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                                    ome::compat::shared_ptr<Reference>&                      b)
         {
           reference_map_type::iterator i = references.find(a);
 
@@ -145,7 +145,7 @@ namespace ome
                i != references.end();
                ++i)
             {
-              const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+              const ome::compat::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
 
               if (!a)
                 {
@@ -173,7 +173,7 @@ namespace ome
                         {
                           const std::string& referenceID = (*ref)->getID();
 
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                           if (!b)
                             {
                               std::clog << typeid(*a).name() << "@" << a
@@ -183,7 +183,7 @@ namespace ome
                             }
                           else
                             {
-                              std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> aw(ome::compat::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
                               aw->link(*ref, b);
                             }
                         }

--- a/cpp/lib/ome/xml/model/detail/OMEModel.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.h
@@ -70,16 +70,16 @@ namespace ome
           ~OMEModel ();
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
           addModelObject (const std::string&                                   id,
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
           removeModelObject (const std::string& id);
 
           // Documented in parent.
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
           getModelObject (const std::string& id) const;
 
           // Documented in parent.
@@ -88,8 +88,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModel::addReference
           bool
-          addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                        std::shared_ptr<Reference>&                          b);
+          addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                        ome::compat::shared_ptr<Reference>&                          b);
 
           // Documented in parent.
           const reference_map_type&

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -85,8 +85,8 @@ namespace ome
         }
 
         bool
-        OMEModelObject::link (std::shared_ptr<Reference>&                          /* reference */,
-                              std::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
+        OMEModelObject::link (ome::compat::shared_ptr<Reference>&                          /* reference */,
+                              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
         {
           return false;
         }

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.h
@@ -103,8 +103,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModelObject::link
           virtual bool
-          link (std::shared_ptr<Reference>&                          reference,
-                std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+          link (ome::compat::shared_ptr<Reference>&                          reference,
+                ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           /**
            * Retrieve all the children of an element that have a given
@@ -144,7 +144,7 @@ namespace ome
           {
           private:
             /// The element to compare other elements with.
-            const std::shared_ptr<const T>& cmp;
+            const ome::compat::shared_ptr<const T>& cmp;
 
           public:
             /**
@@ -152,7 +152,7 @@ namespace ome
              *
              * @param cmp the element to compare other elements with.
              */
-            compare_element(const std::shared_ptr<const T>& cmp):
+            compare_element(const ome::compat::shared_ptr<const T>& cmp):
               cmp(cmp)
             {}
 
@@ -164,7 +164,7 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const std::shared_ptr<T>& element)
+            operator () (const ome::compat::shared_ptr<T>& element)
             {
               return cmp && element && cmp == element;
             }
@@ -176,7 +176,7 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const std::shared_ptr<const T>& element)
+            operator () (const ome::compat::shared_ptr<const T>& element)
             {
               return cmp && element && cmp == element;
             }
@@ -188,9 +188,9 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const std::weak_ptr<T>& element)
+            operator () (const ome::compat::weak_ptr<T>& element)
             {
-              std::shared_ptr<const T> shared_element(element);
+              ome::compat::shared_ptr<const T> shared_element(element);
               return cmp && shared_element && cmp == shared_element;
             }
 
@@ -201,9 +201,9 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const std::weak_ptr<const T>& element)
+            operator () (const ome::compat::weak_ptr<const T>& element)
             {
-              std::shared_ptr<const T> shared_element(element);
+              ome::compat::shared_ptr<const T> shared_element(element);
               return cmp && shared_element && cmp == shared_element;
             }
           };
@@ -221,7 +221,7 @@ namespace ome
           template<class C, typename T>
           bool
           contains(const C&                  container,
-                   const std::shared_ptr<T>& element)
+                   const ome::compat::shared_ptr<T>& element)
           {
             return (std::find_if(container.begin(),
                                  container.end(),

--- a/cpp/lib/ome/xml/model/detail/Parse.h
+++ b/cpp/lib/ome/xml/model/detail/Parse.h
@@ -73,7 +73,7 @@ namespace ome
 
         /// Type trait for shared_ptr.
         template <class T>
-        struct is_shared_ptr<std::shared_ptr<T> >
+        struct is_shared_ptr<ome::compat::shared_ptr<T> >
           : boost::true_type {};
 
         /**
@@ -198,7 +198,7 @@ namespace ome
         {
           typedef typename boost::remove_const<typename boost::remove_reference<T>::type>::type raw_type;
 
-          raw_type attr(std::make_shared<typename raw_type::element_type>());
+          raw_type attr(ome::compat::make_shared<typename raw_type::element_type>());
           parse_value(text, *attr, klass, property);
           return attr;
         }

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -141,10 +141,10 @@ protected:
     return in == "Valid file content";
   }
 
-  std::shared_ptr<CoreMetadata>
+  ome::compat::shared_ptr<CoreMetadata>
   makeCore()
   {
-    std::shared_ptr<CoreMetadata> c(std::make_shared<CoreMetadata>());
+    ome::compat::shared_ptr<CoreMetadata> c(ome::compat::make_shared<CoreMetadata>());
 
     c->sizeX = 512;
     c->sizeY = 1024;
@@ -204,7 +204,7 @@ protected:
         // 5 series, 3 with subresolutions
         core.clear();
         {
-          std::shared_ptr<CoreMetadata> c(makeCore());
+          ome::compat::shared_ptr<CoreMetadata> c(makeCore());
           c->resolutionCount = 3;
           core.push_back(c);
           core.push_back(makeCore());
@@ -212,7 +212,7 @@ protected:
         }
 
         {
-          std::shared_ptr<CoreMetadata> c(makeCore());
+          ome::compat::shared_ptr<CoreMetadata> c(makeCore());
           c->resolutionCount = 2;
           core.push_back(c);
           core.push_back(makeCore());
@@ -222,7 +222,7 @@ protected:
         core.push_back(makeCore());
 
         {
-          std::shared_ptr<CoreMetadata> c(makeCore());
+          ome::compat::shared_ptr<CoreMetadata> c(makeCore());
           c->resolutionCount = 2;
           core.push_back(c);
           core.push_back(makeCore());
@@ -914,17 +914,17 @@ TEST_P(FormatReaderTest, FlatMetadata)
 
 TEST_P(FormatReaderTest, DefaultMetadataStore)
 {
-  std::shared_ptr<MetadataStore> store(std::make_shared<OMEXMLMetadata>());
+  ome::compat::shared_ptr<MetadataStore> store(ome::compat::make_shared<OMEXMLMetadata>());
 
   EXPECT_NO_THROW(r.setMetadataStore(store));
-  EXPECT_EQ(store, std::dynamic_pointer_cast<OMEXMLMetadata>(r.getMetadataStore()));
+  EXPECT_EQ(store, ome::compat::dynamic_pointer_cast<OMEXMLMetadata>(r.getMetadataStore()));
 }
 
 TEST_P(FormatReaderTest, FlatMetadataStore)
 {
   r.setId("flat");
 
-  std::shared_ptr<MetadataStore> store(std::make_shared<OMEXMLMetadata>());
+  ome::compat::shared_ptr<MetadataStore> store(ome::compat::make_shared<OMEXMLMetadata>());
 
   EXPECT_THROW(r.setMetadataStore(store), std::logic_error);
 }

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -230,9 +230,9 @@ public:
 
 private:
   void
-  makeMetadata(std::shared_ptr< ::ome::xml::meta::MetadataStore> store,
-               dimension_size_type                               series,
-               std::shared_ptr<CoreMetadata>                     core)
+  makeMetadata(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore> store,
+               dimension_size_type                                       series,
+               ome::compat::shared_ptr<CoreMetadata>                     core)
   {
     store->setImageID(createID("Image", series), series);
     store->setImageAcquisitionDate
@@ -258,10 +258,10 @@ private:
       }
   }
 
-  std::shared_ptr<CoreMetadata>
+  ome::compat::shared_ptr<CoreMetadata>
   makeCore()
   {
-    std::shared_ptr<CoreMetadata> c(std::make_shared<CoreMetadata>());
+    ome::compat::shared_ptr<CoreMetadata> c(ome::compat::make_shared<CoreMetadata>());
 
     c->sizeX = 512;
     c->sizeY = 1024;
@@ -289,7 +289,7 @@ public:
   {
     if (!currentId)
       {
-        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+        ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
 
         if (id == "output.test")
           {
@@ -300,7 +300,7 @@ public:
             makeMetadata(m, 3, makeCore());
           }
 
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
         setMetadataRetrieve(mr);
 
         FormatWriter::setId(id);
@@ -608,8 +608,8 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
 
 TEST_P(FormatWriterTest, DefaultMetadataRetrieve)
 {
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
-  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
+  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
 
   EXPECT_NO_THROW(w.getMetadataRetrieve());
   EXPECT_NO_THROW(w.setMetadataRetrieve(mr));
@@ -620,9 +620,9 @@ TEST_P(FormatWriterTest, DefaultMetadataRetrieve)
 
 TEST_P(FormatWriterTest, OutputMetadataRetrieve)
 {
-  std::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr;
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m2(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
-  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr2(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m2));
+  ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr;
+  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m2(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr2(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m2));
 
   w.setId("output.test");
 

--- a/cpp/test/ome-bioformats/pixel.h
+++ b/cpp/test/ome-bioformats/pixel.h
@@ -119,12 +119,12 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typedef typename ::ome::bioformats::PixelProperties<P>::std_type src_type;
   typedef ::ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
 
-  const std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > *src;
+  const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > *src;
   ::ome::bioformats::VariantPixelBuffer& dest;
 
   PixelTypeConversionVisitor(const ::ome::bioformats::VariantPixelBuffer& src,
                              ::ome::bioformats::VariantPixelBuffer& dest):
-    src(boost::get<std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > >(&src.vbuffer())),
+    src(boost::get<ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > >(&src.vbuffer())),
     dest(dest)
   {
 
@@ -141,7 +141,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_integral<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -167,7 +167,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_floating_point<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -192,7 +192,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_complex<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -216,7 +216,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   // and the upper part being set to true for the destination boolean
   // pixel type.
   void
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& lhs)
+  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     bit_type *dest_buf = lhs->data();

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -115,7 +115,7 @@ namespace
             static ome::compat::regex tile_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-tiles-([[:digit:]]+)x([[:digit:]]+)\\.tiff");
             static ome::compat::regex strip_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-strips-([[:digit:]]+)\\.tiff");
 
-            std::smatch found;
+            ome::compat::smatch found;
             std::string file(i->path().string());
             path wpath(i->path().parent_path());
             wpath /= std::string("w-") + i->path().filename().string();

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -112,15 +112,15 @@ namespace
       {
         for(directory_iterator i(dir); i != directory_iterator(); ++i)
           {
-            static std::regex tile_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-tiles-([[:digit:]]+)x([[:digit:]]+)\\.tiff");
-            static std::regex strip_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-strips-([[:digit:]]+)\\.tiff");
+            static ome::compat::regex tile_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-tiles-([[:digit:]]+)x([[:digit:]]+)\\.tiff");
+            static ome::compat::regex strip_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-strips-([[:digit:]]+)\\.tiff");
 
             std::smatch found;
             std::string file(i->path().string());
             path wpath(i->path().parent_path());
             wpath /= std::string("w-") + i->path().filename().string();
             std::string wfile(wpath.string());
-            if (std::regex_match(file, found, tile_match))
+            if (ome::compat::regex_match(file, found, tile_match))
               {
                 TileTestParameters p;
                 p.tile = true;
@@ -149,7 +149,7 @@ namespace
 
                 params.push_back(p);
               }
-            else if (std::regex_match(file, found, strip_match))
+            else if (ome::compat::regex_match(file, found, strip_match))
               {
                 TileTestParameters p;
                 p.tile = false;
@@ -196,7 +196,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_integral<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       float v = static_cast<float>(buf->at(idx));
@@ -209,7 +209,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_floating_point<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -220,7 +220,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -231,7 +231,7 @@ namespace
     // and the upper half being set to true for the destination boolean
     // pixel type.
     float
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf,
+    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf,
          const ::ome::bioformats::PixelBuffer<bit_type>::indices_type& idx)
     {
       return buf->at(idx) ? 1.0f : 0.0f;
@@ -316,13 +316,13 @@ TEST(TIFFTest, ConstructFailFile)
 
 TEST(TIFFTest, IFDsByIndex)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t =TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
   for (directory_index_type i = 0; i < 10; ++i)
     {
-      std::shared_ptr<IFD> ifd;
+      ome::compat::shared_ptr<IFD> ifd;
       ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(i));
     }
 
@@ -331,14 +331,14 @@ TEST(TIFFTest, IFDsByIndex)
 
 TEST(TIFFTest, IFDsByOffset)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t =TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
   for (directory_index_type i = 0; i < 10; ++i)
     {
       uint64_t offset = t->getDirectoryByIndex(i)->getOffset();
-      std::shared_ptr<IFD> ifd;
+      ome::compat::shared_ptr<IFD> ifd;
       ASSERT_NO_THROW(ifd = t->getDirectoryByOffset(offset));
       ASSERT_EQ(ifd->getOffset(), offset);
     }
@@ -348,11 +348,11 @@ TEST(TIFFTest, IFDsByOffset)
 
 TEST(TIFFTest, IFDSimpleIter)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd = t->getDirectoryByIndex(0);
+  ome::compat::shared_ptr<IFD> ifd = t->getDirectoryByIndex(0);
 
   while(ifd)
     {
@@ -362,7 +362,7 @@ TEST(TIFFTest, IFDSimpleIter)
 
 TEST(TIFFTest, TIFFIter)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
@@ -373,7 +373,7 @@ TEST(TIFFTest, TIFFIter)
 
 TEST(TIFFTest, TIFFConstIter)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
@@ -384,7 +384,7 @@ TEST(TIFFTest, TIFFConstIter)
 
 TEST(TIFFTest, TIFFConstIter2)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
@@ -395,11 +395,11 @@ TEST(TIFFTest, TIFFConstIter2)
 
 TEST(TIFFTest, RawField)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -409,11 +409,11 @@ TEST(TIFFTest, RawField)
 
 TEST(TIFFTest, RawField0)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -423,11 +423,11 @@ TEST(TIFFTest, RawField0)
 
 TEST(TIFFTest, FieldWrapString)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -447,11 +447,11 @@ TEST(TIFFTest, FieldWrapString)
 
 TEST(TIFFTest, FieldWrapStringArray)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -464,11 +464,11 @@ TEST(TIFFTest, FieldWrapStringArray)
 
 TEST(TIFFTest, FieldWrapUInt16)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -490,11 +490,11 @@ TEST(TIFFTest, FieldWrapUInt16)
 
 TEST(TIFFTest, FieldWrapCompression)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -506,11 +506,11 @@ TEST(TIFFTest, FieldWrapCompression)
 
 TEST(TIFFTest, FieldWrapFillOrder)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -521,11 +521,11 @@ TEST(TIFFTest, FieldWrapFillOrder)
 
 TEST(TIFFTest, FieldWrapOrientation)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -536,11 +536,11 @@ TEST(TIFFTest, FieldWrapOrientation)
 
 TEST(TIFFTest, FieldWrapPlanarConfiguration)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -552,11 +552,11 @@ TEST(TIFFTest, FieldWrapPlanarConfiguration)
 
 TEST(TIFFTest, FieldWrapPhotometricInterpretation)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -568,11 +568,11 @@ TEST(TIFFTest, FieldWrapPhotometricInterpretation)
 
 TEST(TIFFTest, FieldWrapPredictor)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -583,11 +583,11 @@ TEST(TIFFTest, FieldWrapPredictor)
 
 TEST(TIFFTest, FieldWrapSampleFormat)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -598,11 +598,11 @@ TEST(TIFFTest, FieldWrapSampleFormat)
 
 TEST(TIFFTest, FieldWrapThreshholding)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -613,11 +613,11 @@ TEST(TIFFTest, FieldWrapThreshholding)
 
 TEST(TIFFTest, FieldWrapYCbCrPosition)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -628,11 +628,11 @@ TEST(TIFFTest, FieldWrapYCbCrPosition)
 
 TEST(TIFFTest, FieldWrapUInt16Pair)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -646,11 +646,11 @@ TEST(TIFFTest, FieldWrapUInt16Pair)
 
 TEST(TIFFTest, FieldWrapFloat)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -666,11 +666,11 @@ TEST(TIFFTest, FieldWrapFloat)
 
 TEST(TIFFTest, FieldWrapFloat2)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -681,11 +681,11 @@ TEST(TIFFTest, FieldWrapFloat2)
 
 TEST(TIFFTest, FieldWrapFloat3)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -697,11 +697,11 @@ TEST(TIFFTest, FieldWrapFloat3)
 
 TEST(TIFFTest, FieldWrapFloat6)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -713,11 +713,11 @@ TEST(TIFFTest, FieldWrapFloat6)
 
 TEST(TIFFTest, FieldWrapUInt16ExtraSamplesArray)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -727,11 +727,11 @@ TEST(TIFFTest, FieldWrapUInt16ExtraSamplesArray)
 
 TEST(TIFFTest, FieldWrapUInt16Array3)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -742,11 +742,11 @@ TEST(TIFFTest, FieldWrapUInt16Array3)
 
 TEST(TIFFTest, FieldWrapUInt32)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -771,11 +771,11 @@ TEST(TIFFTest, FieldWrapUInt32)
 
 TEST(TIFFTest, FieldWrapUInt32Array)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -786,11 +786,11 @@ TEST(TIFFTest, FieldWrapUInt32Array)
 
 TEST(TIFFTest, FieldWrapUInt64Array)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -804,11 +804,11 @@ TEST(TIFFTest, FieldWrapUInt64Array)
 
 TEST(TIFFTest, FieldWrapByteArray)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -823,11 +823,11 @@ TEST(TIFFTest, FieldWrapByteArray)
 
 TEST(TIFFTest, ValueProxy)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -838,11 +838,11 @@ TEST(TIFFTest, ValueProxy)
 
 TEST(TIFFTest, Value)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -852,11 +852,11 @@ TEST(TIFFTest, Value)
 
 TEST(TIFFTest, FieldName)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -872,11 +872,11 @@ TEST(TIFFTest, FieldName)
 
 TEST(TIFFTest, FieldCount)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -888,11 +888,11 @@ TEST(TIFFTest, FieldCount)
 
 TEST(TIFFTest, PixelType)
 {
-  std::shared_ptr<TIFF> t;
+  ome::compat::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -902,8 +902,8 @@ TEST(TIFFTest, PixelType)
 class TIFFTileTest : public ::testing::TestWithParam<TileTestParameters>
 {
 public:
-  std::shared_ptr<TIFF> tiff;
-  std::shared_ptr<IFD> ifd;
+  ome::compat::shared_ptr<TIFF> tiff;
+  ome::compat::shared_ptr<IFD> ifd;
   uint32_t iwidth;
   uint32_t iheight;
   ome::bioformats::tiff::PlanarConfiguration planarconfig;
@@ -972,7 +972,7 @@ public:
     pngdata_chunky.setBuffer(shape, PT::UINT8, order_chunky);
     pngdata_planar.setBuffer(shape, PT::UINT8, order_planar);
 
-    std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> >& uint8_pngdata_chunky(boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> > >(pngdata_chunky.vbuffer()));
+    ome::compat::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> >& uint8_pngdata_chunky(boost::get<ome::compat::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> > >(pngdata_chunky.vbuffer()));
     std::vector<png_bytep> row_pointers(pheight);
     for (dimension_size_type y = 0; y < pheight; ++y)
       {
@@ -1254,10 +1254,10 @@ namespace
   read_test(const std::string& file,
             const VariantPixelBuffer& reference)
   {
-    std::shared_ptr<TIFF> tiff;
+    ome::compat::shared_ptr<TIFF> tiff;
     ASSERT_NO_THROW(tiff = TIFF::open(file, "r"));
     ASSERT_TRUE(static_cast<bool>(tiff));
-    std::shared_ptr<IFD> ifd;
+    ome::compat::shared_ptr<IFD> ifd;
     ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
     ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -1464,10 +1464,10 @@ TEST_P(PixelTest, WriteTIFF)
 
   // Write TIFF
   {
-    std::shared_ptr<TIFF> wtiff;
+    ome::compat::shared_ptr<TIFF> wtiff;
     ASSERT_NO_THROW(wtiff = TIFF::open(params.filename, "w"));
     ASSERT_TRUE(static_cast<bool>(wtiff));
-    std::shared_ptr<IFD> wifd;
+    ome::compat::shared_ptr<IFD> wifd;
     ASSERT_NO_THROW(wifd = wtiff->getCurrentDirectory());
     ASSERT_TRUE(static_cast<bool>(wifd));
 
@@ -1560,10 +1560,10 @@ TEST_P(PixelTest, WriteTIFF)
   {
     // Note "c" to disable automatic strip chopping so we can verify
     // the exact tag content of ROWSPERSTRIP.
-    std::shared_ptr<TIFF> tiff;
+    ome::compat::shared_ptr<TIFF> tiff;
     ASSERT_NO_THROW(tiff = TIFF::open(params.filename, "rc"));
     ASSERT_TRUE(static_cast<bool>(tiff));
-    std::shared_ptr<IFD> ifd;
+    ome::compat::shared_ptr<IFD> ifd;
     ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
     ASSERT_TRUE(static_cast<bool>(ifd));
 

--- a/cpp/test/ome-bioformats/tilecache.cpp
+++ b/cpp/test/ome-bioformats/tilecache.cpp
@@ -58,7 +58,7 @@ TEST(TileCache, Insert)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
       ASSERT_TRUE(static_cast<bool>(c.find(i)));
       ASSERT_TRUE(static_cast<bool>(cc.find(i)));
     }
@@ -72,11 +72,11 @@ TEST(TileCache, InsertFail)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_FALSE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_FALSE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
 }
 
@@ -94,7 +94,7 @@ TEST(TileCache, IndexOperator)
   c.clear();
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      c[i] = std::shared_ptr<TileBuffer>(new TileBuffer((8192)));
+      c[i] = ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)));
       ASSERT_TRUE(static_cast<bool>(c[i]));
     }
 
@@ -108,7 +108,7 @@ TEST(TileCache, Remove)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
       ASSERT_TRUE(static_cast<bool>(c.find(i)));
       ASSERT_TRUE(static_cast<bool>(cc.find(i)));
     }
@@ -126,7 +126,7 @@ TEST(TileCache, Clear)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
 
   ASSERT_EQ(16, c.size());

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -165,7 +165,7 @@ struct RandomAssignTestVisitor : public boost::static_visitor<>
   }
 
   void
-  operator() (const std::shared_ptr<PixelBuffer<PixelProperties<PT::BIT>::std_type> >& v)
+  operator() (const ome::compat::shared_ptr<PixelBuffer<PixelProperties<PT::BIT>::std_type> >& v)
   {
     typedef PixelProperties<PT::BIT>::std_type value_type;
 
@@ -240,7 +240,7 @@ struct ConstructExtentRefTestVisitor : public boost::static_visitor<>
 
     // VariantPixelBuffer with unmanaged backing store.
     value_type backing[10];
-    std::shared_ptr<PixelBuffer<value_type> > buf
+    ome::compat::shared_ptr<PixelBuffer<value_type> > buf
       (new PixelBuffer<value_type>(&backing[0], extents));
     VariantPixelBuffer mbuf(buf);
 
@@ -264,7 +264,7 @@ struct ConstructRangeRefTestVisitor : public boost::static_visitor<>
 
     // VariantPixelBuffer with unmanaged backing store.
     value_type backing[100];
-    std::shared_ptr<PixelBuffer<value_type> > buf
+    ome::compat::shared_ptr<PixelBuffer<value_type> > buf
       (new PixelBuffer<value_type>(&backing[0],
                                    boost::extents[10][10][1][1][1][1][1][1][1]));
     VariantPixelBuffer mbuf(buf);
@@ -336,7 +336,7 @@ struct ManagedTestVisitor : public boost::static_visitor<>
     {
       // VariantPixelBuffer with unmanaged backing store.
       value_type backing[100];
-      std::shared_ptr<PixelBuffer<value_type> > buf
+      ome::compat::shared_ptr<PixelBuffer<value_type> > buf
         (new PixelBuffer<value_type>(&backing[0],
                                      boost::extents[10][10][1][1][1][1][1][1][1]));
       VariantPixelBuffer mbuf(buf);

--- a/cpp/test/ome-compat/memory.cpp
+++ b/cpp/test/ome-compat/memory.cpp
@@ -58,77 +58,77 @@ public:
   virtual ~fail() {}
 };
 
-class cshared : public std::enable_shared_from_this<cshared>
+class cshared : public ome::compat::enable_shared_from_this<cshared>
 {
 public:
 public:
   virtual ~cshared() {}
 
-  std::shared_ptr<cshared>
+  ome::compat::shared_ptr<cshared>
   getptr()
   { return shared_from_this(); }
 };
 
 TEST(Memory, CreateShared)
 {
-  std::shared_ptr<inh> p(std::make_shared<inh>());
+  ome::compat::shared_ptr<inh> p(ome::compat::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(p));
 }
 
 TEST(Memory, CreateWeak)
 {
-  std::shared_ptr<inh> p(std::make_shared<inh>());
+  ome::compat::shared_ptr<inh> p(ome::compat::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(p));
 
-  std::shared_ptr<inh> w(p);
-  std::shared_ptr<inh> p2(w);
+  ome::compat::shared_ptr<inh> w(p);
+  ome::compat::shared_ptr<inh> p2(w);
   ASSERT_TRUE(static_cast<bool>(p2));
 }
 
 TEST(Memory, StaticPointerCast)
 {
-  std::shared_ptr<inh> p(std::make_shared<inh>());
+  ome::compat::shared_ptr<inh> p(ome::compat::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(p));
 
-  std::shared_ptr<base> b(std::static_pointer_cast<base>(p));
+  ome::compat::shared_ptr<base> b(ome::compat::static_pointer_cast<base>(p));
   ASSERT_TRUE(static_cast<bool>(b));
 }
 
 TEST(Memory, DynamicPointerCast)
 {
-  std::shared_ptr<base> b(std::make_shared<inh>());
+  ome::compat::shared_ptr<base> b(ome::compat::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(b));
 
-  std::shared_ptr<inh> p = std::dynamic_pointer_cast<inh>(b);
+  ome::compat::shared_ptr<inh> p = ome::compat::dynamic_pointer_cast<inh>(b);
   ASSERT_TRUE(static_cast<bool>(p));
 }
 
 TEST(Memory, DynamicPointerCastFail)
 {
-  std::shared_ptr<base> b(std::make_shared<inh>());
+  ome::compat::shared_ptr<base> b(ome::compat::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(b));
 
-  std::shared_ptr<fail> f = std::dynamic_pointer_cast<fail>(b);
+  ome::compat::shared_ptr<fail> f = ome::compat::dynamic_pointer_cast<fail>(b);
   ASSERT_FALSE(static_cast<bool>(f));
 }
 
 TEST(Memory, ConstPointerCast)
 {
-  std::shared_ptr<base> b(std::make_shared<inh>());
+  ome::compat::shared_ptr<base> b(ome::compat::make_shared<inh>());
   ASSERT_TRUE(static_cast<bool>(b));
 
-  std::shared_ptr<const base> c = std::const_pointer_cast<base>(b);
+  ome::compat::shared_ptr<const base> c = ome::compat::const_pointer_cast<base>(b);
   ASSERT_TRUE(static_cast<bool>(c));
 }
 
 TEST(Memory, EnableSharedFromThis)
 {
-  std::shared_ptr<cshared> c(std::make_shared<cshared>());
+  ome::compat::shared_ptr<cshared> c(ome::compat::make_shared<cshared>());
   ASSERT_TRUE(static_cast<bool>(c));
   ASSERT_EQ(c.use_count(), 1);
 
   {
-    std::shared_ptr<cshared> c2 = c->getptr();
+    ome::compat::shared_ptr<cshared> c2 = c->getptr();
     ASSERT_TRUE(static_cast<bool>(c2));
     ASSERT_EQ(c.use_count(), 2);
     ASSERT_EQ(c2.use_count(), 2);

--- a/cpp/test/ome-compat/regex.cpp
+++ b/cpp/test/ome-compat/regex.cpp
@@ -42,41 +42,41 @@
 
 TEST(Regex, Construct)
 {
-  std::regex foo("^foo[bar]$");
-  std::regex bar("^foo[bar]$", std::regex::extended);
-  std::regex chk("^[^:/,.][^:/,]*$", std::regex::extended);
+  ome::compat::regex foo("^foo[bar]$");
+  ome::compat::regex bar("^foo[bar]$", ome::compat::regex::extended);
+  ome::compat::regex chk("^[^:/,.][^:/,]*$", ome::compat::regex::extended);
 }
 
 TEST(Regex, Search)
 {
-  std::regex foo("^foo[bar]$");
-  std::regex bar("^foo[bar]$", std::regex::extended);
-  std::regex chk("^[^:/,.][^:/,]*$", std::regex::extended);
+  ome::compat::regex foo("^foo[bar]$");
+  ome::compat::regex bar("^foo[bar]$", ome::compat::regex::extended);
+  ome::compat::regex chk("^[^:/,.][^:/,]*$", ome::compat::regex::extended);
 
   std::string test("foob");
   std::string fail("fail:");
 
-  ASSERT_TRUE(std::regex_search(test, foo));
-  ASSERT_TRUE(std::regex_search(test, bar));
-  ASSERT_TRUE(std::regex_search(test, chk));
-  ASSERT_FALSE(std::regex_search(fail, foo));
-  ASSERT_FALSE(std::regex_search(fail, bar));
-  ASSERT_FALSE(std::regex_search(fail, chk));
+  ASSERT_TRUE(ome::compat::regex_search(test, foo));
+  ASSERT_TRUE(ome::compat::regex_search(test, bar));
+  ASSERT_TRUE(ome::compat::regex_search(test, chk));
+  ASSERT_FALSE(ome::compat::regex_search(fail, foo));
+  ASSERT_FALSE(ome::compat::regex_search(fail, bar));
+  ASSERT_FALSE(ome::compat::regex_search(fail, chk));
 }
 
 TEST(Regex, Match)
 {
-  std::regex foo("^foo[bar]$");
-  std::regex bar("^foo[bar]$", std::regex::extended);
-  std::regex chk("^[^:/,.][^:/,]*$", std::regex::extended);
+  ome::compat::regex foo("^foo[bar]$");
+  ome::compat::regex bar("^foo[bar]$", ome::compat::regex::extended);
+  ome::compat::regex chk("^[^:/,.][^:/,]*$", ome::compat::regex::extended);
 
   std::string test("foob");
   std::string fail("fail:");
 
-  ASSERT_TRUE(std::regex_match(test, foo));
-  ASSERT_TRUE(std::regex_match(test, bar));
-  ASSERT_TRUE(std::regex_match(test, chk));
-  ASSERT_FALSE(std::regex_match(fail, foo));
-  ASSERT_FALSE(std::regex_match(fail, bar));
-  ASSERT_FALSE(std::regex_match(fail, chk));
+  ASSERT_TRUE(ome::compat::regex_match(test, foo));
+  ASSERT_TRUE(ome::compat::regex_match(test, bar));
+  ASSERT_TRUE(ome::compat::regex_match(test, chk));
+  ASSERT_FALSE(ome::compat::regex_match(fail, foo));
+  ASSERT_FALSE(ome::compat::regex_match(fail, bar));
+  ASSERT_FALSE(ome::compat::regex_match(fail, chk));
 }

--- a/cpp/test/ome-compat/tuple.cpp
+++ b/cpp/test/ome-compat/tuple.cpp
@@ -42,15 +42,15 @@
 
 TEST(Tuple, Create)
 {
-  typedef std::tuple<int,double,std::string> t1;
+  typedef ome::compat::tuple<int,double,std::string> t1;
   t1 i(34, 2342.23, "test");
 }
 
 TEST(Tuple, Get)
 {
-  typedef std::tuple<int,std::string> t2;
+  typedef ome::compat::tuple<int,std::string> t2;
   t2 i(34, "test");
 
-  ASSERT_EQ(std::get<0>(i), 34);
-  ASSERT_EQ(std::get<1>(i), "test");
+  ASSERT_EQ(ome::compat::get<0>(i), 34);
+  ASSERT_EQ(ome::compat::get<1>(i), "test");
 }

--- a/cpp/test/ome-xml/model.cpp
+++ b/cpp/test/ome-xml/model.cpp
@@ -139,7 +139,7 @@ TEST_P(ModelTest, Update)
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
-  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::xerces::dom::Element docroot(doc.getDocumentElement());
   root->update(docroot, model);
 }
@@ -151,7 +151,7 @@ TEST_P(ModelTest, CreateXML)
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
-  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::xerces::dom::Element docroot(doc.getDocumentElement());
   root->update(docroot, model);
 
@@ -169,7 +169,7 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
-  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::xerces::dom::Element docroot(doc.getDocumentElement());
   root->update(docroot, model);
 
@@ -185,7 +185,7 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
   ome::xerces::dom::Document doc2(ome::xerces::dom::createDocument(omexml));
   ome::xml::meta::OMEXMLMetadata meta2;
   ome::xml::model::detail::OMEModel model2;
-  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root2(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root2(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
   ome::xerces::dom::Element docroot2(doc2.getDocumentElement());
   root2->update(docroot2, model2);
 

--- a/docs/sphinx/developers/cpp-conversion.txt
+++ b/docs/sphinx/developers/cpp-conversion.txt
@@ -267,17 +267,17 @@ The Bio-Formats API **never** passes pointers allocated with
 “smart” pointers are used throughout to manage memory safely and
 automatically.
 
-:cpp:class:`std::shared_ptr` as a “smart” pointer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:cpp:class:`ome::compat::shared_ptr` as a “smart” pointer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The unsafe example above, has been rewritten to use
-:cpp:class:`std::shared_ptr`:
+:cpp:class:`ome::compat::shared_ptr`:
 
 .. code-block:: cpp
 
     // Start of block
     {
-      std::shared_ptr<Image> i(std::make_shared<Image>(filename));
+      ome::compat::shared_ptr<Image> i(ome::compat::make_shared<Image>(filename));
 
       i->read_plane(); // throws exception
 
@@ -286,13 +286,20 @@ The unsafe example above, has been rewritten to use
     }
 
 Rather than managing the memory by hand, responsibility for this is
-delegated to a “smart” pointer, :cpp:class:`std::shared_ptr`.  The
-memory is freed by the :cpp:class:`std::shared_ptr` destructor which
-is run at the end of the block scope, on explicit :c:type:`return`, or
-when cleaned up by exception stack unwinding.
+delegated to a “smart” pointer, :cpp:class:`ome::compat::shared_ptr`.
+The memory is freed by the :cpp:class:`ome::compat::shared_ptr`
+destructor which is run at the end of the block scope, on explicit
+:c:type:`return`, or when cleaned up by exception stack unwinding.
+
+.. note::
+
+    :cpp:class:`ome::compat::shared_ptr` is either a
+    :cpp:class:`std::shared_ptr` or a :cpp:class:`boost::shared_ptr`,
+    depending upon whether C++11 features are avaiable or not,
+    respectively.
 
 - :cpp:class:`shared_ptr` object lifetime manages the resource
-- :cpp:class:`new` replaced with :cpp:class:`std::make_shared`
+- :cpp:class:`new` replaced with :cpp:class:`ome::compat::make_shared`
 - May be used as class members; lifetime is tied to class instance
 - Clean up for all exit points is automatic and safe
 - Allows ownership transfer and sharing
@@ -333,30 +340,30 @@ C++ reference variants
 
 .. code-block:: cpp
 
-    //          Non-constant                              Constant
-    // -----------------------------       ---------------------------------------
+    //              Non-constant                                 Constant
+    // -------------------------------------  ----------------------------------------------
     // Pointer
-                           Image *i;                               const Image *i;
-                    Image * const i;                        const Image * const i;
+                                   Image *i;                                 const Image *i;
+                            Image * const i;                          const Image * const i;
 
     // Reference
-                         Image& i;                               const Image& i;
+                                   Image& i;                                 const Image& i;
 
     // Shared pointer
-           std::shared_ptr<Image> i;               std::shared_ptr<const Image> i;
-     const std::shared_ptr<Image> i;         const std::shared_ptr<const Image> i;
+           ome::compat::shared_ptr<Image> i;         ome::compat::shared_ptr<const Image> i;
+     const ome::compat::shared_ptr<Image> i;   const ome::compat::shared_ptr<const Image> i;
 
     // Shared pointer reference
-          std::shared_ptr<Image>& i;              std::shared_ptr<const Image>& i;
-    const std::shared_ptr<Image>& i;        const std::shared_ptr<const Image>& i;
+          ome::compat::shared_ptr<Image>& i;        ome::compat::shared_ptr<const Image>& i;
+    const ome::compat::shared_ptr<Image>& i;  const ome::compat::shared_ptr<const Image>& i;
 
     // Weak pointer
-             std::weak_ptr<Image> i;                 std::weak_ptr<const Image> i;
-       const std::weak_ptr<Image> i;           const std::weak_ptr<const Image> i;
+             ome::compat::weak_ptr<Image> i;           ome::compat::weak_ptr<const Image> i;
+       const ome::compat::weak_ptr<Image> i;     const ome::compat::weak_ptr<const Image> i;
 
    // Weak pointer reference
-            std::weak_ptr<Image>& i;                std::weak_ptr<const Image>& i;
-      const std::weak_ptr<Image>& i;          const std::weak_ptr<const Image>& i;
+            ome::compat::weak_ptr<Image>& i;          ome::compat::weak_ptr<const Image>& i;
+      const ome::compat::weak_ptr<Image>& i;    const ome::compat::weak_ptr<const Image>& i;
 
 Java has one reference type.  Here, we have **22**.  Clearly, not all
 of these will typically be used.  Below, a subset of these are shown
@@ -366,23 +373,24 @@ Class member types:
 
 .. code-block:: cpp
 
-  Image i;                     // Concrete instance
-  std::shared_ptr<Image> i;    // Reference
-  std::weak_ptr<Image> i;      // Weak reference
+  Image i;                             // Concrete instance
+  ome::compat::shared_ptr<Image> i;    // Reference
+  ome::compat::weak_ptr<Image> i;      // Weak reference
 
 Wherever possible, a concrete instance should be preferred.  This is
 not possible for polymorphic types, where a reference is required.  In
-this situation, a :cpp:class:`std::shared_ptr` is preferred if the
-class owns the member and/or needs control over its lifetime.  If the
-class does not have ownership then a :cpp:class:`std::weak_ptr` will
-allow safe access to the object if it still exists.  In circumstances
-where manual lifetime management is required, e.g. for performance,
-and the member is guaranteed to exist for the duration of the object's
-lifetime, a plain pointer or reference may be used.  A pointer will be
-used if it is possible for it to be :cpp:class:`null`, or it may be
-reassigned more than once, or if is assigned after initial
-construction.  If properly using RAII, using references should be
-possible and preferred over bare pointers in all cases.
+this situation, an :cpp:class:`ome::compat::shared_ptr` is preferred
+if the class owns the member and/or needs control over its lifetime.
+If the class does not have ownership then an
+:cpp:class:`ome::compat::weak_ptr` will allow safe access to the
+object if it still exists.  In circumstances where manual lifetime
+management is required, e.g. for performance, and the member is
+guaranteed to exist for the duration of the object's lifetime, a plain
+pointer or reference may be used.  A pointer will be used if it is
+possible for it to be :cpp:class:`null`, or it may be reassigned more
+than once, or if is assigned after initial construction.  If properly
+using RAII, using references should be possible and preferred over
+bare pointers in all cases.
 
 Argument types:
 
@@ -391,7 +399,7 @@ Argument types:
   // Ownership retained
   void read_plane(const Image& image);
   // Ownership shared or transferred
-  void read_plane(const std::shared_ptr<Image>& image);
+  void read_plane(const ome::compat::shared_ptr<Image>& image);
 
 Passing primitive types by value is acceptable.  However, passing a
 struct or class by value will implicitly copy the object into the
@@ -400,13 +408,13 @@ constructor which will not be guaranteed or even possible for
 polymorphic types).  Passing by reference avoids the need for any
 copying, and passing by :c:type:`const` reference will prevent the
 callee from modifying the object, also making it clear that there is
-no transfer of ownership.  Passing using a
-:cpp:class:`std::shared_ptr` is possible but not recommended---the
-copy will involve reference counting overhead which can kill
-multi-threaded performance since it requires synchronization between
-all threads; use a :c:type:`const` reference to a
-:cpp:class:`std::shared_ptr` to avoid the overhead.  If ownership
-should be transferred or shared with the callee, use a
+no transfer of ownership.  Passing using an
+:cpp:class:`ome::compat::shared_ptr` is possible but not
+recommended---the copy will involve reference counting overhead which
+can kill multi-threaded performance since it requires synchronization
+between all threads; use a :c:type:`const` reference to an
+:cpp:class:`ome::compat::shared_ptr` to avoid the overhead.  If
+ownership should be transferred or shared with the callee, use a
 non-:c:type:`const` reference.
 
 To be absolutely clear, plain pointers are never used and are not
@@ -417,10 +425,10 @@ Return types:
 
 .. code-block:: cpp
 
-                    Image get_image(); // Ownership transferred
-                   Image& get_image(); // Ownership retained
-   std::shared_ptr<Image> get_image(); // Ownership shared/trans
-  std::shared_ptr<Image>& get_image(); // Ownership shared
+                            Image get_image(); // Ownership transferred
+                           Image& get_image(); // Ownership retained
+   ome::compat::shared_ptr<Image> get_image(); // Ownership shared/trans
+  ome::compat::shared_ptr<Image>& get_image(); // Ownership shared
 
 If the callee does not retain a copy of the original object, it can't
 pass by reference since it can't guarantee the object remaining in
@@ -428,11 +436,11 @@ scope after it returns, hence it must create a temporary value and
 pass by value.  If the callee does retain a copy, it has the option of
 passing by reference.  Passing by reference is preferred when
 possible.  Passing by value implies ownership transfer.  Passing by
-reference implies ownership retention.  Passing a
-:cpp:class:`std::shared_ptr` by value or reference implies sharing
-ownership since the caller can retain a reference; if passing by value
-ownership *may* be transferred since this implies the callee is not
-retaining a reference to it (but this is not guaranteed).
+reference implies ownership retention.  Passing an
+:cpp:class:`ome::compat::shared_ptr` by value or reference implies
+sharing ownership since the caller can retain a reference; if passing
+by value ownership *may* be transferred since this implies the callee
+is not retaining a reference to it (but this is not guaranteed).
 
 Again, to be absolutely clear, plain pointers are never used and are
 not acceptable for ownership transfer.  A plain reference also makes
@@ -501,14 +509,15 @@ Types with a common base
 
 .. code-block:: cpp
 
-    std::vector<std::shared_ptr<Base> > v;
-    v.push_back(std::make_shared<Derived>());
+    std::vector<ome::compat::shared_ptr<Base> > v;
+    v.push_back(ome::compat::make_shared<Derived>());
 
-This can store any type derived from :cpp:class:`Base`.  A
-:cpp:class:`std::shared_ptr` is **essential**.  Without it, bare
-pointers to the base would be stored, and memory would be leaked when
-elements are removed from the container (unless externally managed
-[generally unsafe]).  The same applies to passing polymorphic types.
+This can store any type derived from :cpp:class:`Base`.  An
+:cpp:class:`ome::compat::shared_ptr` is **essential**.  Without it,
+bare pointers to the base would be stored, and memory would be leaked
+when elements are removed from the container (unless externally
+managed [generally unsafe]).  The same applies to passing polymorphic
+types.
 
 Java containers can be problematic:
 
@@ -568,8 +577,8 @@ code to operate on all of the supported types.  The variant type may
 be used as a class member, passed by value, passed by reference or
 stored in a container like any other type.  Due to the way it is
 implemented to store values, it does not necessarily need wrapping in
-a :cpp:class:`std::shared_ptr` since it can behave as a value type
-(depending upon the context).
+an :cpp:class:`ome::compat::shared_ptr` since it can behave as a value
+type (depending upon the context).
 
 
 Java uses polymorphism to store and pass the root :cpp:class:`Object`
@@ -766,7 +775,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_integral<T>::value, void
         >::type
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Integer algorithm.
       }
@@ -776,7 +785,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_floating_point<T>::value, void
         >::type
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Floating point algorithm.
       }
@@ -786,7 +795,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_complex<T>::value, void
         >::type
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Complex floating point algorithm.
       }
@@ -794,7 +803,7 @@ integer, floating point, complex floating point and bitmask cases.
       // BIT/bool pixel type.  Note this is a simple overload since it is
       // a simple type, not a category of different types.
       void
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf)
+      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf)
       {
         // Boolean algorithm.
       }

--- a/docs/sphinx/developers/cpp.txt
+++ b/docs/sphinx/developers/cpp.txt
@@ -614,11 +614,13 @@ for further details of all configurable options, and run ``cmake
 C++11
 ^^^^^
 
-C++11 features such as :cpp:type:`std::shared_ptr` are used when using
-a C++11 compiler.  When using an older compiler, the Boost equivalents
-will be used as fallbacks to provide the same functionality.
-:program:`cmake` will automatically detect and use C++11 features when
-available.
+C++11 features such as :cpp:class:`std::shared_ptr` are used when
+using a C++11 compiler.  When using an older compiler, the Boost
+equivalents will be used as fallbacks to provide the same
+functionality.  :program:`cmake` will automatically detect and use
+C++11 features when available.  These types are imported into the
+:cpp:class:`ome::compat` namespace, for example as
+:cpp:class:`ome::compat::shared_ptr`.
 
 
 Linux and MacOS X

--- a/tools/test-build
+++ b/tools/test-build
@@ -53,11 +53,16 @@ cppwrap()
     )
 }
 
+# Check python sources with flake8
+flake()
+{
+    flake8 -v components cpp docs
+}
+
 # Test sphinx docs build
 sphinx()
 {
     (
-        flake8 -v .
         export SPHINXOPTS="-W"
         ant -Dsphinx.opts=$SPHINXOPTS clean-docs-sphinx
         ant -Dsphinx.opts=$SPHINXOPTS docs-sphinx
@@ -100,6 +105,8 @@ do
             cpp ;;
         cppwrap)
             cppwrap ;;
+        flake8)
+            flake ;;
         sphinx)
             sphinx ;;
         ant)


### PR DESCRIPTION
This is a basic search and replace of:

`std::shared_ptr` → `ome::compat::shared_ptr`
`std::tuple` → `ome::compat::tuple`
`std::regex` → `ome::compat::regex`

(plus associated types and functions like `weak_ptr`, `make_shared`, `regex_search` etc.)

The reason for this is that we were abusing the `std` namespace by importing `boost`/`std::tr1` types into it, since this could potentially cause problems given that we are exposing "`std`" types in our interfaces which don't actually exist.  If an end user uses these they will cause problems when they upgrade and the `std` types actually do exist.  With this change, all types are imported into the `ome::compat` namespace, be they in `std`, `std::tr1` or `boost`.  This makes our API independent of any system changes, and will be safe under all circumstances.  Note that the types will still end up in the ABI using their original namespaces, but the API will be safe.  See https://trac.openmicroscopy.org/ome/ticket/12174 for further details.

--no-rebase

--------

Testing: if it builds and is green, it's OK; any mistakes would result in build failure.  Note documentation updates in addition to code.