### PR TITLE
Updating ZEN Zeiss link (rebased onto dev_5_0)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2366,7 +2366,7 @@ extensions = `.czi <http://www.zeiss.com/czi>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/czi>`_
 bsd = no
 export = no
-software = `Zeiss ZEN  <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen.html>`_
+software = `Zeiss ZEN <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen.html>`_
 weHave = * many example datasets \n
 * official specification documents
 pixelsRating = Outstanding

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2366,7 +2366,7 @@ extensions = `.czi <http://www.zeiss.com/czi>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/czi>`_
 bsd = no
 export = no
-software = `Zeiss ZEN 2012 <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen-2012.html>`_
+software = `Zeiss ZEN  <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen.html>`_
 weHave = * many example datasets \n
 * official specification documents
 pixelsRating = Outstanding


### PR DESCRIPTION


This is the same as gh-1606 but rebased onto dev_5_0.

----

See http://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-5.1-merge-docs/697/warnings3Result/? - ZEN links no longer have 2012 in them.

                    