### PR TITLE
Add generate-sources target

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -125,6 +125,7 @@ Type "ant -p" for a list of targets.
     description="remove build files for all components">
     <delete dir="${artifact.dir}"/>
     <delete dir="build"/>
+    <delete dir="generated-sources"/>
   </target>
 
   <target name="test"
@@ -957,6 +958,16 @@ Type "ant -p" for a list of targets.
   <target name="clean-xsd-fu"
     description="remove build files for xsd-fu">
     <ant dir="components/xsd-fu" target="xsd-fu.clean"/>
+  </target>
+
+  <target name="generate-sources"
+    description="generate sources using xsd-fu"
+    depends="ome-xml-src, metadata-src">
+    <mkdir dir="generated-sources"/>
+	<copy todir="generated-sources">
+	    <fileset dir="components/ome-xml/target/generated-sources"/>
+	</copy>
+    <ant dir="components/ome-xml" target="generate-source"/>
   </target>
 
   <target name="ome-xml-src"


### PR DESCRIPTION
See https://trello.com/c/ZC4Zm0BL/197-autogenerated-code-diffs

This PR is adding a new ant target allowing to commit generated sources. This top-level target copies the source-generated files to a `generated-sources` folder that can be put under version control. The idea is to have this new folder committed and pushed on a branch of @snoopycrimecop as part of latest and merge builds (like `develop/merge/autogen`, `develop/latest/autogen` for the auto-generated documentation). Comparing these branches should allow to compare the generated source changes with/without PRs.

Alternatively, this changes could be pushed to a separate repository if that makes more sense.

/cc @rleigh-dundee @qidane @joshmoore 