### PR TITLE
display OME-XML and rois.

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/BF.java
+++ b/components/bio-formats-plugins/src/loci/plugins/BF.java
@@ -33,6 +33,7 @@ import ij.ImagePlus;
 import java.io.IOException;
 
 import loci.formats.FormatException;
+import loci.plugins.in.DisplayHandler;
 import loci.plugins.in.ImagePlusReader;
 import loci.plugins.in.ImportProcess;
 import loci.plugins.in.ImporterOptions;
@@ -89,8 +90,16 @@ public final class BF {
   {
     ImportProcess process = new ImportProcess(options);
     if (!process.execute()) return null;
+    DisplayHandler displayHandler = new DisplayHandler(process);
+    if (options != null && options.isShowOMEXML()) {
+         displayHandler.displayOMEXML();
+    }
     ImagePlusReader reader = new ImagePlusReader(process);
     ImagePlus[] imps = reader.openImagePlus();
+    if (options != null && options.showROIs()) {
+        displayHandler.displayROIs(imps);
+   }
+    displayHandler.displayROIs(imps);
     if (!options.isVirtual()) {
       process.getReader().close();
     }

--- a/components/bio-formats-plugins/src/loci/plugins/BF.java
+++ b/components/bio-formats-plugins/src/loci/plugins/BF.java
@@ -92,14 +92,13 @@ public final class BF {
     if (!process.execute()) return null;
     DisplayHandler displayHandler = new DisplayHandler(process);
     if (options != null && options.isShowOMEXML()) {
-         displayHandler.displayOMEXML();
+      displayHandler.displayOMEXML();
     }
     ImagePlusReader reader = new ImagePlusReader(process);
     ImagePlus[] imps = reader.openImagePlus();
     if (options != null && options.showROIs()) {
-        displayHandler.displayROIs(imps);
-   }
-    displayHandler.displayROIs(imps);
+      displayHandler.displayROIs(imps);
+    }
     if (!options.isVirtual()) {
       process.getReader().close();
     }


### PR DESCRIPTION
Add option to display OME-XML and rois.
See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7746
This can be tested using fiji (you need to replace the bio-formats_plugins jar and other B-F jars ( if not already using develop jars i.e. jars/bioformats)
and running the following code
Please select a file with ROI, you can easily generate an ome-tiff with rois using BF- exporter
Edit pathToFile
```
from loci.common import Region
from loci.plugins.in import ImporterOptions
from loci.plugins import BF
options = ImporterOptions()
options.setShowROIs(True)
options.setShowOMEXML(True)
options.setColorMode(ImporterOptions.COLOR_MODE_COLORIZED)
options.setId(pathToFile)
imps = BF.openImagePlus(options)
for imp in imps:
   imp.show()
```
