### PR TITLE
Add xercesImpl 2.8.1 to ivy.xml and Javadoc classpath

### DIFF
--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -28,7 +28,8 @@ merged-docs.classpath = ${lib.dir}/jgoodies-forms-1.7.2.jar:\
                         ${lib.dir}/JWlz-1.4.0.jar:\
                         ${lib.dir}/commons-logging.jar:\
                         ${lib.dir}/metadata-extractor-2.6.2.jar:\
-                        ${lib.dir}/xmpcore-5.1.2.jar:
+                        ${lib.dir}/xmpcore-5.1.2.jar:\
+                        ${lib.dir}/xercesImpl-2.8.1.jar
 merged-docs.dir       = ${root.dir}/build/docs
 merged-docs.source    = ${root.dir}/components/formats-common/build/src:\
                         ${root.dir}/components/formats-api/build/src:\

--- a/ivy.xml
+++ b/ivy.xml
@@ -38,6 +38,7 @@
     <dependency org="bf-deps" name="JWlz" rev="1.4.0"/>
     <dependency org="bf-deps" name="metadata-extractor" rev="2.6.2"/>
     <dependency org="bf-deps" name="xmpcore" rev="5.1.2"/>
+    <dependency org="bf-deps" name="xercesImpl" rev="2.8.1"/>
     <dependency org="bf-deps" name="guava" rev="${versions.guava}"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/12287; this ensures that xercesImpl 2.8.1 will be available to OMERO.