### PR TITLE
Add tiling options to bfconvert

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -113,9 +113,163 @@ public final class ImageConverter {
   private IFormatReader reader;
   private MinMaxCalculator minMax;
 
+  private HashMap<String, Integer> nextOutputIndex = new HashMap<String, Integer>();
+
   // -- Constructor --
 
   private ImageConverter() { }
+
+  private boolean parseArgs(String[] args) {
+    if (args == null) {
+      return true;
+    }
+    for (int i=0; i<args.length; i++) {
+      if (args[i].startsWith("-") && args.length > 1) {
+        if (args[i].equals("-debug")) {
+          DebugTools.enableLogging("DEBUG");
+        }
+        else if (args[i].equals("-stitch")) stitch = true;
+        else if (args[i].equals("-separate")) separate = true;
+        else if (args[i].equals("-merge")) merge = true;
+        else if (args[i].equals("-expand")) fill = true;
+        else if (args[i].equals("-bigtiff")) bigtiff = true;
+        else if (args[i].equals("-map")) map = args[++i];
+        else if (args[i].equals("-compression")) compression = args[++i];
+        else if (args[i].equals("-nogroup")) group = false;
+        else if (args[i].equals("-autoscale")) autoscale = true;
+        else if (args[i].equals("-overwrite")) {
+          overwrite = true;
+        }
+        else if (args[i].equals("-nooverwrite")) {
+          overwrite = false;
+        }
+        else if (args[i].equals("-channel")) {
+          channel = Integer.parseInt(args[++i]);
+        }
+        else if (args[i].equals("-z")) {
+          zSection = Integer.parseInt(args[++i]);
+        }
+        else if (args[i].equals("-timepoint")) {
+          timepoint = Integer.parseInt(args[++i]);
+        }
+        else if (args[i].equals("-series")) {
+          try {
+            series = Integer.parseInt(args[++i]);
+          }
+          catch (NumberFormatException exc) { }
+        }
+        else if (args[i].equals("-range")) {
+          try {
+            firstPlane = Integer.parseInt(args[++i]);
+            lastPlane = Integer.parseInt(args[++i]) + 1;
+          }
+          catch (NumberFormatException exc) { }
+        }
+        else if (args[i].equals("-crop")) {
+          String[] tokens = args[++i].split(",");
+          xCoordinate = Integer.parseInt(tokens[0]);
+          yCoordinate = Integer.parseInt(tokens[1]);
+          width = Integer.parseInt(tokens[2]);
+          height = Integer.parseInt(tokens[3]);
+        }
+        else if (args[i].equals("-tilex")) {
+          try {
+            saveTileWidth = Integer.parseInt(args[++i]);
+          }
+          catch (NumberFormatException e) { }
+        }
+        else if (args[i].equals("-tiley")) {
+          try {
+            saveTileHeight = Integer.parseInt(args[++i]);
+          }
+          catch (NumberFormatException e) { }
+        }
+        else if (!args[i].equals(NO_UPGRADE_CHECK)) {
+          LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
+          return false;
+        }
+      }
+      else {
+        if (args[i].equals("-version")) printVersion = true;
+        else if (in == null) in = args[i];
+        else if (out == null) out = args[i];
+        else {
+          LOGGER.error("Found unknown argument: {}; exiting.", args[i]);
+          LOGGER.error("You should specify exactly one input file and " +
+            "exactly one output file.");
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private void printUsage() {
+    String[] s = {
+      "To convert a file between formats, run:",
+      "  bfconvert [-debug] [-stitch] [-separate] [-merge] [-expand]",
+      "    [-bigtiff] [-compression codec] [-series series] [-map id]",
+      "    [-range start end] [-crop x,y,w,h] [-channel channel] [-z Z]",
+      "    [-timepoint timepoint] [-nogroup] [-autoscale] [-version]",
+      "    [-no-upgrade] in_file out_file",
+      "",
+      "    -version: print the library version and exit",
+      " -no-upgrade: do not perform the upgrade check",
+      "      -debug: turn on debugging output",
+      "     -stitch: stitch input files with similar names",
+      "   -separate: split RGB images into separate channels",
+      "      -merge: combine separate channels into RGB image",
+      "     -expand: expand indexed color to RGB",
+      "    -bigtiff: force BigTIFF files to be written",
+      "-compression: specify the codec to use when saving images",
+      "     -series: specify which image series to convert",
+      "        -map: specify file on disk to which name should be mapped",
+      "      -range: specify range of planes to convert (inclusive)",
+      "    -nogroup: force multi-file datasets to be read as individual" +
+      "              files",
+      "  -autoscale: automatically adjust brightness and contrast before",
+      "              converting; this may mean that the original pixel",
+      "              values are not preserved",
+      "  -overwrite: always overwrite the output file, if it already exists",
+      "-nooverwrite: never overwrite the output file, if it already exists",
+      "       -crop: crop images before converting; argument is 'x,y,w,h'",
+      "    -channel: only convert the specified channel (indexed from 0)",
+      "          -z: only convert the specified Z section (indexed from 0)",
+      "  -timepoint: only convert the specified timepoint (indexed from 0)",
+      "",
+      "If any of the following patterns are present in out_file, they will",
+      "be replaced with the indicated metadata value from the input file.",
+      "",
+      "   Pattern:\tMetadata value:",
+      "   ---------------------------",
+      "   " + FormatTools.SERIES_NUM + "\t\tseries index",
+      "   " + FormatTools.SERIES_NAME + "\t\tseries name",
+      "   " + FormatTools.CHANNEL_NUM + "\t\tchannel index",
+      "   " + FormatTools.CHANNEL_NAME +"\t\tchannel name",
+      "   " + FormatTools.Z_NUM + "\t\tZ index",
+      "   " + FormatTools.T_NUM + "\t\tT index",
+      "   " + FormatTools.TIMESTAMP + "\t\tacquisition timestamp",
+      "",
+      "If any of these patterns are present, then the images to be saved",
+      "will be split into multiple files.  For example, if the input file",
+      "contains 5 Z sections and 3 timepoints, and out_file is",
+      "",
+      "  converted_Z" + FormatTools.Z_NUM + "_T" +
+      FormatTools.T_NUM + ".tiff",
+      "",
+      "then 15 files will be created, with the names",
+      "",
+      "  converted_Z0_T0.tiff",
+      "  converted_Z0_T1.tiff",
+      "  converted_Z0_T2.tiff",
+      "  converted_Z1_T0.tiff",
+      "  ...",
+      "  converted_Z4_T2.tiff",
+      "",
+      "Each file would have a single image plane."
+    };
+    for (int i=0; i<s.length; i++) LOGGER.info(s[i]);
+  }
 
   // -- Utility methods --
 
@@ -123,86 +277,11 @@ public final class ImageConverter {
   public boolean testConvert(IFormatWriter writer, String[] args)
     throws FormatException, IOException
   {
+    nextOutputIndex.clear();
     DebugTools.enableLogging("INFO");
-    if (args != null) {
-      for (int i=0; i<args.length; i++) {
-        if (args[i].startsWith("-") && args.length > 1) {
-          if (args[i].equals("-debug")) {
-            DebugTools.enableLogging("DEBUG");
-          }
-          else if (args[i].equals("-stitch")) stitch = true;
-          else if (args[i].equals("-separate")) separate = true;
-          else if (args[i].equals("-merge")) merge = true;
-          else if (args[i].equals("-expand")) fill = true;
-          else if (args[i].equals("-bigtiff")) bigtiff = true;
-          else if (args[i].equals("-map")) map = args[++i];
-          else if (args[i].equals("-compression")) compression = args[++i];
-          else if (args[i].equals("-nogroup")) group = false;
-          else if (args[i].equals("-autoscale")) autoscale = true;
-          else if (args[i].equals("-overwrite")) {
-            overwrite = true;
-          }
-          else if (args[i].equals("-nooverwrite")) {
-            overwrite = false;
-          }
-          else if (args[i].equals("-channel")) {
-            channel = Integer.parseInt(args[++i]);
-          }
-          else if (args[i].equals("-z")) {
-            zSection = Integer.parseInt(args[++i]);
-          }
-          else if (args[i].equals("-timepoint")) {
-            timepoint = Integer.parseInt(args[++i]);
-          }
-          else if (args[i].equals("-series")) {
-            try {
-              series = Integer.parseInt(args[++i]);
-            }
-            catch (NumberFormatException exc) { }
-          }
-          else if (args[i].equals("-range")) {
-            try {
-              firstPlane = Integer.parseInt(args[++i]);
-              lastPlane = Integer.parseInt(args[++i]) + 1;
-            }
-            catch (NumberFormatException exc) { }
-          }
-          else if (args[i].equals("-crop")) {
-            String[] tokens = args[++i].split(",");
-            xCoordinate = Integer.parseInt(tokens[0]);
-            yCoordinate = Integer.parseInt(tokens[1]);
-            width = Integer.parseInt(tokens[2]);
-            height = Integer.parseInt(tokens[3]);
-          }
-          else if (args[i].equals("-tilex")) {
-            try {
-              saveTileWidth = Integer.parseInt(args[++i]);
-            }
-            catch (NumberFormatException e) { }
-          }
-          else if (args[i].equals("-tiley")) {
-            try {
-              saveTileHeight = Integer.parseInt(args[++i]);
-            }
-            catch (NumberFormatException e) { }
-          }
-          else if (!args[i].equals(NO_UPGRADE_CHECK)) {
-            LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
-            return false;
-          }
-        }
-        else {
-          if (args[i].equals("-version")) printVersion = true;
-          else if (in == null) in = args[i];
-          else if (out == null) out = args[i];
-          else {
-            LOGGER.error("Found unknown argument: {}; exiting.", args[i]);
-            LOGGER.error("You should specify exactly one input file and " +
-              "exactly one output file.");
-            return false;
-          }
-        }
-      }
+    boolean success = parseArgs(args);
+    if (!success) {
+      return false;
     }
 
     if (printVersion) {
@@ -213,70 +292,7 @@ public final class ImageConverter {
     }
 
     if (in == null || out == null) {
-      String[] s = {
-        "To convert a file between formats, run:",
-        "  bfconvert [-debug] [-stitch] [-separate] [-merge] [-expand]",
-        "    [-bigtiff] [-compression codec] [-series series] [-map id]",
-        "    [-range start end] [-crop x,y,w,h] [-channel channel] [-z Z]",
-        "    [-timepoint timepoint] [-nogroup] [-autoscale] [-version]",
-        "    [-no-upgrade] in_file out_file",
-        "",
-        "    -version: print the library version and exit",
-        " -no-upgrade: do not perform the upgrade check",
-        "      -debug: turn on debugging output",
-        "     -stitch: stitch input files with similar names",
-        "   -separate: split RGB images into separate channels",
-        "      -merge: combine separate channels into RGB image",
-        "     -expand: expand indexed color to RGB",
-        "    -bigtiff: force BigTIFF files to be written",
-        "-compression: specify the codec to use when saving images",
-        "     -series: specify which image series to convert",
-        "        -map: specify file on disk to which name should be mapped",
-        "      -range: specify range of planes to convert (inclusive)",
-        "    -nogroup: force multi-file datasets to be read as individual" +
-        "              files",
-        "  -autoscale: automatically adjust brightness and contrast before",
-        "              converting; this may mean that the original pixel",
-        "              values are not preserved",
-        "  -overwrite: always overwrite the output file, if it already exists",
-        "-nooverwrite: never overwrite the output file, if it already exists",
-        "       -crop: crop images before converting; argument is 'x,y,w,h'",
-        "    -channel: only convert the specified channel (indexed from 0)",
-        "          -z: only convert the specified Z section (indexed from 0)",
-        "  -timepoint: only convert the specified timepoint (indexed from 0)",
-        "",
-        "If any of the following patterns are present in out_file, they will",
-        "be replaced with the indicated metadata value from the input file.",
-        "",
-        "   Pattern:\tMetadata value:",
-        "   ---------------------------",
-        "   " + FormatTools.SERIES_NUM + "\t\tseries index",
-        "   " + FormatTools.SERIES_NAME + "\t\tseries name",
-        "   " + FormatTools.CHANNEL_NUM + "\t\tchannel index",
-        "   " + FormatTools.CHANNEL_NAME +"\t\tchannel name",
-        "   " + FormatTools.Z_NUM + "\t\tZ index",
-        "   " + FormatTools.T_NUM + "\t\tT index",
-        "   " + FormatTools.TIMESTAMP + "\t\tacquisition timestamp",
-        "",
-        "If any of these patterns are present, then the images to be saved",
-        "will be split into multiple files.  For example, if the input file",
-        "contains 5 Z sections and 3 timepoints, and out_file is",
-        "",
-        "  converted_Z" + FormatTools.Z_NUM + "_T" +
-        FormatTools.T_NUM + ".tiff",
-        "",
-        "then 15 files will be created, with the names",
-        "",
-        "  converted_Z0_T0.tiff",
-        "  converted_Z0_T1.tiff",
-        "  converted_Z0_T2.tiff",
-        "  converted_Z1_T0.tiff",
-        "  ...",
-        "  converted_Z4_T2.tiff",
-        "",
-        "Each file would have a single image plane."
-      };
-      for (int i=0; i<s.length; i++) LOGGER.info(s[i]);
+      printUsage();
       return false;
     }
 
@@ -413,10 +429,8 @@ public final class ImageConverter {
       }
       else {
         for (int i=0; i<reader.getSeriesCount(); i++) {
-          if (width != reader.getSizeX() || height != reader.getSizeY()) {
-            store.setPixelsSizeX(new PositiveInteger(width), 0);
-            store.setPixelsSizeY(new PositiveInteger(height), 0);
-          }
+          store.setPixelsSizeX(new PositiveInteger(width), 0);
+          store.setPixelsSizeY(new PositiveInteger(height), 0);
 
           if (autoscale) {
             store.setPixelsType(PixelType.UINT8, i);
@@ -490,7 +504,6 @@ public final class ImageConverter {
       total += numImages;
 
       int count = 0;
-      HashMap<String, Integer> nextOutputIndex = new HashMap<String, Integer>();
       for (int i=startPlane; i<endPlane; i++) {
         int[] coords = reader.getZCTCoords(i);
 
@@ -501,8 +514,20 @@ public final class ImageConverter {
         }
 
         String outputName = FormatTools.getFilename(q, i, reader, out);
-        writer.setId(outputName);
-        if (compression != null) writer.setCompression(compression);
+        if (outputName.equals(FormatTools.getTileFilename(0, 0, 0, outputName))) {
+          writer.setId(outputName);
+          if (compression != null) writer.setCompression(compression);
+        }
+        else {
+          int tileNum = outputName.indexOf(FormatTools.TILE_NUM);
+          int tileX = outputName.indexOf(FormatTools.TILE_X);
+          int tileY = outputName.indexOf(FormatTools.TILE_Y);
+          if (tileNum < 0 && (tileX < 0 || tileY < 0)) {
+            throw new FormatException("Invalid file name pattern; " +
+              FormatTools.TILE_NUM + " or both of " + FormatTools.TILE_X +
+              " and " + FormatTools.TILE_Y + " must be specified.");
+          }
+        }
 
         int outputIndex = 0;
         if (nextOutputIndex.containsKey(outputName)) {
@@ -510,7 +535,7 @@ public final class ImageConverter {
         }
 
         long s = System.currentTimeMillis();
-        long m = convertPlane(writer, i, outputIndex);
+        long m = convertPlane(writer, i, outputIndex, outputName);
         long e = System.currentTimeMillis();
         read += m - s;
         write += e - m;
@@ -554,7 +579,8 @@ public final class ImageConverter {
 
   // -- Helper methods --
 
-  private long convertPlane(IFormatWriter writer, int index, int outputIndex)
+  private long convertPlane(IFormatWriter writer, int index, int outputIndex,
+    String currentFile)
     throws FormatException, IOException
   {
     if (DataTools.safeMultiply64(width, height) >=
@@ -567,7 +593,7 @@ public final class ImageConverter {
       if ((writer instanceof TiffWriter) || ((writer instanceof ImageWriter) &&
         (((ImageWriter) writer).getWriter(out) instanceof TiffWriter)))
       {
-        return convertTilePlane(writer, index, outputIndex);
+        return convertTilePlane(writer, index, outputIndex, currentFile);
       }
     }
 
@@ -581,7 +607,8 @@ public final class ImageConverter {
     return m;
   }
 
-  private long convertTilePlane(IFormatWriter writer, int index, int outputIndex)
+  private long convertTilePlane(IFormatWriter writer, int index, int outputIndex,
+    String currentFile)
     throws FormatException, IOException
   {
     int w = reader.getOptimalTileWidth();
@@ -592,6 +619,7 @@ public final class ImageConverter {
     if (saveTileHeight > 0 && saveTileHeight <= height) {
       h = saveTileHeight;
     }
+
     int nXTiles = width / w;
     int nYTiles = height / h;
 
@@ -616,6 +644,41 @@ public final class ImageConverter {
         byte[] buf =
           reader.openBytes(index, tileX, tileY, tileWidth, tileHeight);
 
+        String tileName =
+          FormatTools.getTileFilename(x, y, y * nXTiles + x, currentFile);
+        if (!currentFile.equals(tileName)) {
+          int nTileRows = getTileRows(currentFile);
+          int nTileCols = getTileColumns(currentFile);
+
+          int sizeX = nTileCols == 1 ? width : tileWidth;
+          int sizeY = nTileRows == 1 ? height : tileHeight;
+          MetadataRetrieve retrieve = writer.getMetadataRetrieve();
+          if (retrieve instanceof MetadataStore) {
+            ((MetadataStore) retrieve).setPixelsSizeX(
+              new PositiveInteger(sizeX), reader.getSeries());
+            ((MetadataStore) retrieve).setPixelsSizeY(
+              new PositiveInteger(sizeY), reader.getSeries());
+          }
+
+          writer.close();
+          writer.setMetadataRetrieve(retrieve);
+          writer.setId(tileName);
+          if (compression != null) writer.setCompression(compression);
+
+          outputIndex = 0;
+          if (nextOutputIndex.containsKey(tileName)) {
+            outputIndex = nextOutputIndex.get(tileName);
+          }
+          nextOutputIndex.put(tileName, outputIndex + 1);
+
+          if (nTileRows > 1) {
+            tileY = 0;
+          }
+          if (nTileCols > 1) {
+            tileX = 0;
+          }
+        }
+
         autoscalePlane(buf, index);
         applyLUT(writer);
         if (m == null) {
@@ -636,6 +699,41 @@ public final class ImageConverter {
       }
     }
     return m;
+  }
+
+  private int getTileRows(String outputName) {
+    if (outputName.indexOf(FormatTools.TILE_Y) >= 0 ||
+      outputName.indexOf(FormatTools.TILE_NUM) >= 0)
+    {
+      int h = reader.getOptimalTileHeight();
+      if (saveTileHeight > 0 && saveTileHeight <= height) {
+        h = saveTileHeight;
+      }
+      int nYTiles = height / h;
+      if (nYTiles * h != height) {
+        nYTiles++;
+      }
+      return nYTiles;
+    }
+    return 1;
+  }
+
+  public int getTileColumns(String outputName) {
+    if (outputName.indexOf(FormatTools.TILE_X) >= 0 ||
+      outputName.indexOf(FormatTools.TILE_NUM) >= 0)
+    {
+      int w = reader.getOptimalTileWidth();
+      if (saveTileWidth > 0 && saveTileWidth <= width) {
+        w = saveTileWidth;
+      }
+
+      int nXTiles = width / w;
+      if (nXTiles * w != width) {
+        nXTiles++;
+      }
+      return nXTiles;
+    }
+    return 1;
   }
 
   private void autoscalePlane(byte[] buf, int index)

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -108,6 +108,7 @@ public final class ImageConverter {
   private int lastPlane = Integer.MAX_VALUE;
   private int channel = -1, zSection = -1, timepoint = -1;
   private int xCoordinate = 0, yCoordinate = 0, width = 0, height = 0;
+  private int saveTileWidth = 0, saveTileHeight = 0;
 
   private IFormatReader reader;
   private MinMaxCalculator minMax;
@@ -172,6 +173,18 @@ public final class ImageConverter {
             yCoordinate = Integer.parseInt(tokens[1]);
             width = Integer.parseInt(tokens[2]);
             height = Integer.parseInt(tokens[3]);
+          }
+          else if (args[i].equals("-tilex")) {
+            try {
+              saveTileWidth = Integer.parseInt(args[++i]);
+            }
+            catch (NumberFormatException e) { }
+          }
+          else if (args[i].equals("-tiley")) {
+            try {
+              saveTileHeight = Integer.parseInt(args[++i]);
+            }
+            catch (NumberFormatException e) { }
           }
           else if (!args[i].equals(NO_UPGRADE_CHECK)) {
             LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
@@ -545,10 +558,11 @@ public final class ImageConverter {
     throws FormatException, IOException
   {
     if (DataTools.safeMultiply64(width, height) >=
-      DataTools.safeMultiply64(4096, 4096))
+      DataTools.safeMultiply64(4096, 4096) ||
+      saveTileWidth > 0 || saveTileHeight > 0)
     {
-      // this is a "big image", so we will attempt to convert it one tile
-      // at a time
+      // this is a "big image" or an output tile size was set, so we will attempt
+      // to convert it one tile at a time
 
       if ((writer instanceof TiffWriter) || ((writer instanceof ImageWriter) &&
         (((ImageWriter) writer).getWriter(out) instanceof TiffWriter)))
@@ -572,6 +586,12 @@ public final class ImageConverter {
   {
     int w = reader.getOptimalTileWidth();
     int h = reader.getOptimalTileHeight();
+    if (saveTileWidth > 0 && saveTileWidth <= width) {
+      w = saveTileWidth;
+    }
+    if (saveTileHeight > 0 && saveTileHeight <= height) {
+      h = saveTileHeight;
+    }
     int nXTiles = width / w;
     int nYTiles = height / h;
 

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -114,6 +114,7 @@ public final class ImageConverter {
   private MinMaxCalculator minMax;
 
   private HashMap<String, Integer> nextOutputIndex = new HashMap<String, Integer>();
+  private boolean firstTile = true;
 
   // -- Constructor --
 
@@ -278,6 +279,7 @@ public final class ImageConverter {
     throws FormatException, IOException
   {
     nextOutputIndex.clear();
+    firstTile = true;
     DebugTools.enableLogging("INFO");
     boolean success = parseArgs(args);
     if (!success) {
@@ -475,6 +477,7 @@ public final class ImageConverter {
     long timeLastLogged = System.currentTimeMillis();
     for (int q=first; q<last; q++) {
       reader.setSeries(q);
+      firstTile = true;
 
       if (!dimensionsSet) {
         width = reader.getSizeX();
@@ -618,6 +621,11 @@ public final class ImageConverter {
     }
     if (saveTileHeight > 0 && saveTileHeight <= height) {
       h = saveTileHeight;
+    }
+
+    if (firstTile) {
+      LOGGER.info("Tile size = {} x {}", w, h);
+      firstTile = false;
     }
 
     int nXTiles = width / w;

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -186,6 +186,9 @@ public final class FormatTools {
   public static final String Z_NUM = "%z";
   public static final String T_NUM = "%t";
   public static final String TIMESTAMP = "%A";
+  public static final String TILE_X = "%x";
+  public static final String TILE_Y = "%y";
+  public static final String TILE_NUM = "%m";
 
   // -- Constants - versioning --
 
@@ -987,6 +990,16 @@ public final class FormatTools {
   }
 
   // -- Utility methods -- export
+
+  public static String getTileFilename(int tileX, int tileY,
+    int tileIndex, String pattern)
+  {
+    String filename = pattern;
+    filename = filename.replaceAll(TILE_X, String.valueOf(tileX));
+    filename = filename.replaceAll(TILE_Y, String.valueOf(tileY));
+    filename = filename.replaceAll(TILE_NUM, String.valueOf(tileIndex));
+    return filename;
+  }
 
   /**
    * @throws FormatException Never actually thrown.

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -46,6 +46,24 @@ To convert images between certain indices (inclusive):
 
   bfconvert -range 0 2 /path/to/input output-first-3-images.tiff
 
+All images larger than 4096x4096 will be saved as a set of tiles if the output
+format supports doing so.  The default tile size is determined by the input
+format, and can be overridden like this:
+
+::
+
+  bfconvert -tilex 512 -tiley 512 /path/to/input output-512x512-tiles.tiff
+
+``-tilex`` is the width in pixel of each tile; ``-tiley`` is the height in
+pixels of each tile.  The last row and column of tiles may be slightly smaller
+if the image width and height are not multiples of the specified tile width
+and height.  Note that specifying ``-tilex`` and ``-tiley`` will cause tiles
+to be written even if the image is smaller than 4096x4096.
+
+Also note that the specified tile size will affect performance.  If large
+amounts of data are being processed, it is a good idea to try converting a
+single tile with a few different tile sizes using the ``-crop`` option.
+This gives an idea of what the most performant size will be.
 
 Images can also be written to multiple files by specifying a pattern string
 in the output file.  For example, to write one series, timepoint, channel, and
@@ -57,6 +75,19 @@ Z section per file:
 
 ``%s`` is the series index, ``%z`` is the Z section index, ``%c`` is the
 channel index, and ``%t`` is the timepoint index (all indices begin at 0).
+
+For large images in particular, it can also be useful to write each tile to
+a separate file:
+
+::
+
+  bfconvert -tilex 512 -tiley 512 /path/to/input output_tile_%x_%y_%m.jpg
+
+``%x`` is the row index of the tile, ``%y`` is the column
+index of the tile, and ``%m`` is the overall tile index.  As above, all
+indices begin at 0.  Note that if ``%x`` or ``%y`` is included in the file
+name pattern, then the other must be included too.  The only exception is if
+``%m`` was also included in the pattern.
 
 By default, all images will be written uncompressed.  Supported compression
 modes vary based upon the output format, but when multiple modes are available


### PR DESCRIPTION
Fixes http://trac.openmicroscopy.org/ome/ticket/10292.

There are documentation updates as part of the PR that summarize what the new options are.  To further summarize, the tile size used during conversion can be specified explicitly:

```bfconvert -tilex 256 -tiley 256 input-file output-file.tiff```

and each tile can be written to a separate file:

```bfconvert -tilex 256 -tiley 256 input-file output-file_X%x_Y%y.tiff```

where the ```-tilex``` and ```-tiley``` values can be changed as desired.  Note that this only works if the output format is TIFF at the moment, due to known difficulties with writing other formats tile-wise.

To test, pick one or two of your favorite files and run a few ```bfconvert``` commands using varying values for ```-tilex``` and ```-tiley```.  Also verify that writing each tile to a separate file results in readable files that look like the corresponding tile from the original image, and that the documentation page is clear enough.