### PR TITLE
Micromanager: fix helper reader usage when working with a memo file

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -809,11 +809,13 @@ public class MicromanagerReader extends FormatReader {
   /** Initialize the TIFF reader with the first file in the current series. */
   private void setupReader() {
     try {
-      String file = positions.get(getSeries()).getFile(0);
+      String file = positions.get(getSeries()).getFile(
+        getDimensionOrder(), getSizeZ(), getSizeC(), getSizeT(),
+        getImageCount(), 0);
       tiffReader.setId(file);
     }
     catch (Exception e) {
-      LOGGER.debug("", e);
+      LOGGER.warn("", e);
     }
   }
 


### PR DESCRIPTION
This prevents an exception when initializing the helper reader, particularly during
calls to getOptimalTile* immediately after setId with a memo file.

Fixes http://trac.openmicroscopy.org/ome/ticket/12750.

To test, unzip the file from QA 10526 and import ```Acqusition.xml``` into OMERO.  Verify that the resulting image can be opened in web and/or that the gateway commands in the ticket result in the tile size being shown with no exception.

See also openmicroscopy/openmicroscopy#3512
/cc @will-moore 