### PR TITLE
Exporter windowless

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -200,7 +200,6 @@ public class Exporter {
                 outfile = new File(p, n).getAbsolutePath();
                 if (Recorder.record) Recorder.recordPath("outputfile", outfile);
                 IJ.log("exporter outputfile "+outfile);
-                
             } catch (Exception e) {
                 //fall back to window mode.
             } finally {

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -140,7 +140,6 @@ public class Exporter {
         String compression = null;
 
         Boolean windowless = Boolean.FALSE;
-        IJ.log(plugin.arg);
         if (plugin.arg != null) {
             outfile = Macro.getValue(plugin.arg, "outfile", null);
 
@@ -178,10 +177,11 @@ public class Exporter {
         }
         //create a temporary file if window less
         if (windowless && (outfile == null || outfile.length() == 0)) {
+            File tmp = null;
             try {
                 String name = removeExtension(imp.getTitle());
                 String n = name+ ".ome.tif";
-                File tmp = File.createTempFile(name, ".ome.tif");
+                tmp = File.createTempFile(name, ".ome.tif");
                 File p = tmp.getParentFile();
                 File[] list = p.listFiles();
                 //make sure we delete a previous tmp file with same name if any
@@ -199,8 +199,12 @@ public class Exporter {
                 }
                 outfile = new File(p, n).getAbsolutePath();
                 if (Recorder.record) Recorder.recordPath("outputfile", outfile);
+                IJ.log("exporter outputfile "+outfile);
+                
             } catch (Exception e) {
                 //fall back to window mode.
+            } finally {
+                if (tmp != null) tmp.delete();
             }
         }
         File f = null;

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -198,6 +198,7 @@ public class Exporter {
                     }
                 }
                 outfile = new File(p, n).getAbsolutePath();
+                if (Recorder.record) Recorder.recordPath("outputfile", outfile);
             } catch (Exception e) {
                 //fall back to window mode.
             }


### PR DESCRIPTION
Allow to save the images w/o passing all parameters
if no file specified,  a temporary file using the name of the image selected is created. We may want to change that and stop if no output specified.
To test: 
 * Open Fiji, update the b-f_plugins jar and all b-f jars if you are not already using develop jar (jars/bioformats)
 * Run the following code (new>script language>python)

```
from loci.plugins.in import ImporterOptions
from loci.plugins import BF
from ij import IJ
options = ImporterOptions()
options.setId(fileToView)
imps = BF.openImagePlus(options)
for imp in imps:
   imp.show()
   image = IJ.runPlugIn("loci.plugins.LociExporter", "outfile=fileToSaveTo.ome.tif windowless=true ")
```
Remove the outfile param to create the tmp file.