### PR TITLE
cpp: bioformats: Correct OME-TIFF dimension order when reading

### DIFF
--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -1225,7 +1225,7 @@ namespace ome
                   std::string channelName(meta.getChannelName(series, 0));
                   ome::compat::shared_ptr<CoreMetadata> coreMeta(core.at(series));
                   if (meta.getTiffDataCount(series) > 0 &&
-                      files.find("__omero_export") == files.end() &&
+                      files.find("__omero_export") != files.end() &&
                       coreMeta)
                     coreMeta->dimensionOrder = ome::xml::model::enums::DimensionOrder("XYZCT");
                 }


### PR DESCRIPTION
By default it was being forced to `XYZCT` when not required.

--no-rebase

--------

Testing:

Run showinf on a 2013-06 OME-TIFF whose dimension order is *not* `XYZCT` and which was *not* exported from OMERO.  Without the PR the dimension order will be `XYZCT`; with the PR merged the order will be the intended order matching the OME-XML metadata.