### PR TITLE
ImagePlus and series

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/Slicer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/Slicer.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
+import loci.plugins.in.ImagePlusReader;
 import loci.plugins.util.BFVirtualStack;
 import loci.plugins.util.ImageProcessorReader;
 import loci.plugins.util.LibraryChecker;
@@ -161,6 +162,8 @@ public class Slicer implements PlugInFilter {
         p = new ImagePlus(title, newStacks[i]);
       }
 
+      p.setProperty(ImagePlusReader.PROP_SERIES,
+              imp.getProperty(ImagePlusReader.PROP_SERIES));
       p.setProperty("Info", imp.getProperty("Info"));
       p.setDimensions(realSizeC, realSizeZ, realSizeT);
       p.setCalibration(calibration);

--- a/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
@@ -172,6 +172,7 @@ public class Colorizer {
             toClose.close();
           }
         };
+        compImage.setProperty(ImagePlusReader.PROP_SERIES, series);
         if (luts != null) compImage.setLuts(luts);
         imps.set(i, compImage);
         imp = compImage;


### PR DESCRIPTION
The series value was not preserved when preparing the imageplus
This was noticed when testing https://github.com/openmicroscopy/openmicroscopy/pull/3535
using some lei file (e.g. ```leica/tropo/tropo.lei```)

Testing while reviewing https://github.com/openmicroscopy/openmicroscopy/pull/3535

but this can be tested w/o OMERO
To test, run the following in Fiji. (you will first need to upgrade the b-f plugins jar)
```
from loci.plugins.in import ImporterOptions
from loci.plugins import BF
from ij import IJ, WindowManager
IJ.runPlugIn("loci.plugins.LociImporter", "PathTo/tropo.lei")
for i in WindowManager.getIDList():
    print WindowManager.getImage(i).getProperty("Series")
```

When the B-F window pops up select all series
The values printed out should be 0,1,2,3 