### PR TITLE
docs: Add support for generating manual pages with Sphinx

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -189,6 +189,8 @@ Type "ant -p" for a list of targets.
     <ant dir="docs/sphinx" target="html"/>
     <echo>----------=========== Sphinx PDF ===========----------</echo>
     <ant dir="docs/sphinx" target="pdf"/>
+    <echo>----------=========== Sphinx MAN ===========----------</echo>
+    <ant dir="docs/sphinx" target="man"/>
   </target>
 
   <target name="clean-docs-sphinx"

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -39,6 +39,22 @@ Type "ant -p" for a list of targets.
     </exec>
   </target>
 
+  <target name="man">
+    <exec executable="${sphinx.build}" failonerror="true">
+      <env key="SOURCE_BRANCH" value="${source.branch}"/>
+      <env key="SOURCE_USER" value="${source.user}"/>
+      <env key="BF_RELEASE" value="${bf.release}"/>
+      <env key="JENKINS_JOB" value="${jenkins.job}"/>
+      <env key="JENKINS_CPP_JOB" value="${jenkins.cpp.job}"/>
+      <env key="OMERODOC_URI" value="${omerodoc.uri}"/>
+      <arg value="-b"/>
+      <arg value="man"/>
+      <arg line="${sphinx.opts}"/>
+      <arg value="."/>
+      <arg value="${sphinx.builddir}/man"/>
+    </exec>
+  </target>
+
   <macrodef name="xelatex" description="Run XeLaTeX">
     <attribute name="file" default=""/>
     <sequential>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -12,6 +12,7 @@ Type "ant -p" for a list of targets.
   <import file="${root.dir}/ant/global.xml"/>
 
   <property name="sphinx.build" value="sphinx-build"/>
+  <property name="sphinx.warnopts" value=""/>
   <property name="sphinx.opts" value=""/>
   <property name="sphinx.builddir" location="_build"/>
   <property name="latex.opts" value=""/>
@@ -34,6 +35,7 @@ Type "ant -p" for a list of targets.
       <arg value="-b"/>
       <arg value="html"/>
       <arg line="${sphinx.opts}"/>
+      <arg line="${sphinx.warnopts}"/>
       <arg value="."/>
       <arg value="${sphinx.builddir}/html"/>
     </exec>
@@ -106,6 +108,7 @@ Type "ant -p" for a list of targets.
       <arg value="-b"/>
       <arg value="latex"/>
       <arg line="${sphinx.opts}"/>
+      <arg line="${sphinx.warnopts}"/>
       <arg value="."/>
       <arg value="${sphinx.builddir}/latex"/>
     </exec>
@@ -133,6 +136,7 @@ Type "ant -p" for a list of targets.
       <arg value="-b"/>
       <arg value="linkcheck"/>
       <arg line="${sphinx.opts}"/>
+      <arg line="${sphinx.warnopts}"/>
       <arg value="."/>
       <arg value="${sphinx.builddir}/linkcheck"/>
     </exec>

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -356,7 +356,8 @@ latex_show_urls = 'footnote'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'OMERO', title, author, 1)
+    ('developers/cpp', 'bf-cpp-overview', 'C++ implementation overview', author, 7),
+    ('developers/cpp-conversion', 'bf-cpp-conversion', 'C++ conventions for Java programmers switching to the C++ implementation', author, 7)
 ]
 
 # If true, show URL addresses after external links.

--- a/tools/test-build
+++ b/tools/test-build
@@ -64,8 +64,8 @@ sphinx()
 {
     (
         export SPHINXOPTS="-W"
-        ant -Dsphinx.opts=$SPHINXOPTS clean-docs-sphinx
-        ant -Dsphinx.opts=$SPHINXOPTS docs-sphinx
+        ant -Dsphinx.warnopts=$SPHINXOPTS clean-docs-sphinx
+        ant -Dsphinx.warnopts=$SPHINXOPTS docs-sphinx
     )
 }
 


### PR DESCRIPTION
- add `man` target to docs/sphinx `build.xml`
- add manpage generation to toplevel `docs-sphinx` target -- ensures Travis tests them
- manpages are generated in `_build/man`

Known issue: version in the manpages is only major.minor, rather than the full version.

--------

Testing:

- Run `ant man` in `docs/sphinx`
- Run `man -l _build/man/$manpage` and verify it looks OK.