### PR TITLE
Move EXIF parsing to a service

### DIFF
--- a/components/formats-bsd/build.properties
+++ b/components/formats-bsd/build.properties
@@ -27,6 +27,7 @@ component.classpath      = ${artifact.dir}/jai_imageio.jar:\
                            ${lib.dir}/perf4j-0.9.13.jar:\
                            ${lib.dir}/metadata-extractor-2.6.2.jar:\
                            ${lib.dir}/xmpcore-5.1.2.jar:\
+                           ${lib.dir}/xercesImpl-2.8.1.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/guava-${guava.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
@@ -55,6 +56,9 @@ component.cp.no-xml      = ${artifact.dir}/jai_imageio.jar:\
                            ${lib.dir}/jgoodies-common-1.7.0.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
                            ${lib.dir}/netcdf-4.3.19.jar:\
+                           ${lib.dir}/metadata-extractor-2.6.2.jar:\
+                           ${lib.dir}/xmpcore-5.1.2.jar:\
+                           ${lib.dir}/xercesImpl-2.8.1.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
 
@@ -65,6 +69,9 @@ component.cp.no-jai      = ${artifact.dir}/formats-common.jar:\
                            ${artifact.dir}/ome-poi.jar:\
                            ${lib.dir}/jgoodies-common-1.7.0.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
+                           ${lib.dir}/metadata-extractor-2.6.2.jar:\
+                           ${lib.dir}/xmpcore-5.1.2.jar:\
+                           ${lib.dir}/xercesImpl-2.8.1.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
 
@@ -75,7 +82,32 @@ component.cp.no-lurawave = ${artifact.dir}/formats-common.jar:\
                            ${artifact.dir}/ome-poi.jar:\
                            ${lib.dir}/jgoodies-common-1.7.0.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
+                           ${lib.dir}/metadata-extractor-2.6.2.jar:\
+                           ${lib.dir}/xmpcore-5.1.2.jar:\
+                           ${lib.dir}/xercesImpl-2.8.1.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
+
+component.cp.no-exif = ${artifact.dir}/formats-common.jar:\
+                       ${artifact.dir}/../components/formats-api/build/classes/:\
+                       ${artifact.dir}/jai_imageio.jar:\
+                       ${artifact.dir}/ome-xml.jar:\
+                       ${artifact.dir}/ome-poi.jar:\
+                       ${lib.dir}/jgoodies-common-1.7.0.jar:\
+                       ${lib.dir}/jgoodies-forms-1.7.2.jar:\
+                       ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
+                       ${lib.dir}/testng-${testng.version}.jar
+
+component.cp.no-xerces = ${artifact.dir}/formats-common.jar:\
+                       ${artifact.dir}/../components/formats-api/build/classes/:\
+                       ${artifact.dir}/jai_imageio.jar:\
+                       ${artifact.dir}/ome-xml.jar:\
+                       ${artifact.dir}/ome-poi.jar:\
+                       ${lib.dir}/jgoodies-common-1.7.0.jar:\
+                       ${lib.dir}/jgoodies-forms-1.7.2.jar:\
+                       ${lib.dir}/metadata-extractor-2.6.2.jar:\
+                       ${lib.dir}/xmpcore-5.1.2.jar:\
+                       ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
+                       ${lib.dir}/testng-${testng.version}.jar
 
 test-component.jar       = formats-bsd-test.jar

--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -13,7 +13,7 @@ Type "ant -p" for a list of targets.
   <property file="build.properties"/>
 
   <target name="test" depends="jar,compile-tests,test-no-ome-xml,
-    test-no-lurawave, test-no-jai, test-spec"
+    test-no-lurawave, test-no-jai, test-no-exif, test-no-xerces, test-spec"
     description="run tests">
     <!-- NOTE: Overrides default "test" target from java.xml -->
     <copy tofile="${build.dir}/testng.xml" overwrite="true"
@@ -74,6 +74,40 @@ Type "ant -p" for a list of targets.
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-xml}"/>
+      </classpath>
+      <xmlfileset file="${build.dir}/testng.xml"/>
+      <jvmarg value="-mx${testng.memory}"/>
+    </testng>
+    <fail if="failedTest"/>
+  </target>
+
+  <target name="test-no-exif" depends="compile-tests"
+    description="run missing EXIF JAR tests" if="doTests">
+    <copy tofile="${build.dir}/testng.xml" overwrite="true"
+      file="${tests.dir}/loci/formats/utests/testng-no-exif.xml"/>
+    <testng failureProperty="failedTest">
+      <classpath>
+        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${test-classes.dir}"/>
+        <pathelement location="${classes.dir}"/>
+        <pathelement path="${component.cp.no-exif}"/>
+      </classpath>
+      <xmlfileset file="${build.dir}/testng.xml"/>
+      <jvmarg value="-mx${testng.memory}"/>
+    </testng>
+    <fail if="failedTest"/>
+  </target>
+
+  <target name="test-no-xerces" depends="compile-tests"
+    description="run missing Xerces JAR tests" if="doTests">
+    <copy tofile="${build.dir}/testng.xml" overwrite="true"
+      file="${tests.dir}/loci/formats/utests/testng-no-xerces.xml"/>
+    <testng failureProperty="failedTest">
+      <classpath>
+        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${test-classes.dir}"/>
+        <pathelement location="${classes.dir}"/>
+        <pathelement path="${component.cp.no-xerces}"/>
       </classpath>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>

--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -41,18 +41,16 @@ import loci.common.ByteArrayHandle;
 import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
 import loci.formats.DelegateReader;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
+import loci.formats.services.EXIFService;
 
-import com.drew.imaging.ImageMetadataReader;
-import com.drew.metadata.exif.ExifSubIFDDirectory;
-import com.drew.metadata.Metadata;
-import com.drew.metadata.Directory;
-import com.drew.metadata.Tag;
-import com.drew.imaging.ImageProcessingException;
-import java.io.File;
 import java.util.Date;
+import java.util.HashMap;
 import org.joda.time.DateTime;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
@@ -189,36 +187,36 @@ public class JPEGReader extends DelegateReader {
 
     /* @see loci.formats.FormatReader#initFile(String) */
     protected void initFile(String id) throws FormatException, IOException {
-        super.initFile(id);
+      super.initFile(id);
 
-        MetadataStore store = makeFilterMetadata();
-        LOGGER.info("Parsing JPEG EXIF data");
+      MetadataStore store = makeFilterMetadata();
+      LOGGER.info("Parsing JPEG EXIF data");
 
-        try {
-            File jpegFile = new File(id);
-            Metadata metadata = ImageMetadataReader.readMetadata(jpegFile);
-
-            // obtain the Exif directory
-            ExifSubIFDDirectory directory = metadata.getDirectory(ExifSubIFDDirectory.class);
-
-            if ( directory != null ) {
-
-                // Set the acquisition date
-                Date date = directory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
-                Timestamp timestamp = new Timestamp( new DateTime(date) );
-                store.setImageAcquisitionDate(timestamp, 0);
-
-                for (Tag tag : directory.getTags()) {
-                    addGlobalMeta(tag.getTagName(), tag.getDescription());
-                }
-            }
-
-        } catch ( ImageProcessingException e ) {
-            LOGGER.info("Error parsing JPEG EXIF data");
+      try {
+        EXIFService exif = new ServiceFactory().getInstance(EXIFService.class);
+        if (exif == null) {
+          return;
         }
-        catch (IOException e) {
-          LOGGER.info("Error parsing JPEG EXIF data");
+        exif.initialize(id);
+
+        // Set the acquisition date
+        Date date = exif.getCreationDate();
+        if (date != null) {
+          Timestamp timestamp = new Timestamp(new DateTime(date));
+          store.setImageAcquisitionDate(timestamp, 0);
         }
+
+        HashMap<String, String> tags = exif.getTags();
+        for (String tagName : tags.keySet()) {
+          addGlobalMeta(tagName, tags.get(tagName));
+        }
+      }
+      catch (ServiceException e) {
+        LOGGER.debug("Could not parse EXIF data", e);
+      }
+      catch (DependencyException e) {
+        LOGGER.debug("Could not parse EXIF data", e);
+      }
     }
 
     /* @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */

--- a/components/formats-bsd/src/loci/formats/services/EXIFService.java
+++ b/components/formats-bsd/src/loci/formats/services/EXIFService.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2015 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.services;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+
+import loci.common.services.Service;
+import loci.common.services.ServiceException;
+
+/**
+ *
+ */
+public interface EXIFService extends Service {
+
+  void initialize(String file) throws ServiceException, IOException;
+
+  HashMap<String, String> getTags();
+
+  Date getCreationDate();
+
+  void close() throws IOException;
+
+}

--- a/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
@@ -74,9 +74,6 @@ public class EXIFServiceImpl extends AbstractService implements EXIFService {
       Metadata metadata = ImageMetadataReader.readMetadata(jpegFile);
       directory = metadata.getDirectory(ExifSubIFDDirectory.class);
     }
-    catch (IOException e) {
-      throw e;
-    }
     catch (Throwable e) {
       throw new ServiceException("Could not read EXIF data", e);
     }

--- a/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
@@ -1,0 +1,110 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2015 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.services;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+
+import loci.common.services.AbstractService;
+import loci.common.services.ServiceException;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.metadata.exif.ExifSubIFDDirectory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Tag;
+import com.drew.imaging.ImageProcessingException;
+
+/**
+ *
+ */
+public class EXIFServiceImpl extends AbstractService implements EXIFService {
+
+  private ExifSubIFDDirectory directory;
+
+  // -- Constructor --
+
+  public EXIFServiceImpl() {
+    // check for metadata-extractor.jar
+    checkClassDependency(ImageMetadataReader.class);
+    // check for xmpcore.jar
+    checkClassDependency(com.adobe.xmp.XMPMeta.class);
+    // check for xercesImpl.jar
+    checkClassDependency(org.apache.xerces.dom.NodeImpl.class);
+  }
+
+  // -- EXIFService API methods --
+
+  @Override
+  public void initialize(String file) throws ServiceException, IOException {
+    try {
+      File jpegFile = new File(file);
+      Metadata metadata = ImageMetadataReader.readMetadata(jpegFile);
+      directory = metadata.getDirectory(ExifSubIFDDirectory.class);
+    }
+    catch (IOException e) {
+      throw e;
+    }
+    catch (Throwable e) {
+      throw new ServiceException("Could not read EXIF data", e);
+    }
+  }
+
+  @Override
+  public HashMap<String, String> getTags() {
+    HashMap<String, String> tagMap = new HashMap<String, String>();
+    if (directory != null) {
+      for (Tag tag : directory.getTags()) {
+        tagMap.put(tag.getTagName(), tag.getDescription());
+      }
+    }
+
+    return tagMap;
+  }
+
+  @Override
+  public Date getCreationDate() {
+    if (directory != null) {
+      return directory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
+    }
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+    directory = null;
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/MissingEXIFTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MissingEXIFTest.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2015 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import static org.testng.AssertJUnit.assertNotNull;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceFactory;
+import loci.formats.services.EXIFService;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ *
+ */
+public class MissingEXIFTest {
+
+  private ServiceFactory sf;
+
+  @BeforeMethod
+  public void setUp() throws DependencyException {
+    sf = new ServiceFactory();
+  }
+
+  @Test(expectedExceptions={DependencyException.class})
+  public void testInstantiate() throws DependencyException {
+    EXIFService service = sf.getInstance(EXIFService.class);
+    assertNotNull(service);
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/testng-no-exif.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng-no-exif.xml
@@ -1,0 +1,40 @@
+<!--
+  #%L
+  BSD implementations of Bio-Formats readers and writers
+  %%
+  Copyright (C) 2015 Open Microscopy Environment:
+    - Board of Regents of the University of Wisconsin-Madison
+    - Glencoe Software, Inc.
+    - University of Dundee
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+<suite name="Missing EXIF Tests">
+    <test name="MissingEXIF">
+        <groups/>
+        <classes>
+            <class name="loci.formats.utests.MissingEXIFTest"/>
+        </classes>
+        <packages/>
+    </test>
+</suite>

--- a/components/formats-bsd/test/loci/formats/utests/testng-no-xerces.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng-no-xerces.xml
@@ -1,0 +1,40 @@
+<!--
+  #%L
+  BSD implementations of Bio-Formats readers and writers
+  %%
+  Copyright (C) 2015 Open Microscopy Environment:
+    - Board of Regents of the University of Wisconsin-Madison
+    - Glencoe Software, Inc.
+    - University of Dundee
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+<suite name="Missing Xerces Tests">
+    <test name="MissingXerces">
+        <groups/>
+        <classes>
+            <class name="loci.formats.utests.MissingEXIFTest"/>
+        </classes>
+        <packages/>
+    </test>
+</suite>

--- a/components/formats-common/src/loci/common/services/services.properties
+++ b/components/formats-common/src/loci/common/services/services.properties
@@ -54,3 +54,4 @@ loci.formats.services.MetakitService=loci.formats.services.MetakitServiceImpl
 loci.formats.services.JPEGTurboService=loci.formats.services.JPEGTurboServiceImpl
 # Woolz service (interface and implementation in bio-formats)
 loci.formats.services.WlzService=loci.formats.services.WlzServiceImpl
+loci.formats.services.EXIFService=loci.formats.services.EXIFServiceImpl


### PR DESCRIPTION
This adds an ```EXIFService``` and implementation, which call the ```metadata-extractor``` library.  The service checks for the presence of ```metadata-extractor```, ```xmpcore```, and ```xercesImpl```, and will throw an exception in the constructor if they are missing.

The actual EXIF reading is now wrapped in a try block which catches Throwable, which should prevent an exception from being thrown if the ```xercesImpl``` version precedes 2.8.1.  I couldn't come up with a good way to check the ```xercesImpl``` version in the service constructor.

Tests have also been added to check that the service construction throws an appropriate exception when the ```metadata-extractor``` and ```xercesImpl``` libraries are missing.

To test, verify that all builds are green, and that JPEG files in ```test_images_good/jpeg``` and ```from_skyking/jpeg/exif``` open in showinf/ImageJ and import into OMERO.