### PR TITLE
Adding bar to units

### DIFF
--- a/components/ome-xml/src/ome/units/UNITS.java
+++ b/components/ome-xml/src/ome/units/UNITS.java
@@ -69,7 +69,6 @@ public final class UNITS
   public static final ome.units.unit.Unit<Length>            INCH    = METRE.multiply(0.0254).setSymbol("in");
   public static final ome.units.unit.Unit<Power>             WATT    = ome.units.unit.Unit.<Power>CreateBaseUnit("SI.WATT", "W");
   public static final ome.units.unit.Unit<Pressure>          PASCAL  = ome.units.unit.Unit.<Pressure>CreateBaseUnit("SI.PASCAL", "Pa");
-  public static final ome.units.unit.Unit<Pressure>          BAR     = PASCAL.multiply(100000).setSymbol("bar");
   public static final ome.units.unit.Unit<Temperature>       KELVIN  = ome.units.unit.Unit.<Temperature>CreateBaseUnit("SI.KELVIN", "K");
   public static final ome.units.unit.Unit<Time>              SECOND  = ome.units.unit.Unit.<Time>CreateBaseUnit("SI.SECOND", "s");
 
@@ -200,6 +199,7 @@ public final class UNITS
   public static final ome.units.unit.Unit<Pressure> APA =     ATTO(PASCAL);
   public static final ome.units.unit.Unit<Pressure> ZPA =     ZEPTO(PASCAL);
   public static final ome.units.unit.Unit<Pressure> YPA =     YOCTO(PASCAL);
+  public static final ome.units.unit.Unit<Pressure> BAR     = PASCAL.multiply(100000).setSymbol("bar");
   public static final ome.units.unit.Unit<Pressure> MEGABAR = MEGA(BAR);
   public static final ome.units.unit.Unit<Pressure> KBAR =    KILO(BAR);
   public static final ome.units.unit.Unit<Pressure> DBAR =    DECI(BAR);

--- a/components/specification/released-schema/2015-01/ome.xsd
+++ b/components/specification/released-schema/2015-01/ome.xsd
@@ -760,7 +760,14 @@
 			<xsd:attribute name="NDFilter" use="optional" type="xsd:float">
 				<xsd:annotation>
 					<xsd:documentation>
-						The NDfilter attribute is used to specify the combined effect of any neutral density filters used. [units optical density expressed as a PercentFraction]
+						The NDfilter attribute is used to specify the combined effect of any neutral density filters used.
+						The amount of light the filter transmits at a maximum [units:none]
+						A fraction, as a value from 0.0 to 1.0.
+
+						NOTE: This was formerly described as "units optical density expressed as a PercentFraction".
+						      This was how the field had been described in the schema from the beginning but all
+						      the use of it has been in the opposite direction, i.e. as a amount transmitted,
+						      not the amount blocked. This change has been made to make the model reflect this usage.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/components/specification/released-schema/2015-01/ome.xsd
+++ b/components/specification/released-schema/2015-01/ome.xsd
@@ -33,7 +33,7 @@
 	xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2015-01"
 	xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace"
-	version="1"
+	version="2"
 	elementFormDefault="qualified">
 	<xsd:import namespace="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
 		schemaLocation="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01/BinaryFile.xsd"/>
@@ -1687,7 +1687,7 @@
 			<xsd:enumeration value =  "aPa"><xsd:annotation><xsd:documentation>The pressure unit is  atto pascal.</xsd:documentation></xsd:annotation></xsd:enumeration>
 			<xsd:enumeration value =  "zPa"><xsd:annotation><xsd:documentation>The pressure unit is zepto pascal.</xsd:documentation></xsd:annotation></xsd:enumeration>
 			<xsd:enumeration value =  "yPa"><xsd:annotation><xsd:documentation>The pressure unit is yocto pascal.</xsd:documentation></xsd:annotation></xsd:enumeration>
-<!-- Add bar? -->
+			<xsd:enumeration value =   "bar"><xsd:annotation><xsd:documentation>The pressure unit is       bar.</xsd:documentation></xsd:annotation></xsd:enumeration>
 			<xsd:enumeration value =  "Mbar"><xsd:annotation><xsd:documentation>The pressure unit is  mega bar.</xsd:documentation></xsd:annotation></xsd:enumeration>
 			<xsd:enumeration value =  "kbar"><xsd:annotation><xsd:documentation>The pressure unit is  kilo bar.</xsd:documentation></xsd:annotation></xsd:enumeration>
 			<xsd:enumeration value =  "dbar"><xsd:annotation><xsd:documentation>The pressure unit is  deci bar.</xsd:documentation></xsd:annotation></xsd:enumeration>

--- a/components/specification/released-schema/2015-01/ome.xsd
+++ b/components/specification/released-schema/2015-01/ome.xsd
@@ -1440,7 +1440,7 @@
 				A simple type that restricts the value to a float between >=0 and max 32-bit float {i.e. (2−2^-23) × 2^27 ≈ 3.4 × 10^38}
 			</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="xsd:long">
+		<xsd:restriction base="xsd:float">
 			<xsd:minInclusive value="0"/>
 		</xsd:restriction>
 	</xsd:simpleType>


### PR DESCRIPTION
This adds the unit 'bar' to pressure.

It is the same 2015-01 but has had its version number bumped to 2. This make it a minor release. 

The xsd change should require a major release but coming so soon on the back of the last release and being in a completely new section for the schema no one should have reader/writer code for this to break.

See version info at: http://www.openmicroscopy.org/site/support/ome-model/schemas/index.html

----

Also some other late schema documentation changes for:
http://trac.openmicroscopy.org/ome/ticket/12693

----

--exclude