### PR TITLE
Ome xml reader

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -127,6 +127,7 @@ public class OMEXMLReader extends FormatReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
+    if (binDataOffsets.size() == 0) return buf;
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     int index = no;
@@ -251,10 +252,6 @@ public class OMEXMLReader extends FormatReader {
         lineNumber++;
       }
       binDataOffsets.add(in.getFilePointer() + col - 1);
-    }
-
-    if (binDataOffsets.size() == 0) {
-      throw new FormatException("Pixel data not found");
     }
 
     LOGGER.info("Populating metadata");

--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -34,7 +34,6 @@ package loci.formats.in;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Hashtable;
 import java.util.Vector;
 
 import loci.common.CBZip2InputStream;
@@ -63,7 +62,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
 import org.xml.sax.helpers.DefaultHandler;
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.ByteStreams;
 
 
 /**


### PR DESCRIPTION
Allow to import OME-XML w/o binary data.
This is useful when testing https://github.com/openmicroscopy/samples/pull/3

To test:
 * ```./showinf``` on one of the xml file from samples.
 * Import one of the XML files into OMERO. 


 