### PR TITLE
cpp: compat: Move std::array into the compat namespace

### DIFF
--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -833,7 +833,7 @@ namespace ome
        * @todo unify with the pixel buffer dimension indexes.
        */
       virtual
-      std::array<dimension_size_type, 3>
+      ome::compat::array<dimension_size_type, 3>
       getZCTCoords(dimension_size_type index) const = 0;
 
       /**
@@ -853,7 +853,7 @@ namespace ome
        * @todo unify with the pixel buffer dimension indexes.
        */
       virtual
-      std::array<dimension_size_type, 6>
+      ome::compat::array<dimension_size_type, 6>
       getZCTModuloCoords(dimension_size_type index) const = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -418,7 +418,7 @@ namespace ome
 
     }
 
-    std::array<dimension_size_type, 3>
+    ome::compat::array<dimension_size_type, 3>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,
@@ -436,7 +436,7 @@ namespace ome
       dimension_size_type v1 = index / len0 % len1;
       dimension_size_type v2 = index / len0 / len1;
 
-      std::array<dimension_size_type, 3> ret;
+      ome::compat::array<dimension_size_type, 3> ret;
       ret[0] = iz == 0 ? v0 : (iz == 1 ? v1 : v2); // z
       ret[1] = ic == 0 ? v0 : (ic == 1 ? v1 : v2); // c
       ret[2] = it == 0 ? v0 : (it == 1 ? v1 : v2); // t
@@ -444,7 +444,7 @@ namespace ome
       return ret;
     }
 
-    std::array<dimension_size_type, 6>
+    ome::compat::array<dimension_size_type, 6>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,
@@ -455,7 +455,7 @@ namespace ome
                  dimension_size_type num,
                  dimension_size_type index)
     {
-      std::array<dimension_size_type, 3> coords
+      ome::compat::array<dimension_size_type, 3> coords
         (getZCTCoords(order,
                       zSize,
                       cSize,
@@ -463,7 +463,7 @@ namespace ome
                       num,
                       index));
 
-      std::array<dimension_size_type, 6> ret;
+      ome::compat::array<dimension_size_type, 6> ret;
       ret[0] = coords[0] / moduloZSize;
       ret[1] = coords[1] / moduloCSize;
       ret[2] = coords[2] / moduloTSize;

--- a/cpp/lib/ome/bioformats/FormatTools.h
+++ b/cpp/lib/ome/bioformats/FormatTools.h
@@ -179,7 +179,7 @@ namespace ome
      * @param index 1D (rasterized) index to convert to ZCT coordinates.
      * @returns an array containing the ZCT coordinates (real sizes, in that order).
      */
-    std::array<dimension_size_type, 3>
+    ome::compat::array<dimension_size_type, 3>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,
@@ -215,7 +215,7 @@ namespace ome
      * @returns an array containing the ZCTmZmCmT coordinates (effective sizes, in that
      * order).
      */
-    std::array<dimension_size_type, 6>
+    ome::compat::array<dimension_size_type, 6>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -341,7 +341,7 @@ namespace ome
             {
               for (dimension_size_type p = 0; p < reader.getImageCount(); ++p)
                 {
-                  std::array<dimension_size_type, 3> coords = reader.getZCTCoords(p);
+                  ome::compat::array<dimension_size_type, 3> coords = reader.getZCTCoords(p);
                   // The cast to int here is nasty, but the data model
                   // isn't using unsigned types…
                   store.setPlaneTheZ(static_cast<int>(coords[0]), s, p);

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -111,7 +111,7 @@ namespace ome
       typedef boost::multi_array_types::index index;
 
       /// Type used to index all dimensions in public interfaces.
-      typedef std::array<boost::multi_array_types::index,
+      typedef ome::compat::array<boost::multi_array_types::index,
                          PixelBufferBase::dimensions> indices_type;
 
       /// Storage ordering type for controlling pixel memory layout.

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
@@ -235,7 +235,7 @@ namespace
     void
     operator() (T& lhs, const T& rhs) const
     {
-      std::array<VariantPixelBuffer::size_type, 9> source_shape, dest_shape;
+      ome::compat::array<VariantPixelBuffer::size_type, 9> source_shape, dest_shape;
 
       const VariantPixelBuffer::size_type *source_shape_ptr(rhs->shape());
       std::copy(source_shape_ptr, source_shape_ptr + T::element_type::dimensions,

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -135,7 +135,7 @@ namespace ome
       typedef boost::multi_array_types::size_type size_type;
 
       /// Type used to index all dimensions in public interfaces.
-      typedef std::array<boost::multi_array_types::index, PixelBufferBase::dimensions> indices_type;
+      typedef ome::compat::array<boost::multi_array_types::index, PixelBufferBase::dimensions> indices_type;
 
       /// Storage ordering type for controlling pixel memory layout.
       typedef PixelBufferBase::storage_order_type storage_order_type;
@@ -897,7 +897,7 @@ namespace ome
         void
         operator()(const T& v)
         {
-          std::array<VariantPixelBuffer::size_type, 9> dest_shape;
+          ome::compat::array<VariantPixelBuffer::size_type, 9> dest_shape;
           const VariantPixelBuffer::size_type *shape_ptr(v->shape());
           std::copy(shape_ptr, shape_ptr + PixelBufferBase::dimensions,
                     dest_shape.begin());

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -357,7 +357,7 @@ namespace ome
       {
         // Get reader and buffer size, order and type.
         const dimension_size_type c(getRGBChannelCount());
-        std::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
+        ome::compat::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
         shape[DIM_SPATIAL_X] = w;
         shape[DIM_SPATIAL_Y] = h;
         shape[DIM_SUBCHANNEL] = c;
@@ -634,12 +634,12 @@ namespace ome
         return getCoreMetadata(getCoreIndex()).moduloC;
       }
 
-      std::array<dimension_size_type, 2>
+      ome::compat::array<dimension_size_type, 2>
       FormatReader::getThumbSize() const
       {
         assertId(currentId, true);
 
-        std::array<dimension_size_type, 2> ret;
+        ome::compat::array<dimension_size_type, 2> ret;
         ret[0] = getCoreMetadata(getCoreIndex()).thumbSizeX;
         ret[1] = getCoreMetadata(getCoreIndex()).thumbSizeY;
 
@@ -978,7 +978,7 @@ namespace ome
                                          moduloZ, moduloC, moduloT);
       }
 
-      std::array<dimension_size_type, 3>
+      ome::compat::array<dimension_size_type, 3>
       FormatReader::getZCTCoords(dimension_size_type index) const
       {
         assertId(currentId, true);
@@ -990,7 +990,7 @@ namespace ome
                                              index);
       }
 
-      std::array<dimension_size_type, 6>
+      ome::compat::array<dimension_size_type, 6>
       FormatReader::getZCTModuloCoords(dimension_size_type index) const
       {
         assertId(currentId, true);

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -511,7 +511,7 @@ namespace ome
          * @returns an array containing the X and Y dimension
          * thumbnail size (in that order).
          */
-        std::array<dimension_size_type, 2>
+        ome::compat::array<dimension_size_type, 2>
         getThumbSize() const;
 
       public:
@@ -664,11 +664,11 @@ namespace ome
                  dimension_size_type moduloT) const;
 
         // Documented in superclass.
-        std::array<dimension_size_type, 3>
+        ome::compat::array<dimension_size_type, 3>
         getZCTCoords(dimension_size_type index) const;
 
         // Documented in superclass.
-        std::array<dimension_size_type, 6>
+        ome::compat::array<dimension_size_type, 6>
         getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -807,7 +807,7 @@ namespace ome
                   {
                     try
                       {
-                        std::array<std::vector<uint16_t>, 3> cmap;
+                        ome::compat::array<std::vector<uint16_t>, 3> cmap;
                         pifd->getField(ome::bioformats::tiff::COLORMAP).get(cmap);
                         coreMeta->indexed = true;
                       }

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -1182,7 +1182,7 @@ namespace ome
         uint16_t subC;
         getField(SAMPLESPERPIXEL).get(subC);
 
-        std::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
+        ome::compat::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
         shape[DIM_SPATIAL_X] = w;
         shape[DIM_SPATIAL_Y] = h;
         shape[DIM_SUBCHANNEL] = subC;
@@ -1212,10 +1212,10 @@ namespace ome
       void
       IFD::readLookupTable(VariantPixelBuffer& buf) const
       {
-        std::array<std::vector<uint16_t>, 3> cmap;
+        ome::compat::array<std::vector<uint16_t>, 3> cmap;
         getField(tiff::COLORMAP).get(cmap);
 
-        std::array<VariantPixelBuffer::size_type, 9> shape;
+        ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
         shape[DIM_SPATIAL_X] = cmap.at(0).size();
         shape[DIM_SPATIAL_Y] = 1;
         shape[DIM_SUBCHANNEL] = cmap.size();
@@ -1269,7 +1269,7 @@ namespace ome
         uint16_t subC;
         getField(SAMPLESPERPIXEL).get(subC);
 
-        std::array<VariantPixelBuffer::size_type, 9> shape, source_shape;
+        ome::compat::array<VariantPixelBuffer::size_type, 9> shape, source_shape;
         shape[DIM_SPATIAL_X] = w;
         shape[DIM_SPATIAL_Y] = h;
         shape[DIM_SUBCHANNEL] = subC;
@@ -1456,7 +1456,7 @@ namespace ome
           {
             try
               {
-                std::array<std::vector<uint16_t>, 3> cmap;
+                ome::compat::array<std::vector<uint16_t>, 3> cmap;
                 ifd.getField(tiff::COLORMAP).get(cmap);
                 m->indexed = true;
                 m->rgb = false;

--- a/cpp/lib/ome/bioformats/tiff/Tags.h
+++ b/cpp/lib/ome/bioformats/tiff/Tags.h
@@ -636,7 +636,7 @@ namespace ome
         struct TagProperties< ::ome::bioformats::tiff::UInt16Tag2>
         {
           /// uint16_t array type.
-          typedef std::array<uint16_t, 2> value_type;
+          typedef ome::compat::array<uint16_t, 2> value_type;
         };
 
         /// Properties of UInt16Tag6 tags.
@@ -644,7 +644,7 @@ namespace ome
         struct TagProperties< ::ome::bioformats::tiff::UInt16Tag6>
         {
           /// uint16 array type.
-          typedef std::array<uint16_t, 6> value_type;
+          typedef ome::compat::array<uint16_t, 6> value_type;
         };
 
         /// Properties of UInt16ExtraSamplesArray1 tags.
@@ -660,7 +660,7 @@ namespace ome
         struct TagProperties< ::ome::bioformats::tiff::UInt16TagArray3>
         {
           /// uint16_t array type.
-          typedef std::array<std::vector<uint16_t>, 3> value_type;
+          typedef ome::compat::array<std::vector<uint16_t>, 3> value_type;
         };
 
         /// Properties of UInt32Tag1 tags.
@@ -708,7 +708,7 @@ namespace ome
         struct TagProperties< ::ome::bioformats::tiff::FloatTag2>
         {
           /// float array type.
-          typedef std::array<float, 2> value_type;
+          typedef ome::compat::array<float, 2> value_type;
         };
 
         /// Properties of FloatTag3 tags.
@@ -716,7 +716,7 @@ namespace ome
         struct TagProperties< ::ome::bioformats::tiff::FloatTag3>
         {
           /// float array type.
-          typedef std::array<float, 3> value_type;
+          typedef ome::compat::array<float, 3> value_type;
         };
 
         /// Properties of FloatTag6 tags.
@@ -724,7 +724,7 @@ namespace ome
         struct TagProperties< ::ome::bioformats::tiff::FloatTag6>
         {
           /// float array type.
-          typedef std::array<float, 6> value_type;
+          typedef ome::compat::array<float, 6> value_type;
         };
 
       }

--- a/cpp/lib/ome/compat/array.h
+++ b/cpp/lib/ome/compat/array.h
@@ -52,10 +52,21 @@
 
 # ifdef OME_HAVE_ARRAY
 #  include <array>
+namespace ome
+{
+  namespace compat
+  {
+    using std::array;
+  }
+}
 # elif OME_HAVE_BOOST_ARRAY
 #  include <boost/array.hpp>
-namespace std {
+namespace ome
+{
+  namespace compat
+  {
     using boost::array;
+  }
 }
 # else
 #  error An array implementation is not available

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -233,7 +233,7 @@ namespace ome
               dimension_size_type mt = reader->getModuloT().size();
               dimension_size_type mc = reader->getModuloC().size();
 
-              std::array<dimension_size_type, 3> coords(reader->getZCTCoords(plane));
+              ome::compat::array<dimension_size_type, 3> coords(reader->getZCTCoords(plane));
               reader->setSeries(oldseries);
 
               // Effective and modulo dimension positions

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -135,7 +135,7 @@ namespace ome
       Grid2D::setSize(const glm::vec2& xlim,
                       const glm::vec2& ylim)
       {
-        std::array<glm::vec3, 3> gridcol;
+        ome::compat::array<glm::vec3, 3> gridcol;
         gridcol[0] = glm::vec3(0.5f, 0.5f, 0.5f);
         gridcol[1] = glm::vec3(0.7f, 0.7f, 0.7f);
         gridcol[2] = glm::vec3(0.9f, 0.9f, 0.9f);

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -68,8 +68,8 @@ using ome::xml::meta::OMEXMLMetadata;
 using ome::xml::model::enums::PixelType;
 
 typedef ome::xml::model::enums::PixelType PT;
-typedef std::array<dimension_size_type, 3> dim;
-typedef std::array<dimension_size_type, 6> moddim;
+typedef ome::compat::array<dimension_size_type, 3> dim;
+typedef ome::compat::array<dimension_size_type, 6> moddim;
 
 class FormatReaderTestParameters
 {
@@ -543,9 +543,9 @@ struct dims
     z(z), t(t), c(c)
   {}
 
-  operator std::array<dimension_size_type, 3>() const
+  operator ome::compat::array<dimension_size_type, 3>() const
   {
-    std::array<dimension_size_type, 3> ret;
+    ome::compat::array<dimension_size_type, 3> ret;
     ret[0] = z;
     ret[1] = c;
     ret[2] = t;
@@ -571,9 +571,9 @@ struct moddims
     z(z), t(t), c(c), mz(mz), mt(mt), mc(mc)
   {}
 
-  operator std::array<dimension_size_type, 6>() const
+  operator ome::compat::array<dimension_size_type, 6>() const
   {
-    std::array<dimension_size_type, 6> ret;
+    ome::compat::array<dimension_size_type, 6> ret;
     ret[0] = z;
     ret[1] = c;
     ret[2] = t;
@@ -682,9 +682,9 @@ TEST_P(FormatReaderTest, SubresolutionFlattenedSeries)
 
   EXPECT_EQ(0U, r.getIndex(0, 0, 0));
   EXPECT_EQ(0U, r.getIndex(0, 0, 0, 0, 0, 0));
-  std::array<dimension_size_type, 3> coords;
+  ome::compat::array<dimension_size_type, 3> coords;
   coords[0] = coords[1] = coords[2] = 0;
-  std::array<dimension_size_type, 6> modcoords;
+  ome::compat::array<dimension_size_type, 6> modcoords;
   modcoords[0] = modcoords[1] = modcoords[2] = modcoords[3] = modcoords[4] = modcoords[5] = 0;
 
   // EXPECT_EQ should work here, but fails for Boost 1.42; works
@@ -713,9 +713,9 @@ TEST_P(FormatReaderTest, SubresolutionUnflattenedSeries)
 
   EXPECT_EQ(0U, r.getIndex(0, 0, 0));
   EXPECT_EQ(0U, r.getIndex(0, 0, 0, 0, 0, 0));
-  std::array<dimension_size_type, 3> coords;
+  ome::compat::array<dimension_size_type, 3> coords;
   coords[0] = coords[1] = coords[2] = 0;
-  std::array<dimension_size_type, 6> modcoords;
+  ome::compat::array<dimension_size_type, 6> modcoords;
   modcoords[0] = modcoords[1] = modcoords[2] = modcoords[3] = modcoords[4] = modcoords[5] = 0;
 
   // EXPECT_EQ should work here, but fails for Boost 1.42; works

--- a/cpp/test/ome-bioformats/formattools.cpp
+++ b/cpp/test/ome-bioformats/formattools.cpp
@@ -50,8 +50,8 @@ using ome::bioformats::getIndex;
 using ome::bioformats::getZCTCoords;
 using ome::xml::model::enums::DimensionOrder;
 
-typedef std::array<dimension_size_type, 3> dims;
-typedef std::array<dimension_size_type, 6> moddims;
+typedef ome::compat::array<dimension_size_type, 3> dims;
+typedef ome::compat::array<dimension_size_type, 6> moddims;
 
 namespace std
 {

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -118,7 +118,7 @@ namespace std
 }
 
 typedef ome::xml::model::enums::PixelType PT;
-typedef std::array<dimension_size_type, 3> dim;
+typedef ome::compat::array<dimension_size_type, 3> dim;
 
 class FormatWriterTestParameters
 {

--- a/cpp/test/ome-bioformats/pixelbuffer.h
+++ b/cpp/test/ome-bioformats/pixelbuffer.h
@@ -89,7 +89,7 @@ TYPED_TEST_P(PixelBufferType, ConstructExtent)
   for (uint32_t i = 0; i < 10; ++i)
     source.push_back(pixel_value<TypeParam>(i));
 
-  std::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
+  ome::compat::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
   extents[0] = 5;
   extents[1] = 2;
   extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;
@@ -107,11 +107,11 @@ TYPED_TEST_P(PixelBufferType, ConstructExtent)
 
 TYPED_TEST_P(PixelBufferType, ConstructExtentRef)
 {
-  std::array<TypeParam, 10> source;
+  ome::compat::array<TypeParam, 10> source;
   for (uint32_t i = 0; i < 10; ++i)
     source[i] = pixel_value<TypeParam>(i);
 
-  std::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
+  ome::compat::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
   extents[0] = 5;
   extents[1] = 2;
   extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;
@@ -146,7 +146,7 @@ TYPED_TEST_P(PixelBufferType, ConstructRange)
 
 TYPED_TEST_P(PixelBufferType, ConstructRangeRef)
 {
-  std::array<TypeParam, 10> source;
+  ome::compat::array<TypeParam, 10> source;
   for (uint32_t i = 0; i < 10; ++i)
     source[i] = pixel_value<TypeParam>(i);
 

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -636,7 +636,7 @@ TEST(TIFFTest, FieldWrapUInt16Pair)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  std::array<uint16_t, 2> value;
+  ome::compat::array<uint16_t, 2> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::DOTRANGE).get(value), ome::bioformats::tiff::Exception);
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::HALFTONEHINTS).get(value), ome::bioformats::tiff::Exception);
@@ -674,7 +674,7 @@ TEST(TIFFTest, FieldWrapFloat2)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  std::array<float, 2> value;
+  ome::compat::array<float, 2> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::WHITEPOINT).get(value), ome::bioformats::tiff::Exception);
 }
@@ -689,7 +689,7 @@ TEST(TIFFTest, FieldWrapFloat3)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  std::array<float, 3> value;
+  ome::compat::array<float, 3> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::YCBCRCOEFFICIENTS).get(value), ome::bioformats::tiff::Exception);
 }
@@ -705,7 +705,7 @@ TEST(TIFFTest, FieldWrapFloat6)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  std::array<float, 6> value;
+  ome::compat::array<float, 6> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::PRIMARYCHROMATICITIES).get(value), ome::bioformats::tiff::Exception);
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::REFERENCEBLACKWHITE).get(value), ome::bioformats::tiff::Exception);
@@ -735,7 +735,7 @@ TEST(TIFFTest, FieldWrapUInt16Array3)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  std::array<std::vector<uint16_t>, 3> value;
+  ome::compat::array<std::vector<uint16_t>, 3> value;
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::COLORMAP).get(value), ome::bioformats::tiff::Exception);
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::TRANSFERFUNCTION).get(value), ome::bioformats::tiff::Exception);
 }
@@ -959,7 +959,7 @@ public:
     png_set_interlace_handling(pngptr);
     png_read_update_info(pngptr, infoptr);
 
-    std::array<VariantPixelBuffer::size_type, 9> shape;
+    ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
     shape[::ome::bioformats::DIM_SPATIAL_X] = pwidth;
     shape[::ome::bioformats::DIM_SPATIAL_Y] = pheight;
     shape[::ome::bioformats::DIM_SUBCHANNEL] = 3U;
@@ -1531,7 +1531,7 @@ TEST_P(PixelTest, WriteTIFF)
       {
         const PlaneRegion& r = *i;
 
-        std::array<VariantPixelBuffer::size_type, 9> shape;
+        ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
         shape[::ome::bioformats::DIM_SPATIAL_X] = r.w;
         shape[::ome::bioformats::DIM_SPATIAL_Y] = r.h;
         shape[::ome::bioformats::DIM_SUBCHANNEL] = 3U;

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -233,7 +233,7 @@ struct ConstructExtentRefTestVisitor : public boost::static_visitor<>
   {
     typedef typename T::element_type::value_type value_type;
 
-    std::array<typename PixelBuffer<value_type>::size_type, 9> extents;
+    ome::compat::array<typename PixelBuffer<value_type>::size_type, 9> extents;
     extents[0] = 5;
     extents[1] = 2;
     extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;
@@ -579,7 +579,7 @@ TEST_P(VariantPixelBufferTest, ConstructExtent)
 {
   const VariantPixelBufferTestParameters& params = GetParam();
 
-  std::array<VariantPixelBuffer::size_type, 9> extents;
+  ome::compat::array<VariantPixelBuffer::size_type, 9> extents;
   extents[0] = 5;
   extents[1] = 2;
   extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;

--- a/cpp/test/ome-compat/array.cpp
+++ b/cpp/test/ome-compat/array.cpp
@@ -42,7 +42,7 @@
 
 TEST(Array, DefaultConstruct)
 {
-  std::array<int, 10> a;
+  ome::compat::array<int, 10> a;
   // We're not explicitly testing here, but it squashed an unused
   // variable compiler warning.
   a[0] = 0;
@@ -51,7 +51,7 @@ TEST(Array, DefaultConstruct)
 
 TEST(Array, Assign)
 {
-  std::array<int, 10> a;
+  ome::compat::array<int, 10> a;
   a[4] = 453;
   ASSERT_EQ(a[4], 453);
 }

--- a/docs/sphinx/developers/cpp/conversion.txt
+++ b/docs/sphinx/developers/cpp/conversion.txt
@@ -481,25 +481,26 @@ is not known unless passed separately.
 C++ arrays “decay” to “bare” pointers, and pointers have no associated
 size information.
 
-:cpp:class:`std::array` is a safe alternative.  This is a C++11
-feature; older compilers use :cpp:class:`boost::array` as a fallback.
+:cpp:class:`ome::compat::array` is a safe alternative.  This is either
+a C++11 :cpp:class:`std::array` or :cpp:class:`boost::array` with
+older compilers.
 
 .. code-block:: cpp
 
   class Image
   {
-    typedef std::array<uint8_t, 256> LUT;
+    typedef ome::compat::array<uint8_t, 256> LUT;
 
     // Safe; size defined
     const LUT& getLUT() const;
           void setLUT(const LUT&);
   };
 
-:cpp:class:`std::array` is a array-like object (a class which behaves
-like an array).  Its type and size are defined in the template, and it
-may be passed around like any other object.  Its :cpp:func:`array::at()`
-method provides strict bounds checking, while its index
-:cpp:func:`array::operator[]` provides unchecked access.
+:cpp:class:`ome::compat::array` is a array-like object (a class which
+behaves like an array).  Its type and size are defined in the
+template, and it may be passed around like any other object.  Its
+:cpp:func:`array::at()` method provides strict bounds checking, while
+its index :cpp:func:`array::operator[]` provides unchecked access.
 
 Storing and passing unrelated types
 -----------------------------------


### PR DESCRIPTION
This matches the move of shared_ptr, regex etc. in previous PRs.

--no-rebase

--------

Testing: All tests should remain green.  No need for manual testing; any errors should result in compile failure.