### PR TITLE
Re-ordering cpp bindings docs

### DIFF
--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -40,6 +40,7 @@ Using Bio-Formats as a Java library
     conversion
     matlab-dev
     python-dev
+    non-java-code
 
 Using Bio-Formats as a native C++ library
 =========================================
@@ -51,22 +52,6 @@ Using Bio-Formats as a native C++ library
     cpp/overview
     cpp/conversion
     cpp/showinf
-
-.. _bfapplications:
-
-Interfacing with the Java library from non-Java code
-====================================================
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    non-java-code
-    jace/overview
-    jace/build
-    jace/build-windows
-    jace/build-macosx
-    jace/build-linux
 
 Contributing to Bio-Formats
 ===========================

--- a/docs/sphinx/developers/non-java-code.txt
+++ b/docs/sphinx/developers/non-java-code.txt
@@ -15,3 +15,14 @@ For details, see LOCI's article
 Recommended **in-process solution**: :doc:`jace/overview`
 
 Recommended **inter-process solution**: :doc:`/users/subimager/index`
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    jace/overview
+    jace/build
+    jace/build-windows
+    jace/build-macosx
+    jace/build-linux
+


### PR DESCRIPTION
As discussed on #1635 - re-ordering of cpp-bindings docs so they are a sub-set of the Java library docs.