### PR TITLE
cpp: compat: Add boost cstdint fallback

### DIFF
--- a/cpp/cmake/BoostChecks.cmake
+++ b/cpp/cmake/BoostChecks.cmake
@@ -84,6 +84,11 @@ if(NOT OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP)
   message(WARNING "Spatial indexes not available with this version of Boost.Geometry; tile coverage lookups will have reduced performance (linear scan replacing quadratic R*Tree)")
 endif()
 
+check_cxx_source_compiles("
+#include <boost/cstdint.hpp>
+int main() { uint16_t test(134); }
+" OME_HAVE_BOOST_CSTDINT)
+
 # Boost library checks could be dropped?
 # boost::program_options::variables_map in -lboost_program_options
 # + BOOST_PROGRAM_OPTIONS_DESCRIPTION_OLD (drop?)

--- a/cpp/lib/ome/compat/config.h.in
+++ b/cpp/lib/ome/compat/config.h.in
@@ -44,6 +44,7 @@
 #cmakedefine OME_HAVE_ARRAY 1
 #cmakedefine OME_HAVE_BOOST_ARRAY 1
 #cmakedefine OME_HAVE_CSTDINT 1
+#cmakedefine OME_HAVE_BOOST_CSTDINT 1
 #cmakedefine OME_HAVE_MEMORY 1
 #cmakedefine OME_HAVE_BOOST_SHARED_PTR 1
 #cmakedefine OME_HAVE_BOOST_OWNER_LESS 1

--- a/cpp/lib/ome/compat/cstdint.h
+++ b/cpp/lib/ome/compat/cstdint.h
@@ -40,9 +40,9 @@
  * @file ome/compat/cstdint.h Standard integer types.
  *
  * This header substitutes C++ cstdint types for the same types in the
- * C99 stdint.h header when not using a conforming C++11 compiler.
- * This permits all code to use the C++11 standard types irrespective
- * of the compiler being used.
+ * Boost boost/cstdint.hpp or C99 stdint.h header when not using a
+ * conforming C++11 compiler.  This permits all code to use the C++11
+ * standard types irrespective of the compiler being used.
  */
 
 #ifndef OME_COMPAT_CSTDINT_H

--- a/cpp/lib/ome/compat/cstdint.h
+++ b/cpp/lib/ome/compat/cstdint.h
@@ -52,6 +52,8 @@
 
 # ifdef OME_HAVE_CSTDINT
 #  include <cstdint>
+# elif OME_HAVE_BOOST_CSTDINT
+#  include <boost/cstdint.hpp>
 # else
 #  include <stdint.h>
 # endif


### PR DESCRIPTION
Final boost compatibility addition to match the fallbacks in the other headers.  Not needed on any of the current platforms, but likely needed on Windows where a C++11 `cstdint` and C99 `cstdint.h` were missing until very recently.

--------

Testing: Check jobs are green.  After running `cmake` edit `cpp/lib/ome/compat/config.h` and comment out/delete the OME_HAVE_CSTDINT line; the build should succeed and use the boost header instead.