### PR TITLE
Add version history for 5.1.0

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -59,6 +59,8 @@ Version history
         - fix reading of files larger than 4 GB
     - AIM
         - fix reading of files larger than 4 GB
+    - MRC
+        - add support for signed 8-bit data
     - Fix build errors in MIPAV plugin
     - ImageJ
         - fix export from a script/macro

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,74 @@
 Version history
 ===============
 
+5.1.0 (2015 March 24)
+---------------------
+
+* Improvements to performance with network file systems
+* Improvements to developer documentation
+* Improved support for opening and saving ROI data with ImageJ
+* Added support for CellH5 data (thanks to Christophe Sommer)
+* Added support for Perkin Elmer Nuance data (thanks to Lee Kamentsky)
+* Added support for Amaris FlowSight data (thanks to Lee Kamentsky and Sebastien Simard)
+* Added support for Veeco AFM data
+* Added support for Zeiss .lms data (not to be confused with .lsm)
+* Added support for I2I data
+* Added support for writing Vaa3D data (thanks to Brian Long)
+* Updated to OME schema 2015-01
+* Update RandomAccessInputStream and RandomAccessOutputStream to read and write bits
+* Many bug fixes, including:
+    - Leica SCN
+        - fix pixel data decompression
+        - fix handling of files with multiple channels
+        - parse magnification and physical pixel size data
+    - Olympus/CellSens .vsi
+        - more thorough parsing of metadata
+        - improved reading of thumbnails and multi-resolution images
+    - NDPI
+        - fix reading of files larger than 4GB
+        - parse magnification data
+    - Zeiss CZI
+        - improve parsing of plane position coordinates
+    - Inveon
+        - fix reading of files larger than 2 GB
+    - Nikon ND2
+        - many improvements to dimension detection
+        - many improvements to metadata parsing accuracy
+        - update original metadata table to include PFS data
+    - Gatan DM3
+        - fix encoding when parsing metadata
+        - fix physical pixel size parsing
+    - Metamorph
+        - fix off-by-one in metadata parsing
+        - fix number parsing to be independent of the system locale
+    - JPEG
+        - parse EXIF data, if present (thanks to Paul Van Schayck)
+    - OME-XML/OME-TIFF
+        - fix handling of missing image data
+    - PrairieView
+        - improved support for version 5.2 data (thanks to Curtis Rueden)
+    - DICOM
+        - fix dimensions for multi-file datasets
+        - fix pixel data decoding for files with multiple images
+    - PNG
+        - reduce memory required to read large images
+    - Imspector OBF
+        - fix support for version 5 data (thanks to Bjoern Thiel)
+    - PCORAW
+        - fix reading of files larger than 4 GB
+    - AIM
+        - fix reading of files larger than 4 GB
+    - Fix build errors in MIPAV plugin
+    - ImageJ
+        - fix export from a script/macro
+        - fix windowless export
+        - allow exporting from any open image window
+        - allow the "Group files with similar names" and "Swap dimensions"
+          options to be used from a script/macro
+    - bfconvert
+        - fix writing each channel, Z section, and/or timepoint to a separate file
+        - add options for configuring the tile size to be used when saving images
+
 5.0.8 (2015 February 10)
 ------------------------
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -6,15 +6,16 @@ Version history
 
 * Improvements to performance with network file systems
 * Improvements to developer documentation
+* Initial version of :doc:`native C++ implementation </developers/cpp/overview>`
 * Improved support for opening and saving ROI data with ImageJ
-* Added support for CellH5 data (thanks to Christophe Sommer)
-* Added support for Perkin Elmer Nuance data (thanks to Lee Kamentsky)
-* Added support for Amaris FlowSight data (thanks to Lee Kamentsky and Sebastien Simard)
-* Added support for Veeco AFM data
-* Added support for Zeiss .lms data (not to be confused with .lsm)
-* Added support for I2I data
+* Added support for :doc:`CellH5 </formats/cellh5>` data (thanks to Christophe Sommer)
+* Added support for :doc:`Perkin Elmer Nuance </formats/perkinelmer-nuance>` data (thanks to Lee Kamentsky)
+* Added support for :doc:`Amnis FlowSight </formats/amnis-flowsight>` data (thanks to Lee Kamentsky and Sebastien Simard)
+* Added support for :doc:`Veeco AFM </formats/veeco-afm>` data
+* Added support for :doc:`Zeiss .lms </formats/zeiss-axio-csm>` data (not to be confused with .lsm)
+* Added support for :doc:`I2I </formats/i2i>` data
 * Added support for writing Vaa3D data (thanks to Brian Long)
-* Updated to OME schema 2015-01
+* Updated to :model_doc:`OME schema 2015-01 </schemas/january-2015.html>`
 * Update RandomAccessInputStream and RandomAccessOutputStream to read and write bits
 * Many bug fixes, including:
     - Leica SCN

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.1.0 (2015 March 31)
+5.1.0 (2015 April 2)
 ---------------------
 
 * Improvements to performance with network file systems

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.1.0 (2015 March 24)
+5.1.0 (2015 March 31)
 ---------------------
 
 * Improvements to performance with network file systems


### PR DESCRIPTION
This probably needs a little more work before tagging - minimally I would like to add doc links for new formats once the format page PR is opened and merged.

Happy to add anything that seems to be missing - I think all of the major or important changes are here, but there were a ton of PRs to go through so it's possible that a few slipped through the cracks.  Also happy to remove some of the more minor fixes if the list is too long as it is.