### PR TITLE
OME-TIFF: reduce the number of times the OME-XML is parsed

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -92,6 +92,9 @@ public class OMETiffReader extends FormatReader {
   private int[] tileHeight;
 
   private OMEXMLService service;
+  private transient OMEXMLMetadata meta;
+  private String metaFile;
+
   private String metadataFile;
 
   // -- Constructor --
@@ -129,6 +132,7 @@ public class OMETiffReader extends FormatReader {
     OMEXMLMetadata meta;
     try {
       meta = service.createOMEXMLMetadata(xml);
+      metaFile = new Location(id).getAbsolutePath();
     }
     catch (ServiceException se) {
       throw new FormatException(se);
@@ -156,6 +160,7 @@ public class OMETiffReader extends FormatReader {
       // force the reader to pick up binary-only companion files
       return true;
     }
+    metaFile = new Location(name).getAbsolutePath();
     return super.isThisType(name, open);
   }
 
@@ -196,7 +201,7 @@ public class OMETiffReader extends FormatReader {
 
     try {
       if (service == null) setupService();
-      IMetadata meta = service.createOMEXMLMetadata(comment);
+      meta = service.createOMEXMLMetadata(comment);
 
       try {
         String metadataFile = meta.getBinaryOnlyMetadataFile();
@@ -420,9 +425,11 @@ public class OMETiffReader extends FormatReader {
     }
 
     if (service == null) setupService();
-    OMEXMLMetadata meta;
     try {
-      meta = service.createOMEXMLMetadata(xml);
+      if (meta == null || !metaFile.equals(currentId)) {
+        meta = service.createOMEXMLMetadata(xml);
+        metaFile = currentId;
+      }
       if (companion) {
         String firstTIFF = meta.getUUIDFileName(0, 0);
         initFile(new Location(dir, firstTIFF).getAbsolutePath());


### PR DESCRIPTION
If an ```OMEXMLMetadata``` was successfully parsed by ```isThisType(RandomAccessInputStream)``` or ```isSingleFile(String)``` prior to calling ```setId(String)```, it will now be re-used.  In common cases where ```isThisType``` is always called before calling ```setId``` on the same file, this should roughly halve the initialization time.

To test, compare the initialization times logged by ```showinf``` with and without this PR merged.  Also verify that all builds remain green.

/cc @ctrueden 