### PR TITLE
DV reader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -617,7 +617,7 @@ public class DeltavisionReader extends FormatReader {
     String[] title = new String[10];
     for (int i=0; i<title.length; i++) {
       // Make sure that "null" characters are stripped out
-      title[i] = in.readString(80).replaceAll("\0", "");
+      title[i] = in.readByteToString(80).replaceAll("\0", "");
     }
 
     // --- compute some secondary values ---

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -44,7 +44,6 @@ import loci.formats.meta.MetadataStore;
 
 import ome.xml.model.enums.Correction;
 import ome.xml.model.enums.Immersion;
-import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Frequency;


### PR DESCRIPTION
Problem noticed by @bramalingam while testing file formats
Some characters not correctly read in DV reader 
see ```test_images_good/dv/CFPNEAT01_R3D.dv```

w/o this PR
```
Title #1: �?�?
Title #2: R'3��i�A
Title #3: �EE
```

with the PR
```
Title #1: ??
Title #2: R'3çïiÒA
Title #3: ÖEE
```

To test
 * run ```.showinf``` on the image above. Try other DV files too.
