### PR TITLE
IMOD: fix MetadataLevel checks when populating MetadataStore

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/IMODReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IMODReader.java
@@ -438,7 +438,9 @@ public class IMODReader extends FormatReader {
         store.setROIID(roiIDs.get(i), i);
         store.setImageROIRef(roiIDs.get(i), 0, i);
       }
+    }
 
+    if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       if (physicalX > 0) {
         store.setPixelsPhysicalSizeX(
           FormatTools.createLength(adjustForUnits(pixSizeUnits, physicalX), UNITS.MICROM), 0);


### PR DESCRIPTION
Physical pixel sizes should be populated if the level is not MINIMUM,
not only if the level is ALL (to include NO_OVERLAYS).

This should fix test/build failures exposed by gh-1637.  No testing needed other than to verify that the merge builds turn green with this PR included.