### PR TITLE
JPEG files have pixels

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -156,7 +156,7 @@ public class JPEGReader extends DelegateReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    return new String[] {currentId.replaceAll(".fixed", "")};
+    return noPixels ? null : new String[] {currentId.replaceAll(".fixed", "")};
   }
 
   /* @see IFormatReader#close(boolean) */


### PR DESCRIPTION
The JPEG reader should return nothing when asked for companion files.

--no-rebase