### PR TITLE
Flake8 2.4.0 imposes cap on PEP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - if [[ $BUILD != 'sphinx' ]]; then sudo apt-get install -qq python-genshi; fi
   - if [[ $BUILD == 'cpp' ]] || [[ $BUILD == 'cppwrap' ]]; then sudo apt-get install -qq build-essential cmake libboost1.48-all-dev; fi
   - if [[ $BUILD == 'cpp' ]]; then sudo apt-get install -qq libgtest-dev libxerces-c-dev libtiff4-dev doxygen graphviz graphicsmagick; fi
-  - if [[ $BUILD == 'sphinx' ]] || [[ $BUILD == 'flake8' ]]; then sudo pip install flake8 pep8==1.6.2 Sphinx; fi
+  - if [[ $BUILD == 'sphinx' ]] || [[ $BUILD == 'flake8' ]]; then sudo pip install flake8 Sphinx; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo fc-cache -rsfv; fi


### PR DESCRIPTION
This should fix failing the Travis build due to conflicting versions

--no-rebase