### PR TITLE
Update OME-XML URLs

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -312,7 +312,7 @@ public final class FormatTools {
 
   /** URL of OME-TIFF web page. */
   public static final String URL_OME_TIFF =
-    "http://ome-xml.org/wiki/OmeTiff";
+    "http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/";
 
   // -- Constructor --
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -73,7 +73,8 @@ import ome.xml.model.primitives.Timestamp;
 
 /**
  * OMETiffReader is the file format reader for
- * <a href="http://ome-xml.org/wiki/OmeTiff">OME-TIFF</a> files.
+ * <a href="http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/">OME-TIFF</a>
+ * files.
  */
 public class OMETiffReader extends FormatReader {
 

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -16,7 +16,7 @@
 
   <name>OME-XML Java library</name>
   <description>A library for working with OME-XML metadata structures.</description>
-  <url>http://ome-xml.org/wiki/OmeXmlJava</url>
+  <url>http://www.openmicroscopy.org/site/support/ome-model/ome-xml/java-library.html</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>


### PR DESCRIPTION
The ome-xml.org domain is retired in favor of openmicroscopy.org.
So let's use the current URLs for the relevant links.

Replaces #1652 
to be rebased to dev_5_0