### PR TITLE
MRC: add signed bytes support

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -254,21 +254,6 @@ public class MRCReader extends FormatReader {
     }
     double pixelTypeMax = pixelTypeMin + range;
 
-    if (pixelTypeMax < maxValue || pixelTypeMin > minValue && signed) {
-      // make the pixel type unsigned
-      switch (getPixelType()) {
-        case FormatTools.INT8:
-          m.pixelType = FormatTools.UINT8;
-          break;
-        case FormatTools.INT16:
-          m.pixelType = FormatTools.UINT16;
-          break;
-        case FormatTools.INT32:
-          m.pixelType = FormatTools.UINT32;
-          break;
-      }
-    }
-
     in.skipBytes(4);
 
     extHeaderSize = in.readInt();

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -254,6 +254,19 @@ public class MRCReader extends FormatReader {
     }
     double pixelTypeMax = pixelTypeMin + range;
 
+    // Fix for EMAN2 generated MRC files containining unsigned 16-bit data
+    // See https://trac.openmicroscopy.org.uk/ome/ticket/4619
+    if (pixelTypeMax < maxValue || pixelTypeMin > minValue && signed) {
+      switch (getPixelType()) {
+        case FormatTools.INT16:
+          m.pixelType = FormatTools.UINT16;
+          break;
+        case FormatTools.INT32:
+          m.pixelType = FormatTools.UINT32;
+          break;
+      }
+    }
+
     in.skipBytes(4);
 
     extHeaderSize = in.readInt();

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -59,7 +59,9 @@ public class MRCReader extends FormatReader {
     {"mrc", "st", "ali", "map", "rec"};
 
   private static final int HEADER_SIZE = 1024;
+  private static final int GRIDSIZE_OFFSET = 28;
   private static final int ENDIANNESS_OFFSET = 212;
+  private static final int IMODSTAMP_OFFSET = 152;
 
   // -- Fields --
 
@@ -174,7 +176,15 @@ public class MRCReader extends FormatReader {
     int mode = in.readInt();
     switch (mode) {
       case 0:
-        m.pixelType = FormatTools.UINT8;
+        in.seek(IMODSTAMP_OFFSET);
+        if (in.readInt() == 1146047817)
+        {
+          m.pixelType = FormatTools.INT8;
+        }
+        else
+        {
+          m.pixelType = FormatTools.UINT8;
+        }
         break;
       case 1:
         m.pixelType = FormatTools.INT16;
@@ -198,7 +208,7 @@ public class MRCReader extends FormatReader {
         break;
     }
 
-    in.skipBytes(12);
+    in.seek(GRIDSIZE_OFFSET);
 
     // pixel size = xlen / mx
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -872,7 +872,9 @@ public class FormatReaderTest {
       if (reader.getPixelType() !=
         FormatTools.pixelTypeFromString(config.getPixelType()))
       {
-        result(testName, false, "Series " + i + " (expected " + config.getPixelType() + ", actual " + reader.getPixelType() + ")");
+        result(testName, false, "Series " + i + " (expected " +
+               config.getPixelType() + ", actual " +
+               FormatTools.getPixelTypeString(reader.getPixelType()) + ")");
       }
     }
     result(testName, true);


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7757&p=15458#p15458 and http://bio3d.colorado.edu/imod/doc/mrc_format.txt.

According to the MRC specification, mode 0 can correspond to `int8` data depending on the value of `imodStamp`. At the moment MRCReader is imposing `uint8`. This PR adds support for `int8` mrc data by adding an extra check for mode 0 and removing the block which flips the pixel type to unsigned bytes depending on the maximum and minimum pixel values.