### PR TITLE
Impose Sphinx 1.2.3 for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - if [[ $BUILD != 'sphinx' ]]; then sudo apt-get install -qq python-genshi; fi
   - if [[ $BUILD == 'cpp' ]] || [[ $BUILD == 'cppwrap' ]]; then sudo apt-get install -qq build-essential cmake libboost1.48-all-dev; fi
   - if [[ $BUILD == 'cpp' ]]; then sudo apt-get install -qq libgtest-dev libxerces-c-dev libtiff4-dev doxygen graphviz graphicsmagick; fi
-  - if [[ $BUILD == 'sphinx' ]] || [[ $BUILD == 'flake8' ]]; then sudo pip install flake8 Sphinx; fi
+  - if [[ $BUILD == 'sphinx' ]] || [[ $BUILD == 'flake8' ]]; then sudo pip install flake8 Sphinx==1.2.3; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre; fi
   - if [[ $BUILD == 'sphinx' ]]; then sudo fc-cache -rsfv; fi


### PR DESCRIPTION
Sphinx 1.3.0 has been released on March 10 and is installed by default.
However our code currently fails with this version. Fixes will need to
be brought to the documentation. In the meantime, the version is capped
to 1.2.3 to let Travis pass.