### PR TITLE
remove usage of ConcurrentHashMap

### DIFF
--- a/components/formats-common/build.properties
+++ b/components/formats-common/build.properties
@@ -15,6 +15,7 @@ component.classpath      = ${lib.dir}/jgoodies-forms-1.7.2.jar:\
                            ${lib.dir}/logback-classic-${logback.version}.jar:\
                            ${lib.dir}/logback-core-${logback.version}.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
+                           ${lib.dir}/guava-${guava.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
 component.java-version   = 1.6
 component.deprecation    = true

--- a/components/formats-common/pom.xml
+++ b/components/formats-common/pom.xml
@@ -38,6 +38,11 @@
       <version>2.2</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/components/formats-common/src/loci/common/Location.java
+++ b/components/formats-common/src/loci/common/Location.java
@@ -41,10 +41,11 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.MapMaker;
 
 /**
  * Pseudo-extension of java.io.File that supports reading over HTTP (among
@@ -83,8 +84,8 @@ public class Location {
       this.time = time;
     }
   }
-  private static Map<String, ListingsResult> fileListings =
-    new ConcurrentHashMap<String, ListingsResult>();
+  private static final Map<String, ListingsResult> fileListings =
+    new MapMaker().makeMap();  // like Java's ConcurrentHashMap
 
   // -- Fields --
 
@@ -176,7 +177,7 @@ public class Location {
    * Do this if directory contents might have changed in a significant way.
    */
   public static void clearDirectoryListingsCache() {
-    fileListings = new ConcurrentHashMap<String, ListingsResult>();
+    fileListings.clear();
   }
 
   /**

--- a/components/formats-common/src/loci/common/Location.java
+++ b/components/formats-common/src/loci/common/Location.java
@@ -40,6 +40,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -185,14 +186,12 @@ public class Location {
    */
   public static void cleanStaleCacheEntries() {
     long t = System.nanoTime() - cacheNanos;
-    ArrayList<String> staleKeys = new ArrayList();
-    for (String key : fileListings.keySet()) {
-      if (fileListings.get(key).time < t) {
-        staleKeys.add(key);
+    final Iterator<ListingsResult> cacheValues =
+      fileListings.values().iterator();
+    while (cacheValues.hasNext()) {
+      if (cacheValues.next().time < t) {
+        cacheValues.remove();
       }
-    }
-    for (String key : staleKeys) {
-      fileListings.remove(key);
     }
   }
 


### PR DESCRIPTION
ConcurrentHashMap undergoes API changes among Java 6, 7, 8, so to keep code nicely portable it's generally easier to simply avoid using it given that we already have Guava available and that offers a suitable substitute.

(A larger refactoring could use Guava's CacheBuilder so it would handle expiration for us too, but 5.1.0 has more urgent demands!)

Testing: No tests or builds should break, and the Bio-Formats source should no longer contain direct usage of ConcurrentHashMap.

--no-rebase