### PR TITLE
OME-TIFF: check file contents in multi-file datasets

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -143,7 +143,7 @@ public class MinimalTiffReader extends FormatReader {
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (ifds == null || lastPlane < 0 || lastPlane > ifds.size()) return null;
+    if (ifds == null || lastPlane < 0 || lastPlane >= ifds.size()) return null;
     IFD lastIFD = ifds.get(lastPlane);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 8) {
@@ -180,7 +180,7 @@ public class MinimalTiffReader extends FormatReader {
   @Override
   public short[][] get16BitLookupTable() throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (ifds == null || lastPlane < 0 || lastPlane > ifds.size()) return null;
+    if (ifds == null || lastPlane < 0 || lastPlane >= ifds.size()) return null;
     IFD lastIFD = ifds.get(lastPlane);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 16 && bits[0] > 8) {

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -795,13 +795,19 @@ public class OMETiffReader extends FormatReader {
       CoreMetadata m = core.get(s);
       info[s] = planes;
       try {
-        if (!info[s][0].reader.isThisType(info[s][0].id)) {
+        RandomAccessInputStream testFile = new RandomAccessInputStream(info[s][0].id);
+        if (!info[s][0].reader.isThisType(testFile)) {
           info[s][0].id = currentId;
+          info[s][0].exists = false;
         }
+        testFile.close();
         for (int plane=0; plane<info[s].length; plane++) {
-          if (!info[s][plane].reader.isThisType(info[s][plane].id)) {
+          testFile = new RandomAccessInputStream(info[s][plane].id);
+          if (!info[s][plane].reader.isThisType(testFile)) {
             info[s][plane].id = info[s][0].id;
+            info[s][plane].exists = false;
           }
+          testFile.close();
         }
 
         info[s][0].reader.setId(info[s][0].id);


### PR DESCRIPTION
This is more robust than just checking the file name suffix, as it
prevents initializing corrupt files with correct file names.

Fixes QA 10902.  To test, open all of the filesets from QA 10902 (or import into OMERO) and verify that an exception is not thrown.