### PR TITLE
Update OME-XML URLs (rebased onto dev_5_0)

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -296,7 +296,7 @@ public final class FormatTools {
 
   /** URL of OME-TIFF web page. */
   public static final String URL_OME_TIFF =
-    "http://ome-xml.org/wiki/OmeTiff";
+    "http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/";
 
   // -- Constructor --
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -73,7 +73,7 @@ import ome.xml.model.primitives.Timestamp;
 
 /**
  * OMETiffReader is the file format reader for
- * <a href="http://ome-xml.org/wiki/OmeTiff">OME-TIFF</a> files.
+ * <a href="http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/"">OME-TIFF</a> files.
  *
  * <dl><dt><b>Source code:</b></dt>
  * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/in/OMETiffReader.java">Trac</a>,

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -16,7 +16,7 @@
 
   <name>OME-XML Java library</name>
   <description>A library for working with OME-XML metadata structures.</description>
-  <url>http://ome-xml.org/wiki/OmeXmlJava</url>
+  <url>http://www.openmicroscopy.org/site/support/ome-model/ome-xml/java-library.html</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>


### PR DESCRIPTION


This is the same as gh-1654 but rebased onto dev_5_0.

----

The ome-xml.org domain is retired in favor of openmicroscopy.org.
So let's use the current URLs for the relevant links.

Replaces #1652 
to be rebased to dev_5_0

                    