### PR TITLE
C++: Small fixes for the OME-TIFF reader

### DIFF
--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -642,7 +642,16 @@ namespace ome
                 else
                   {
                     // All the other cases will already have a canonical path.
-                    filename = canonical(*filename, dir);
+                    if (fs::exists(*filename))
+                      filename = canonical(*filename, dir);
+                    else
+                      {
+                        boost::format fmt("UUID filename %1% not found; falling back to %2%");
+                        fmt % *filename % *currentId;
+                        BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+
+                        filename = *currentId;
+                      }
                   }
 
                 addTIFF(*filename);

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -198,8 +198,8 @@ namespace ome
       }
 
       OMETIFFReader::OMETIFFReader():
-        logger(ome::common::createLogger("OMETIFFReader")),
         detail::FormatReader(props),
+        logger(ome::common::createLogger("OMETIFFReader")),
         files(),
         tiffs(),
         metadataFile(),

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -423,22 +423,23 @@ namespace ome
       OMETIFFReader::initFile(const boost::filesystem::path& id)
       {
         detail::FormatReader::initFile(id);
-        path dir(id.parent_path());
+        // Note: Use canonical currentId rather than non-canonical id after this point.
+        path dir((*currentId).parent_path());
 
-        if (checkSuffix(id, companion_suffixes))
+        if (checkSuffix(*currentId, companion_suffixes))
           {
             // This is a companion file.  Read the metadata, get the
             // TIFF for the TiffData for the first image, and then
             // recurse with this file as the id.
-            ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(id));
+            ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(*currentId));
             path firstTIFF(path(meta->getUUIDFileName(0, 0)));
             initFile(canonical(firstTIFF, dir));
             return;
           }
 
         // Cache and use this TIFF.
-        addTIFF(id);
-        const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(id));
+        addTIFF(*currentId);
+        const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(*currentId));
 
         // Get the OME-XML from the first TIFF, and create OME-XML
         // metadata from it.
@@ -503,7 +504,7 @@ namespace ome
           core.push_back(ome::compat::make_shared<OMETIFFMetadata>());
 
         // UUID → file mapping and used files.
-        findUsedFiles(*meta, id, dir, currentUUID);
+        findUsedFiles(*meta, *currentId, dir, currentUUID);
 
         // Process TiffData elements.
         for (index_type series = 0; series < seriesCount; ++series)
@@ -630,7 +631,7 @@ namespace ome
                   {
                     if (!uuid)
                       {
-                        filename = id;
+                        filename = *currentId;
                       }
                     else
                       {
@@ -671,7 +672,7 @@ namespace ome
                       }
                     else
                       {
-                        filename = id;
+                        filename = *currentId;
                         exists = usedFiles.size() == 1;
                       }
                   }
@@ -761,7 +762,7 @@ namespace ome
                     for (dimension_size_type p = 0; p < nIFD; ++p)
                       {
                         OMETIFFPlane& plane(coreMeta->tiffPlanes.at(p));
-                        plane.id = id;
+                        plane.id = *currentId;
                         plane.ifd = p;
                       }
                     break;

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -73,13 +73,19 @@ namespace ome
         ome::common::Logger logger;
 
         /// Map UUID to filename.
-        typedef std::map<std::string, boost::filesystem::path> file_map;
+        typedef std::map<std::string, boost::filesystem::path> uuid_file_map;
+
+        /// Map filename to another file.
+        typedef std::map<boost::filesystem::path, boost::filesystem::path> invalid_file_map;
 
         /// Map filename to open TIFF handle.
         typedef std::map<boost::filesystem::path, ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
 
         /// UUID to filename mapping.
-        file_map files;
+        uuid_file_map files;
+
+        /// Invalid filename to valid filename mapping.
+        invalid_file_map invalidFiles;
 
         // Mutable to allow opening TIFFs when const.
         /// Open TIFF files


### PR DESCRIPTION
- Cope with OME-TIFF file renaming (invalid UUID filename in the metadata)
- Only use canonical paths

--no-rebase

--------

Testing:

- Use bfconvert to create a 2013-06 OME-TIFF
- Run `bf info` to check this is readable and has valid metadata
- Rename the OME-TIFF (retaining the `.ome.tiff` extension)
- `bf info` will now fail (without this PR) or will continue to work with a warning (with this PR)