### PR TITLE
Bug Fix (Color Properties): Open OmeroROI's in ImageJ

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
@@ -211,8 +211,10 @@ public class DisplayHandler implements StatusListener {
 
   public void displayROIs(ImagePlus[] imps) {
     if (!options.showROIs()) return;
-    ROIHandler.openROIs(process.getOMEMetadata(), imps);
+    ROIHandler.openROIs(process.getOMEMetadata(), imps, options.isOMERO());
+    
   }
+   
 
   // -- StatusListener methods --
 

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -79,6 +79,10 @@ public class ROIHandler {
      * them to the given images and display them in the ROI manager.
      */
     public static void openROIs(IMetadata retrieve, ImagePlus[] images) {
+        openROIs(retrieve,images, false);
+    }
+    
+    public static void openROIs(IMetadata retrieve, ImagePlus[] images, boolean isOMERO) {
         if (!(retrieve instanceof OMEXMLMetadata)) return;
         int nextRoi = 0;
         RoiManager manager = RoiManager.getInstance();
@@ -94,6 +98,7 @@ public class ROIHandler {
             if (roiCount > 0 && manager == null) {
                 manager = new RoiManager();
             }
+            
             for (int roiNum=0; roiNum<roiCount; roiNum++) {
                 Union shapeSet = root.getROI(roiNum).getUnion();
                 int shapeCount = shapeSet.sizeOfShapeList();
@@ -114,10 +119,16 @@ public class ROIHandler {
                         if( ellipse.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = ellipse.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if(ellipse.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = ellipse.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if(ellipse.getStrokeWidth() != null){
                             sw = ellipse.getStrokeWidth().value().floatValue();
@@ -134,10 +145,16 @@ public class ROIHandler {
                         if(line.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = line.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if(line.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = line.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if(line.getStrokeWidth() != null){
                             sw = line.getStrokeWidth().value().floatValue();
@@ -152,10 +169,16 @@ public class ROIHandler {
                         if (point.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = point.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if (point.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = point.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if (point.getStrokeWidth() != null){
                             sw = point.getStrokeWidth().value().floatValue();
@@ -171,10 +194,16 @@ public class ROIHandler {
                         if (polyline.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = polyline.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if (polyline.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = polyline.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if (polyline.getStrokeWidth() != null){
                             sw = polyline.getStrokeWidth().value().floatValue();
@@ -190,10 +219,16 @@ public class ROIHandler {
                         if (polygon.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = polygon.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if (polygon.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = polygon.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if (polygon.getStrokeWidth() != null){
                             sw = polygon.getStrokeWidth().value().floatValue();
@@ -214,10 +249,16 @@ public class ROIHandler {
                         if (label.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = label.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if (label.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = label.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if (label.getStrokeWidth() != null){
                             sw = label.getStrokeWidth().value().floatValue();
@@ -237,10 +278,16 @@ public class ROIHandler {
                         if (rectangle.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = rectangle.getStrokeColor();
                             sc = new Color(StrokeColor.getRed(),StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha());
+                            if(isOMERO){
+                                sc = new Color(StrokeColor.getGreen(),StrokeColor.getBlue(),StrokeColor.getAlpha(),StrokeColor.getRed());
+                            }
                         }
                         if (rectangle.getFillColor() != null){
                             ome.xml.model.primitives.Color FillColor = rectangle.getFillColor();
                             fc = new Color(FillColor.getRed(),FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha());
+                            if(isOMERO){
+                                fc = new Color(FillColor.getGreen(),FillColor.getBlue(),FillColor.getAlpha(),FillColor.getRed());
+                            }
                         }
                         if (rectangle.getStrokeWidth() != null){
                             sw = rectangle.getStrokeWidth().value().floatValue();
@@ -276,7 +323,9 @@ public class ROIHandler {
                 }
             }
         }
+        
     }
+
 
     public static Roi[] readFromRoiManager(){
 
@@ -667,5 +716,6 @@ public class ROIHandler {
         return test ;
 
     }
-
+    
+    
 }


### PR DESCRIPTION
Testing Instructions:

1) Open an omero Image in Insight, create/modify ROI shape properties (Specifically stroke width and stroke colour of the ROI's) and save them.
2) Now open the Image on ImageJ using the OMERO-IJ Plugin and check if the ROI's are added to the ROIManager (and the shape properties are replicated in ImageJ).

 