### PR TITLE
cpp: qtwidgets: Correct camera pan direction in GLView2D

### DIFF
--- a/cpp/lib/ome/qtwidgets/GLView2D.cpp
+++ b/cpp/lib/ome/qtwidgets/GLView2D.cpp
@@ -336,8 +336,8 @@ namespace ome
             setZoom(camera.zoom + 8 * dy);
             break;
           case MODE_PAN:
-            setXTranslation(camera.xTran + 2 *  dx);
-            setYTranslation(camera.yTran + 2 * -dy);
+            setXTranslation(camera.xTran + 2 * -dx);
+            setYTranslation(camera.yTran + 2 *  dy);
             break;
           case MODE_ROTATE:
             setZRotation(camera.zRot + 8 * -dy);


### PR DESCRIPTION
--no-rebase

--------

Testing:

Run `bf-test view` and open an image.  Without the PR, the "pan" action will be the opposite of the mouse movement i.e. moving the scene rather than the camera.  With the PR the x and y motion is inverted, making panning act like a click-drag operation where the scene being moved will correspond 1:1 with the mouse movement.

/cc @pwalczysko @mtbc 