### PR TITLE
mock-up

### DIFF
--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -1083,9 +1083,6 @@ public class XMLMockObjects
     for (int i = 0; i < SIZE_C; i++) {
       channel = createChannel(i);
       channel.setID("Channel:" + index + ":" + i);
-      channel.setPinholeSize(new Length(3, UNITS.NM));
-      channel.setEmissionWavelength(new Length(2, UNITS.NM));
-      channel.setExcitationWavelength(new Length(500, UNITS.NM));
       if (metadata) {
         if (j == n) j = 0;
         channel.setLightSourceSettings(createLightSourceSettings(j));


### PR DESCRIPTION
Pinhole and wavelength were wrongly reset.
This was resulting a test failure
https://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-java/lastCompletedBuild/testngreports/integration/ImporterTest/testImportImageWithAcquisitionData/

Check that the test is green