### PR TITLE
C++: Add metadata examples to tutorial

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -45,7 +45,11 @@ target_link_libraries(model-io ome-xml ${CMAKE_THREAD_LIBS_INIT})
 add_executable(metadata-io "${exampledir}/metadata-io.cpp")
 target_link_libraries(metadata-io ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(pixeldata "${exampledir}/pixeldata.cpp")
+target_link_libraries(pixeldata ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
+
 if(BUILD_TESTS)
   bf_add_test(examples/model-io model-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
   bf_add_test(examples/metadata-io metadata-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
+  bf_add_test(examples/pixeldata pixeldata "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
 endif(BUILD_TESTS)

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2015 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee
@@ -34,20 +34,18 @@
 # policies, either expressed or implied, of any organization.
 # #L%
 
-set(OME_TOPLEVEL_INCLUDES
-    ${CMAKE_CURRENT_SOURCE_DIR}/lib
-    ${CMAKE_CURRENT_BINARY_DIR}/lib)
+include_directories(${OME_TOPLEVEL_INCLUDES}
+                    ${Boost_INCLUDE_DIRS})
 
-# Add test, making sure it's run with a suitable environment.
-# If updated, make sure to update the wrappers in cpp/cmake.
-function(bf_add_test)
-  add_test(${ARGV})
-  set_tests_properties(${ARGV0}
-    PROPERTIES ENVIRONMENT "BIOFORMATS_SCHEMADIR=${PROJECT_SOURCE_DIR}/components/specification/released-schema")
-endfunction()
+set(exampledir "${PROJECT_SOURCE_DIR}/docs/sphinx/developers/cpp/examples")
 
-add_subdirectory(lib)
-add_subdirectory(libexec)
-add_subdirectory(share/icons)
-add_subdirectory(test)
-add_subdirectory(examples)
+add_executable(model-io "${exampledir}/model-io.cpp")
+target_link_libraries(model-io ome-xml ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(metadata-io "${exampledir}/metadata-io.cpp")
+target_link_libraries(metadata-io ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
+
+if(BUILD_TESTS)
+  bf_add_test(examples/model-io model-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
+  bf_add_test(examples/metadata-io metadata-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
+endif(BUILD_TESTS)

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -336,7 +336,7 @@ namespace ome
     {
       std::string xml(omexml.dumpXML());
 
-      if (!validateOMEXML(xml))
+      if (validate && !validateOMEXML(xml))
         throw std::runtime_error("Invalid OME-XML");
 
       return xml;

--- a/cpp/lib/ome/bioformats/XMLTools.cpp
+++ b/cpp/lib/ome/bioformats/XMLTools.cpp
@@ -134,6 +134,7 @@ namespace ome
 
       try
         {
+          ome::common::xml::Platform xmlplat;
           ome::common::xml::dom::createDocument(s);
         }
       catch (const std::runtime_error& e)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -36,14 +36,6 @@
 
 include_directories(${GTEST_INCLUDE_DIR})
 
-# Add test, making sure it's run with a suitable environment.
-# If updated, make sure to update the wrappers in cpp/cmake.
-function(bf_add_test)
-  add_test(${ARGV})
-  set_tests_properties(${ARGV0}
-    PROPERTIES ENVIRONMENT "BIOFORMATS_SCHEMADIR=${PROJECT_SOURCE_DIR}/components/specification/released-schema")
-endfunction()
-
 add_subdirectory(ome-compat)
 add_subdirectory(ome-common)
 add_subdirectory(ome-internal)

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -196,7 +196,7 @@ extlinks = {
     # Downloads
     'downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),
     'javadoc' : (downloads_root + '/latest/bio-formats5.1/api/%s', ''),
-    'doxygen' : (downloads_root + '/latest/bio-formats5.1/doxygen/%s', ''),
+    'doxygen' : (downloads_root + '/latest/bio-formats-cpp5.1/api/%s', ''),
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', '')

--- a/docs/sphinx/developers/cpp/examples/metadata-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-io.cpp
@@ -1,0 +1,272 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <iostream>
+
+#include <ome/compat/memory.h>
+
+#include <ome/common/filesystem.h>
+#include <ome/common/xml/Platform.h>
+#include <ome/common/xml/dom/Document.h>
+
+#include <ome/xml/meta/Convert.h>
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+#include <ome/bioformats/FormatTools.h>
+#include <ome/bioformats/MetadataTools.h>
+
+using boost::filesystem::path;
+using ome::compat::array;
+using ome::compat::make_shared;
+using ome::compat::shared_ptr;
+using ome::bioformats::dimension_size_type;
+using ome::bioformats::addMetadataOnly;
+using ome::bioformats::createOMEXMLMetadata;
+using ome::bioformats::createID;
+using ome::bioformats::getZCTCoords;
+using ome::bioformats::getOMEXML;
+namespace xml = ome::common::xml;
+namespace meta = ome::xml::meta;
+namespace model = ome::xml::model;
+typedef meta::OMEXMLMetadata::index_type index_type;
+
+namespace
+{
+
+  shared_ptr<meta::OMEXMLMetadata>
+  readMetadata(const path& filename)
+  {
+    /* read-file-example-start */
+    // Create metadata directly from file
+    shared_ptr<meta::OMEXMLMetadata> filemeta(createOMEXMLMetadata(filename));
+    /* read-file-example-end */
+
+    // Alternatively, create metadata from XML DOM tree:
+
+    /* read-dom-example-start */
+    // XML platform (required by Xerces)
+    xml::Platform xmlplat;
+    // XML DOM tree containing parsed file content
+    xml::dom::Document inputdoc(xml::dom::createDocument(filename));
+    // Create metadata from DOM document
+    shared_ptr<meta::OMEXMLMetadata> dommeta(createOMEXMLMetadata(inputdoc));
+    /* read-dom-example-end */
+
+    return filemeta;
+  }
+
+  /* query-example-start */
+  void
+  queryMetadata(const meta::MetadataRetrieve& meta,
+                const std::string&            state,
+                std::ostream&                 stream)
+  {
+    // Get total number of images
+    index_type ic = meta.getImageCount();
+    stream << "Image count: " << ic << '\n';
+
+    // Loop over images
+    for (index_type i = 0 ; i < ic; ++i)
+      {
+        // Print image dimensions (for this image index)
+        stream << "Dimensions for Image " << i << ' ' << state << ':'
+               << "\n\tX = " << meta.getPixelsSizeX(i)
+               << "\n\tY = " << meta.getPixelsSizeY(i)
+               << "\n\tZ = " << meta.getPixelsSizeZ(i)
+               << "\n\tT = " << meta.getPixelsSizeT(i)
+               << "\n\tC = " << meta.getPixelsSizeC(i)
+               << '\n';
+
+        // Get total number of planes (for this image index)
+        index_type pc = meta.getPlaneCount(i);
+        stream << "\tPlane count: " << pc << '\n';
+
+        // Loop over planes (for this image index)
+        for (index_type p = 0 ; p < pc; ++p)
+          {
+            // Print plane position (for this image index and plane
+            // index)
+            stream << "\tPosition of Plane " << p << ':'
+                   << "\n\t\tTheZ = " << meta.getPlaneTheZ(i, p)
+                   << "\n\t\tTheT = " << meta.getPlaneTheT(i, p)
+                   << "\n\t\tTheC = " << meta.getPlaneTheC(i, p)
+                   << '\n';
+          }
+      }
+  }
+  /* query-example-end */
+
+  /* update-example-start */
+  void
+  updateMetadata(meta::Metadata& meta)
+  {
+    // Get total number of images
+    index_type ic = meta.getImageCount();
+
+    // Loop over images
+    for (index_type i = 0 ; i < ic; ++i)
+      {
+        // Change image dimensions (for this image index)
+        meta.setPixelsSizeX(12, i);
+        meta.setPixelsSizeY(24, i);
+        meta.setPixelsSizeZ(6, i);
+        meta.setPixelsSizeT(30, i);
+        meta.setPixelsSizeC(4, i);
+      }
+  }
+  /* update-example-end */
+
+  /* add-example-start */
+  void
+  addMetadata(meta::Metadata& meta)
+  {
+    // Get total number of images
+    index_type i = meta.getImageCount();
+
+    // Size of Z, T and C dimensions
+    index_type nz = 3;
+    index_type nt = 1;
+    index_type nc = 4;
+
+    // Create new image; the image index is the same as the image
+    // count, i.e. one past the end of the current limit; createID
+    // creates a unique identifier for the image
+    meta.setImageID(createID("Image", i), i);
+    // Set Pixels identifier using createID and the same image index
+    meta.setPixelsID(createID("Pixels", i), i);
+    // Now set the dimension order, pixel type and dimension sizes for
+    // this image, using the same image index
+    meta.setPixelsDimensionOrder(model::enums::DimensionOrder::XYZTC, i);
+    meta.setPixelsType(model::enums::PixelType::UINT8, i);
+    meta.setPixelsSizeX(256, i);
+    meta.setPixelsSizeY(256, i);
+    meta.setPixelsSizeZ(nz, i);
+    meta.setPixelsSizeT(nt, i);
+    meta.setPixelsSizeC(nc, i);
+
+    // Plane count
+    index_type pc = nz * nc * nt;
+
+    // Loop over planes
+    for(index_type p = 0; p < pc; ++p)
+      {
+        // Get the Z, T and C coordinate for this plane index
+        array<dimension_size_type, 3> coord =
+          getZCTCoords("XYZTC", nz, nc, nt, pc, p);
+
+        // Set the plane position using the image index and plane
+        // index to reference the correct plane
+        meta.setPlaneTheZ(coord[0], i, p);
+        meta.setPlaneTheT(coord[2], i, p);
+        meta.setPlaneTheC(coord[1], i, p);
+      }
+
+    // Add MetadataOnly to Pixels since this is an example without
+    // TiffData or BinData
+    meta::OMEXMLMetadata *omexmlmeta = dynamic_cast<meta::OMEXMLMetadata *>(&meta);
+    if (omexmlmeta)
+      addMetadataOnly(*omexmlmeta, i);
+  }
+  /* add-example-end */
+
+  void
+  writeMetadata(meta::MetadataRetrieve& meta,
+                std::ostream&           stream)
+  {
+    /* write-example-start */
+    meta::OMEXMLMetadata *omexmlmeta = dynamic_cast<meta::OMEXMLMetadata *>(&meta);
+    shared_ptr<meta::OMEXMLMetadata> convertmeta;
+    if (!omexmlmeta)
+      {
+        convertmeta = make_shared<meta::OMEXMLMetadata>();
+        meta::convert(meta, *convertmeta);
+        omexmlmeta = &*convertmeta;
+      }
+    // Get OME-XML text from metadata store (and validate it)
+    std::string omexml(getOMEXML(*omexmlmeta, true));
+    /* write-example-end */
+
+    // Dump OME-XML text to stream
+    stream << omexml << '\n';
+  }
+
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      if (argc > 1)
+        {
+          // Portable path
+          path filename(argv[1]);
+
+          // Read XML file content into OME-XML metadata store
+          shared_ptr<meta::OMEXMLMetadata> meta(readMetadata(filename));
+
+          // Get size information from the metadata store
+          queryMetadata(*meta, "before update", std::cout);
+
+          // Update the size information and query again
+          updateMetadata(*meta);
+          queryMetadata(*meta, "after update", std::cout);
+
+          // Add new image and query again
+          addMetadata(*meta);
+          queryMetadata(*meta, "after image insertion", std::cout);
+
+          // Write XML content from OME-XML metadata store to stream
+          writeMetadata(*meta, std::cout);
+        }
+      else
+        {
+          std::cerr << "Usage: " << argv[0] << " ome-xml.xml\n";
+          std::exit(1);
+        }
+    }
+  catch (const std::exception& e)
+    {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+      std::exit(1);
+    }
+  catch (...)
+    {
+      std::cerr << "Caught unknown exception\n";
+      std::exit(1);
+    }
+}

--- a/docs/sphinx/developers/cpp/examples/model-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/model-io.cpp
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <iostream>
+
+#include <ome/compat/memory.h>
+
+#include <ome/common/filesystem.h>
+#include <ome/common/xml/Platform.h>
+#include <ome/common/xml/dom/Document.h>
+
+#include <ome/xml/model/OME.h>
+#include <ome/xml/model/OMEModel.h>
+#include <ome/xml/model/detail/OMEModel.h>
+
+using boost::filesystem::path;
+using ome::compat::shared_ptr;
+using ome::compat::make_shared;
+namespace xml = ome::common::xml;
+namespace model = ome::xml::model;
+
+namespace
+{
+
+  shared_ptr<model::OME>
+  readModel(const path& filename)
+  {
+    /* read-example-start */
+    // XML DOM tree containing parsed file content
+    xml::dom::Document inputdoc(xml::dom::createDocument(filename));
+    // OME Model (needed only during parsing to track model object references)
+    model::detail::OMEModel model;
+    // OME Model root object
+    shared_ptr<model::OME> modelroot(make_shared<model::OME>());
+    // Fill OME model object tree from XML DOM tree
+    modelroot->update(inputdoc.getDocumentElement(), model);
+    /* read-example-end */
+
+    return modelroot;
+  }
+
+  void
+  writeModel(shared_ptr<model::OME>& modelroot,
+             std::ostream&           stream)
+  {
+    /* write-example-start */
+    // Schema version to use
+    const std::string schema("http://www.openmicroscopy.org/Schemas/OME/2013-06");
+    // XML DOM tree (initially containing an empty OME root element)
+    xml::dom::Document outputdoc(xml::dom::createEmptyDocument(schema, "OME"));
+    // Fill output DOM document from OME-XML model
+    modelroot->asXMLElement(outputdoc);
+    // Dump DOM tree as text to stream
+    xml::dom::writeDocument(outputdoc, stream);
+    /* write-example-end */
+    stream << '\n';
+  }
+
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      if (argc > 1)
+        {
+          // XML platform (required by Xerces)
+          xml::Platform xmlplat;
+
+          // Portable path
+          path filename(argv[1]);
+
+          // Read XML file content into OME-XML model object tree
+          shared_ptr<model::OME> model(readModel(filename));
+
+          // Write XML content from OME-XML model object tree to stream
+          writeModel(model, std::cout);
+        }
+      else
+        {
+          std::cerr << "Usage: " << argv[0] << " ome-xml.xml\n";
+          std::exit(1);
+        }
+    }
+  catch (const std::exception& e)
+    {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+      std::exit(1);
+    }
+  catch (...)
+    {
+      std::cerr << "Caught unknown exception\n";
+      std::exit(1);
+    }
+}

--- a/docs/sphinx/developers/cpp/examples/pixeldata.cpp
+++ b/docs/sphinx/developers/cpp/examples/pixeldata.cpp
@@ -1,0 +1,250 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+
+#include <ome/bioformats/PixelBuffer.h>
+#include <ome/bioformats/PixelProperties.h>
+#include <ome/bioformats/VariantPixelBuffer.h>
+
+#include <ome/xml/model/enums/DimensionOrder.h>
+#include <ome/xml/model/enums/PixelType.h>
+
+using ome::bioformats::PixelBuffer;
+using ome::bioformats::PixelBufferBase;
+using ome::bioformats::PixelProperties;
+using ome::bioformats::VariantPixelBuffer;
+using ome::xml::model::enums::DimensionOrder;
+using ome::xml::model::enums::PixelType;
+
+namespace
+{
+
+  void
+  createPixelBuffer()
+  {
+    /* create-example-start */
+    // Language type for FLOAT pixel data
+    typedef PixelProperties<PixelType::FLOAT>::std_type float_pixel_type;
+    // Create PixelBuffer for floating point data
+    // X=512 Y=512 Z=16 T=1 C=3 S/z/t/c=1
+    PixelBuffer<float_pixel_type> buffer
+      (boost::extents[512][512][16][1][3][1][1][1][1], PixelType::FLOAT);
+    /* create-example-end */
+
+    /* at-example-start */
+    // Set all pixel values for Z=2 and C=1 to 0.5
+    // 9D index, default values default to zero if unused
+    PixelBuffer<float_pixel_type>::indices_type idx;
+    // Set Z and C indices
+    idx[ome::bioformats::DIM_SPATIAL_Z] = 2;
+    idx[ome::bioformats::DIM_CHANNEL] = 1;
+    idx[ome::bioformats::DIM_TEMPORAL_T] =
+      idx[ome::bioformats::DIM_SUBCHANNEL] =
+      idx[ome::bioformats::DIM_MODULO_Z] =
+      idx[ome::bioformats::DIM_MODULO_T] =
+      idx[ome::bioformats::DIM_MODULO_C] = 0;
+
+    for (uint16_t x = 0; x < 512; ++x)
+      {
+        idx[ome::bioformats::DIM_SPATIAL_X] = x;
+        for (uint16_t y = 0; y < 512; ++y)
+          {
+            idx[ome::bioformats::DIM_SPATIAL_Y] = y;
+            buffer.at(idx) = 0.5f;
+          }
+      }
+    /* at-example-end */
+  }
+
+  void
+  createPixelBufferOrdered()
+  {
+    /* create-ordered-example-start */
+    // Language type for UINT16 pixel data
+    typedef PixelProperties<PixelType::UINT16>::std_type uint16_pixel_type;
+    // Storage order is XYSZCTztc; subchannels are not interleaved
+    // ("planar") after XY
+    PixelBufferBase::storage_order_type order1
+      (PixelBufferBase::make_storage_order(DimensionOrder::XYCTZ, false));
+    // Create PixelBuffer for unsigned 16-bit data with specified
+    // storage order
+    // X=512 Y=512 Z=16 T=1 C=3 S/z/t/c=1
+    PixelBuffer<uint16_pixel_type> buffer1
+      (boost::extents[512][512][16][1][3][1][1][1][1],
+       PixelType::UINT16,
+       ome::bioformats::ENDIAN_NATIVE,
+       order1);
+
+    // Language type for INT8 pixel data
+    typedef PixelProperties<PixelType::INT8>::std_type int8_pixel_type;
+    // Storage order is SXYCTZztc; subchannels are interleaved
+    // ("chunky") before XY
+    PixelBufferBase::storage_order_type order2
+      (PixelBufferBase::make_storage_order(DimensionOrder::XYZCT, true));
+    // Create PixelBuffer for signed 8-bit RGB data with specified storage
+    // order
+    // X=1024 Y=1024 Z=1 T=1 C=1 S=3 z/t/c=1
+    PixelBuffer<int8_pixel_type> buffer2
+      (boost::extents[1024][1024][1][1][1][3][1][1][1],
+       PixelType::INT8,
+       ome::bioformats::ENDIAN_NATIVE,
+       order2);
+    /* create-ordered-example-end */
+  }
+
+  /* visitor-example-start */
+  // Visitor to compute min and max pixel value for pixel buffer of
+  // any pixel type
+  // The static_visitor specialisation is the required return type of
+  // the operator() methods and boost::apply_visitor()
+  struct MinMaxVisitor : public boost::static_visitor<std::pair<double, double> >
+  {
+    // The min and max values will be returned in a pair.  double is
+    // used since it can contain the value for any pixel type
+    typedef std::pair<double, double> result_type;
+
+    // Get min and max for any non-complex pixel type
+    template<typename T>
+    result_type
+    operator() (const T& v)
+    {
+      typedef typename T::element_type::value_type value_type;
+
+      value_type *min = std::min_element(v->data(),
+                                         v->data() + v->num_elements());
+      value_type *max = std::max_element(v->data(),
+                                         v->data() + v->num_elements());
+
+      return result_type(static_cast<double>(*min),
+                         static_cast<double>(*max));
+    }
+
+    // Less than comparison for real part of complex numbers
+    template <typename T>
+    static bool
+    complex_real_less(const T& lhs, const T& rhs)
+    {
+      return std::real(lhs) < std::real(rhs);
+    }
+
+    // Greater than comparison for real part of complex numbers
+    template <typename T>
+    static bool
+    complex_real_greater(const T& lhs, const T& rhs)
+    {
+      return std::real(lhs) > std::real(rhs);
+    }
+
+    // Get min and max for complex pixel types (COMPLEX and
+    // DOUBLECOMPLEX)
+    // This is the same as for simple pixel types, except for the
+    // addition of custom comparison functions and conversion of the
+    // result to the real part.
+    template <typename T>
+    typename boost::enable_if_c<
+      boost::is_complex<T>::value, result_type
+      >::type
+    operator() (const ome::compat::shared_ptr<PixelBuffer<T> >& v)
+    {
+      typedef T value_type;
+
+      value_type *min = std::min_element(v->data(),
+                                         v->data() + v->num_elements(),
+                                         complex_real_less<T>);
+      value_type *max = std::max_element(v->data(),
+                                         v->data() + v->num_elements(),
+                                         complex_real_greater<T>);
+
+      return result_type(static_cast<double>(std::real(*min)),
+                         static_cast<double>(std::real(*max)));
+    }
+  };
+
+  void
+  applyVariant()
+  {
+    // Make variant buffer (int32, 16×16 single plane)
+    VariantPixelBuffer variant(boost::extents[16][16][1][1][1][1][1][1][1],
+                               PixelType::INT32);
+    // Get buffer size
+    VariantPixelBuffer::size_type size = variant.num_elements();
+    // Create sample random-ish data
+    std::vector<int32_t> vec;
+    for (VariantPixelBuffer::size_type i = 0; i < size; ++i)
+      {
+        int32_t val = static_cast<int32_t>(i + 42);
+        vec.push_back(val);
+      }
+    std::random_shuffle(vec.begin(), vec.end());
+    // Assign sample data to buffer.
+    variant.assign(vec.begin(), vec.end());
+
+    // Create and apply visitor
+    MinMaxVisitor visitor;
+    MinMaxVisitor::result_type result = boost::apply_visitor(visitor, variant.vbuffer());
+
+    std::cout << "Min is " << result.first
+              << ", max is " << result.second << '\n';
+  }
+  /* visitor-example-end */
+
+
+}
+
+int
+main()
+{
+  try
+    {
+      createPixelBuffer();
+      createPixelBufferOrdered();
+      applyVariant();
+    }
+  catch (const std::exception& e)
+    {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+      std::exit(1);
+    }
+  catch (...)
+    {
+      std::cerr << "Caught unknown exception\n";
+      std::exit(1);
+    }
+}

--- a/docs/sphinx/developers/cpp/examples/pixeldata.cpp
+++ b/docs/sphinx/developers/cpp/examples/pixeldata.cpp
@@ -70,7 +70,7 @@ namespace
 
     /* at-example-start */
     // Set all pixel values for Z=2 and C=1 to 0.5
-    // 9D index, default values default to zero if unused
+    // 9D index, default values to zero if unused
     PixelBuffer<float_pixel_type>::indices_type idx;
     // Set Z and C indices
     idx[ome::bioformats::DIM_SPATIAL_Z] = 2;
@@ -99,8 +99,9 @@ namespace
     /* create-ordered-example-start */
     // Language type for UINT16 pixel data
     typedef PixelProperties<PixelType::UINT16>::std_type uint16_pixel_type;
-    // Storage order is XYSZCTztc; subchannels are not interleaved
-    // ("planar") after XY
+    // Storage order is XYSCTZztc; subchannels are not interleaved
+    // ("planar") after XY; lowercase letters are unused Modulo
+    // dimensions
     PixelBufferBase::storage_order_type order1
       (PixelBufferBase::make_storage_order(DimensionOrder::XYCTZ, false));
     // Create PixelBuffer for unsigned 16-bit data with specified
@@ -114,8 +115,9 @@ namespace
 
     // Language type for INT8 pixel data
     typedef PixelProperties<PixelType::INT8>::std_type int8_pixel_type;
-    // Storage order is SXYCTZztc; subchannels are interleaved
-    // ("chunky") before XY
+    // Storage order is SXYZCTztc; subchannels are interleaved
+    // ("chunky") before XY; lowercase letters are unused Modulo
+    // dimensions
     PixelBufferBase::storage_order_type order2
       (PixelBufferBase::make_storage_order(DimensionOrder::XYZCT, true));
     // Create PixelBuffer for signed 8-bit RGB data with specified storage
@@ -132,7 +134,7 @@ namespace
   /* visitor-example-start */
   // Visitor to compute min and max pixel value for pixel buffer of
   // any pixel type
-  // The static_visitor specialisation is the required return type of
+  // The static_visitor specialization is the required return type of
   // the operator() methods and boost::apply_visitor()
   struct MinMaxVisitor : public boost::static_visitor<std::pair<double, double> >
   {

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -125,9 +125,11 @@ If possible, install one of the following packages:
 | RedHat/CentOS    | boost-devel      |
 +------------------+------------------+
 
-1.41 is known to not work nicely with :program:`cmake`; 1.48 or later
-needed for Boost.Geometry; 1.54 or later needed for Boost.Geometry
-spatial indexes.
+1.48 or later needed for Boost.Geometry; 1.54 or later needed for
+Boost.Geometry spatial indexes.  RHEL/CentOS 6 users might want to
+look at the `Boost 1.48 SCL
+<https://www.softwarecollections.org/en/scls/denisarnaud/boost148/>`_
+or build a more recent Boost release.
 
 CMake
 ^^^^^

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -188,7 +188,7 @@ Full example source: :download:`metadata-io.cpp <examples/metadata-io.cpp>`
 
   - :doxygen:`Metadata classes <namespaceome_1_1xml_1_1meta.html>`
   - :doxygen:`createID <namespaceome_1_1bioformats.html#ab3bf80ec03bcf20b199ce2761d48fe01>`
-  - :doxygen:`createOMEXMLMetadata <namespaceome_1_1bioformats.html#a094cce3a9581c222d128cc9f366aaa75>`
+  - :doxygen:`createOMEXMLMetadata <namespaceome_1_1bioformats.html#ae61f12958973765e8328348874a85731>`
   - :doxygen:`getOMEXML <namespaceome_1_1bioformats.html#a32e5424991ce09b857ddc0d5be37c4f1>`
 
 

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -1,0 +1,235 @@
+Tutorial
+========
+
+
+Metadata
+--------
+
+Bio-Formats supports several different classes of metadata, from very
+basic information about the image dimensions and pixel type to
+detailed information about the acquisition hardware and experimental
+parameters.  From simplest to most complex, these are:
+
+Core metadata
+  Basic information describing an individual 5D image (series),
+  including dimension sizes, dimension order and pixel type
+
+Original metadata
+  Key-value pairs describing metadata from the original file format
+  for the image.  Two forms exist: global metadata for an entire
+  dataset (image collection) and series metadata for an individual 5D
+  image
+
+Metadata store
+  A container for all image metadata providing interfaces to get and
+  set individual metadata values.  This is a superset of the core and
+  original metadata content (it can represent all values contained
+  within the core and original metadata).  It is an alternative
+  representation of the OME-XML data model objects, and is used by the
+  Bio-Formats reader and writer interfaces.
+
+OME-XML data model objects
+  The abstract OME-XML data model is realised as a collection of
+  *model objects*.  Classes are generated from the elements of the
+  OME-XML data model schema, and a tree of the model objects acts as a
+  representation of the OME data model which may be modified and
+  manipulated.  The model objects may be created from an OME-XML text
+  document, and vice versa.
+
+For the simplest cases of reading and writing image data, the core
+metadata interface will likely be sufficient.  If specific individual
+parameters from the original file format are needed, then original
+metadata may also be useful.  For more advanced processing and
+rendering, the metadata store should be the next source of
+information, for example to get information about the image scale,
+stage position, instrument setup including light sources, light paths,
+detectors etc., and access to plate/well information, regions of
+interest etc.  Direct access to the OME-XML data model objects is an
+alternative to the metadata store, but is more difficult to use;
+certain modifications to the data model may only be made via direct
+access to the model objects, otherwise the higher-level metadata store
+interface should be preferred.
+
+Core metadata
+^^^^^^^^^^^^^
+
+Core metadata is accessible through the getter methods in the
+:cpp:class:`FormatReader` interface.  These operate on the *current*
+series, set using the :cpp:func:`setSeries` method.  The
+:cpp:class:`CoreMetadata` objects are also accessible directly using
+the :cpp:class:`getCoreMetadataList` method.  The
+:cpp:class:`FormatReader` interface should be preferred; the objects
+themselves are more of an implementation detail at present.
+
+.. seealso::
+
+  - :doxygen:`CoreMetadata <classome_1_1bioformats_1_1CoreMetadata.html>`
+  - :doxygen:`FormatReader <classome_1_1bioformats_1_1FormatReader.html>`
+
+
+Original metadata
+^^^^^^^^^^^^^^^^^
+
+Original metadata is stored in two forms: in a
+:cpp:class:`MetadataMap` which is accessible through the
+:cpp:class:`FormatReader` interface, which offers access to individual
+keys and the whole map for both global and series metadata.  It is
+also accessible using the metadata store; original metadata is stored
+as an :cpp:class:`XMLAnnotation`.
+
+.. seealso::
+
+  - :doxygen:`MetadataMap <classome_1_1bioformats_1_1MetadataMap.html>`
+  - :doxygen:`FormatReader <classome_1_1bioformats_1_1FormatReader.html>`
+  - :doxygen:`OriginalMetadataAnnotation <classome_1_1xml_1_1model_1_1OriginalMetadataAnnotation.html>`
+
+Metadata store
+^^^^^^^^^^^^^^
+
+Access to metadata is provided via the :cpp:class:`MetadataStore` and
+:cpp:class:`MetadataRetrieve` interfaces.  These provide setters and
+getters, respectively, to store and retrieve metadata from an
+underlying abstract metadata store.  The primary store is the
+:cpp:class:`OMEXMLMetadata` which stores the metadata in OME-XML data
+model objects (see below), and implements both interfaces.  However,
+other storage classes are available, and may be used to filter the
+stored metadata, combine different stores, or do nothing at all.
+Additional storage backends could also be implemented, for example to
+allow metadata retrieval from a relational database, or JSON/YAML.
+
+When using :cpp:class:`OMEXMLMetadata` the convenience function
+:cpp:func:`createOMEXMLMetadata` is the recommended method for
+creating a new instance and then filling it with the content from an
+OME-XML document.  This is overloaded to allow the OME-XML to be
+obtained from various sources.  For example, from a file:
+
+.. literalinclude:: examples/metadata-io.cpp
+   :language: cpp
+   :start-after: read-file-example-start
+   :end-before: read-file-example-end
+
+Alternatively from a DOM tree:
+
+.. literalinclude:: examples/metadata-io.cpp
+   :language: cpp
+   :start-after: read-dom-example-start
+   :end-before: read-dom-example-end
+
+The convenience function :cpp:func:`getOMEXML` may be used to reverse
+the process, i.e. obtain an OME-XML document from the store.  Note the
+use of :cpp:func:`convert`.  Only the :cpp:class:`OMEXMLMetadata`
+class can dump an OME-XML document, therefore if the source of the
+data is another class implementing the :cpp:class:`MetadataRetrieve`
+interface, the stored data will need to be copied into an
+:cpp:class:`OMEXMLMetadata` instance first.
+
+.. literalinclude:: examples/metadata-io.cpp
+   :language: cpp
+   :start-after: write-example-start
+   :end-before: write-example-end
+
+Conceptually, the metadata store contains lists of objects, accessed
+by index (insertion order).  In the example below,
+:cpp:func:`getImageCount` method is used to find the number of images.
+This is then used to safely loop through each of the available images.
+Each of the :cpp:func:`getPixelsSizeA` methods takes the image index
+as its only argument.  Internally, this is used to find the
+:cpp:class:`Image` model object for the specified index, and then call
+the :cpp:func:`getSizeA` method on that object and return the result.
+Since objects can contain other objects, some accessor methods require
+the use of more than one index.  For example, an :cpp:class:`Image`
+object can contain multiple :cpp:class:`Plane` objects.  Similar to
+the above example, there is a :cpp:func:`getPlaneCount` method,
+however since it's contained by an :cpp:class:`Image` it has an
+additional image index argument to get the plane count for the
+specified image.  Likewise its accessors such as
+:cpp:func:`getPlaneTheZ` contain two arguments, the image index and
+the plane index.  Internally, these indices will be used to find the
+:cpp:class:`Image`, then the :cpp:class:`Plane`, and then call
+:cpp:func:`getTheZ`.  When using the :cpp:class:`MetadataRetrieve`
+interface with an :cpp:class:`OMEXMLMetadata` store, the methods are
+simply a shorthand for navigating through the tree of model objects.
+
+.. literalinclude:: examples/metadata-io.cpp
+   :language: cpp
+   :start-after: query-example-start
+   :end-before: query-example-end
+
+The methods for storing data using the :cpp:class:`MetadataStore`
+interface are similar.  The set methods use the same indices as the
+get methods, with the value to set as an additional initial argument.
+The following example demonstrates how to update dimension sizes for
+images in the store:
+
+.. literalinclude:: examples/metadata-io.cpp
+   :language: cpp
+   :start-after: update-example-start
+   :end-before: update-example-end
+
+When adding new objects to the store, as opposed to updating existing
+ones, some additional considerations apply.  An new object is added to
+the store if the object corresponding to an index does not exist and
+the index is the current object count (i.e. one past the end of the
+last valid index).  Note that for data model objects with a
+:cpp:func:`setID` method, this method alone will trigger insertion and
+must be called first, before any other methods which modify the
+object.  The following example demonstrates the addition of a new
+:cpp:class:`Image` to the store, plus contained :cpp:class:`Plane`
+objects.
+
+.. literalinclude:: examples/metadata-io.cpp
+   :language: cpp
+   :start-after: add-example-start
+   :end-before: add-example-end
+
+Full example source: :download:`metadata-io.cpp <examples/metadata-io.cpp>`
+
+.. seealso::
+
+  - :doxygen:`Metadata classes <namespaceome_1_1xml_1_1meta.html>`
+  - :doxygen:`createID <namespaceome_1_1bioformats.html#ab3bf80ec03bcf20b199ce2761d48fe01>`
+  - :doxygen:`createOMEXMLMetadata <namespaceome_1_1bioformats.html#a094cce3a9581c222d128cc9f366aaa75>`
+  - :doxygen:`getOMEXML <namespaceome_1_1bioformats.html#a32e5424991ce09b857ddc0d5be37c4f1>`
+
+
+OME-XML data model objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The data model objects are not typically used directly, but are
+created, modified and queried using the :cpp:class:`Metadata`
+interfaces (above), so in practice these examples should not be
+needed.
+
+To create a tree of OME-XML data model objects from OME-XML text:
+
+.. literalinclude:: examples/model-io.cpp
+   :language: cpp
+   :start-after: read-example-start
+   :end-before: read-example-end
+
+In this example, the OME-XML text is read from a file into a DOM tree.
+This could have been read directly from a string or stream if the
+source was not a file.  The DOM tree is then processed using the
+:cpp:class:`OME` root object's :cpp:func:`update` method, which uses
+the data from the DOM tree elements to create a tree of corresponding
+model objects contained by the root object.
+
+To reverse the process, taking a tree of OME-XML model objects and
+converting them back of OME-XML text:
+
+.. literalinclude:: examples/model-io.cpp
+   :language: cpp
+   :start-after: write-example-start
+   :end-before: write-example-end
+
+Here, the :cpp:class:`OME` root object's :cpp:func:`asXMLElement`
+method is used to copy the data from the OME root object and its
+children into an XML DOM tree.  The DOM tree is then converted to text
+for output.
+
+Full example source: :download:`model-io.cpp <examples/model-io.cpp>`
+
+.. seealso::
+
+  - :doxygen:`OME model classes <namespaceome_1_1xml_1_1model.html>`
+  - :doxygen:`OME <classome_1_1xml_1_1model_1_1OME.html>`

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -233,3 +233,174 @@ Full example source: :download:`model-io.cpp <examples/model-io.cpp>`
 
   - :doxygen:`OME model classes <namespaceome_1_1xml_1_1model.html>`
   - :doxygen:`OME <classome_1_1xml_1_1model_1_1OME.html>`
+
+
+Pixel data
+----------
+
+The Bio-Formats Java implementation stores and passes pixel values in
+a raw :cpp:type:`byte` array.  Due to limitations with C++ array
+passing, this was not possible for the C++ implementation.  While a
+vector or other container could have been used, several problems
+remain.  The type and endianness of the data in the raw bytes is not
+known, and the dimension ordering and dimension extents are also
+unknown, which imposes a significant burden on the programmer to
+correctly process the data.  The C++ implementation provides two types
+to solve these problems.
+
+The :cpp:class:`PixelBuffer` class is a container of pixel data.  It
+is a template class, templated on the pixel type in use.  The class
+contains the order of the dimensions, and the size of each dimension,
+making it possible to process pixel data without need for
+externally-provided metadata to describe its structure.  This class
+may be used to contain and process pixel data of a specific pixel
+type.  Internally, the pixel data is contained within a
+:cpp:class:`boost::multi_array` as a 9D hyper-volume, though its usage
+in this release of Bio-Formats is limited to 5D.  The class can either
+contain its own memory allocation for pixel data or reference memory
+allocated or mapped externally, allowing use with memory-mapped data,
+for example.
+
+In many situations, it is desirable to work with arbitrary pixel
+types, or at least the set of pixel types defined in the OME data
+model in its :cpp:class:`PixelType` enumeration.  The
+:cpp:class:`VariantPixelBuffer` fulfills this need, using
+:cpp:class:`boost::variant` to allow it to contain a
+:cpp:class:`PixelBuffer` specialised for any of the pixel types in the
+OME data model.  This is used to allow transfer and processing of any
+supported pixel type, for example by the :cpp:class:`FormatReader`
+class' :cpp:func:`getLookupTable` and :cpp:func:`openBytes` methods,
+and the corresponding :cpp:class:`FormatWriter` class'
+:cpp:func:`setLookupTable` and :cpp:func:`saveBytes` methods.
+
+An additional problem with supporting many different pixel types is
+that each operation upon the pixel data, for example for display or
+analysis, may require implementing separately for each pixel type.
+This imposes a significant testing and maintenance burden.
+:cpp:class:`VariantPixelBuffer` solves this problem through use of
+:cpp:func:`boost::apply_visitor` and
+:cpp:class:`boost::static_visitor`, which allow algorithms to be
+defined in a template and compiled for each pixel type.  They also
+allow algorithms to be specialised for different classes of pixel
+type, for example signed vs. unsigned, integer vs. floating point, or
+simple vs. complex, or special-cased per type e.g. for bitmasks.  When
+:cpp:func:`boost::apply_visitor` is called with a specified algorithm
+and :cpp:class:`VariantPixelBuffer` object, it will select the
+matching algorithm for the pixel type contained within the buffer, and
+then invoke it on the buffer.  This permits the programmer to support
+arbitrary pixel types without creating a maintenance nightmare, and
+without unnecessary code duplication.
+
+The 9D pixel buffer makes a distinction between the logical dimension
+order (used by the API) and the storage order (the layout of the pixel
+data in memory).  The logical order is defined by the values in the
+:doxygen:`Dimensions
+<namespaceome_1_1bioformats.html#ad9ebb405a4815c189fa788325f68a91a>`
+enum.  The storage order is specified by the programmer when creating
+a pixel buffer.
+
+The following example shows creation of a pixel buffer with a defined
+size, and :doxygen:`default storage order
+<classome_1_1bioformats_1_1PixelBufferBase.html#a419ad49f2ea90937a57b81a74b56380b>`:
+
+.. literalinclude:: examples/pixeldata.cpp
+   :language: cpp
+   :start-after: create-example-start
+   :end-before: create-example-end
+
+The storage order may be set explicitly.  The order may be created by
+hand, or with a :doxygen:`helper function
+<classome_1_1bioformats_1_1PixelBufferBase.html#ac7e922610bf561f311d13c3d7fcaeb69>`.
+While the helper function is limited to supporting the ordering
+defined by the data model, specifying the order by hand allows
+additional flexibility, for example allowing the indexing for
+individual dimensions to run backwards which is useful for example if
+the Y-axis requires inverting.  The following example shows creation
+of a pixel buffer with defined storage order using the helper
+function:
+
+.. literalinclude:: examples/pixeldata.cpp
+   :language: cpp
+   :start-after: create-ordered-example-start
+   :end-before: create-ordered-example-end
+
+Note that the logical order of the dimension extents is unchanged.
+
+In practice, it is unlikely that you will need to create any
+:cpp:class:`PixelBuffer` objects directly.  The
+:cpp:class:`FormatReader` and :cpp:class:`FormatWriter` interfaces use
+:cpp:class:`VariantPixelBuffer` objects, and in the case of the reader
+interface the :cpp:func:`getLookupTable` and :cpp:func:`openBytes`
+methods can be passed a default-constructed
+:cpp:class:`VariantPixelBuffer` and it will be set up automatically,
+changing the image dimensions, dimension order and pixel type to match
+the data being fetched, if the size, order and type do not match.
+
+Both buffer classes provide access to the pixel data so that it may be
+access, manipulated and passed elsewhere.  The
+:cpp:class:`PixelBuffer` class provides an :cpp:class:`at` method.
+This will allow access to individual pixel values using a 9D
+coordinate:
+
+.. literalinclude:: examples/pixeldata.cpp
+   :language: cpp
+   :start-after: at-example-start
+   :end-before: at-example-end
+
+The :cpp:class:`VariantPixelBuffer` does not provide an
+:cpp:class:`at` method for efficiency reasons.  Instead, visitors
+should be used for processing of bulk pixel data.  For example, this
+is one way the minimum and maximum pixel values could be obtained:
+
+.. literalinclude:: examples/pixeldata.cpp
+   :language: cpp
+   :start-after: visitor-example-start
+   :end-before: visitor-example-end
+
+This example demonstrates several features:
+
+- The visitor operators can return values to the caller (for more
+  complex algorithms, the visitor class could use member variables and
+  additional methods)
+- The operator is expanded once for each pixel type
+- The operators can be special-cased for individual pixel types; here
+  we use SFINAE to implement a specialisation for an entire category
+  of pixel types (complex numbers), but standard function overloading
+  and templates will also work for more common cases
+- Pixel data can be assigned to the buffer with a single
+  :cpp:func:`assign` call.
+
+The Bio-Formats source uses this for several purposes, for example to
+load pixel data into OpenGL textures, handling format conversion and
+repacking of pixel data as needed.
+
+While the pixel buffers may appear complex, they do permit the
+Bio-Formats library to support all pixel types with relative ease, and
+it will allow your applications to also handle multiple pixel types by
+writing your own visitors.  Assignment of one buffer to another will
+also repack the pixel data if they use different storage ordering
+(i.e. the logical ordering is used for the copy), which can be useful
+if you need the pixel data in a defined ordering.
+
+If all your want is access to the raw data, as in the Java API, you
+are not required to use the above features.  Simply use the
+:cpp:func:`data` method on the buffer to get a pointer to the raw
+data.  Note that you will need to multiply the buffer size obtained
+with :cpp:func:`num_elements` by the size of the pixel type (use
+:cpp:func:`bytesPerPixel` or :cpp:func:`sizeof` on the buffer
+:cpp:type:`value_type`).
+
+Alternatively, it is also possible to access the underlying
+:cpp:class:`boost::multi_array` using the :cpp:func:`array` method, if
+you need access to functionality not wrapped by
+:cpp:class:`PixelBuffer`.
+
+.. seealso::
+
+  - :doxygen:`PixelType <classome_1_1xml_1_1model_1_1enums_1_1PixelType.html>`
+  - :doxygen:`PixelBuffer <classome_1_1bioformats_1_1PixelBuffer.html>`
+  - :doxygen:`VariantPixelBuffer <classome_1_1bioformats_1_1VariantPixelBuffer.html>`
+  - :doxygen:`FormatReader::getLookupTable <classome_1_1bioformats_1_1FormatReader.html#a416742287de02c29d68147e7965316c4>`
+  - :doxygen:`FormatReader::openBytes <classome_1_1bioformats_1_1FormatReader.html#a91184deaf16c42b51eb564ee11e76fe2>`
+  - :doxygen:`FormatWriter::setLookupTable <classome_1_1bioformats_1_1FormatWriter.html#a7ee8eaab7b440be78f3707d1f34ec372>`
+  - :doxygen:`FormatWriter::saveBytes <classome_1_1bioformats_1_1FormatWriter.html#a3f75d001c244c06883c986df988d31b5>`

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -29,7 +29,7 @@ Metadata store
   Bio-Formats reader and writer interfaces.
 
 OME-XML data model objects
-  The abstract OME-XML data model is realised as a collection of
+  The abstract OME-XML data model is realized as a collection of
   *model objects*.  Classes are generated from the elements of the
   OME-XML data model schema, and a tree of the model objects acts as a
   representation of the OME data model which may be modified and
@@ -88,7 +88,7 @@ Metadata store
 
 Access to metadata is provided via the :cpp:class:`MetadataStore` and
 :cpp:class:`MetadataRetrieve` interfaces.  These provide setters and
-getters, respectively, to store and retrieve metadata from an
+getters, respectively, to store and retrieve metadata to and from an
 underlying abstract metadata store.  The primary store is the
 :cpp:class:`OMEXMLMetadata` which stores the metadata in OME-XML data
 model objects (see below), and implements both interfaces.  However,
@@ -140,10 +140,10 @@ Since objects can contain other objects, some accessor methods require
 the use of more than one index.  For example, an :cpp:class:`Image`
 object can contain multiple :cpp:class:`Plane` objects.  Similar to
 the above example, there is a :cpp:func:`getPlaneCount` method,
-however since it's contained by an :cpp:class:`Image` it has an
+however since it is contained by an :cpp:class:`Image` it has an
 additional image index argument to get the plane count for the
 specified image.  Likewise its accessors such as
-:cpp:func:`getPlaneTheZ` contain two arguments, the image index and
+:cpp:func:`getPlaneTheZ` take two arguments, the image index and
 the plane index.  Internally, these indices will be used to find the
 :cpp:class:`Image`, then the :cpp:class:`Plane`, and then call
 :cpp:func:`getTheZ`.  When using the :cpp:class:`MetadataRetrieve`

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -257,16 +257,16 @@ may be used to contain and process pixel data of a specific pixel
 type.  Internally, the pixel data is contained within a
 :cpp:class:`boost::multi_array` as a 9D hyper-volume, though its usage
 in this release of Bio-Formats is limited to 5D.  The class can either
-contain its own memory allocation for pixel data or reference memory
-allocated or mapped externally, allowing use with memory-mapped data,
-for example.
+contain its own memory allocation for pixel data, or it can reference
+memory allocated or mapped externally, allowing use with memory-mapped
+data, for example.
 
 In many situations, it is desirable to work with arbitrary pixel
 types, or at least the set of pixel types defined in the OME data
 model in its :cpp:class:`PixelType` enumeration.  The
 :cpp:class:`VariantPixelBuffer` fulfills this need, using
 :cpp:class:`boost::variant` to allow it to contain a
-:cpp:class:`PixelBuffer` specialised for any of the pixel types in the
+:cpp:class:`PixelBuffer` specialized for any of the pixel types in the
 OME data model.  This is used to allow transfer and processing of any
 supported pixel type, for example by the :cpp:class:`FormatReader`
 class' :cpp:func:`getLookupTable` and :cpp:func:`openBytes` methods,
@@ -281,7 +281,7 @@ This imposes a significant testing and maintenance burden.
 :cpp:func:`boost::apply_visitor` and
 :cpp:class:`boost::static_visitor`, which allow algorithms to be
 defined in a template and compiled for each pixel type.  They also
-allow algorithms to be specialised for different classes of pixel
+allow algorithms to be specialized for different classes of pixel
 type, for example signed vs. unsigned, integer vs. floating point, or
 simple vs. complex, or special-cased per type e.g. for bitmasks.  When
 :cpp:func:`boost::apply_visitor` is called with a specified algorithm
@@ -313,11 +313,11 @@ hand, or with a :doxygen:`helper function
 <classome_1_1bioformats_1_1PixelBufferBase.html#ac7e922610bf561f311d13c3d7fcaeb69>`.
 While the helper function is limited to supporting the ordering
 defined by the data model, specifying the order by hand allows
-additional flexibility, for example allowing the indexing for
-individual dimensions to run backwards which is useful for example if
-the Y-axis requires inverting.  The following example shows creation
-of a pixel buffer with defined storage order using the helper
-function:
+additional flexibility.  Manual ordering may be used to allow the
+indexing for individual dimensions to run backward rather than
+forward, which is useful if the Y-axis requires inverting, for
+example.  The following example shows creation of two pixel buffers with
+defined storage order using the helper function:
 
 .. literalinclude:: examples/pixeldata.cpp
    :language: cpp
@@ -337,20 +337,22 @@ changing the image dimensions, dimension order and pixel type to match
 the data being fetched, if the size, order and type do not match.
 
 Both buffer classes provide access to the pixel data so that it may be
-access, manipulated and passed elsewhere.  The
+accessed, manipulated and passed elsewhere.  The
 :cpp:class:`PixelBuffer` class provides an :cpp:class:`at` method.
-This will allow access to individual pixel values using a 9D
-coordinate:
+This allows access to individual pixel values using a 9D coordinate:
 
 .. literalinclude:: examples/pixeldata.cpp
    :language: cpp
    :start-after: at-example-start
    :end-before: at-example-end
 
-The :cpp:class:`VariantPixelBuffer` does not provide an
-:cpp:class:`at` method for efficiency reasons.  Instead, visitors
-should be used for processing of bulk pixel data.  For example, this
-is one way the minimum and maximum pixel values could be obtained:
+Conceptually, this is the same as using an index for a normal 1D
+array, but extended to use an array of nine indices for each of the
+nine dimensions, in the logical storage order.  The
+:cpp:class:`VariantPixelBuffer` does not provide an :cpp:class:`at`
+method for efficiency reasons.  Instead, visitors should be used for
+the processing of bulk pixel data.  For example, this is one way the
+minimum and maximum pixel values could be obtained:
 
 .. literalinclude:: examples/pixeldata.cpp
    :language: cpp
@@ -364,15 +366,18 @@ This example demonstrates several features:
   additional methods)
 - The operator is expanded once for each pixel type
 - The operators can be special-cased for individual pixel types; here
-  we use SFINAE to implement a specialisation for an entire category
-  of pixel types (complex numbers), but standard function overloading
-  and templates will also work for more common cases
+  we use the `SFINAE rule
+  <http://en.cppreference.com/w/cpp/language/sfinae>`_ to implement a
+  specialization for an entire category of pixel types (complex
+  numbers), but standard function overloading and templates will also
+  work for more common cases
 - Pixel data can be assigned to the buffer with a single
   :cpp:func:`assign` call.
 
-The Bio-Formats source uses this for several purposes, for example to
-load pixel data into OpenGL textures, handling format conversion and
-repacking of pixel data as needed.
+The Bio-Formats source uses pixel buffer visitors for several
+purposes, for example to load pixel data into OpenGL textures, which
+automatically handles pixel format conversion and repacking of pixel
+data as needed.
 
 While the pixel buffers may appear complex, they do permit the
 Bio-Formats library to support all pixel types with relative ease, and
@@ -382,8 +387,8 @@ also repack the pixel data if they use different storage ordering
 (i.e. the logical ordering is used for the copy), which can be useful
 if you need the pixel data in a defined ordering.
 
-If all your want is access to the raw data, as in the Java API, you
-are not required to use the above features.  Simply use the
+If all you want is access to the raw data, as in the Java API, you are
+not required to use the above features.  Simply use the
 :cpp:func:`data` method on the buffer to get a pointer to the raw
 data.  Note that you will need to multiply the buffer size obtained
 with :cpp:func:`num_elements` by the size of the pixel type (use

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -51,6 +51,7 @@ Using Bio-Formats as a native C++ library
 
     cpp/overview
     cpp/conversion
+    cpp/tutorial
     cpp/bf-env
     cpp/commands/bf-test
     cpp/commands/bf-test-info


### PR DESCRIPTION
- First installment of examples, initially just metadata plus a single bugfix and link addition

--no-rebase

--------

Testing: the examples are tested as part of the unit tests, so jobs should remain green.  The examples on the tutorial page are selected bits pulled out of the example code in `docs/sphinx/developers/cpp/examples`.