### PR TITLE
Re-use getImageCreationDate logic to populate global DateTime metadata

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -186,7 +186,7 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     put("Instrument Make", firstIFD, IFD.MAKE);
     put("Instrument Model", firstIFD, IFD.MODEL);
     put("Document Name", firstIFD, IFD.DOCUMENT_NAME);
-    put("DateTime", firstIFD, IFD.DATE_TIME);
+    put("DateTime", getImageCreationDate());
     put("Artist", firstIFD, IFD.ARTIST);
 
     put("HostComputer", firstIFD, IFD.HOST_COMPUTER);


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-March/005128.html

Under some conditions, retrieving `IFD.DATE_TIME` can return a String array. This is already handled by the `getImageCreationDate()` method which returns the first item of the array. This PR re-uses the existing logic to fill the global `DateTime` metadata with a `String` instead of a `String []`.

To test this PR, run `showinf` on the file mentioned in the forum thread. `DateTime` should be populated in the `Global metadata` section with a string. Alternatively, reproduce the MATLAB steps described in the thread.

--no-rebase