### PR TITLE
Fix PCIReader test failures on Windows

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -9,15 +9,15 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the 
+ * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public 
+ *
+ * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
@@ -300,8 +300,8 @@ public class PCIReader extends FormatReader {
         {
           uniqueZ.add(zPos);
         }
-        if (name.indexOf("Field 1/") != -1) firstZ = zPos;
-        else if (name.indexOf("Field 2/") != -1) secondZ = zPos;
+        if (name.indexOf("Field 1" + File.separator) != -1) firstZ = zPos;
+        else if (name.indexOf("Field 2" + File.separator) != -1) secondZ = zPos;
       }
       else if (relativePath.equals("First Field Date & Time")) {
         long date = (long) stream.readDouble() * 1000;


### PR DESCRIPTION
This PR should fix the few Bio-Rad PIC `test_images_good` samples still failing on Windows. Tested against the PCI subset of the full repository. Automated tests should pass under Windows (to be tested manually) and LInux (see full-repository job)

--no-rebase