### PR TITLE
C++: Add FormatReader section to tutorial

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -45,11 +45,15 @@ target_link_libraries(model-io ome-xml ${CMAKE_THREAD_LIBS_INIT})
 add_executable(metadata-io "${exampledir}/metadata-io.cpp")
 target_link_libraries(metadata-io ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(metadata-formatreader "${exampledir}/metadata-formatreader.cpp")
+target_link_libraries(metadata-formatreader ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(pixeldata "${exampledir}/pixeldata.cpp")
 target_link_libraries(pixeldata ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
 
 if(BUILD_TESTS)
   bf_add_test(examples/model-io model-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
   bf_add_test(examples/metadata-io metadata-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
+  bf_add_test(examples/metadata-formatreader metadata-formatreader "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/set-1-meta-companion/18x24y5z1t1c8b-text-split-Z1.ome.tiff")
   bf_add_test(examples/pixeldata pixeldata "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
 endif(BUILD_TESTS)

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -54,6 +54,7 @@ namespace ome
 
     }
 
+    /// Reader implementations.
     namespace in
     {
 

--- a/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
@@ -1,0 +1,226 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <iostream>
+
+#include <ome/bioformats/VariantPixelBuffer.h>
+#include <ome/bioformats/in/TIFFReader.h>
+
+#include <ome/compat/memory.h>
+
+#include <ome/common/filesystem.h>
+
+using boost::filesystem::path;
+using ome::compat::make_shared;
+using ome::compat::shared_ptr;
+using ome::bioformats::dimension_size_type;
+using ome::bioformats::FormatReader;
+using ome::bioformats::MetadataMap;
+using ome::bioformats::in::TIFFReader;
+using ome::bioformats::VariantPixelBuffer;
+
+namespace
+{
+
+  /* read-example-start */
+  void
+  readMetadata(const FormatReader& reader,
+               std::ostream&       stream)
+  {
+    // Get total number of images (series)
+    dimension_size_type ic = reader.getSeriesCount();
+    stream << "Image count: " << ic << '\n';
+
+    // Loop over images
+    for (dimension_size_type i = 0 ; i < ic; ++i)
+      {
+        // Change the current series to this index
+        reader.setSeries(i);
+
+        // Print image dimensions (for this image index)
+        stream << "Dimensions for Image " << i << ':'
+               << "\n\tX = " << reader.getSizeX()
+               << "\n\tY = " << reader.getSizeY()
+               << "\n\tZ = " << reader.getSizeZ()
+               << "\n\tT = " << reader.getSizeT()
+               << "\n\tC = " << reader.getSizeC()
+               << "\n\tEffectiveC = " << reader.getEffectiveSizeC()
+               << "\n\tRGB = " << (reader.isRGB() ? "true" : "false")
+               << "\n\tRGBC = " << reader.getRGBChannelCount()
+               << '\n';
+
+        // Get total number of planes (for this image index)
+        dimension_size_type pc = reader.getImageCount();
+        stream << "\tPlane count: " << pc << '\n';
+
+        // Loop over planes (for this image index)
+        for (dimension_size_type p = 0 ; p < pc; ++p)
+          {
+            // Print plane position (for this image index and plane
+            // index)
+            ome::compat::array<dimension_size_type, 3> coords =
+              reader.getZCTCoords(p);
+            stream << "\tPosition of Plane " << p << ':'
+                   << "\n\t\tTheZ = " << coords[0]
+                   << "\n\t\tTheT = " << coords[2]
+                   << "\n\t\tTheC = " << coords[1]
+                   << '\n';
+          }
+      }
+  }
+  /* read-example-end */
+
+  /* original-example-start */
+  void
+  readOriginalMetadata(const FormatReader& reader,
+                       std::ostream&       stream)
+  {
+    // Get total number of images (series)
+    dimension_size_type ic = reader.getSeriesCount();
+    stream << "Image count: " << ic << '\n';
+
+    // Get global metadata
+    const MetadataMap& global = reader.getGlobalMetadata();
+
+    // Print global metadata
+    stream << "Global metadata:\n" << global << '\n';
+
+    // Loop over images
+    for (dimension_size_type i = 0 ; i < ic; ++i)
+      {
+        // Change the current series to this index
+        reader.setSeries(i);
+
+        // Print series metadata
+        const MetadataMap& series = reader.getSeriesMetadata();
+
+        // Print image dimensions (for this image index)
+        stream << "Metadata for Image " << i << ":\n"
+               << series
+               << '\n';
+      }
+  }
+  /* original-example-end */
+
+  /* pixel-example-start */
+  void
+  readPixelData(const FormatReader& reader,
+                std::ostream&       stream)
+  {
+    // Get total number of images (series)
+    dimension_size_type ic = reader.getSeriesCount();
+    stream << "Image count: " << ic << '\n';
+
+    // Loop over images
+    for (dimension_size_type i = 0 ; i < ic; ++i)
+      {
+        // Change the current series to this index
+        reader.setSeries(i);
+
+        // Get total number of planes (for this image index)
+        dimension_size_type pc = reader.getImageCount();
+        stream << "\tPlane count: " << pc << '\n';
+
+        // Pixel buffer
+        VariantPixelBuffer buf;
+
+        // Loop over planes (for this image index)
+        for (dimension_size_type p = 0 ; p < pc; ++p)
+          {
+            // Read the entire plane into the pixel buffer.
+            reader.openBytes(p, buf);
+
+            // If this wasn't an example, we would do something
+            // exciting with the pixel data here.
+            stream << "Pixel data for Image " << i
+                   << " Plane " << p << " contains "
+                   << buf.num_elements() << " pixels\n";
+          }
+      }
+  }
+  /* pixel-example-end */
+
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      if (argc > 1)
+        {
+          // Portable path
+          path filename(argv[1]);
+
+          /* reader-example-start */
+          // Create TIFF reader
+          shared_ptr<FormatReader> reader(make_shared<TIFFReader>());
+
+          // Set reader options before opening a file
+          reader->setMetadataFiltered(false);
+          reader->setGroupFiles(true);
+
+          // Open the file
+          reader->setId(filename);
+
+          // Display series core metadata
+          readMetadata(*reader, std::cout);
+
+          // Display global and series original metadata
+          readOriginalMetadata(*reader, std::cout);
+
+          // Read pixel data
+          readPixelData(*reader, std::cout);
+          /* reader-example-end */
+        }
+      else
+        {
+          std::cerr << "Usage: " << argv[0] << " ome-xml.xml\n";
+          std::exit(1);
+        }
+    }
+  catch (const std::exception& e)
+    {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+      std::exit(1);
+    }
+  catch (...)
+    {
+      std::cerr << "Caught unknown exception\n";
+      std::exit(1);
+    }
+}

--- a/docs/sphinx/developers/cpp/examples/metadata-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-io.cpp
@@ -95,7 +95,7 @@ namespace
                 const std::string&            state,
                 std::ostream&                 stream)
   {
-    // Get total number of images
+    // Get total number of images (series)
     index_type ic = meta.getImageCount();
     stream << "Image count: " << ic << '\n';
 
@@ -134,7 +134,7 @@ namespace
   void
   updateMetadata(meta::Metadata& meta)
   {
-    // Get total number of images
+    // Get total number of images (series)
     index_type ic = meta.getImageCount();
 
     // Loop over images
@@ -154,7 +154,7 @@ namespace
   void
   addMetadata(meta::Metadata& meta)
   {
-    // Get total number of images
+    // Get total number of images (series)
     index_type i = meta.getImageCount();
 
     // Size of Z, T and C dimensions

--- a/docs/sphinx/developers/cpp/examples/pixeldata.cpp
+++ b/docs/sphinx/developers/cpp/examples/pixeldata.cpp
@@ -227,7 +227,6 @@ namespace
   }
   /* visitor-example-end */
 
-
 }
 
 int

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -61,6 +61,13 @@ the :cpp:class:`getCoreMetadataList` method.  The
 :cpp:class:`FormatReader` interface should be preferred; the objects
 themselves are more of an implementation detail at present.
 
+.. literalinclude:: examples/metadata-formatreader.cpp
+   :language: cpp
+   :start-after: read-example-start
+   :end-before: read-example-end
+
+Full example source: :download:`metadata-formatreader.cpp <examples/metadata-formatreader.cpp>`
+
 .. seealso::
 
   - :doxygen:`CoreMetadata <classome_1_1bioformats_1_1CoreMetadata.html>`
@@ -75,7 +82,23 @@ Original metadata is stored in two forms: in a
 :cpp:class:`FormatReader` interface, which offers access to individual
 keys and the whole map for both global and series metadata.  It is
 also accessible using the metadata store; original metadata is stored
-as an :cpp:class:`XMLAnnotation`.
+as an :cpp:class:`XMLAnnotation`.  The following example demonstrates
+access to the global and series metadata using the
+:cpp:class:`FormatReader` interface to get access to the maps:
+
+.. literalinclude:: examples/metadata-formatreader.cpp
+   :language: cpp
+   :start-after: original-example-start
+   :end-before: original-example-end
+
+It would also be possible to use :cpp:func:`getMetadataValue` and
+:cpp:func:`getSeriesMetadataValue` to obtain values for individual
+keys.  Note that the :cpp:class:`MetadataMap` values can be scalar
+values or lists of scalar values; call the :cpp:func:`flatten` method
+to split the lists into separate key-value pairs with a numbered
+suffix.
+
+Full example source: :download:`metadata-formatreader.cpp <examples/metadata-formatreader.cpp>`
 
 .. seealso::
 
@@ -334,7 +357,14 @@ interface the :cpp:func:`getLookupTable` and :cpp:func:`openBytes`
 methods can be passed a default-constructed
 :cpp:class:`VariantPixelBuffer` and it will be set up automatically,
 changing the image dimensions, dimension order and pixel type to match
-the data being fetched, if the size, order and type do not match.
+the data being fetched, if the size, order and type do not match.  For
+example, to read all pixel data in an image using
+:cpp:func:`openBytes`:
+
+.. literalinclude:: examples/metadata-formatreader.cpp
+   :language: cpp
+   :start-after: pixel-example-start
+   :end-before: pixel-example-end
 
 Both buffer classes provide access to the pixel data so that it may be
 accessed, manipulated and passed elsewhere.  The
@@ -400,6 +430,8 @@ Alternatively, it is also possible to access the underlying
 you need access to functionality not wrapped by
 :cpp:class:`PixelBuffer`.
 
+Full example source: :download:`pixeldata.cpp <examples/pixeldata.cpp>`
+
 .. seealso::
 
   - :doxygen:`PixelType <classome_1_1xml_1_1model_1_1enums_1_1PixelType.html>`
@@ -409,3 +441,55 @@ you need access to functionality not wrapped by
   - :doxygen:`FormatReader::openBytes <classome_1_1bioformats_1_1FormatReader.html#a91184deaf16c42b51eb564ee11e76fe2>`
   - :doxygen:`FormatWriter::setLookupTable <classome_1_1bioformats_1_1FormatWriter.html#a7ee8eaab7b440be78f3707d1f34ec372>`
   - :doxygen:`FormatWriter::saveBytes <classome_1_1bioformats_1_1FormatWriter.html#a3f75d001c244c06883c986df988d31b5>`
+
+Reading images
+--------------
+
+Image reading is performed using the :cpp:class:`FormatReader`
+interface.  This is an abstract reader interface implemented by file
+format-specific reader classes.  Examples of readers include
+:cpp:class:`TIFFReader`, which implements reading of Baseline TIFF
+(optionally with additional ImageJ metadata), and
+:cpp:class:`OMETIFFReader` which implements reading of OME-TIFF (TIFF
+with OME-XML metadata).
+
+Using a reader involves these steps:
+
+#. Create a reader instance
+#. Set options to control reader behavior
+#. Call :cpp:func:`setId` to read a specific image file
+#. Retrieve desired metadata and pixel data
+
+These steps are illustrated in this example:
+
+.. literalinclude:: examples/metadata-formatreader.cpp
+   :language: cpp
+   :start-after: reader-example-start
+   :end-before: reader-example-end
+
+Here we create a reader to read TIFF files, set two options (metadata
+filtering and file grouping), and then call :cpp:func:`setId`.  At
+this point the reader has been set up and initialized, and we can then
+read metadata and pixel data, which we covered in the preceding
+sections.  You might like to combine this example with the
+:cpp:class:`MinMaxVisitor` example to make it display the minimum and
+maximum values for each plane in an image; if you try running the
+example with TIFF images of different pixel types, it will
+transparently adapt to any supported pixel type.
+
+.. note::
+
+  - reader option methods may only be called *before* :cpp:func:`setId`
+  - reader state changing methods such as :cpp:func:`setSeries`,
+    metadata retrieval and pixel data retrieval methods may only be
+    called *after* :cpp:func:`setId`
+  - if these constraints are violated, a :cpp:class:`FormatException`
+    will be thrown
+
+Full example source: :download:`metadata-formatreader.cpp <examples/metadata-formatreader.cpp>`
+
+.. seealso::
+
+  - :doxygen:`FormatReader <classome_1_1bioformats_1_1FormatReader.html>`
+  - :doxygen:`TIFFReader <classome_1_1bioformats_1_1in_1_1TIFFReader.html>`
+  - :doxygen:`OMETIFFReader <classome_1_1bioformats_1_1in_1_1OMETIFFReader.html>`

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -446,8 +446,8 @@ Reading images
 --------------
 
 Image reading is performed using the :cpp:class:`FormatReader`
-interface.  This is an abstract reader interface implemented by file
-format-specific reader classes.  Examples of readers include
+interface.  This is an abstract reader interface implemented by
+file-format-specific reader classes.  Examples of readers include
 :cpp:class:`TIFFReader`, which implements reading of Baseline TIFF
 (optionally with additional ImageJ metadata), and
 :cpp:class:`OMETIFFReader` which implements reading of OME-TIFF (TIFF
@@ -479,12 +479,12 @@ transparently adapt to any supported pixel type.
 
 .. note::
 
-  - reader option methods may only be called *before* :cpp:func:`setId`
-  - reader state changing methods such as :cpp:func:`setSeries`,
-    metadata retrieval and pixel data retrieval methods may only be
-    called *after* :cpp:func:`setId`
-  - if these constraints are violated, a :cpp:class:`FormatException`
-    will be thrown
+  Reader option-setting methods may only be called *before*
+  :cpp:func:`setId`.  Reader state changing and querying methods such
+  as :cpp:func:`setSeries` and :cpp:func:`getSeries`, metadata
+  retrieval and pixel data retrieval methods may only be called
+  *after* :cpp:func:`setId`.  If these constraints are violated, a
+  :cpp:class:`FormatException` will be thrown.
 
 Full example source: :download:`metadata-formatreader.cpp <examples/metadata-formatreader.cpp>`
 


### PR DESCRIPTION
- Examples of bits of the FormatReader API
- Document `in` namespace

Is there anything missing from the tutorial which should be added for 5.1.0?

--no-rebase