### PR TITLE
Improve the units API

### DIFF
--- a/components/ome-xml/src/ome/units/quantity/Angle.java
+++ b/components/ome-xml/src/ome/units/quantity/Angle.java
@@ -66,6 +66,7 @@ public class Angle extends Quantity implements Comparable<Angle>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Angle extends Quantity implements Comparable<Angle>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Angle extends Quantity implements Comparable<Angle>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Angle> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Angle.java
+++ b/components/ome-xml/src/ome/units/quantity/Angle.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Angle class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/ElectricPotential.java
+++ b/components/ome-xml/src/ome/units/quantity/ElectricPotential.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the ElectricPotential class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/ElectricPotential.java
+++ b/components/ome-xml/src/ome/units/quantity/ElectricPotential.java
@@ -66,6 +66,7 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.ElectricPotential> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Frequency.java
+++ b/components/ome-xml/src/ome/units/quantity/Frequency.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Frequency class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/Frequency.java
+++ b/components/ome-xml/src/ome/units/quantity/Frequency.java
@@ -66,6 +66,7 @@ public class Frequency extends Quantity implements Comparable<Frequency>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Frequency extends Quantity implements Comparable<Frequency>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Frequency extends Quantity implements Comparable<Frequency>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Frequency> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Length.java
+++ b/components/ome-xml/src/ome/units/quantity/Length.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Length class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/Length.java
+++ b/components/ome-xml/src/ome/units/quantity/Length.java
@@ -66,6 +66,7 @@ public class Length extends Quantity implements Comparable<Length>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Length extends Quantity implements Comparable<Length>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Length extends Quantity implements Comparable<Length>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Length> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Power.java
+++ b/components/ome-xml/src/ome/units/quantity/Power.java
@@ -66,6 +66,7 @@ public class Power extends Quantity implements Comparable<Power>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Power extends Quantity implements Comparable<Power>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Power extends Quantity implements Comparable<Power>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Power> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Power.java
+++ b/components/ome-xml/src/ome/units/quantity/Power.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Power class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/Pressure.java
+++ b/components/ome-xml/src/ome/units/quantity/Pressure.java
@@ -66,6 +66,7 @@ public class Pressure extends Quantity implements Comparable<Pressure>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Pressure extends Quantity implements Comparable<Pressure>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Pressure extends Quantity implements Comparable<Pressure>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Pressure> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Pressure.java
+++ b/components/ome-xml/src/ome/units/quantity/Pressure.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Pressure class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/Quantity.java
+++ b/components/ome-xml/src/ome/units/quantity/Quantity.java
@@ -31,6 +31,8 @@
 
 package ome.units.quantity;
 
+import ome.units.unit.Unit;
+
 /**
  * A wrapper for the Quantity class from the units implimintation.
  *
@@ -44,4 +46,6 @@ package ome.units.quantity;
  */
 public abstract class Quantity
 {
+  public abstract Number value();
+  public abstract Unit<? extends Quantity> unit();
 }

--- a/components/ome-xml/src/ome/units/quantity/Temperature.java
+++ b/components/ome-xml/src/ome/units/quantity/Temperature.java
@@ -66,6 +66,7 @@ public class Temperature extends Quantity implements Comparable<Temperature>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Temperature extends Quantity implements Comparable<Temperature>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Temperature extends Quantity implements Comparable<Temperature>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Temperature> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Temperature.java
+++ b/components/ome-xml/src/ome/units/quantity/Temperature.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Temperature class from the units implementation.

--- a/components/ome-xml/src/ome/units/quantity/Time.java
+++ b/components/ome-xml/src/ome/units/quantity/Time.java
@@ -66,6 +66,7 @@ public class Time extends Quantity implements Comparable<Time>
     hashCodeValue = SEED2 * hashCodeValue + unit.getSymbol().hashCode();
   }
 
+  @Override
   public Number value()
   {
     return value;
@@ -84,6 +85,7 @@ public class Time extends Quantity implements Comparable<Time>
     return null;
   }
 
+  @Override
   public boolean equals(Object other)
   {
     if (other == null)
@@ -138,6 +140,7 @@ public class Time extends Quantity implements Comparable<Time>
     return result.toString();
   }
 
+  @Override
   public Unit<ome.units.quantity.Time> unit()
   {
     return unit;

--- a/components/ome-xml/src/ome/units/quantity/Time.java
+++ b/components/ome-xml/src/ome/units/quantity/Time.java
@@ -31,9 +31,7 @@
 
 package ome.units.quantity;
 
-import ome.units.quantity.Quantity;
 import ome.units.unit.Unit;
-import ome.units.UNITS;
 
 /**
  * A wrapper for the Time class from the units implementation.


### PR DESCRIPTION
Specifically, this branch makes the `Quantity` superclass nicer to work with, and adds some helpful constructors with default unit specifications, to avoid errors when converting downstream code to the new API.

See [here](https://github.com/scifio/scifio-ome-xml/compare/ome-5.1) for an example where these changes would be helpful.

/cc @qidane