### PR TITLE
cpp: cmake: Special-case bf-test shell wrapper rootdir determination for empty path

### DIFF
--- a/cpp/cmake/TemplateShellWrapper.cmake.in
+++ b/cpp/cmake/TemplateShellWrapper.cmake.in
@@ -132,7 +132,11 @@ if [ -d "$INSTALL_PREFIX" ]; then
   fi
 else
   bindir=$(dirname "$prog")
-  rootdir=${bindir%@CMAKE_INSTALL_FULL_BINDIR@}
+  rootdir=$(eval echo "\${bindir%$INSTALL_BINDIR}")
+  rootdir=${rootdir%/}
+  if [ -z "$rootdir" ]; then
+    rootdir=$(pwd)
+  fi
 
   PATH="${rootdir}${INSTALL_FULL_BINDIR}:$PATH"
   LIBEXECDIR="${rootdir}${BF_INSTALL_FULL_LIBEXECDIR}"


### PR DESCRIPTION
- Handle the case where stripping the bindir results in an empty string (set to '.')
- Also handle the case where `dirname` does not have a leading slash
- Use `eval` to strip substring with dynamic string; this makes it clear where the string to strip comes from rather than having cmake substitute it in multiple places

--no-rebase

/cc @joshmoore 

--------

Testing:

Obtain and unpack merge build tar archive.

```
tar xfv bioformats-xxx.tar.xz
cd bioformats-xxx
./bin/bf-test
bin/bf-test
$(pwd)/bin/bf-test
```

All three forms of `bf-test` invocation should work, where previously the middle form was broken.