### PR TITLE
build: Also provide source zip without binary content

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -1029,11 +1029,21 @@ Type "ant -p" for a list of targets.
   <target name="init"/>
 
   <!-- Source release -->
-  <target name="release" description="zip the git release as bioformats-${release.version}.zip" depends="release-version">
+  <target name="release" description="zip the git release as bioformats-[dfsg-]${release.version}.zip" depends="release-version">
     <mkdir dir="${artifact.dir}"/>
     <exec executable="python" failonerror="true">
       <arg value="${root.dir}/tools/source-archive.py"/>
       <arg value="--release=bioformats"/>
+      <arg value="--bioformats-shortversion=${release.shortversion}"/>
+      <arg value="--bioformats-version=${release.version}"/>
+      <arg value="--bioformats-vcsrevision=${vcs.revision}"/>
+      <arg value="--bioformats-vcsdate=${vcs.date}"/>
+      <arg value="--bioformats-vcsdate-unix=${vcs.date_unix}"/>
+      <arg value="--target=${artifact.dir}"/>
+    </exec>
+    <exec executable="python" failonerror="true">
+      <arg value="${root.dir}/tools/source-archive.py"/>
+      <arg value="--release=bioformats-dfsg"/>
       <arg value="--bioformats-shortversion=${release.shortversion}"/>
       <arg value="--bioformats-version=${release.version}"/>
       <arg value="--bioformats-vcsrevision=${vcs.revision}"/>

--- a/tools/source-archive.py
+++ b/tools/source-archive.py
@@ -124,6 +124,13 @@ if __name__ == "__main__":
                     os.path.basename(info.filename) == '.gitmodule' or
                     os.path.basename(info.filename) == '.travis.yml'):
                 continue
+            # Skip files for which we don't have source in this repository, for GPL compliance
+            if (options.release.endswith("-dfsg") and
+                (os.path.splitext(info.filename)[1] == ".jar" or
+                 os.path.splitext(info.filename)[1] == ".dll" or
+                 os.path.splitext(info.filename)[1] == ".dylib" or
+                 os.path.splitext(info.filename)[1] == ".so")):
+                continue
             # Repack a single zip object; preserve the metadata
             # directly via the ZipInfo object and rewrite the content
             # (which unfortunately requires decompression and

--- a/tools/source-archive.py
+++ b/tools/source-archive.py
@@ -131,6 +131,10 @@ if __name__ == "__main__":
                  os.path.splitext(info.filename)[1] == ".dylib" or
                  os.path.splitext(info.filename)[1] == ".so")):
                 continue
+            if (options.release.endswith("-dfsg") and
+                info.filename.startswith("%s/components/xsd-fu/python/genshi" % (prefix))):
+                continue
+            print("File: %s" % (info.filename))
             # Repack a single zip object; preserve the metadata
             # directly via the ZipInfo object and rewrite the content
             # (which unfortunately requires decompression and


### PR DESCRIPTION
- Add "bioformats-dfsg-$version.zip"; this is a DFSG (Debian Free Software Guidelines) compliant archive which omits binaries (jars and libraries such as .so/.dylib/.dll for which we don't have source in the repository and hence in the source distribution).  This is to make a "clean" source release which is acceptable for public redistribution in compliance with the GPL, for use by upstream homebrew, Debian/Ubuntu/Fedora, BSD ports, etc.

This change is a precursor to being able to provide Bio-Formats (both Java and C++) in distributions directly.  Are there any other generated files imported into git which might also need excising for licence compliance?  How about source files under BSD/GPL-incompatible terms?  Is there a better prefix name than "-dfsg" (which is already used elsewhere for sanitised versions of upstream sources with problematic content stripped out) ?  (I originally used "-clean")