### PR TITLE
Fix disabled file grouping for Micro-Manager and OME-TIFF

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -126,6 +126,12 @@ public class MicromanagerReader extends FormatReader {
         return false;
       }
     }
+    else if (!isGroupFiles()) {
+      // if file grouping was disabled, allow each of the TIFFs to be
+      // read separately; this will have no effect if the metadata file
+      // is chosen
+      return false;
+    }
     try {
       Location parent = new Location(name).getAbsoluteFile().getParentFile();
       Location metaFile = new Location(parent, METADATA);

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -162,7 +162,17 @@ public class OMETiffReader extends FormatReader {
       return true;
     }
     metaFile = new Location(name).getAbsolutePath();
-    return super.isThisType(name, open);
+    boolean valid = super.isThisType(name, open);
+    if (valid && !isGroupFiles()) {
+      try {
+        return isSingleFile(metaFile);
+      }
+      catch (Exception e) {
+        LOGGER.debug("", e);
+        return false;
+      }
+    }
+    return valid;
   }
 
   /* @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */


### PR DESCRIPTION
For both formats, if a TIFF file is chosen and file grouping is
disabled, then the file will be treated as a regular TIFF.
Some metadata will be unavailable (as is expected when file grouping is
disabled), but the images will be more quickly accessible.

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-March/005124.html.

I was testing with ```micromanager/scott/MM_1.4/Pos1``` as it's the largest Micro-Manager dataset we have; ```showinf -nopix -nogroup``` on one of the TIFF files with this PR should be significantly faster with this PR, and result in only the chosen file being read.