### PR TITLE
JHDFServiceImpl: catch checked exceptions

### DIFF
--- a/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
@@ -33,11 +33,11 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
+import ncsa.hdf.hdf5lib.exceptions.HDF5JavaException;
 import loci.common.Constants;
 import loci.common.Location;
 import loci.common.services.AbstractService;
 import loci.common.services.ServiceException;
-
 import ch.systemsx.cisd.base.mdarray.MDByteArray;
 import ch.systemsx.cisd.base.mdarray.MDIntArray;
 import ch.systemsx.cisd.base.mdarray.MDShortArray;
@@ -169,14 +169,24 @@ public class JHDFServiceImpl extends AbstractService
      * @see loci.formats.JHDFService#readStringArray()
      */
     public String[] readStringArray(String path) {
-        return this.hdfReader.string().readArray(path);
+        try {
+            return this.hdfReader.string().readArray(path);
+        }
+        catch (HDF5JavaException exc) {
+            throw new RuntimeException(exc);
+        }
     }
 
     /* (non-Javadoc)
      * @see loci.formats.JHDFService#readCompoundArrayDataMap()
      */
     public HDF5CompoundDataMap[] readCompoundArrayDataMap(String path) {
-        return this.hdfReader.readCompoundArray(path, HDF5CompoundDataMap.class);
+        try {
+            return this.hdfReader.readCompoundArray(path, HDF5CompoundDataMap.class);
+        }
+        catch (HDF5JavaException exc) {
+            throw new RuntimeException(exc);
+        }
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This fixes the following build errors on the command line:

    [javac] /Users/curtis/code/ome/bf5/components/formats-gpl/build/src/loci/formats/services/JHDFServiceImpl.java:172: error: unreported exception HDF5JavaException; must be caught or declared to be thrown
    [javac]         return this.hdfReader.string().readArray(path);
    [javac]                                                 ^
    [javac] /Users/curtis/code/ome/bf5/components/formats-gpl/build/src/loci/formats/services/JHDFServiceImpl.java:179: error: unreported exception HDF5JavaException; must be caught or declared to be thrown
    [javac]         return this.hdfReader.readCompoundArray(path, HDF5CompoundDataMap.class);
    [javac]                                                ^