### PR TITLE
Bug Fix : Conversion of Point Roi from Omero to ImageJ : RoiHandler bug

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -168,7 +168,7 @@ public class ROIHandler {
                         Point point = (Point) shapeObject;
                         int x = point.getX().intValue();
                         int y = point.getY().intValue();
-                        roi = new OvalRoi(x, y, 0, 0);
+                        roi = new PointRoi(x, y);
 
                         if (point.getStrokeColor() != null){
                             ome.xml.model.primitives.Color StrokeColor = point.getStrokeColor();


### PR DESCRIPTION
Testing Instructions :

Without this PR,
1) Open an Image in Omero. Create Point ROI's and save.
2) Now open the image in ImageJ using the OMERO IJ plugin with "display ROI's" checked. This will open the ROI's without any issue (but the Point ROI's are wrongly converted to Ellipses). This will not be noticeable to the eye, so to confirm, just click "Plugins-->Omero-->Save ROI's to OMERO" without clearing the ROI Handler. 
3) This will create a duplicate copy of the ROI's in OMERO.
4) The only way to check the bug , will be to check the Type column in the Insight ROI tool. This will show that the newly imported ROI's will be ellipse, and the old ROI's will be points. 

With this PR.

The round trop from ImageJ to Omero to ImageJ should preserve the Point ROI type.

Problem noticed during week 4 testing https://trello.com/c/4Dgz8Hs1/88-weekly-testing
