### PR TITLE
Display private fields and methods in Javadocs

### DIFF
--- a/ant/global.xml
+++ b/ant/global.xml
@@ -11,6 +11,22 @@ Type "ant -p" for a list of targets.
   <property file="${user.home}/.ant-global.properties"/>
   <property file="${root.dir}/ant/global.properties"/>
 
+  <!-- Convenient JDK version properties -->
+
+  <available property="jdk1.6+" classname="java.util.ServiceLoader"/>
+  <available property="jdk1.7+" classname="java.util.Objects"/>
+  <available property="jdk1.8+" classname="java.util.stream.IntStream"/>
+
+  <target name="javadoc-properties">
+    <if>
+      <isset property="jdk1.8+"/>
+      <then>
+        <property name="javadoc.doclint" value="-Xdoclint:none"/>
+      </then>
+    </if>
+    <property name="javadoc.doclint" value=""/>
+  </target>
+
   <!-- Convenient platform properties -->
 
   <condition property="isUnix">

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -187,7 +187,7 @@ your FindBugs installation's lib directory. E.g.:
     </javac>
   </target>
 
-  <target name="docs" depends="compile"
+  <target name="docs" depends="compile, javadoc-properties"
     description="generate javadocs">
     <javadoc sourcepath="${dest.dir}" destdir="${docs.dir}/api"
       classpath="${component.classpath}:${classes.dir}"
@@ -195,7 +195,7 @@ your FindBugs installation's lib directory. E.g.:
       author="true" version="true" use="true"
       access="private"
       nodeprecated="false" windowtitle="Bio-Formats API"
-      additionalparam="-Xdoclint:none">
+      additionalparam="${javadoc.doclint}">
       <packageset dir="${dest.dir}"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -193,6 +193,7 @@ your FindBugs installation's lib directory. E.g.:
       classpath="${component.classpath}:${classes.dir}"
       encoding="UTF-8"
       author="true" version="true" use="true"
+      access="private"
       nodeprecated="false" windowtitle="Bio-Formats API">
       <packageset dir="${dest.dir}"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -194,7 +194,8 @@ your FindBugs installation's lib directory. E.g.:
       encoding="UTF-8"
       author="true" version="true" use="true"
       access="private"
-      nodeprecated="false" windowtitle="Bio-Formats API">
+      nodeprecated="false" windowtitle="Bio-Formats API"
+      additionalparam="-Xdoclint:none">
       <packageset dir="${dest.dir}"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -155,7 +155,7 @@ Type "ant -p" for a list of targets.
       utils-formats-bsd"
     description="compile all extra utilities"/>
 
-  <target name="docs" depends="jars"
+  <target name="docs" depends="jars, javadoc-properties"
     description="generate the Javadocs for most components">
     <echo>----------=========== Javadocs ===========----------</echo>
     <tstamp>
@@ -169,7 +169,7 @@ Type "ant -p" for a list of targets.
       failonerror="true" author="true" version="true" use="true"
       access="private"
       nodeprecated="false" windowtitle="Bio-Formats API"
-      additionalparam="-Xdoclint:none">
+      additionalparam="${javadoc.doclint}">
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/6/docs/api/"/>

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -167,6 +167,7 @@ Type "ant -p" for a list of targets.
       maxmemory="${merged-docs.memory}"
       encoding="UTF-8"
       failonerror="true" author="true" version="true" use="true"
+      access="private"
       nodeprecated="false" windowtitle="Bio-Formats API">
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -168,7 +168,8 @@ Type "ant -p" for a list of targets.
       encoding="UTF-8"
       failonerror="true" author="true" version="true" use="true"
       access="private"
-      nodeprecated="false" windowtitle="Bio-Formats API">
+      nodeprecated="false" windowtitle="Bio-Formats API"
+      additionalparam="-Xdoclint:none">
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/6/docs/api/"/>

--- a/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageWriter.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/plugins/gif/GIFImageWriter.java
@@ -767,21 +767,21 @@ public class GIFImageWriter extends ImageWriter {
         } else {
             throw new IllegalArgumentException("Must write header for single image!");
         }
-        
+
         // Write extension blocks, Image Descriptor, and image data.
         writeImage(iioimage.getRenderedImage(), imageMetadata, p,
                    globalColorTable, sourceBounds, destSize);
-        
+
         // Write the trailer.
         if (writeTrailer) {
             writeTrailer();
         }
     }
-    
+
     /**
      * Writes any extension blocks, the Image Descriptor, and the image data
      *
-     * @param iioimage The image and image metadata.
+     * @param image The image and image metadata.
      * @param param The write parameters.
      * @param globalColorTable The Global Color Table.
      * @param sourceBounds The source region.

--- a/components/forks/mdbtools/src/mdbtools/dbengine/Engine.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/Engine.java
@@ -56,7 +56,7 @@ public class Engine
 
   /**
    * Execute a sql select query
-   * @param sql
+   * @param select
    */
   private Data execute(Select select)
     throws SQLException

--- a/components/forks/mdbtools/src/mdbtools/dbengine/MemoryData.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/MemoryData.java
@@ -151,7 +151,7 @@ public class MemoryData implements Data
   /**
    * sort the data by the given column using only the given rows
    * insertion sort is used for the sort
-   * @todo replace with a better sorting algorithm
+   * todo: replace with a better sorting algorithm
    * @param columnToSort the column to sort
    * @param startAt the row to start sorting at
    * @param endAt the row to end sorting at

--- a/components/forks/mdbtools/src/mdbtools/dbengine/SelectEngine.java
+++ b/components/forks/mdbtools/src/mdbtools/dbengine/SelectEngine.java
@@ -464,9 +464,6 @@ public class SelectEngine
 
   /**
    * merge the data from several datasets to a single dataset
-   * @param s
-   * @param tables
-   * @param index
    */
   private void mergeData(MemoryData memData,
                          Object[] _row,int columnIndex,
@@ -523,7 +520,7 @@ public class SelectEngine
 
   /**
    * resolve a column down to it's final value
-   * @param value the value from the data set
+   * @param data the value from the data set
    * @param column the object from the sql query
    * @return Object
    */
@@ -548,7 +545,7 @@ public class SelectEngine
 
   /**
    * sort the data
-   * @todo allow for sorting non-memory data
+   * todo: allow for sorting non-memory data
    * @param data
    * @return Data
    */

--- a/components/forks/poi/src/loci/poi/hssf/model/FormulaParser.java
+++ b/components/forks/poi/src/loci/poi/hssf/model/FormulaParser.java
@@ -340,10 +340,9 @@ public class FormulaParser {
             }
         }
     }
-    
+
     /**
      * Adds a pointer to the last token to the latest function argument list.
-     * @param obj
      */
     private void addArgumentPointer() {
 		if (this.functionTokens.size() > 0) {

--- a/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/components/forks/poi/src/loci/poi/hssf/usermodel/HSSFWorkbook.java
@@ -303,12 +303,12 @@ public class HSSFWorkbook extends POIDocument
       * contained strings will be written to the Shared String tabel (SSTRecord) within
       * the Workbook.
       *
-      * @param wb sheet's matching low level Workbook structure containing the SSTRecord.
+      * @param records sheet's matching low level Workbook structure containing the SSTRecord.
       * @see loci.poi.hssf.record.LabelRecord
       * @see loci.poi.hssf.record.LabelSSTRecord
       * @see loci.poi.hssf.record.SSTRecord
       */
- 
+
      private void convertLabelRecords(List records, int offset)
      {
          if (log.check( POILogger.DEBUG ))

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1439,7 +1439,7 @@ public abstract class FormatReader extends FormatHandler
     }
   }
 
-  /** Initialize the OMEXMLService needed by {@link setId(String)} */
+  /** Initialize the OMEXMLService needed by {@link #setId(String)} */
   private void setupService() {
     try {
       if (factory == null) factory = new ServiceFactory();

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -330,7 +330,7 @@ public class Memoizer extends ReaderWrapper {
 
   /**
    * Minimum number of milliseconds which must elapse during the call to
-   * {@link setId} before a memo file will be created.
+   * {@link #setId} before a memo file will be created.
    */
   private final long minimumElapsed;
 
@@ -387,14 +387,14 @@ public class Memoizer extends ReaderWrapper {
    * no special actions are taken during {@link #setId(String)}. If a value
    * is set, however, we must be careful with attempting to serialize it
    *
-   * @see {@link #handleMetadataStore()}
+   * @see #handleMetadataStore(IFormatReader)
    */
   private MetadataStore userMetadataStore = null;
 
   /**
    * {@link MetadataStore} created internally.
    *
-   * @see {@link #handleMetadataStore()}
+   * @see #handleMetadataStore(IFormatReader)
    */
   private MetadataStore replacementMetadataStore = null;
 

--- a/components/formats-bsd/src/loci/formats/in/IM3Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/IM3Reader.java
@@ -834,7 +834,7 @@ public class IM3Reader extends FormatReader {
      * Parse the spectrum record
      *
      * @param is the file handle
-     * @param subRec the spectrum container record
+     * @param rec the spectrum container record
      * @throws IOException
      */
     private void parseSpectrumRecord(IRandomAccess is, ContainerRecord rec) throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1430,7 +1430,7 @@ public class MetamorphReader extends BaseTiffReader {
    * stage X/Y positions,
    * camera chip offsets,
    * stage labels...
-   * @param long uic4offset: offset of UIC4 table (not tiff-compliant)
+   * @param uic4offset offset of UIC4 table (not tiff-compliant)
    * @throws IOException
    */
   private void parseUIC4Tags(long uic4offset) throws IOException {
@@ -1527,8 +1527,8 @@ public class MetamorphReader extends BaseTiffReader {
   /**
    * UIC1 entry parser
    * @throws IOException
-   * @param long uic1offset : offset as found in the tiff tag 33628 (UIC1Tag)
-   * @param int uic1count : number of entries in UIC1 table (not tiff-compliant)
+   * @param uic1offset offset as found in the tiff tag 33628 (UIC1Tag)
+   * @param uic1count number of entries in UIC1 table (not tiff-compliant)
    */
   private void parseUIC1Tags(long uic1offset, int uic1count) throws IOException
   {

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
@@ -641,7 +641,7 @@ public class ZeissTIFFHandler extends DefaultHandler {
     /**
      * Get a dimension by its index.  If the dimension does not yet
      * exist, a new one will be created.
-     * @param An XML element name.  The index number will be parsed
+     * @param key An XML element name.  The index number will be parsed
      * from this name.
      * @return A Dimension object.
      */

--- a/components/ome-xml/src/ome/xml/model/primitives/PrimitiveType.java
+++ b/components/ome-xml/src/ome/xml/model/primitives/PrimitiveType.java
@@ -54,7 +54,6 @@ public abstract class PrimitiveType<T> {
 
   /**
    * Default constructor.
-   * @param value The delegate value to use.
    */
   PrimitiveType() {
   }


### PR DESCRIPTION
See gh-1693.  Private fields (e.g. ```minimumElapsed``` in Memoizer) should be present in the Javadocs with this PR included.  Feel free to cherry pick the commit, or close outright if this isn't helpful.