### PR TITLE
MetamorphHandler: Whitelist valid keys in Description

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -133,16 +133,18 @@ public class MetamorphHandler extends BaseHandler {
     String k = null, v = null;
 
     String delim = " #13; #10;";
-    if (desc != null && desc.indexOf(delim) < 0) {
+    if (desc.indexOf(delim) < 0) {
       delim = "&#13;&#10;";
+    }
+    if (desc.indexOf(delim) < 0) {
+      delim = "\n";
     }
 
     if (desc.indexOf(delim) != -1) {
       String vDescription = null;
 
-      int currentIndex = -delim.length();
+      int currentIndex = 0;
       while (currentIndex != -1) {
-        currentIndex += delim.length();
         int nextIndex = desc.indexOf(delim, currentIndex);
 
         String line = null;
@@ -153,6 +155,8 @@ public class MetamorphHandler extends BaseHandler {
           line = desc.substring(currentIndex, nextIndex);
         }
         currentIndex = nextIndex;
+        if (currentIndex != -1)
+          currentIndex += delim.length();
 
         if (line.isEmpty()) {
           continue;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1146,15 +1146,11 @@ public class MetamorphReader extends BaseTiffReader {
     // parse (mangle) TIFF comment
     String descr = ifds.get(0).getComment();
     if (descr != null) {
-      String[] lines = descr.split("\n");
       StringBuffer sb = new StringBuffer();
-      for (int i=0; i<lines.length; i++) {
-        String line = lines[i].trim();
+      String line = descr.substring(0, descr.indexOf("\n"));
 
-        if (line.startsWith("<") && line.endsWith(">")) {
-          // XML comment; this will have already been parsed so can be ignored
-          break;
-        }
+      if (!line.startsWith("<") || !line.endsWith(">")) {
+        // Not an XML comment (which will have already been parsed so can be ignored)
 
         Hashtable<String, Object> meta = getSeriesMetadata();
         MetamorphHandler handler = new MetamorphHandler(meta);

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1147,8 +1147,10 @@ public class MetamorphReader extends BaseTiffReader {
     String descr = ifds.get(0).getComment();
     if (descr != null) {
       StringBuffer sb = new StringBuffer();
-      String line = descr.substring(0, descr.indexOf("\n"));
-
+      String line = descr;
+      if (descr.indexOf("\n") != -1) {
+        line = descr.substring(0, descr.indexOf("\n"));
+      }
       if (!line.startsWith("<") || !line.endsWith(">")) {
         // Not an XML comment (which will have already been parsed so can be ignored)
 


### PR DESCRIPTION
If a key isn't present in the whitelist, treat it as part of the free text comment.  I have also updated the main reader to use the handler logic to parse the description as well.  There may be a slight behaviour change here--the old code assumed that '=' was a separator for `Exposure`, but I only see `Exposure: <value> <unit>` in the samples I've checked, so not sure of its validity--might be in some particular samples?

--no-rebase
--exclude

/cc @emmenlau