### PR TITLE
Doc Fix : Update VoxelSize documentation to include Units

### DIFF
--- a/components/formats-gpl/test/matlab/ReaderTest.m
+++ b/components/formats-gpl/test/matlab/ReaderTest.m
@@ -50,6 +50,7 @@ classdef ReaderTest < TestBfMatlab
             self.sizeC = self.reader.DEFAULT_SIZE_C;
             self.sizeT = self.reader.DEFAULT_SIZE_T;
             loci.common.DebugTools.enableLogging('ERROR');
+            import ome.units.UNITS.*;
         end
         
         function tearDown(self)

--- a/components/formats-gpl/test/matlab/TestBfGetReader.m
+++ b/components/formats-gpl/test/matlab/TestBfGetReader.m
@@ -169,5 +169,35 @@ classdef TestBfGetReader < ReaderTest
             self.reader = bfGetReader('interleaved-test&interleaved=false.fake');
             assertFalse(self.reader.isInterleaved());
         end
+        
+        function testGetPixelsPhysicalSizeX(self)
+            self.reader = bfGetReader('pixelSize-test&physicalSizeX=.3.fake');
+            metadata = self.reader.getMetadataStore();
+            physicalSizeX = metadata.getPixelsPhysicalSizeX(0);
+            assertFalse(isempty(physicalSizeX));
+            assertEqual(physicalSizeX.value().doubleValue(), .3);
+            assertEqual(char(physicalSizeX.unit().getSymbol()), 'µm');
+            assertElementsAlmostEqual(physicalSizeX.value(ome.units.UNITS.NM).doubleValue(), 300.0);
+        end
+        
+        function testGetPixelsPhysicalSizeY(self)
+            self.reader = bfGetReader('pixelSize-test&physicalSizeY=.3.fake');
+            metadata = self.reader.getMetadataStore();
+            physicalSizeY = metadata.getPixelsPhysicalSizeY(0);
+            assertFalse(isempty(physicalSizeY));
+            assertEqual(physicalSizeY.value().doubleValue(), .3);
+            assertEqual(char(physicalSizeY.unit().getSymbol()), 'µm');
+            assertElementsAlmostEqual(physicalSizeY.value(ome.units.UNITS.NM).doubleValue(), 300.0);
+        end
+        
+        function testGetPixelsPhysicalSizeZ(self)
+            self.reader = bfGetReader('pixelSize-test&physicalSizeZ=.3.fake');
+            metadata = self.reader.getMetadataStore();
+            physicalSizeZ = metadata.getPixelsPhysicalSizeZ(0);
+            assertFalse(isempty(physicalSizeZ));
+            assertEqual(physicalSizeZ.value().doubleValue(), .3);
+            assertEqual(char(physicalSizeZ.unit().getSymbol()), 'µm');
+            assertElementsAlmostEqual(physicalSizeZ.value(ome.units.UNITS.NM).doubleValue(), 300.0);
+        end
     end
 end

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -188,8 +188,8 @@ To access physical voxel and stack sizes of the data:
       stackSizeY = omeMeta.getPixelsSizeY(0).getValue(); % image height, pixels
       stackSizeZ = omeMeta.getPixelsSizeZ(0).getValue(); % number of Z slices
 
-      voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(); % returns value in default unit
-	    voxelSizeXunit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
+      voxelSizeXdefaultValue = omeMeta.getPixelsPhysicalSizeX(0).value();           % returns value in default unit
+	    voxelSizeXdefaultUnit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
 	    voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
       voxelSizeY = omeMeta.getPixelsPhysicalSizeY(0).value(ome.units.UNITS.MICROM); % in µm
       voxelSizeZ = omeMeta.getPixelsPhysicalSizeZ(0).value(ome.units.UNITS.MICROM); % in µm

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -189,8 +189,8 @@ To access physical voxel and stack sizes of the data:
       stackSizeZ = omeMeta.getPixelsSizeZ(0).getValue(); % number of Z slices
 
       voxelSizeXdefaultValue = omeMeta.getPixelsPhysicalSizeX(0).value();           % returns value in default unit
-	    voxelSizeXdefaultUnit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
-	    voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
+      voxelSizeXdefaultUnit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
+      voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
       voxelSizeY = omeMeta.getPixelsPhysicalSizeY(0).value(ome.units.UNITS.MICROM); % in µm
       voxelSizeZ = omeMeta.getPixelsPhysicalSizeZ(0).value(ome.units.UNITS.MICROM); % in µm
 

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -187,9 +187,12 @@ To access physical voxel and stack sizes of the data:
       stackSizeX = omeMeta.getPixelsSizeX(0).getValue(); % image width, pixels
       stackSizeY = omeMeta.getPixelsSizeY(0).getValue(); % image height, pixels
       stackSizeZ = omeMeta.getPixelsSizeZ(0).getValue(); % number of Z slices
-      voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).getValue(); % in µm
-      voxelSizeY = omeMeta.getPixelsPhysicalSizeY(0).getValue(); % in µm
-      voxelSizeZ = omeMeta.getPixelsPhysicalSizeZ(0).getValue(); % in µm
+
+      voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(); % returns value in default unit
+	  voxelSizeXunit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
+	  voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
+      voxelSizeY = omeMeta.getPixelsPhysicalSizeY(0).value(ome.units.UNITS.MICROM); % in µm
+      voxelSizeZ = omeMeta.getPixelsPhysicalSizeZ(0).value(ome.units.UNITS.MICROM); % in µm
 
 For more information about the methods to retrieve the metadata, see the
 :javadoc:`MetadataRetrieve <loci/formats/meta/MetadataRetrieve.html>` Javadoc

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -189,8 +189,8 @@ To access physical voxel and stack sizes of the data:
       stackSizeZ = omeMeta.getPixelsSizeZ(0).getValue(); % number of Z slices
 
       voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(); % returns value in default unit
-	  voxelSizeXunit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
-	  voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
+	    voxelSizeXunit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
+	    voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
       voxelSizeY = omeMeta.getPixelsPhysicalSizeY(0).value(ome.units.UNITS.MICROM); % in µm
       voxelSizeZ = omeMeta.getPixelsPhysicalSizeZ(0).value(ome.units.UNITS.MICROM); % in µm
 


### PR DESCRIPTION
Please check if the following lines work:

```
     data = bfopen('/path/to/data/file');
      omeMeta = data{1, 4};
      stackSizeX = omeMeta.getPixelsSizeX(0).getValue(); % image width, pixels
      stackSizeY = omeMeta.getPixelsSizeY(0).getValue(); % image height, pixels
      stackSizeZ = omeMeta.getPixelsSizeZ(0).getValue(); % number of Z slices

      voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(); % returns value in default unit
	  voxelSizeXunit = omeMeta.getPixelsPhysicalSizeX(0).unit().getSymbol(); % returns the default unit type
	  voxelSizeX = omeMeta.getPixelsPhysicalSizeX(0).value(ome.units.UNITS.MICROM); % in µm
      voxelSizeY = omeMeta.getPixelsPhysicalSizeY(0).value(ome.units.UNITS.MICROM); % in µm
      voxelSizeZ = omeMeta.getPixelsPhysicalSizeZ(0).value(ome.units.UNITS.MICROM); % in µm
```