### PR TITLE
Temporarily disable cpp matrix component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 
 env:
   - BUILD=maven
-  - BUILD=cpp
+#  - BUILD=cpp
   - BUILD=cppwrap
   - BUILD=flake8
   - BUILD=sphinx


### PR DESCRIPTION
This is related to recent failures in the `cpp` components of Travis. @rleigh-dundee suggested this should be fixed by cleaning temporary files during the tests.

In the meantime this commit is disabling the `cpp` component to allow PR validation. It can be reverted when the `cpp` tests are fixed with small disk space.

--no-rebase