### PR TITLE
cpp: test: Delete generated test files to conserve disc space

### DIFF
--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -1450,6 +1450,14 @@ operator<< (std::basic_ostream<charT,traits>& os,
 
 class PixelTest : public ::testing::TestWithParam<PixelTestParameters>
 {
+  void
+  TearDown()
+  {
+    // Delete file (if any)
+    const PixelTestParameters& params = GetParam();
+    if (boost::filesystem::exists(params.filename))
+      boost::filesystem::remove(params.filename);
+  }
 };
 
 TEST_P(PixelTest, WriteTIFF)


### PR DESCRIPTION
--no-rebase

We were already running a reduced number of testcases, so the amount of discspace we were using wasn't really that great, so this problem might recur in the future during the main build itself; the simple fact of this failure is that the travis build nodes don't have enough disc space, so it could affect any job, particularly openmicroscopy.git where the repo size and checkout size is huge.  Hopefully it's a temporary situation the Travis people will resolve.  We could further reduce space by doing a Release rather than Debug build, which should reduce the object file size significantly.

--------

Testing: Unit tests should continue to pass but disc space usage will be reduced.