### PR TITLE
Refactor sphinx ant build and add cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,10 +132,10 @@ include(QtGLChecks)
 include(XsdFu)
 include(GTest)
 include(Doxygen)
-include(Sphinx)
 include(HeaderTest)
 
 add_subdirectory(docs/doxygen)
+add_subdirectory(docs/sphinx)
 add_subdirectory(cpp)
 
 set(LIBRARY_PREFIX OME)

--- a/ant/version.xml
+++ b/ant/version.xml
@@ -9,6 +9,7 @@ Ant build file for release version numbering.
   <import file="${root.dir}/ant/gitversion.xml" optional="true"/>
 
   <target name="release-version">
+    <property name="release.version.regex" value="v([0-9]+)[.]([0-9]+)[.]([0-9]+)(.*)"/>
     <!-- check for Git versioning information -->
     <property name="git.path" value="${root.dir}/.git"/>
     <available file="${git.path}" property="git.present"/>
@@ -67,7 +68,6 @@ Ant build file for release version numbering.
         <if>
           <isset property="git.describe"/>
           <then>
-            <property name="release.version.regex" value="v([0-9]+)[.]([0-9]+)[.]([0-9]+)(.*)"/>
             <propertyregex property="tag.major" input="${git.describe}" regexp="${release.version.regex}" select="\1"/>
             <propertyregex property="tag.minor" input="${git.describe}" regexp="${release.version.regex}" select="\2"/>
             <propertyregex property="tag.patch" input="${git.describe}" regexp="${release.version.regex}" select="\3"/>
@@ -102,6 +102,12 @@ Ant build file for release version numbering.
         </if>
       </then>
     </if>
+
+    <!-- set version components -->
+    <propertyregex property="release.major" input="${release.version}" regexp="${release.version.regex}" select="\1"/>
+    <propertyregex property="release.minor" input="${release.version}" regexp="${release.version.regex}" select="\2"/>
+    <propertyregex property="release.patch" input="${release.version}" regexp="${release.version.regex}" select="\3"/>
+    <propertyregex property="release.extra" input="${release.version}" regexp="${release.version.regex}" select="\4"/>
 
     <!-- set release version by default if nothing is set -->
     <property name="release.version" value="UNKNOWN"/>

--- a/cpp/cmake/Sphinx.cmake
+++ b/cpp/cmake/Sphinx.cmake
@@ -41,31 +41,69 @@ if (SPHINX_BUILD)
 else()
   message(STATUS "Looking for sphinx-build - not found")
 endif()
+find_program(XELATEX xelatex)
+if (XELATEX)
+  message(STATUS "Looking for xelatex - ${XELATEX}")
+else()
+  message(STATUS "Looking for xelatex - not found")
+endif()
+find_program(MAKEINDEX makeindex)
+if (MAKEINDEX)
+  message(STATUS "Looking for makeindex - ${MAKEINDEX}")
+else()
+  message(STATUS "Looking for makeindex - not found")
+endif()
 
-if (SPHINX_BUILD)
+set(SPHINX_DEFAULT OFF)
+if(SPHINX_BUILD)
+  set(SPHINX_DEFAULT ON)
+endif()
+option(sphinx "Enable sphinx manual page and HTML documentation" ${SPHINX_DEFAULT})
+set(BUILD_SPHINX ${sphinx})
+set(SPHINX_PDF_DEFAULT OFF)
+if(SPHINX_DEFAULT AND XELATEX AND MAKEINDEX)
+  set(SPHINX_PDF_DEFAULT ON)
+endif()
+option(sphinx-pdf "Enable sphinx PDF documentation" ${SPHINX_PDF_DEFAULT})
+set(BUILD_SPHINX_PDF ${sphinx-pdf})
+
+if (BUILD_SPHINX AND SPHINX_BUILD)
   message(STATUS "Checking manual page dependencies")
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/docs/sphinx")
   execute_process(COMMAND python -B ${CMAKE_CURRENT_LIST_DIR}/list-manpages.py
                           "${PROJECT_SOURCE_DIR}/docs/sphinx"
                           "${PROJECT_BINARY_DIR}/cpp/man"
                   RESULT_VARIABLE sphinx_man_fail
                   OUTPUT_VARIABLE MAN_PAGES
-                  ERROR_FILE cpp/man/sphinx-man.log)
+                  ERROR_FILE docs/sphinx/sphinx-man.log)
   string(REPLACE "\n" ";" MAN_PAGES "${MAN_PAGES}")
   execute_process(COMMAND python -B ${CMAKE_CURRENT_LIST_DIR}/list-manpage-dependencies.py
                           "${PROJECT_SOURCE_DIR}/docs/sphinx"
                   RESULT_VARIABLE sphinx_man_dep_fail
                   OUTPUT_VARIABLE MAN_PAGE_DEPENDENCIES
-                  ERROR_FILE cpp/man/sphinx-man-dep.log)
+                  ERROR_FILE docs/sphinx/sphinx-man-dep.log)
   string(REPLACE "\n" ";" MAN_PAGE_DEPENDENCIES "${MAN_PAGE_DEPENDENCIES}")
 
-  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cpp/man")
-  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cpp/doc/sphinx")
+  file(GLOB_RECURSE CRUDE_SPHINX_DEPENDENCIES "${PROJECT_SOURCE_DIR}/docs/sphinx/*.txt")
+  foreach(file ${CRUDE_SPHINX_DEPENDENCIES})
+    string(FIND "${file}" "_build" FILE_MATCH)
+    if(FILE_MATCH EQUAL -1)
+      list(APPEND SPHINX_DEPENDENCIES "${file}")
+    endif()
+  endforeach()
+
+  # Generate and install man pages
+
   add_custom_command(OUTPUT ${MAN_PAGES}
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/cpp/man"
                      COMMAND ${SPHINX_BUILD}
                              -D "release=${OME_VERSION_SHORT}"
                              -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                             -d "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
                              -b man
-                             "${PROJECT_SOURCE_DIR}/docs/sphinx" cpp/man
+                             "${PROJECT_SOURCE_DIR}/docs/sphinx" "${PROJECT_BINARY_DIR}/cpp/man"
+                     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/docs/sphinx"
                      DEPENDS ${MAN_PAGE_DEPENDENCIES})
 
   add_custom_target(man ALL DEPENDS ${MAN_PAGES})
@@ -75,6 +113,56 @@ if (SPHINX_BUILD)
     install(FILES "${man}"
             DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man${man_section}")
   endforeach()
+
+  # Generate and install HTML manual
+
+  add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/docs/sphinx/html/index.html"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/html"
+                     COMMAND ${SPHINX_BUILD}
+                             -D "release=${OME_VERSION_SHORT}"
+                             -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                             -d "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                             -b html
+                             "${PROJECT_SOURCE_DIR}/docs/sphinx" "${PROJECT_BINARY_DIR}/docs/sphinx/html"
+                     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                     DEPENDS ${SPHINX_DEPENDENCIES})
+
+  add_custom_target(doc-html ALL DEPENDS "${PROJECT_BINARY_DIR}/docs/sphinx/html/index.html")
+
+  install(DIRECTORY "${PROJECT_BINARY_DIR}/docs/sphinx/html"
+          DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
+
+  # Generate and install PDF manual
+
+  if (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
+    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.tex"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
+                       COMMAND ${SPHINX_BUILD}
+                               -D "release=${OME_VERSION_SHORT}"
+                               -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                               -d "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                               -b latex
+                               "${PROJECT_SOURCE_DIR}/docs/sphinx" "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
+                       COMMAND ${CMAKE_COMMAND} -E copy "preamble.tex" "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
+                       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                       DEPENDS ${SPHINX_DEPENDENCIES})
+    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.pdf"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${MAKEINDEX} -s python.ist "Bio-Formats.idx"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
+                       DEPENDS "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.tex")
+
+    add_custom_target(doc-pdf ALL DEPENDS "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.pdf")
+
+    install(FILES "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.pdf"
+            DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
+  endif (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
 else()
-  message(WARNING "Manual pages will not be generated or installed")
+  message(WARNING "Manual pages and HTML manual will not be generated or installed")
 endif()

--- a/cpp/cmake/Sphinx.cmake
+++ b/cpp/cmake/Sphinx.cmake
@@ -67,114 +67,38 @@ endif()
 option(sphinx-pdf "Enable sphinx PDF documentation" ${SPHINX_PDF_DEFAULT})
 set(BUILD_SPHINX_PDF ${sphinx-pdf})
 
-if (BUILD_SPHINX AND SPHINX_BUILD)
-  message(STATUS "Checking manual page dependencies")
-
-  # Create build directory and conf.py
-  set(sphinx_srcdir "${PROJECT_SOURCE_DIR}/docs/sphinx")
-  set(sphinx_builddir "${PROJECT_BINARY_DIR}/docs/sphinx")
-  file(MAKE_DIRECTORY "${sphinx_builddir}")
-  configure_file("${sphinx_srcdir}/conf.py.in"
-                 "${sphinx_builddir}/conf.py")
-
-  execute_process(COMMAND python -B ${CMAKE_CURRENT_LIST_DIR}/list-manpages.py
-                          "${sphinx_builddir}"
-                          "${sphinx_srcdir}"
-                          "${PROJECT_BINARY_DIR}/cpp/man"
+function(sphinx_manpages srcdir confdir mandir manvar)
+  execute_process(COMMAND python -B ${PROJECT_SOURCE_DIR}/cpp/cmake/list-manpages.py
+                          "${confdir}" "${srcdir}" "${mandir}"
                   RESULT_VARIABLE sphinx_man_fail
-                  OUTPUT_VARIABLE MAN_PAGES
-                  ERROR_FILE docs/sphinx/sphinx-man.log)
+                  OUTPUT_VARIABLE MAN_PAGES)
+  if (sphinx_man_fail)
+    message(WARNING "Failed to get generated sphinx manual pages from ${confdir}")
+  endif()
   string(REPLACE "\n" ";" MAN_PAGES "${MAN_PAGES}")
-  execute_process(COMMAND python -B ${CMAKE_CURRENT_LIST_DIR}/list-manpage-dependencies.py
-                          "${sphinx_builddir}"
-                          "${sphinx_srcdir}"
-                  RESULT_VARIABLE sphinx_man_dep_fail
-                  OUTPUT_VARIABLE MAN_PAGE_DEPENDENCIES
-                  ERROR_FILE docs/sphinx/sphinx-man-dep.log)
-  string(REPLACE "\n" ";" MAN_PAGE_DEPENDENCIES "${MAN_PAGE_DEPENDENCIES}")
+  set(${manvar} "${MAN_PAGES}" PARENT_SCOPE)
+endfunction(sphinx_manpages)
 
-  file(GLOB_RECURSE CRUDE_SPHINX_DEPENDENCIES "${sphinx_srcdir}/*.txt")
+function(sphinx_manpage_dependencies srcdir confdir depvar)
+  execute_process(COMMAND python -B ${PROJECT_SOURCE_DIR}/cpp/cmake/list-manpage-dependencies.py
+                          "${confdir}"
+                          "${srcdir}"
+                  RESULT_VARIABLE sphinx_dep_fail
+                  OUTPUT_VARIABLE SPHINX_MAN_DEPENDENCIES)
+  if (sphinx_dep_fail)
+    message(WARNING "Failed to get Sphinx dependencies from ${confdir}")
+  endif()
+  string(REPLACE "\n" ";" SPHINX_MAN_DEPENDENCIES "${SPHINX_MAN_DEPENDENCIES}")
+  set(${depvar} "${SPHINX_MAN_DEPENDENCIES}" PARENT_SCOPE)
+endfunction(sphinx_manpage_dependencies)
+
+function(sphinx_dependencies srcdir depvar)
+  file(GLOB_RECURSE CRUDE_SPHINX_DEPENDENCIES "${srcdir}/*.txt")
   foreach(file ${CRUDE_SPHINX_DEPENDENCIES})
     string(FIND "${file}" "_build" FILE_MATCH)
     if(FILE_MATCH EQUAL -1)
       list(APPEND SPHINX_DEPENDENCIES "${file}")
     endif()
   endforeach()
-
-  # Generate and install man pages
-
-  add_custom_command(OUTPUT ${MAN_PAGES}
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/cpp/man"
-                     COMMAND ${SPHINX_BUILD}
-                             -D "release=${OME_VERSION_SHORT}"
-                             -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
-                             -c "${sphinx_builddir}"
-                             -d "${sphinx_builddir}/cache"
-                             -b man
-                             "${sphinx_srcdir}" "${PROJECT_BINARY_DIR}/cpp/man"
-                     WORKING_DIRECTORY "${sphinx_srcdir}"
-                     DEPENDS ${MAN_PAGE_DEPENDENCIES})
-
-  add_custom_target(man ALL DEPENDS ${MAN_PAGES})
-
-  foreach (man ${MAN_PAGES})
-    string(REGEX REPLACE ".*(.)\$" "\\1" man_section "${man}")
-    install(FILES "${man}"
-            DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man${man_section}")
-  endforeach()
-
-  # Generate and install HTML manual
-
-  add_custom_command(OUTPUT "${sphinx_builddir}/html/index.html"
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/html"
-                     COMMAND ${SPHINX_BUILD}
-                             -D "release=${OME_VERSION_SHORT}"
-                             -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
-                             -c "${sphinx_builddir}"
-                             -d "${sphinx_builddir}/cache"
-                             -b html
-                             "${sphinx_srcdir}" "${sphinx_builddir}/html"
-                     WORKING_DIRECTORY "${sphinx_srcdir}"
-                     DEPENDS ${SPHINX_DEPENDENCIES})
-
-  add_custom_target(doc-html ALL DEPENDS "${sphinx_builddir}/html/index.html")
-
-  install(DIRECTORY "${sphinx_builddir}/html"
-          DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/user")
-
-  # Generate and install PDF manual
-
-  if (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
-    add_custom_command(OUTPUT "${sphinx_builddir}/latex/Bio-Formats.tex" "${sphinx_builddir}/latex/preamble.tex"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/latex"
-                       COMMAND ${SPHINX_BUILD}
-                               -D "release=${OME_VERSION_SHORT}"
-                               -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
-                               -c "${sphinx_builddir}"
-                               -d "${sphinx_builddir}/cache"
-                               -b latex
-                               "${sphinx_srcdir}" "${sphinx_builddir}/latex"
-                       COMMAND ${CMAKE_COMMAND} -E copy "preamble.tex" "${sphinx_builddir}/latex"
-                       WORKING_DIRECTORY "${sphinx_srcdir}"
-                       DEPENDS ${SPHINX_DEPENDENCIES})
-    add_custom_command(OUTPUT "${sphinx_builddir}/latex/Bio-Formats.pdf"
-                       COMMAND ${XELATEX} "Bio-Formats.tex"
-                       COMMAND ${XELATEX} "Bio-Formats.tex"
-                       COMMAND ${MAKEINDEX} -s python.ist "Bio-Formats.idx"
-                       COMMAND ${XELATEX} "Bio-Formats.tex"
-                       COMMAND ${XELATEX} "Bio-Formats.tex"
-                       COMMAND ${XELATEX} "Bio-Formats.tex"
-                       WORKING_DIRECTORY "${sphinx_builddir}/latex"
-                       DEPENDS "${sphinx_builddir}/latex/Bio-Formats.tex" "${sphinx_builddir}/latex/preamble.tex")
-
-    add_custom_target(doc-pdf ALL DEPENDS "${sphinx_builddir}/latex/Bio-Formats.pdf")
-
-    install(FILES "${sphinx_builddir}/latex/Bio-Formats.pdf"
-            DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/user")
-  endif (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
-else()
-  message(WARNING "Manual pages and HTML manual will not be generated or installed")
-endif()
+  set(${depvar} "${SPHINX_DEPENDENCIES}" PARENT_SCOPE)
+endfunction(sphinx_dependencies)

--- a/cpp/cmake/Sphinx.cmake
+++ b/cpp/cmake/Sphinx.cmake
@@ -69,22 +69,31 @@ set(BUILD_SPHINX_PDF ${sphinx-pdf})
 
 if (BUILD_SPHINX AND SPHINX_BUILD)
   message(STATUS "Checking manual page dependencies")
-  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/docs/sphinx")
+
+  # Create build directory and conf.py
+  set(sphinx_srcdir "${PROJECT_SOURCE_DIR}/docs/sphinx")
+  set(sphinx_builddir "${PROJECT_BINARY_DIR}/docs/sphinx")
+  file(MAKE_DIRECTORY "${sphinx_builddir}")
+  configure_file("${sphinx_srcdir}/conf.py.in"
+                 "${sphinx_builddir}/conf.py")
+
   execute_process(COMMAND python -B ${CMAKE_CURRENT_LIST_DIR}/list-manpages.py
-                          "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                          "${sphinx_builddir}"
+                          "${sphinx_srcdir}"
                           "${PROJECT_BINARY_DIR}/cpp/man"
                   RESULT_VARIABLE sphinx_man_fail
                   OUTPUT_VARIABLE MAN_PAGES
                   ERROR_FILE docs/sphinx/sphinx-man.log)
   string(REPLACE "\n" ";" MAN_PAGES "${MAN_PAGES}")
   execute_process(COMMAND python -B ${CMAKE_CURRENT_LIST_DIR}/list-manpage-dependencies.py
-                          "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                          "${sphinx_builddir}"
+                          "${sphinx_srcdir}"
                   RESULT_VARIABLE sphinx_man_dep_fail
                   OUTPUT_VARIABLE MAN_PAGE_DEPENDENCIES
                   ERROR_FILE docs/sphinx/sphinx-man-dep.log)
   string(REPLACE "\n" ";" MAN_PAGE_DEPENDENCIES "${MAN_PAGE_DEPENDENCIES}")
 
-  file(GLOB_RECURSE CRUDE_SPHINX_DEPENDENCIES "${PROJECT_SOURCE_DIR}/docs/sphinx/*.txt")
+  file(GLOB_RECURSE CRUDE_SPHINX_DEPENDENCIES "${sphinx_srcdir}/*.txt")
   foreach(file ${CRUDE_SPHINX_DEPENDENCIES})
     string(FIND "${file}" "_build" FILE_MATCH)
     if(FILE_MATCH EQUAL -1)
@@ -95,15 +104,16 @@ if (BUILD_SPHINX AND SPHINX_BUILD)
   # Generate and install man pages
 
   add_custom_command(OUTPUT ${MAN_PAGES}
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
                      COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/cpp/man"
                      COMMAND ${SPHINX_BUILD}
                              -D "release=${OME_VERSION_SHORT}"
                              -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
-                             -d "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                             -c "${sphinx_builddir}"
+                             -d "${sphinx_builddir}/cache"
                              -b man
-                             "${PROJECT_SOURCE_DIR}/docs/sphinx" "${PROJECT_BINARY_DIR}/cpp/man"
-                     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                             "${sphinx_srcdir}" "${PROJECT_BINARY_DIR}/cpp/man"
+                     WORKING_DIRECTORY "${sphinx_srcdir}"
                      DEPENDS ${MAN_PAGE_DEPENDENCIES})
 
   add_custom_target(man ALL DEPENDS ${MAN_PAGES})
@@ -116,51 +126,53 @@ if (BUILD_SPHINX AND SPHINX_BUILD)
 
   # Generate and install HTML manual
 
-  add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/docs/sphinx/html/index.html"
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
-                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/html"
+  add_custom_command(OUTPUT "${sphinx_builddir}/html/index.html"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/html"
                      COMMAND ${SPHINX_BUILD}
                              -D "release=${OME_VERSION_SHORT}"
                              -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
-                             -d "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                             -c "${sphinx_builddir}"
+                             -d "${sphinx_builddir}/cache"
                              -b html
-                             "${PROJECT_SOURCE_DIR}/docs/sphinx" "${PROJECT_BINARY_DIR}/docs/sphinx/html"
-                     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                             "${sphinx_srcdir}" "${sphinx_builddir}/html"
+                     WORKING_DIRECTORY "${sphinx_srcdir}"
                      DEPENDS ${SPHINX_DEPENDENCIES})
 
-  add_custom_target(doc-html ALL DEPENDS "${PROJECT_BINARY_DIR}/docs/sphinx/html/index.html")
+  add_custom_target(doc-html ALL DEPENDS "${sphinx_builddir}/html/index.html")
 
-  install(DIRECTORY "${PROJECT_BINARY_DIR}/docs/sphinx/html"
+  install(DIRECTORY "${sphinx_builddir}/html"
           DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
 
   # Generate and install PDF manual
 
   if (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
-    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.tex"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
+    add_custom_command(OUTPUT "${sphinx_builddir}/latex/Bio-Formats.tex" "${sphinx_builddir}/latex/preamble.tex"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/latex"
                        COMMAND ${SPHINX_BUILD}
                                -D "release=${OME_VERSION_SHORT}"
                                -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
-                               -d "${PROJECT_BINARY_DIR}/docs/sphinx/cache"
+                               -c "${sphinx_builddir}"
+                               -d "${sphinx_builddir}/cache"
                                -b latex
-                               "${PROJECT_SOURCE_DIR}/docs/sphinx" "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
-                       COMMAND ${CMAKE_COMMAND} -E copy "preamble.tex" "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
-                       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/docs/sphinx"
+                               "${sphinx_srcdir}" "${sphinx_builddir}/latex"
+                       COMMAND ${CMAKE_COMMAND} -E copy "preamble.tex" "${sphinx_builddir}/latex"
+                       WORKING_DIRECTORY "${sphinx_srcdir}"
                        DEPENDS ${SPHINX_DEPENDENCIES})
-    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.pdf"
+    add_custom_command(OUTPUT "${sphinx_builddir}/latex/Bio-Formats.pdf"
                        COMMAND ${XELATEX} "Bio-Formats.tex"
                        COMMAND ${XELATEX} "Bio-Formats.tex"
                        COMMAND ${MAKEINDEX} -s python.ist "Bio-Formats.idx"
                        COMMAND ${XELATEX} "Bio-Formats.tex"
                        COMMAND ${XELATEX} "Bio-Formats.tex"
                        COMMAND ${XELATEX} "Bio-Formats.tex"
-                       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/docs/sphinx/latex"
-                       DEPENDS "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.tex")
+                       WORKING_DIRECTORY "${sphinx_builddir}/latex"
+                       DEPENDS "${sphinx_builddir}/latex/Bio-Formats.tex" "${sphinx_builddir}/latex/preamble.tex")
 
-    add_custom_target(doc-pdf ALL DEPENDS "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.pdf")
+    add_custom_target(doc-pdf ALL DEPENDS "${sphinx_builddir}/latex/Bio-Formats.pdf")
 
-    install(FILES "${PROJECT_BINARY_DIR}/docs/sphinx/latex/Bio-Formats.pdf"
+    install(FILES "${sphinx_builddir}/latex/Bio-Formats.pdf"
             DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
   endif (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
 else()

--- a/cpp/cmake/Sphinx.cmake
+++ b/cpp/cmake/Sphinx.cmake
@@ -142,7 +142,7 @@ if (BUILD_SPHINX AND SPHINX_BUILD)
   add_custom_target(doc-html ALL DEPENDS "${sphinx_builddir}/html/index.html")
 
   install(DIRECTORY "${sphinx_builddir}/html"
-          DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
+          DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/user")
 
   # Generate and install PDF manual
 
@@ -173,7 +173,7 @@ if (BUILD_SPHINX AND SPHINX_BUILD)
     add_custom_target(doc-pdf ALL DEPENDS "${sphinx_builddir}/latex/Bio-Formats.pdf")
 
     install(FILES "${sphinx_builddir}/latex/Bio-Formats.pdf"
-            DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
+            DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/user")
   endif (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
 else()
   message(WARNING "Manual pages and HTML manual will not be generated or installed")

--- a/cpp/cmake/list-manpage-dependencies.py
+++ b/cpp/cmake/list-manpage-dependencies.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Find manual page dependencies
+# argv1 = doc dir containing conf.py
+
+import imp
+import os.path
+import sys
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 2:
+        sys.exit("Usage: %s sphinx-dir" % (sys.argv[0]))
+
+    dir = os.path.abspath(sys.argv[1])
+    conf = imp.load_source('conf', os.path.join(dir, 'conf.py'))
+
+    for man in conf.man_pages:
+        print os.path.join(dir, "%s%s" % (man[0], conf.source_suffix))
+    print os.path.join(dir, 'conf.py')

--- a/cpp/cmake/list-manpage-dependencies.py
+++ b/cpp/cmake/list-manpage-dependencies.py
@@ -16,5 +16,6 @@ if __name__ == "__main__":
     conf = imp.load_source('conf', os.path.join(dir, 'conf.py'))
 
     for man in conf.man_pages:
-        print os.path.join(sys.argv[2], "%s%s" % (man[0], conf.source_suffix))
+        print os.path.join(sys.argv[2], "%s%s" %
+                           (man[0], conf.source_suffix))
     print os.path.join(dir, 'conf.py')

--- a/cpp/cmake/list-manpage-dependencies.py
+++ b/cpp/cmake/list-manpage-dependencies.py
@@ -9,12 +9,12 @@ import sys
 
 if __name__ == "__main__":
 
-    if len(sys.argv) != 2:
-        sys.exit("Usage: %s sphinx-dir" % (sys.argv[0]))
+    if len(sys.argv) != 3:
+        sys.exit("Usage: %s sphinx-confdir sphinx-srcdir" % (sys.argv[0]))
 
     dir = os.path.abspath(sys.argv[1])
     conf = imp.load_source('conf', os.path.join(dir, 'conf.py'))
 
     for man in conf.man_pages:
-        print os.path.join(dir, "%s%s" % (man[0], conf.source_suffix))
+        print os.path.join(sys.argv[2], "%s%s" % (man[0], conf.source_suffix))
     print os.path.join(dir, 'conf.py')

--- a/cpp/cmake/list-manpages.py
+++ b/cpp/cmake/list-manpages.py
@@ -11,7 +11,8 @@ import sys
 if __name__ == "__main__":
 
     if len(sys.argv) != 4:
-        sys.exit("Usage: %s sphinx-confdir sphinx-srcdir manpage-dir" % (sys.argv[0]))
+        sys.exit("Usage: %s sphinx-confdir sphinx-srcdir manpage-dir" %
+                 (sys.argv[0]))
 
     dir = os.path.abspath(sys.argv[1])
     conf = imp.load_source('conf', os.path.join(dir, 'conf.py'))

--- a/cpp/cmake/list-manpages.py
+++ b/cpp/cmake/list-manpages.py
@@ -10,11 +10,11 @@ import sys
 
 if __name__ == "__main__":
 
-    if len(sys.argv) != 3:
-        sys.exit("Usage: %s sphinx-dir manpage-dir" % (sys.argv[0]))
+    if len(sys.argv) != 4:
+        sys.exit("Usage: %s sphinx-confdir sphinx-srcdir manpage-dir" % (sys.argv[0]))
 
     dir = os.path.abspath(sys.argv[1])
     conf = imp.load_source('conf', os.path.join(dir, 'conf.py'))
 
     for man in conf.man_pages:
-        print os.path.join(sys.argv[2], "%s.%s" % (man[1], man[4]))
+        print os.path.join(sys.argv[3], "%s.%s" % (man[1], man[4]))

--- a/cpp/cmake/list-manpages.py
+++ b/cpp/cmake/list-manpages.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Find manual pages to be generated
+# argv1 = doc dir containing conf.py
+# argv2 = manpage directory to contain generated manpages
+
+import imp
+import os.path
+import sys
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        sys.exit("Usage: %s sphinx-dir manpage-dir" % (sys.argv[0]))
+
+    dir = os.path.abspath(sys.argv[1])
+    conf = imp.load_source('conf', os.path.join(dir, 'conf.py'))
+
+    for man in conf.man_pages:
+        print os.path.join(sys.argv[2], "%s.%s" % (man[1], man[4]))

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -48,5 +48,10 @@ if(BUILD_DOXYGEN)
                     COMMAND ${CMAKE_COMMAND} -Dlogfile=${CMAKE_CURRENT_BINARY_DIR}/bioformats.log -P ${PROJECT_SOURCE_DIR}/cpp/cmake/DoxygenCheck.cmake
                     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/bioformats.log)
 
-  add_custom_target(doc DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/bioformats.log doc-check)
+  add_custom_target(doc-api ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/bioformats.log doc-check)
+  # For backward compatibility
+  add_custom_target(doc DEPENDS doc-api)
+
+  install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bioformats/"
+          DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/cpp-api")
 endif(BUILD_DOXYGEN)

--- a/docs/sphinx/.gitignore
+++ b/docs/sphinx/.gitignore
@@ -1,2 +1,3 @@
 _build
 venv
+conf.py

--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -1,0 +1,146 @@
+# #%L
+# Bio-Formats C++ libraries (cmake build infrastructure)
+# %%
+# Copyright © 2015 Open Microscopy Environment:
+#   - Massachusetts Institute of Technology
+#   - National Institutes of Health
+#   - University of Dundee
+#   - Board of Regents of the University of Wisconsin-Madison
+#   - Glencoe Software, Inc.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of any organization.
+# #L%
+
+include(Sphinx)
+
+if (BUILD_SPHINX AND SPHINX_BUILD)
+  message(STATUS "Checking manual page dependencies")
+
+  # Create build directory and conf.py
+  set(sphinx_srcdir "${PROJECT_SOURCE_DIR}/docs/sphinx")
+  set(sphinx_builddir "${PROJECT_BINARY_DIR}/docs/sphinx")
+  file(MAKE_DIRECTORY "${sphinx_builddir}")
+  configure_file("${sphinx_srcdir}/conf.py.in"
+                 "${sphinx_builddir}/conf.py")
+
+  sphinx_manpages("${sphinx_srcdir}" "${sphinx_builddir}"
+                  "${PROJECT_BINARY_DIR}/cpp/man" MAN_PAGES)
+  sphinx_manpage_dependencies("${sphinx_srcdir}" "${sphinx_builddir}"
+                              MAN_PAGE_DEPENDENCIES)
+  sphinx_dependencies("${sphinx_srcdir}" SPHINX_DEPENDENCIES)
+
+  # Generate and install man pages
+
+  add_custom_command(OUTPUT ${MAN_PAGES}
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/cpp/man"
+                     COMMAND ${SPHINX_BUILD}
+                             -D "release=${OME_VERSION_SHORT}"
+                             -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                             -c "${sphinx_builddir}"
+                             -d "${sphinx_builddir}/cache"
+                             -b man
+                             "${sphinx_srcdir}" "${PROJECT_BINARY_DIR}/cpp/man"
+                     WORKING_DIRECTORY "${sphinx_srcdir}"
+                     DEPENDS ${MAN_PAGE_DEPENDENCIES})
+
+  add_custom_target(man ALL DEPENDS ${MAN_PAGES})
+
+  foreach (man ${MAN_PAGES})
+    string(REGEX REPLACE ".*(.)\$" "\\1" man_section "${man}")
+    install(FILES "${man}"
+            DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man${man_section}")
+  endforeach()
+
+  # Generate and install HTML manual
+  # Depends on man to allow sharing of cache with parallel build.
+
+  add_custom_command(OUTPUT "${sphinx_builddir}/html/index.html"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/html"
+                     COMMAND ${SPHINX_BUILD}
+                             -D "release=${OME_VERSION_SHORT}"
+                             -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                             -c "${sphinx_builddir}"
+                             -d "${sphinx_builddir}/cache"
+                             -b html
+                             "${sphinx_srcdir}" "${sphinx_builddir}/html"
+                     WORKING_DIRECTORY "${sphinx_srcdir}"
+                     DEPENDS man ${SPHINX_DEPENDENCIES})
+
+  add_custom_target(doc-html ALL DEPENDS "${sphinx_builddir}/html/index.html")
+
+  install(DIRECTORY "${sphinx_builddir}/html"
+          DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/manual")
+
+  add_custom_target(doc-linkcheck
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/linkcheck"
+                    COMMAND ${SPHINX_BUILD}
+                            -D "release=${OME_VERSION_SHORT}"
+                            -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                            -c "${sphinx_builddir}"
+                            -d "${sphinx_builddir}/cache"
+                            -b linkcheck
+                            "${sphinx_srcdir}" "${sphinx_builddir}/linkcheck"
+                     WORKING_DIRECTORY "${sphinx_srcdir}"
+                     DEPENDS man ${SPHINX_DEPENDENCIES})
+
+  # Generate and install PDF manual
+  # Depends on man to allow sharing of cache with parallel build.
+
+  if (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
+    add_custom_command(OUTPUT "${sphinx_builddir}/latex/Bio-Formats.tex" "${sphinx_builddir}/latex/preamble.tex"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
+                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/latex"
+                       COMMAND ${SPHINX_BUILD}
+                               -D "release=${OME_VERSION_SHORT}"
+                               -D "version=${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}"
+                               -c "${sphinx_builddir}"
+                               -d "${sphinx_builddir}/cache"
+                               -b latex
+                               "${sphinx_srcdir}" "${sphinx_builddir}/latex"
+                       COMMAND ${CMAKE_COMMAND} -E copy "preamble.tex" "${sphinx_builddir}/latex"
+                       WORKING_DIRECTORY "${sphinx_srcdir}"
+                       DEPENDS man ${SPHINX_DEPENDENCIES})
+    add_custom_command(OUTPUT "${sphinx_builddir}/latex/Bio-Formats.pdf"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${MAKEINDEX} -s python.ist "Bio-Formats.idx"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       COMMAND ${XELATEX} "Bio-Formats.tex"
+                       WORKING_DIRECTORY "${sphinx_builddir}/latex"
+                       DEPENDS "${sphinx_builddir}/latex/Bio-Formats.tex" "${sphinx_builddir}/latex/preamble.tex")
+
+    add_custom_target(doc-pdf ALL DEPENDS "${sphinx_builddir}/latex/Bio-Formats.pdf")
+
+    install(FILES "${sphinx_builddir}/latex/Bio-Formats.pdf"
+            DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}/manual")
+  endif (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
+else()
+  message(WARNING "Manual pages and HTML manual will not be generated or installed")
+endif()

--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -44,7 +44,8 @@ if (BUILD_SPHINX AND SPHINX_BUILD)
   set(sphinx_builddir "${PROJECT_BINARY_DIR}/docs/sphinx")
   file(MAKE_DIRECTORY "${sphinx_builddir}")
   configure_file("${sphinx_srcdir}/conf.py.in"
-                 "${sphinx_builddir}/conf.py")
+                 "${sphinx_builddir}/conf.py"
+                 @ONLY)
 
   sphinx_manpages("${sphinx_srcdir}" "${sphinx_builddir}"
                   "${PROJECT_BINARY_DIR}/cpp/man" MAN_PAGES)

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -5,24 +5,32 @@ ANT_SPHINXOPTS := -Dsphinx.opts="$(SPHINXOPTS)"
 endif
 
 ifdef BF_RELEASE
-ANT_BF_RELEASE := -Dbf.release="$(BF_RELEASE)"
+ANT_BF_RELEASE := -Drelease.version="$(BF_RELEASE)" -Drelease.shortversion="$(BF_RELEASE)"
+endif
+
+ifdef RELEASE
+ANT_RELEASE := -Dsphinx.release="$(RELEASE)"
+endif
+
+ifdef VERSION
+ANT_VERSION := -Dsphinx.version="$(VERSION)"
 endif
 
 ifdef SOURCE_BRANCH
-ANT_SOURCE_BRANCH := -Dsource.branch="$(SOURCE_BRANCH)"
+ANT_SOURCE_BRANCH := -Dsphinx.source.branch="$(SOURCE_BRANCH)"
 endif
 
 ifdef SOURCE_USER
-ANT_SOURCE_USER := -Dsource.user="$(SOURCE_USER)"
+ANT_SOURCE_USER := -Dsphinx.source.user="$(SOURCE_USER)"
 endif
 
 ifdef OMERODOC_URI_JOB
-ANT_OMERODOC_URI_JOB := -Domerodoc.uri="$(OMERODOC_URI_JOB)"
+ANT_OMERODOC_URI_JOB := -Dsphinx.omerodoc.uri="$(OMERODOC_URI_JOB)"
 endif
 
 default: html
 
 %:
-	ant $@ $(ANT_SPHINXOPTS) $(ANT_BF_RELEASE) $(ANT_SOURCE_BRANCH) $(ANT_SOURCE_USER) $(ANT_JENKINS_JOB) $(ANT_JENKINS_CPP_JOB) $(ANT_OMERODOC_URI_JOB)
+	ant $@ $(ANT_SPHINXOPTS) $(ANT_BF_RELEASE) $(ANT_RELEASE) $(ANT_VERSION) $(ANT_SOURCE_BRANCH) $(ANT_SOURCE_USER) $(ANT_JENKINS_JOB) $(ANT_JENKINS_CPP_JOB) $(ANT_OMERODOC_URI_JOB)
 
 .PHONY: default

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -16,14 +16,6 @@ ifdef SOURCE_USER
 ANT_SOURCE_USER := -Dsource.user="$(SOURCE_USER)"
 endif
 
-ifdef JENKINS_JOB
-ANT_JENKINS_JOB := -Djenkins.job="$(JENKINS_JOB)"
-endif
-
-ifdef JENKINS_CPP_JOB
-ANT_JENKINS_CPP_JOB := -Djenkins.cpp.job="$(JENKINS_CPP_JOB)"
-endif
-
 ifdef OMERODOC_URI_JOB
 ANT_OMERODOC_URI_JOB := -Domerodoc.uri="$(OMERODOC_URI_JOB)"
 endif

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -24,6 +24,13 @@ Type "ant -p" for a list of targets.
     <property name="sphinx.source.branch" value="develop"/>
     <property name="sphinx.source.user" value="openmicroscopy"/>
     <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
+
+    <copy file="conf.py.in" tofile="conf.py" overwrite="true"/>
+    <replace file="conf.py" token="$${sphinx_srcdir}" value="."/>
+    <replace file="conf.py" token="$${sphinx_builddir}" value="."/>
+    <replace file="conf.py" token="$${sphinx_source_branch}" value="${sphinx.source.branch}"/>
+    <replace file="conf.py" token="$${sphinx_source_user}" value="${sphinx.source.user}"/>
+    <replace file="conf.py" token="$${sphinx_omerodoc_uri}" value="${sphinx.omerodoc.uri}"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">
@@ -36,12 +43,6 @@ Type "ant -p" for a list of targets.
         <arg value="release=${sphinx.release}"/>
         <arg value="-D"/>
         <arg value="version=${sphinx.version}"/>
-        <arg value="-D"/>
-        <arg value="source_branch=${sphinx.source.branch}"/>
-        <arg value="-D"/>
-        <arg value="user=${sphinx.source.user}"/>
-        <arg value="-D"/>
-        <arg value="omerodoc_uri=${sphinx.omerodoc.uri}"/>
         <arg value="-b"/>
         <arg value="@{buildtype}"/>
         <arg line="${sphinx.opts}"/>
@@ -133,6 +134,7 @@ Type "ant -p" for a list of targets.
 
   <target name="clean">
     <delete dir="${sphinx.builddir}"/>
+    <delete file="conf.py"/>
   </target>
 
 </project>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -17,31 +17,43 @@ Type "ant -p" for a list of targets.
   <property name="sphinx.opts" value=""/>
   <property name="sphinx.builddir" location="_build"/>
   <property name="latex.opts" value=""/>
-  <property name="source.branch" value="develop"/>
-  <property name="source.user" value="openmicroscopy"/>
-  <property name="omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
 
-  <target name="init"/>
+  <target name="init" depends="release-version">
+    <property name="sphinx.release" value="${release.shortversion}"/>
+    <property name="sphinx.version" value="${release.major}.${release.minor}"/>
+    <property name="source.branch" value="develop"/>
+    <property name="source.user" value="openmicroscopy"/>
+    <property name="omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
+  </target>
 
-  <target name="html" depends="release-version">
-    <exec executable="${sphinx.build}" failonerror="true">
-      <arg value="-D"/>
-      <arg value="release=${release.shortversion}"/>
-      <arg value="-D"/>
-      <arg value="version=${release.major}.${release.minor}"/>
-      <arg value="-D"/>
-      <arg value="source_branch=${source.branch}"/>
-      <arg value="-D"/>
-      <arg value="user=${source.user}"/>
-      <arg value="-D"/>
-      <arg value="omerodoc_uri=${omerodoc.uri}"/>
-      <arg value="-b"/>
-      <arg value="html"/>
-      <arg line="${sphinx.opts}"/>
-      <arg line="${sphinx.warnopts}"/>
-      <arg value="."/>
-      <arg value="${sphinx.builddir}/html"/>
-    </exec>
+  <macrodef name="sphinx" description="Run sphinx-build">
+    <attribute name="buildtype" default="html"/>
+    <attribute name="srcdir" default="."/>
+    <attribute name="destdir" default=""/>
+    <sequential>
+      <exec executable="${sphinx.build}" failonerror="true">
+        <arg value="-D"/>
+        <arg value="release=${release.shortversion}"/>
+        <arg value="-D"/>
+        <arg value="version=${release.major}.${release.minor}"/>
+        <arg value="-D"/>
+        <arg value="source_branch=${source.branch}"/>
+        <arg value="-D"/>
+        <arg value="user=${source.user}"/>
+        <arg value="-D"/>
+        <arg value="omerodoc_uri=${omerodoc.uri}"/>
+        <arg value="-b"/>
+        <arg value="@{buildtype}"/>
+        <arg line="${sphinx.opts}"/>
+        <arg line="${sphinx.warnopts}"/>
+        <arg value="@{srcdir}"/>
+        <arg value="@{destdir}"/>
+      </exec>
+    </sequential>
+  </macrodef>
+
+  <target name="html" depends="init">
+    <sphinx buildtype="html" srcdir="." destdir="${sphinx.builddir}/html"/>
     <delete dir="${artifact.dir}/bio-formats-doc-${release.shortversion}"/>
     <copy todir="${artifact.dir}/bio-formats-doc-${release.shortversion}">
       <!--
@@ -55,24 +67,8 @@ Type "ant -p" for a list of targets.
     <delete dir="${artifact.dir}/bio-formats-doc-${release.shortversion}"/>
   </target>
 
-  <target name="man" depends="release-version">
-    <exec executable="${sphinx.build}" failonerror="true">
-      <arg value="-D"/>
-      <arg value="release=${release.shortversion}"/>
-      <arg value="-D"/>
-      <arg value="version=${release.major}.${release.minor}"/>
-      <arg value="-D"/>
-      <arg value="source_branch=${source.branch}"/>
-      <arg value="-D"/>
-      <arg value="user=${source.user}"/>
-      <arg value="-D"/>
-      <arg value="omerodoc_uri=${omerodoc.uri}"/>
-      <arg value="-b"/>
-      <arg value="man"/>
-      <arg line="${sphinx.opts}"/>
-      <arg value="."/>
-      <arg value="${sphinx.builddir}/man"/>
-    </exec>
+  <target name="man" depends="init">
+    <sphinx buildtype="man" srcdir="." destdir="${sphinx.builddir}/man"/>
   </target>
 
   <macrodef name="xelatex" description="Run XeLaTeX">
@@ -114,25 +110,8 @@ Type "ant -p" for a list of targets.
     </sequential>
   </macrodef>
 
-  <target name="latexpdf" depends="release-version">
-    <exec executable="${sphinx.build}" failonerror="true">
-      <arg value="-D"/>
-      <arg value="release=${release.shortversion}"/>
-      <arg value="-D"/>
-      <arg value="version=${release.major}.${release.minor}"/>
-      <arg value="-D"/>
-      <arg value="source_branch=${source.branch}"/>
-      <arg value="-D"/>
-      <arg value="user=${source.user}"/>
-      <arg value="-D"/>
-      <arg value="omerodoc_uri=${omerodoc.uri}"/>
-      <arg value="-b"/>
-      <arg value="latex"/>
-      <arg line="${sphinx.opts}"/>
-      <arg line="${sphinx.warnopts}"/>
-      <arg value="."/>
-      <arg value="${sphinx.builddir}/latex"/>
-    </exec>
+  <target name="latexpdf" depends="init">
+    <sphinx buildtype="latex" srcdir="." destdir="${sphinx.builddir}/latex"/>
     <copy file="preamble.tex" todir="${sphinx.builddir}/latex"/>
 
     <for param="file">
@@ -148,25 +127,8 @@ Type "ant -p" for a list of targets.
 
   <target name="pdf" depends="latexpdf"/>
 
-  <target name="linkcheck" depends="release-version">
-    <exec executable="${sphinx.build}" failonerror="true">
-      <arg value="-D"/>
-      <arg value="release=${release.shortversion}"/>
-      <arg value="-D"/>
-      <arg value="version=${release.major}.${release.minor}"/>
-      <arg value="-D"/>
-      <arg value="source_branch=${source.branch}"/>
-      <arg value="-D"/>
-      <arg value="user=${source.user}"/>
-      <arg value="-D"/>
-      <arg value="omerodoc_uri=${omerodoc.uri}"/>
-      <arg value="-b"/>
-      <arg value="linkcheck"/>
-      <arg line="${sphinx.opts}"/>
-      <arg line="${sphinx.warnopts}"/>
-      <arg value="."/>
-      <arg value="${sphinx.builddir}/linkcheck"/>
-    </exec>
+  <target name="linkcheck" depends="init">
+    <sphinx buildtype="linkcheck" srcdir="." destdir="${sphinx.builddir}/linkcheck"/>
   </target>
 
   <target name="clean">

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -21,9 +21,9 @@ Type "ant -p" for a list of targets.
   <target name="init" depends="release-version">
     <property name="sphinx.release" value="${release.shortversion}"/>
     <property name="sphinx.version" value="${release.major}.${release.minor}"/>
-    <property name="source.branch" value="develop"/>
-    <property name="source.user" value="openmicroscopy"/>
-    <property name="omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
+    <property name="sphinx.source.branch" value="develop"/>
+    <property name="sphinx.source.user" value="openmicroscopy"/>
+    <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">
@@ -33,15 +33,15 @@ Type "ant -p" for a list of targets.
     <sequential>
       <exec executable="${sphinx.build}" failonerror="true">
         <arg value="-D"/>
-        <arg value="release=${release.shortversion}"/>
+        <arg value="release=${sphinx.release}"/>
         <arg value="-D"/>
-        <arg value="version=${release.major}.${release.minor}"/>
+        <arg value="version=${sphinx.version}"/>
         <arg value="-D"/>
-        <arg value="source_branch=${source.branch}"/>
+        <arg value="source_branch=${sphinx.source.branch}"/>
         <arg value="-D"/>
-        <arg value="user=${source.user}"/>
+        <arg value="user=${sphinx.source.user}"/>
         <arg value="-D"/>
-        <arg value="omerodoc_uri=${omerodoc.uri}"/>
+        <arg value="omerodoc_uri=${sphinx.omerodoc.uri}"/>
         <arg value="-b"/>
         <arg value="@{buildtype}"/>
         <arg line="${sphinx.opts}"/>
@@ -54,17 +54,17 @@ Type "ant -p" for a list of targets.
 
   <target name="html" depends="init">
     <sphinx buildtype="html" srcdir="." destdir="${sphinx.builddir}/html"/>
-    <delete dir="${artifact.dir}/bio-formats-doc-${release.shortversion}"/>
-    <copy todir="${artifact.dir}/bio-formats-doc-${release.shortversion}">
+    <delete dir="${artifact.dir}/bio-formats-doc-${sphinx.release}"/>
+    <copy todir="${artifact.dir}/bio-formats-doc-${sphinx.release}">
       <!--
         include (none) to prevent problems if component.resources-bin is empty
       -->
       <fileset dir="_build/html"/>
     </copy>
-    <zip destfile="${artifact.dir}/bio-formats-doc-${release.shortversion}.zip">
-      <zipfileset dir="_build/html" includes="**/*" prefix="bio-formats-doc-${release.shortversion}"/>
+    <zip destfile="${artifact.dir}/bio-formats-doc-${sphinx.release}.zip">
+      <zipfileset dir="_build/html" includes="**/*" prefix="bio-formats-doc-${sphinx.release}"/>
     </zip>
-    <delete dir="${artifact.dir}/bio-formats-doc-${release.shortversion}"/>
+    <delete dir="${artifact.dir}/bio-formats-doc-${sphinx.release}"/>
   </target>
 
   <target name="man" depends="init">
@@ -122,7 +122,7 @@ Type "ant -p" for a list of targets.
         <runlatex file="@{file}"/>
       </sequential>
     </for>
-    <copy file="_build/latex/Bio-Formats.pdf" tofile="${artifact.dir}/Bio-Formats-${release.shortversion}.pdf"/>
+    <copy file="_build/latex/Bio-Formats.pdf" tofile="${artifact.dir}/Bio-Formats-${sphinx.release}.pdf"/>
   </target>
 
   <target name="pdf" depends="latexpdf"/>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -26,11 +26,11 @@ Type "ant -p" for a list of targets.
     <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
 
     <copy file="conf.py.in" tofile="conf.py" overwrite="true"/>
-    <replace file="conf.py" token="$${sphinx_srcdir}" value="."/>
-    <replace file="conf.py" token="$${sphinx_builddir}" value="."/>
-    <replace file="conf.py" token="$${sphinx_source_branch}" value="${sphinx.source.branch}"/>
-    <replace file="conf.py" token="$${sphinx_source_user}" value="${sphinx.source.user}"/>
-    <replace file="conf.py" token="$${sphinx_omerodoc_uri}" value="${sphinx.omerodoc.uri}"/>
+    <replace file="conf.py" token="@sphinx_srcdir@" value="."/>
+    <replace file="conf.py" token="@sphinx_builddir@" value="."/>
+    <replace file="conf.py" token="@sphinx_source_branch@" value="${sphinx.source.branch}"/>
+    <replace file="conf.py" token="@sphinx_source_user@" value="${sphinx.source.user}"/>
+    <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -93,7 +93,6 @@ Type "ant -p" for a list of targets.
       <basename property="file.basename" file="@{file}"/>
       <dirname property="file.dirname" file="@{file}"/>
       <propertyregex property="file.index" input="${file.basename}" regexp="(.*)\.tex" select="\1.idx"/>
-      <echo message="BN: ${file.basename}  IN: ${file.index}"/>
       <exec executable="makeindex" failonerror="true" dir="${file.dirname}">
         <arg value="-s"/>
         <arg value="python.ist"/>
@@ -134,6 +133,7 @@ Type "ant -p" for a list of targets.
       <arg value="."/>
       <arg value="${sphinx.builddir}/latex"/>
     </exec>
+    <copy file="preamble.tex" todir="${sphinx.builddir}/latex"/>
 
     <for param="file">
       <path>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -9,6 +9,7 @@ Type "ant -p" for a list of targets.
 <project name="sphinx" default="html" basedir=".">
   <description>Build file for sphinx documentation</description>
   <property name="root.dir" location="../.."/>
+  <import file="${root.dir}/ant/version.xml"/>
   <import file="${root.dir}/ant/global.xml"/>
 
   <property name="sphinx.build" value="sphinx-build"/>
@@ -16,22 +17,24 @@ Type "ant -p" for a list of targets.
   <property name="sphinx.opts" value=""/>
   <property name="sphinx.builddir" location="_build"/>
   <property name="latex.opts" value=""/>
-  <property name="source.branch" value=""/>
+  <property name="source.branch" value="develop"/>
   <property name="source.user" value="openmicroscopy"/>
-  <property name="jenkins.job" value=""/>
-  <property name="jenkins.cpp.job" value=""/>
-  <property name="omerodoc.uri" value=""/>
+  <property name="omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
 
   <target name="init"/>
 
-  <target name="html">
+  <target name="html" depends="release-version">
     <exec executable="${sphinx.build}" failonerror="true">
-      <env key="SOURCE_BRANCH" value="${source.branch}"/>
-      <env key="SOURCE_USER" value="${source.user}"/>
-      <env key="BF_RELEASE" value="${bf.release}"/>
-      <env key="JENKINS_JOB" value="${jenkins.job}"/>
-      <env key="JENKINS_CPP_JOB" value="${jenkins.cpp.job}"/>
-      <env key="OMERODOC_URI" value="${omerodoc.uri}"/>
+      <arg value="-D"/>
+      <arg value="release=${release.shortversion}"/>
+      <arg value="-D"/>
+      <arg value="version=${release.major}.${release.minor}"/>
+      <arg value="-D"/>
+      <arg value="source_branch=${source.branch}"/>
+      <arg value="-D"/>
+      <arg value="user=${source.user}"/>
+      <arg value="-D"/>
+      <arg value="omerodoc_uri=${omerodoc.uri}"/>
       <arg value="-b"/>
       <arg value="html"/>
       <arg line="${sphinx.opts}"/>
@@ -39,16 +42,31 @@ Type "ant -p" for a list of targets.
       <arg value="."/>
       <arg value="${sphinx.builddir}/html"/>
     </exec>
+    <delete dir="${artifact.dir}/bio-formats-doc-${release.shortversion}"/>
+    <copy todir="${artifact.dir}/bio-formats-doc-${release.shortversion}">
+      <!--
+        include (none) to prevent problems if component.resources-bin is empty
+      -->
+      <fileset dir="_build/html"/>
+    </copy>
+    <zip destfile="${artifact.dir}/bio-formats-doc-${release.shortversion}.zip">
+      <zipfileset dir="_build/html" includes="**/*" prefix="bio-formats-doc-${release.shortversion}"/>
+    </zip>
+    <delete dir="${artifact.dir}/bio-formats-doc-${release.shortversion}"/>
   </target>
 
-  <target name="man">
+  <target name="man" depends="release-version">
     <exec executable="${sphinx.build}" failonerror="true">
-      <env key="SOURCE_BRANCH" value="${source.branch}"/>
-      <env key="SOURCE_USER" value="${source.user}"/>
-      <env key="BF_RELEASE" value="${bf.release}"/>
-      <env key="JENKINS_JOB" value="${jenkins.job}"/>
-      <env key="JENKINS_CPP_JOB" value="${jenkins.cpp.job}"/>
-      <env key="OMERODOC_URI" value="${omerodoc.uri}"/>
+      <arg value="-D"/>
+      <arg value="release=${release.shortversion}"/>
+      <arg value="-D"/>
+      <arg value="version=${release.major}.${release.minor}"/>
+      <arg value="-D"/>
+      <arg value="source_branch=${source.branch}"/>
+      <arg value="-D"/>
+      <arg value="user=${source.user}"/>
+      <arg value="-D"/>
+      <arg value="omerodoc_uri=${omerodoc.uri}"/>
       <arg value="-b"/>
       <arg value="man"/>
       <arg line="${sphinx.opts}"/>
@@ -97,14 +115,18 @@ Type "ant -p" for a list of targets.
     </sequential>
   </macrodef>
 
-  <target name="latexpdf">
+  <target name="latexpdf" depends="release-version">
     <exec executable="${sphinx.build}" failonerror="true">
-      <env key="SOURCE_BRANCH" value="${source.branch}"/>
-      <env key="SOURCE_USER" value="${source.user}"/>
-      <env key="BF_RELEASE" value="${bf.release}"/>
-      <env key="JENKINS_JOB" value="${jenkins.job}"/>
-      <env key="JENKINS_CPP_JOB" value="${jenkins.cpp.job}"/>
-      <env key="OMERODOC_URI" value="${omerodoc.uri}"/>
+      <arg value="-D"/>
+      <arg value="release=${release.shortversion}"/>
+      <arg value="-D"/>
+      <arg value="version=${release.major}.${release.minor}"/>
+      <arg value="-D"/>
+      <arg value="source_branch=${source.branch}"/>
+      <arg value="-D"/>
+      <arg value="user=${source.user}"/>
+      <arg value="-D"/>
+      <arg value="omerodoc_uri=${omerodoc.uri}"/>
       <arg value="-b"/>
       <arg value="latex"/>
       <arg line="${sphinx.opts}"/>
@@ -121,18 +143,23 @@ Type "ant -p" for a list of targets.
         <runlatex file="@{file}"/>
       </sequential>
     </for>
+    <copy file="_build/latex/Bio-Formats.pdf" tofile="${artifact.dir}/Bio-Formats-${release.shortversion}.pdf"/>
   </target>
 
   <target name="pdf" depends="latexpdf"/>
 
-  <target name="linkcheck">
+  <target name="linkcheck" depends="release-version">
     <exec executable="${sphinx.build}" failonerror="true">
-      <env key="SOURCE_BRANCH" value="${source.branch}"/>
-      <env key="SOURCE_USER" value="${source.user}"/>
-      <env key="BF_RELEASE" value="${bf.release}"/>
-      <env key="JENKINS_JOB" value="${jenkins.job}"/>
-      <env key="JENKINS_CPP_JOB" value="${jenkins.cpp.job}"/>
-      <env key="OMERODOC_URI" value="${omerodoc.uri}"/>
+      <arg value="-D"/>
+      <arg value="release=${release.shortversion}"/>
+      <arg value="-D"/>
+      <arg value="version=${release.major}.${release.minor}"/>
+      <arg value="-D"/>
+      <arg value="source_branch=${source.branch}"/>
+      <arg value="-D"/>
+      <arg value="user=${source.user}"/>
+      <arg value="-D"/>
+      <arg value="omerodoc_uri=${omerodoc.uri}"/>
       <arg value="-b"/>
       <arg value="linkcheck"/>
       <arg line="${sphinx.opts}"/>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -37,6 +37,8 @@ Type "ant -p" for a list of targets.
     <attribute name="buildtype" default="html"/>
     <attribute name="srcdir" default="."/>
     <attribute name="destdir" default=""/>
+    <attribute name="opts" default=""/>
+    <attribute name="warnopts" default=""/>
     <sequential>
       <exec executable="${sphinx.build}" failonerror="true">
         <arg value="-D"/>
@@ -45,8 +47,8 @@ Type "ant -p" for a list of targets.
         <arg value="version=${sphinx.version}"/>
         <arg value="-b"/>
         <arg value="@{buildtype}"/>
-        <arg line="${sphinx.opts}"/>
-        <arg line="${sphinx.warnopts}"/>
+        <arg line="@{opts}"/>
+        <arg line="@{warnopts}"/>
         <arg value="@{srcdir}"/>
         <arg value="@{destdir}"/>
       </exec>
@@ -54,7 +56,11 @@ Type "ant -p" for a list of targets.
   </macrodef>
 
   <target name="html" depends="init">
-    <sphinx buildtype="html" srcdir="." destdir="${sphinx.builddir}/html"/>
+    <sphinx buildtype="html"
+            srcdir="."
+            destdir="${sphinx.builddir}/html"
+            opts="${sphinx.opts}"
+            warnopts="${sphinx.warnopts}"/>
     <delete dir="${artifact.dir}/bio-formats-doc-${sphinx.release}"/>
     <copy todir="${artifact.dir}/bio-formats-doc-${sphinx.release}">
       <!--
@@ -69,7 +75,10 @@ Type "ant -p" for a list of targets.
   </target>
 
   <target name="man" depends="init">
-    <sphinx buildtype="man" srcdir="." destdir="${sphinx.builddir}/man"/>
+    <sphinx buildtype="man"
+            srcdir="."
+            destdir="${sphinx.builddir}/man"
+            opts="${sphinx.opts}"/>
   </target>
 
   <macrodef name="xelatex" description="Run XeLaTeX">
@@ -112,7 +121,11 @@ Type "ant -p" for a list of targets.
   </macrodef>
 
   <target name="latexpdf" depends="init">
-    <sphinx buildtype="latex" srcdir="." destdir="${sphinx.builddir}/latex"/>
+    <sphinx buildtype="latex"
+            srcdir="."
+            destdir="${sphinx.builddir}/latex"
+            opts="${sphinx.opts}"
+            warnopts="${sphinx.warnopts}"/>
     <copy file="preamble.tex" todir="${sphinx.builddir}/latex"/>
 
     <for param="file">
@@ -129,7 +142,10 @@ Type "ant -p" for a list of targets.
   <target name="pdf" depends="latexpdf"/>
 
   <target name="linkcheck" depends="init">
-    <sphinx buildtype="linkcheck" srcdir="." destdir="${sphinx.builddir}/linkcheck"/>
+    <sphinx buildtype="linkcheck" srcdir="."
+            destdir="${sphinx.builddir}/linkcheck"
+            opts="${sphinx.opts}"
+            warnopts="${sphinx.warnopts}"/>
   </target>
 
   <target name="clean">

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -17,16 +17,6 @@ import re
 import subprocess
 from datetime import datetime
 
-def popen(args, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
-        copy = os.environ.copy()
-        shell = (sys.platform == "win32")
-        return subprocess.Popen(args,
-                env=copy,
-                stdin=stdin,
-                stdout=stdout,
-                stderr=stderr,
-                shell=shell)
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -67,23 +57,10 @@ copyright = u'2000-%d, %s ' % (now.year, author)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
-# built documents.
+# built documents.  Set on command-line or via ant build to real version.
 #
-try:
-    if "BF_RELEASE" in os.environ and len(os.environ.get('BF_RELEASE')) > 0:
-        release = os.environ.get('BF_RELEASE')
-    else:
-        p = popen(['git','describe'])
-        tag = p.communicate()
-        split_tag = re.split("^(v)?(.*?)(-[0-9]+)?((-)g(.*?))?$",tag[0])
-        # The full version, including alpha/beta/rc tags.
-        release = split_tag[2]
-    split_release =  re.split("^([0-9]\.[0-9])(\.[0-9]+)(.*?)$",release)
-    # The short X.Y version.
-    version = split_release[1]
-except:
-    version = 'UNKNOWN'
-    release = 'UNKNOWN'
+version = 'UNKNOWN'
+release = 'UNKNOWN'
 
 rst_prolog = """
 .. note:: **This documentation is for the new Bio-Formats 5.1 version.**
@@ -128,15 +105,8 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 # Variables used to define Github extlinks
-if "SOURCE_BRANCH" in os.environ and len(os.environ.get('SOURCE_BRANCH')) > 0:
-    source_branch = os.environ.get('SOURCE_BRANCH')
-else:
-    source_branch = 'develop'
-
-if "SOURCE_USER" in os.environ and len(os.environ.get('SOURCE_USER')) > 0:
-    user = os.environ.get('SOURCE_USER')
-else:
-    user = 'openmicroscopy'
+source_branch = 'develop'
+user = 'openmicroscopy'
 
 github_root = 'https://github.com/'
 bf_github_root = github_root + user + '/bioformats/'
@@ -157,10 +127,7 @@ oo_root = 'http://www.openmicroscopy.org'
 oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
-if "OMERODOC_URI" in os.environ and len(os.environ.get('OMERODOC_URI')) > 0:
-    omerodoc_uri = os.environ.get('OMERODOC_URI')
-else:
-    omerodoc_uri = oo_site_root + '/support/omero5.1'
+omerodoc_uri = oo_site_root + '/support/omero5.1'
 
 extlinks = {
     # Trac links
@@ -323,7 +290,7 @@ latex_elements = {
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
-target = project + '-' + release + '.tex'
+target = project + '.tex'
 latex_documents = [
   (master_doc, target, title, author, 'manual'),
 ]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -284,7 +284,7 @@ latex_elements = {
 \\addcontentsline{toc}{part}{\indexname}
 \\printindex''',
     'preamble': '''
-\input{../../preamble.tex}
+\input{preamble.tex}
 ''',
 }
 

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -12,11 +12,11 @@
 # serve to show the default.
 
 # Substitutions from external build system.
-srcdir = '${sphinx_srcdir}'
-builddir = '${sphinx_builddir}'
-ext_source_branch = '${sphinx_source_branch}'
-ext_source_user = '${sphinx_source_user}'
-ext_omerodoc_uri = '${sphinx_omerodoc_uri}'
+srcdir = '@sphinx_srcdir@'
+builddir = '@sphinx_builddir@'
+ext_source_branch = '@sphinx_source_branch@'
+ext_source_user = '@sphinx_source_user@'
+ext_omerodoc_uri = '@sphinx_omerodoc_uri@'
 
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
@@ -115,11 +115,11 @@ pygments_style = 'sphinx'
 # Variables used to define Github extlinks
 source_branch = 'develop'
 if (ext_source_branch is not None and len(ext_source_branch) > 0 and
-    ext_source_branch != "${%s}" % ('sphinx_source_branch')):
+    ext_source_branch != "@%s@" % ('sphinx_source_branch')):
     source_branch = ext_source_branch
 source_user = 'openmicroscopy'
 if (ext_source_user is not None and len(ext_source_user) > 0 and
-    ext_source_user != "${%s}" % ('sphinx_source_user}')):
+    ext_source_user != "@%s@" % ('sphinx_source_user}')):
     source_user = ext_source_user
 
 github_root = 'https://github.com/'
@@ -143,7 +143,7 @@ lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
 omerodoc_uri = oo_site_root + '/support/omero5.1'
 if (ext_omerodoc_uri is not None and len(ext_omerodoc_uri) > 0 and
-    ext_omerodoc_uri != "${%s}" % ('sphinx_omerodoc_uri}')):
+    ext_omerodoc_uri != "@%s@" % ('sphinx_omerodoc_uri}')):
     omerodoc_uri = ext_omerodoc_uri
 
 extlinks = {

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -115,11 +115,11 @@ pygments_style = 'sphinx'
 # Variables used to define Github extlinks
 source_branch = 'develop'
 if (ext_source_branch is not None and len(ext_source_branch) > 0 and
-    ext_source_branch != '${sphinx_source_branch}'):
+    ext_source_branch != "${%s}" % ('sphinx_source_branch')):
     source_branch = ext_source_branch
 user = 'openmicroscopy'
 if (ext_source_user is not None and len(ext_source_user) > 0 and
-    ext_source_user != '${sphinx_source_user}'):
+    ext_source_user != "${%s}" % ('sphinx_source_user}')):
     source_user = ext_source_user
 
 github_root = 'https://github.com/'
@@ -143,7 +143,7 @@ lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
 omerodoc_uri = oo_site_root + '/support/omero5.1'
 if (ext_omerodoc_uri is not None and len(ext_omerodoc_uri) > 0 and
-    ext_omerodoc_uri != '${sphinx_omerodoc_uri}'):
+    ext_omerodoc_uri != "${%s}" % ('sphinx_omerodoc_uri}')):
     omerodoc_uri = ext_omerodoc_uri
 
 extlinks = {

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -90,7 +90,7 @@ rst_prolog = """
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'CMakeLists.txt']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -117,13 +117,13 @@ source_branch = 'develop'
 if (ext_source_branch is not None and len(ext_source_branch) > 0 and
     ext_source_branch != "${%s}" % ('sphinx_source_branch')):
     source_branch = ext_source_branch
-user = 'openmicroscopy'
+source_user = 'openmicroscopy'
 if (ext_source_user is not None and len(ext_source_user) > 0 and
     ext_source_user != "${%s}" % ('sphinx_source_user}')):
     source_user = ext_source_user
 
 github_root = 'https://github.com/'
-bf_github_root = github_root + user + '/bioformats/'
+bf_github_root = github_root + source_user + '/bioformats/'
 bf_github_tree = bf_github_root + 'tree/' + source_branch + '/'
 bf_github_blob = bf_github_root + 'blob/' + source_branch + '/'
 gpl_formats = bf_github_blob + 'components/formats-gpl/src/loci/formats/'

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -11,11 +11,19 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+# Substitutions from external build system.
+srcdir = '${sphinx_srcdir}'
+builddir = '${sphinx_builddir}'
+ext_source_branch = '${sphinx_source_branch}'
+ext_source_user = '${sphinx_source_user}'
+ext_omerodoc_uri = '${sphinx_omerodoc_uri}'
+
 import sys, os
-sys.path.insert(0, os.path.abspath('../sphinx/_ext'))
+sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
 import re
 import subprocess
 from datetime import datetime
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -37,7 +45,7 @@ edit_on_github_branch = 'develop'
 edit_on_github_prefix = 'docs/sphinx'
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['../sphinx/_templates']
+templates_path = [os.path.join(srcdir, '_templates')]
 
 # The suffix of source filenames.
 source_suffix = '.txt'
@@ -106,7 +114,13 @@ pygments_style = 'sphinx'
 
 # Variables used to define Github extlinks
 source_branch = 'develop'
+if (ext_source_branch is not None and len(ext_source_branch) > 0 and
+    ext_source_branch != '${sphinx_source_branch}'):
+    source_branch = ext_source_branch
 user = 'openmicroscopy'
+if (ext_source_user is not None and len(ext_source_user) > 0 and
+    ext_source_user != '${sphinx_source_user}'):
+    source_user = ext_source_user
 
 github_root = 'https://github.com/'
 bf_github_root = github_root + user + '/bioformats/'
@@ -128,6 +142,9 @@ oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
 omerodoc_uri = oo_site_root + '/support/omero5.1'
+if (ext_omerodoc_uri is not None and len(ext_omerodoc_uri) > 0 and
+    ext_omerodoc_uri != '${sphinx_omerodoc_uri}'):
+    omerodoc_uri = ext_omerodoc_uri
 
 extlinks = {
     # Trac links
@@ -297,7 +314,7 @@ latex_documents = [
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-latex_logo = "images/bio-formats-logo.pdf"
+latex_logo = os.path.join(srcdir, 'images/bio-formats-logo.pdf')
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -705,6 +705,12 @@ extra-warnings=(ON|OFF)
 fatal-warnings=(ON|OFF)
   Make compiler warnings into fatal errors.  This is disabled by
   default.
+sphinx=(ON|OFF)
+  Build manual pages and HTML documentation with Sphinx.  Enabled by
+  default if Sphinx is autodetected.
+sphinx-pdf=(ON|OFF)
+  Build PDF documentation with Sphinx.  Enabled by default if Sphinx
+  and XeLaTeX are autodetected.
 test=(ON|OFF)
   Enable unit tests.  Tests are enabled by default.
 


### PR DESCRIPTION
- Allow external configuration of build without environment variables
- Pass release and version numbers with `sphinx-build -D`
- Set nonstandard variables by substitution from `conf.py.in` template
- Versions are obtained from ant's `version.xml` so match the rest of the build, but are overridable using the `sphinx.release` and `sphinx.version` ant properties
- CMake build generates `doc-html` and `doc-pdf` targets if `sphinx-build` and `xelatex` are available, configurable via the `sphinx` and `sphinx-pdf` options (documentation added).  Also adds `doc-linkcheck`
- CMake will install the build documentation into `$CMAKE_INSTALL_PREFIX/share/doc/bioformats` (`manual` subdirectory for the sphinx manual; `cpp-api` for the doxygen API reference)

--no-rebase

--------

Testing: Jobs should remain green

In `docs/sphinx`
- ant html
- ant pdf
- ant clean
- equivalent `make` targets
- you can set the various ant `sphinx.*` properties to check they override (or use the make vars which set them for you)

With CMake:
```
mkdir /tmp/builddir
cd /tmp/builddir
cmake /path/to/bioformats
make man
make doc-html
make doc-pdf
make doc-linkcheck
make
make DESTDIR=/tmp/instdir install
- look in `/tmp/instdir/usr/share/doc/bioformats`; should contain `manual` dir with Sphinx HTML/PDF and `cpp-api` dir with Doxygen API reference.
```

The CMake build only overrides release and version using the git/release version; the other properties are defaulted.  This is because this build is only intended for building by end users for installation, not for building for the website.  It's not expected that any properties here should be overridden.