### PR TITLE
Metamorph: parse lens numerical aperture

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -9,15 +9,15 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
+ * published by the Free Software Foundation, either version 2 of the 
  * License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
+ * 
+ * You should have received a copy of the GNU General Public 
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%

--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -9,15 +9,15 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the 
+ * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public 
+ *
+ * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
@@ -55,6 +55,7 @@ public class MetamorphHandler extends BaseHandler {
   private Vector<Double> zPositions;
   private double pixelSizeX, pixelSizeY;
   private double temperature;
+  private double lensNA;
   private String binning;
   private double readOutRate, zoom;
   private Length positionX, positionY;
@@ -111,6 +112,8 @@ public class MetamorphHandler extends BaseHandler {
   public Length getStagePositionX() { return positionX; }
 
   public Length getStagePositionY() { return positionY; }
+
+  public double getLensNA() { return lensNA; }
 
   public Vector<Double> getExposures() { return exposures; }
 
@@ -255,6 +258,9 @@ public class MetamorphHandler extends BaseHandler {
         gain = new Double(value.replaceAll("[xX]", ""));
       }
       catch (NumberFormatException e) { }
+    }
+    else if (key.equals("_MagNA_")) {
+      lensNA = Double.parseDouble(value);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -9,15 +9,15 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
+ * published by the Free Software Foundation, either version 2 of the 
  * License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
+ * 
+ * You should have received a copy of the GNU General Public 
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -762,9 +762,12 @@ public class MetamorphReader extends BaseTiffReader {
         store.setPixelsPhysicalSizeZ(physicalSizeZ, i);
       }
 
+      String objectiveID = MetadataTools.createLSID("Objective", i, 0);
+      store.setObjectiveID(objectiveID, i, 0);
       if (handler.getLensNA() != 0) {
-          store.setObjectiveLensNA(handler.getLensNA(), 0, 0);
+          store.setObjectiveLensNA(handler.getLensNA(), i, 0);
       }
+      store.setObjectiveSettingsID(objectiveID, i);
 
       int waveIndex = 0;
       for (int c=0; c<getEffectiveSizeC(); c++) {

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -9,15 +9,15 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the 
+ * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public 
+ *
+ * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
@@ -760,6 +760,10 @@ public class MetamorphReader extends BaseTiffReader {
       Length physicalSizeZ = FormatTools.getPhysicalSizeZ(stepSize);
       if (physicalSizeZ != null) {
         store.setPixelsPhysicalSizeZ(physicalSizeZ, i);
+      }
+
+      if (handler.getLensNA() != 0) {
+          store.setObjectiveLensNA(handler.getLensNA(), 0, 0);
       }
 
       int waveIndex = 0;


### PR DESCRIPTION
See https://trac.openmicroscopy.org.uk/ome/ticket/12409

If the lens NA is filled in the metadata, this commit also  adds it to the OME-XML metadata store.

--no-rebase