### PR TITLE
Fix testRequiredDirectories with Windows paths

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -451,13 +451,6 @@ public class FilePattern {
     }
     sb.append(q > 0 ? name.substring(endList[q - 1]) : name);
 
-    for (int i=0; i<sb.length(); i++) {
-      if (sb.charAt(i) == '\\') {
-        sb.insert(i, '\\');
-        i++;
-      }
-    }
-
     return sb.toString();
   }
 

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -1579,6 +1579,9 @@ public class FV1000Reader extends FormatReader {
   private String sanitizeFile(String file, String path) {
     String f = sanitizeValue(file);
     if (path.equals("")) return f;
+    if (path.endsWith(File.separator)) {
+      return path + f;
+    }
     return path + File.separator + f;
   }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1417,6 +1417,11 @@ public class FormatReaderTest {
       String newFile = null;
       for (int i=0; i<usedFiles.length; i++) {
         newFiles[i] = usedFiles[i].replaceAll(toRemove.toString(), "");
+        // sanitize file separators on Windows
+        // a forward-slash should work just as well as a backslash, so we
+        // use that for the mapped file name to avoid problems with creating
+        // a FilePattern that contains multiple files
+        newFiles[i] = newFiles[i].replace('\\', '/');
         LOGGER.debug("mapping {} to {}", newFiles[i], usedFiles[i]);
         Location.mapId(newFiles[i], usedFiles[i]);
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1417,11 +1417,6 @@ public class FormatReaderTest {
       String newFile = null;
       for (int i=0; i<usedFiles.length; i++) {
         newFiles[i] = usedFiles[i].replaceAll(toRemove.toString(), "");
-        // sanitize file separators on Windows
-        // a forward-slash should work just as well as a backslash, so we
-        // use that for the mapped file name to avoid problems with creating
-        // a FilePattern that contains multiple files
-        newFiles[i] = newFiles[i].replace('\\', '/');
         LOGGER.debug("mapping {} to {}", newFiles[i], usedFiles[i]);
         Location.mapId(newFiles[i], usedFiles[i]);
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1390,7 +1390,7 @@ public class FormatReaderTest {
 
       // find the common parent
 
-      String commonParent = new Location(usedFiles[0]).getParent();
+      String commonParent = new Location(usedFiles[0]).getAbsoluteFile().getParent();
       for (int i=1; i<usedFiles.length; i++) {
         while (!usedFiles[i].startsWith(commonParent)) {
           commonParent = commonParent.substring(0, commonParent.lastIndexOf(File.separator));
@@ -1408,7 +1408,7 @@ public class FormatReaderTest {
       for (int i=0; i<f.length - directories - 1; i++) {
         toRemove.append(f[i]);
         if (i < f.length - directories - 2) {
-          toRemove.append(File.separator);
+          toRemove.append(split);
         }
       }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1365,6 +1365,7 @@ public class FormatReaderTest {
     }
     String testName = "testRequiredDirectories";
     String file = reader.getCurrentFile();
+    LOGGER.debug("testRequiredDirectories({})", file);
     int directories = -1;
 
     try {
@@ -1373,6 +1374,8 @@ public class FormatReaderTest {
     catch (Exception e) {
       LOGGER.warn("Could not retrieve directory count", e);
     }
+
+    LOGGER.debug("directories = {}", directories);
 
     if (directories < 0) {
       result(testName, false, "Invalid directory count (" + directories + ")");
@@ -1394,9 +1397,12 @@ public class FormatReaderTest {
         }
       }
 
+      LOGGER.debug("commonParent = {}", commonParent);
+
       // remove extra directories
 
       String split = File.separatorChar == '\\' ? "\\\\" : File.separator;
+      LOGGER.debug("split = {}", split);
       String[] f = commonParent.split(split);
       StringBuilder toRemove = new StringBuilder();
       for (int i=0; i<f.length - directories - 1; i++) {
@@ -1411,6 +1417,7 @@ public class FormatReaderTest {
       String newFile = null;
       for (int i=0; i<usedFiles.length; i++) {
         newFiles[i] = usedFiles[i].replaceAll(toRemove.toString(), "");
+        LOGGER.debug("mapping {} to {}", newFiles[i], usedFiles[i]);
         Location.mapId(newFiles[i], usedFiles[i]);
 
         if (usedFiles[i].equals(file)) {
@@ -1420,6 +1427,8 @@ public class FormatReaderTest {
       if (newFile == null) {
         newFile = newFiles[0];
       }
+
+      LOGGER.debug("newFile = {}", newFile);
 
       IFormatReader check = new FileStitcher();
       try {


### PR DESCRIPTION
Right now, this just adds debug logging to ```testRequiredDirectories```.  I will update this PR with a fix for the test once https://ci.openmicroscopy.org/view/Experimental/job/BIOFORMATS-5.1-merge-test_images_good-win/ has run with the new logging.

All but one of the failures noted in https://ci.openmicroscopy.org/view/Experimental/job/BIOFORMATS-5.1-merge-test_images_good-win/4/ are a result of ```testRequiredDirectories``` failing without logging an exception or failure message; hopefully the additional logging will shed some light as to why.  I suspect that having the mount point be ```\\squig...``` instead of a letter drive may have something to do with it, as the same test works locally.

/cc @sbesson 