### PR TITLE
EPS: consistently detect vector data

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -268,7 +268,7 @@ public class EPSReader extends FormatReader {
           try {
             int newX = Integer.parseInt(t[0]);
             int newY = Integer.parseInt(t[1]);
-            if (newX >= m.sizeX && newY >= m.sizeY) {
+            if (t.length > 2 && Integer.parseInt(t[2]) >= 8) {
               m.sizeX = newX;
               m.sizeY = newY;
               start = lineNum;


### PR DESCRIPTION
This doesn't add support for vector data, but does a better job of
setting the dimensions and throwing a consistent exception during
openBytes.

See https://trac.openmicroscopy.org/ome/ticket/11352 and https://trac.openmicroscopy.org/ome/ticket/11353.  The file for each ticket (QA 7556 and QA 7558, respectively) should now throw a FormatException when reading the image data that indicates that vector data is not supported, instead of the NFE/NPE reported previously.