### PR TITLE
FileStitcher: fix file indexing for RGB images

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1093,7 +1093,7 @@ public class FileStitcher extends ReaderWrapper {
     lenC[sno] = new int[numC + 1];
     lenT[sno] = new int[numT + 1];
     lenZ[sno][0] = sizeZ[sno];
-    lenC[sno][0] = sizeC[sno];
+    lenC[sno][0] = sizeC[sno] / reader.getRGBChannelCount();
     lenT[sno][0] = sizeT[sno];
 
     for (int i=0, z=1, c=1, t=1; i<count.length; i++) {
@@ -1118,10 +1118,7 @@ public class FileStitcher extends ReaderWrapper {
       }
     }
     ms.imageCount = ms.sizeZ * ms.sizeT;
-    if (!isRGB()) {
-      ms.imageCount *= ms.sizeC;
-    }
-    else ms.imageCount *= reader.getEffectiveSizeC();
+    ms.imageCount *= (ms.sizeC / reader.getRGBChannelCount());
 
     ms.moduloC = reader.getModuloC();
     ms.moduloZ = reader.getModuloZ();


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/11095.

```showinf -stitch Series001_t0_z0_ch00.tif``` or opening in ImageJ with ```Group files with similar names``` checked using QA 7328 should now work correctly.  There are 9 files (3 Z sections x 3 channels), each of which contains a single RGB image, so with stitching/grouping enabled there should be 9 planes.  Without this change, all 9 planes would have been cyan (only the files corresponding to the first channel were used); with this change, there should be 3 distinct channels (cyan, red, and green).