### PR TITLE
Imaris HDF: fix SizeC if channels are stored in reverse order

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -550,7 +550,8 @@ public class ImarisHDFReader extends FormatReader {
         int underscore = attr.indexOf("_") + 1;
         int cIndex = Integer.parseInt(attr.substring(underscore,
           attr.indexOf("/", underscore)));
-        if (cIndex == getSizeC()) ms0.sizeC++;
+
+        while (cIndex >= getSizeC()) ms0.sizeC++;
 
         if (name.equals("Gain")) gain.add(value);
         else if (name.equals("LSMEmissionWavelength")) emWave.add(value);


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12170.  Without this change, the file from QA 8019 had 3 Z sections and 1 channel.  With this change, the same file should have 3 Z sections and 3 channels when opened in ImageJ or imported into OMERO.  Note that all planes are fairly dark, so you may need to adjust rendering settings/brightness to see the artifact in the images.