### PR TITLE
Zeiss CZI: ignore null FilterSet references

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -907,7 +907,9 @@ public class ZeissCZIReader extends FormatReader {
         if (c < channels.size()) {
           store.setChannelName(channels.get(c).name, i, c);
           store.setChannelFluor(channels.get(c).fluor, i, c);
-          store.setChannelFilterSetRef(channels.get(c).filterSetRef, i, c);
+          if (channels.get(c).filterSetRef != null) {
+            store.setChannelFilterSetRef(channels.get(c).filterSetRef, i, c);
+          }
 
           String color = channels.get(c).color;
           if (color != null) {


### PR DESCRIPTION
This should prevent warnings similar to ```ome.xml.model.Channel@579e8e6e reference to null missing from object hierarchy.``` when working with some .czi files.  See https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7669.

To test, use the file from QA 10974.  Verify that ```showinf -nopix -omexml``` shows the above warning without this change; with this change, the warning should not be present.