### PR TITLE
Show full TIFF PageNumber information

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -266,7 +266,7 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     }
     put("ResolutionUnit", resUnit);
 
-    putInt("PageNumber", firstIFD, IFD.PAGE_NUMBER);
+    putString("PageNumber", firstIFD, IFD.PAGE_NUMBER);
     putInt("TransferFunction", firstIFD, IFD.TRANSFER_FUNCTION);
 
     int predict = firstIFD.getIFDIntValue(IFD.PREDICTOR);
@@ -531,6 +531,15 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
 
   protected void putInt(String key, IFD ifd, int tag) {
     put(key, ifd.getIFDIntValue(tag));
+  }
+
+  protected void putString(String key, IFD ifd, int tag) {
+    String value = "";
+    try {
+      value = ifd.getIFDStringValue(tag);
+    } catch (FormatException e) {
+    }
+    put(key, value);
   }
 
   // -- Internal FormatReader API methods --

--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -264,8 +264,20 @@ public class IFD extends HashMap<Integer, Object> {
       }
       else {
         try {
-          value = Array.get(value, 0);
-          if (checkClass.isInstance(value)) return value;
+          if (checkClass.equals(String.class)) {
+            StringBuilder sb = new StringBuilder();
+            int l = Array.getLength(value);
+            for (int i = 0; i < l; i++) {
+              sb.append(Array.get(value, i));
+              if (i < l - 1)
+                sb.append(" ");
+            }
+            return sb.toString();
+          } else {
+            value = Array.get(value, 0);
+            if (checkClass.isInstance(value))
+              return value;
+          }
         }
         catch (IllegalArgumentException exc) { }
         catch (ArrayIndexOutOfBoundsException exc) {


### PR DESCRIPTION
Fixes [Ticket 12801](https://trac.openmicroscopy.org/ome/ticket/12801)

Test: Use the image mentioned in the ticket/mail; display the metadata with `./showinf -omexml bBB01-1D_wL08_s3_z1_t1_cCy5_u001.tif`. Check that the PageNumber is shown as `0 1`.
