### PR TITLE
ND2: fix indexing of plane positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1887,10 +1887,10 @@ public class NativeND2Reader extends FormatReader {
 
       String pos = "for position";
       for (int n=0; n<getImageCount(); n++) {
-        int index = i * getImageCount() + n;
+        int index = n * getSeriesCount() + i;
         if (split) {
           int planes = getImageCount() / getSizeC();
-          index = i * planes + (n % planes);
+          index = (n / getSizeC()) * getSeriesCount() + i;
         }
         if (posX != null) {
           if (index >= posX.size()) index = i;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12569.

To test, check the PositionX and PositionY values from ```showinf -nopix -omexml``` with the file from QA 9529.  These should match the values in the ```Experiment Data``` tab of the ```Image Properties``` window in NIS Elements.