### PR TITLE
Preserve the pixel type for floating-point thumbnails

### DIFF
--- a/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
@@ -1768,7 +1768,8 @@ public final class AWTImageTools {
     ColorModel sourceModel = source.getColorModel();
     if ((sourceModel instanceof Index16ColorModel) ||
       (sourceModel instanceof IndexColorModel) ||
-      (sourceModel instanceof SignedColorModel))
+      (sourceModel instanceof SignedColorModel) ||
+      FormatTools.isFloatingPoint(pixelType))
     {
       DataBuffer buffer = source.getData().getDataBuffer();
       WritableRaster raster = Raster.createWritableRaster(


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/6833.

To test, run:

```
showinf -normalize test_images_good/khoros/head.xv
showinf -normalize -thumbs test_images_good/khoros/head.xv
```

and verify that both produce an image with no exception, and that the latter is a reasonable-looking thumbnail of the former.