### PR TITLE
Zeiss CZI: fix series count for fused images

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -645,9 +645,26 @@ public class ZeissCZIReader extends FormatReader {
       seriesCount == (planes.size() / getImageCount()) &&
       prestitched != null && prestitched)
     {
-      prestitched = false;
-      ms0.sizeX = planes.get(planes.size() - 1).x;
-      ms0.sizeY = planes.get(planes.size() - 1).y;
+      boolean equalTiles = true;
+      for (SubBlock plane : planes) {
+        if (plane.x != planes.get(0).x || plane.y != planes.get(0).y) {
+          equalTiles = false;
+          break;
+        }
+      }
+      if (getSizeX() > planes.get(0).x && !equalTiles) {
+        // image was fused; treat the mosaics as a single image
+        seriesCount = 1;
+        positions = 1;
+        acquisitions = 1;
+        mosaics = 1;
+        angles = 1;
+      }
+      else {
+        prestitched = false;
+        ms0.sizeX = planes.get(planes.size() - 1).x;
+        ms0.sizeY = planes.get(planes.size() - 1).y;
+      }
     }
 
     if (ms0.imageCount * seriesCount > planes.size() * scanDim &&


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12789.

To test, use the two files referenced in the ticket (both have been uploaded to ```zeiss-czi/sebastian/fused```).  The ```*_fused.czi``` file would have shown 6 series of strange images without this change; with this change, there should be a single large image that more or less matches what is shown in Zen.  The behavior when opening the ```*_stitched.czi``` file should be unchanged.