### PR TITLE
Bf importer performance

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -493,7 +493,17 @@ public class ImportProcess implements StatusReporter {
     BF.status(options.isQuiet(), "Analyzing " + getIdName());
     baseReader.setMetadataFiltered(true);
     baseReader.setGroupFiles(!options.isUngroupFiles());
+    if(options != null && !options.showROIs()){
+        MetadataOptions mo = baseReader.getMetadataOptions();
+        if(mo == null){
+            mo = new DefaultMetadataOptions();
+        }else{
+            mo.setMetadataLevel(MetadataLevel.NO_OVERLAYS);
+        }
+        baseReader.setMetadataOptions(mo);
+    }
     baseReader.setId(options.getId());
+    
   }
 
   /** Performed following ImportStep.STACK notification. */

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -55,6 +55,9 @@ import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.MinMaxCalculator;
 import loci.formats.TileStitcher;
+import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.MetadataLevel;
+import loci.formats.in.MetadataOptions;
 import loci.formats.meta.IMetadata;
 import loci.formats.services.OMEXMLService;
 import loci.plugins.BF;
@@ -530,6 +533,15 @@ public class ImportProcess implements StatusReporter {
     }
     r = virtualReader = new VirtualReader(r);
     reader = new ImageProcessorReader(r);
+    if(options != null && !options.showROIs()){
+        MetadataOptions mo = reader.getMetadataOptions();
+        if(mo == null){
+            mo = new DefaultMetadataOptions();
+        }else{
+            mo.setMetadataLevel(MetadataLevel.NO_OVERLAYS);
+        }
+        reader.setMetadataOptions(mo);
+    }
     setId();
 
     computeSeriesLabels(reader);

--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -304,7 +304,7 @@ public class CellH5Reader extends FormatReader {
     // Series. This is why they only will be loaded if the CellH5 contains two
     // image / series assuming that the first is the image and 2nd the labels
     if (seriesCount <= 2 &&
-      getMetadataOptions().getMetadataLevel() == MetadataLevel.ALL)
+      getMetadataOptions().getMetadataLevel() != MetadataLevel.NO_OVERLAYS)
     {
         parseROIs(0);
     }

--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -304,7 +304,7 @@ public class CellH5Reader extends FormatReader {
     // Series. This is why they only will be loaded if the CellH5 contains two
     // image / series assuming that the first is the image and 2nd the labels
     if (seriesCount <= 2 &&
-      getMetadataOptions().getMetadataLevel() != MetadataLevel.NO_OVERLAYS)
+      getMetadataOptions().getMetadataLevel() == MetadataLevel.ALL)
     {
         parseROIs(0);
     }


### PR DESCRIPTION
Testing instructions : 

1) Download and update the Bioformats_Package.jar in your ImageJ plugin's folder.
2) Import without ROI's : Import the following image using the Bioformats_Importer: data_repo/from_skyking/cellh5/samples
with the following checkboxes selected in the Importer Options,
             - Display OME-XML metadata.
             - Use virtual stack.
3) Import with ROI's : Import the following image using the Bioformats_Importer: data_repo/from_skyking/cellh5/samples
with the following checkboxes selected in the Importer Options,
           - Display OME-XML metadata.
           - Display ROIs.
           - Use virtual stack.

4) Compare performance between steps 2 and 3. The performance of "Import without ROIs" should be better than the latter. And the OME-XML metadata should not have the ROI information in step 2.
