### PR TITLE
LIFReader: Cope with missing Objective NA following magnification

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1500,7 +1500,10 @@ public class LIFReader extends FormatReader {
             String na = token.substring(x + 1);
 
             magnification[image] = new Double(token.substring(0, x));
-            lensNA[image] = new Double(na);
+
+            if (na.length() > 0) {
+              lensNA[image] = new Double(na);
+            }
           }
           else {
             model.append(token);


### PR DESCRIPTION
See:
Trac: https://trac.openmicroscopy.org.uk/ome/ticket/12825
QA: https://www.openmicroscopy.org/qa2/qa/feedback/10983/

--no-rebase

--------

Testing: With file from above QA, LIFReader should not throw an exception parsing the Objective NA.