### PR TITLE
clean up older Java code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 *.so binary
 *.dylib binary
 *.h5 binary
+*.mdb binary

--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -43,6 +43,7 @@ import java.awt.Panel;
 import java.awt.event.ItemEvent;
 import java.io.File;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Vector;
 
 import javax.swing.Box;
@@ -250,11 +251,11 @@ public class FilePatternDialog extends ImporterDialog {
 
     Vector checkboxes = gd.getCheckboxes();
     Vector fields = gd.getStringFields();
-    Vector labels = new Vector();
+    final ArrayList<Label> labels = new ArrayList<Label>();
 
     for (Component c : gd.getComponents()) {
       if (c instanceof Label) {
-        labels.add(c);
+        labels.add((Label) c);
       }
     }
 

--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -45,9 +45,10 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
@@ -219,17 +220,17 @@ public class MainDialog extends ImporterDialog
   /** Fancies up the importer dialog to look much nicer. */
   private void rebuildDialog(GenericDialog gd) {
     // extract GUI components from dialog and add listeners
-    Vector<Checkbox> boxes = null;
-    Vector<Choice> choices = null;
-    Vector<Label> labels = null;
+    List<Checkbox> boxes = null;
+    List<Choice> choices = null;
+    List<Label> labels = null;
     Label colorModeLabel = null;
     Label stackFormatLabel = null;
     Label stackOrderLabel = null;
     Component[] c = gd.getComponents();
     if (c != null) {
-      boxes = new Vector<Checkbox>();
-      choices = new Vector<Choice>();
-      labels = new Vector<Label>();
+      boxes = new ArrayList<Checkbox>();
+      choices = new ArrayList<Choice>();
+      labels = new ArrayList<Label>();
       for (int i=0; i<c.length; i++) {
         if (c[i] instanceof Checkbox) {
           Checkbox item = (Checkbox) c[i];

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -800,8 +800,8 @@ public class ImageInfo {
           }
         }
         else if (normalize) {
-          min = new Double(0);
-          max = new Double(1);
+          min = Double.valueOf(0);
+          max = Double.valueOf(1);
         }
 
         if (normalize) {

--- a/components/formats-bsd/src/loci/formats/ImageTools.java
+++ b/components/formats-bsd/src/loci/formats/ImageTools.java
@@ -111,7 +111,7 @@ public final class ImageTools {
 
     byte[] b = null;
 
-    if (min == null) min = new Double(0);
+    if (min == null) min = Double.valueOf(0);
     double newRange = 255d;
 
     // adapted from ImageJ's TypeConverter methods

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -37,6 +37,9 @@ import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Vector;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
@@ -74,7 +77,7 @@ public class DicomReader extends FormatReader {
     "dic", "dcm", "dicom", "j2ki", "j2kr"
   };
 
-  private static final Hashtable<Integer, String> TYPES = buildTypes();
+  private static final ImmutableMap<Integer, String> TYPES = buildTypes();
 
   private static final int PIXEL_REPRESENTATION = 0x00280103;
   private static final int PIXEL_SIGN = 0x00281041;
@@ -1307,8 +1310,8 @@ public class DicomReader extends FormatReader {
    * This is incomplete at best, since there are literally thousands of
    * fields defined by the DICOM specifications.
    */
-  private static Hashtable<Integer, String> buildTypes() {
-    Hashtable<Integer, String> dict = new Hashtable<Integer, String>();
+  private static ImmutableMap<Integer, String> buildTypes() {
+    final Builder<Integer, String> dict = ImmutableMap.builder();
 
     dict.put(new Integer(0x00020002), "Media Storage SOP Class UID");
     dict.put(new Integer(0x00020003), "Media Storage SOP Instance UID");
@@ -1923,7 +1926,7 @@ public class DicomReader extends FormatReader {
     dict.put(new Integer(0x00540400), "Image ID");
     dict.put(new Integer(0x20100100), "Border Density");
 
-    return dict;
+    return dict.build();
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -1133,13 +1134,11 @@ public class DicomReader extends FormatReader {
         }
       }
 
-      Integer[] keys = fileList.keySet().toArray(new Integer[0]);
-      Arrays.sort(keys);
-      for (Integer key : keys) {
-        for (int j=0; j<fileList.get(key).size(); j++) {
-          if (fileList.get(key).get(j) == null) {
-            fileList.get(key).remove(j);
-            j--;
+      for (final List<String> files : fileList.values()) {
+        final Iterator<String> fileIterator = files.iterator();
+        while (fileIterator.hasNext()) {
+          if (fileIterator.next() == null) {
+            fileIterator.remove();
           }
         }
       }

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -33,9 +33,11 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Hashtable;
-import java.util.Vector;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
@@ -139,7 +141,7 @@ public class DicomReader extends FormatReader {
   private String pixelSizeX, pixelSizeY;
   private Double pixelSizeZ;
 
-  private Hashtable<Integer, Vector<String>> fileList;
+  private Map<Integer, List<String>> fileList;
   private int imagesPerFile;
 
   private String originalDate, originalTime, originalInstance;
@@ -147,7 +149,7 @@ public class DicomReader extends FormatReader {
 
   private DicomReader helper;
 
-  private Vector<String> companionFiles = new Vector<String>();
+  private List<String> companionFiles = new ArrayList<String>();
 
   // -- Constructor --
 
@@ -185,7 +187,7 @@ public class DicomReader extends FormatReader {
 
     try {
       int tag = getNextTag(stream);
-      return TYPES.get(new Integer(tag)) != null;
+      return TYPES.containsKey(tag);
     }
     catch (NullPointerException e) { }
     catch (FormatException e) { }
@@ -223,11 +225,11 @@ public class DicomReader extends FormatReader {
     if (noPixels || fileList == null) return null;
     Integer[] keys = fileList.keySet().toArray(new Integer[0]);
     Arrays.sort(keys);
-    Vector<String> files = fileList.get(keys[getSeries()]);
+    final List<String> files = fileList.get(keys[getSeries()]);
     if (files == null) {
       return null;
     }
-    Vector<String> uniqueFiles = new Vector<String>();
+    final List<String> uniqueFiles = new ArrayList<String>();
     for (String f : files) {
       if (!uniqueFiles.contains(f)) {
         uniqueFiles.add(f);
@@ -885,7 +887,7 @@ public class DicomReader extends FormatReader {
       inSequence = false;
     }
 
-    String id = TYPES.get(new Integer(tag));
+    String id = TYPES.get(tag);
 
     if (id != null) {
       if (vr == IMPLICIT_VR && id != null) {
@@ -1102,9 +1104,9 @@ public class DicomReader extends FormatReader {
       originalTime != null && isGroupFiles())
     {
       currentId = new Location(currentId).getAbsolutePath();
-      fileList = new Hashtable<Integer, Vector<String>>();
-      Integer s = new Integer(originalSeries);
-      fileList.put(s, new Vector<String>());
+      fileList = new HashMap<Integer, List<String>>();
+      final Integer s = originalSeries;
+      fileList.put(s, new ArrayList<String>());
 
       int instanceNumber = Integer.parseInt(originalInstance) - 1;
       if (instanceNumber == 0) fileList.get(s).add(currentId);
@@ -1143,8 +1145,8 @@ public class DicomReader extends FormatReader {
       }
     }
     else if (fileList == null || !isGroupFiles()) {
-      fileList = new Hashtable<Integer, Vector<String>>();
-      fileList.put(new Integer(0), new Vector<String>());
+      fileList = new HashMap<Integer, List<String>>();
+      fileList.put(0, new ArrayList<String>());
       fileList.get(0).add(currentId);
     }
   }
@@ -1210,7 +1212,7 @@ public class DicomReader extends FormatReader {
       long fp = stream.getFilePointer();
       if (fp + 4 >= stream.length() || fp < 0) break;
       int tag = getNextTag(stream);
-      String key = TYPES.get(new Integer(tag));
+      final String key = TYPES.get(tag);
       if ("Instance Number".equals(key)) {
         instance = stream.readString(elementLength).trim();
         if (instance.length() == 0) instance = null;
@@ -1250,7 +1252,7 @@ public class DicomReader extends FormatReader {
       int position = Integer.parseInt(instance) - 1;
       if (position < 0) position = 0;
       if (fileList.get(fileSeries) == null) {
-        fileList.put(new Integer(fileSeries), new Vector<String>());
+        fileList.put(fileSeries, new ArrayList<String>());
       }
       if (position < fileList.get(fileSeries).size()) {
         while (position < fileList.get(fileSeries).size() &&
@@ -1259,7 +1261,7 @@ public class DicomReader extends FormatReader {
           position++;
         }
         if (position < fileList.get(fileSeries).size()) {
-          fileList.get(fileSeries).setElementAt(file, position);
+          fileList.get(fileSeries).set(position, file);
         }
         else if (!fileList.get(fileSeries).contains(file)) {
           fileList.get(fileSeries).add(file);

--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -1008,7 +1008,7 @@ public class ICSReader extends FormatReader {
               metadata.remove(key);
             }
             else if (key.startsWith("history gain")) {
-              Integer n = new Integer(0);
+              Integer n = 0;
               try {
                 n = new Integer(key.substring(12).trim());
                 n = new Integer(n.intValue() - 1);
@@ -1363,8 +1363,8 @@ public class ICSReader extends FormatReader {
       }
     }
 
-    if (channelLengths.size() == 0) {
-      channelLengths.add(new Integer(1));
+    if (channelLengths.isEmpty()) {
+      channelLengths.add(1);
       channelTypes.add(FormatTools.CHANNEL);
     }
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -33,9 +33,10 @@
 package loci.formats.tiff;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Vector;
+import java.util.List;
 
 import loci.common.ByteArrayHandle;
 import loci.common.Constants;
@@ -294,7 +295,7 @@ public class TiffParser {
     int bytesPerEntry = bigTiff ? TiffConstants.BIG_TIFF_BYTES_PER_ENTRY :
       TiffConstants.BYTES_PER_ENTRY;
 
-    Vector<Long> offsets = new Vector<Long>();
+    final List<Long> offsets = new ArrayList<Long>();
     long offset = getFirstOffset();
     while (offset > 0 && offset < in.length()) {
       in.seek(offset);

--- a/components/formats-bsd/src/loci/formats/tools/PrintDomains.java
+++ b/components/formats-bsd/src/loci/formats/tools/PrintDomains.java
@@ -33,12 +33,12 @@
 package loci.formats.tools;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Hashtable;
-import java.util.Vector;
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.TreeMultimap;
 
 import loci.formats.FormatException;
-import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 
@@ -52,18 +52,13 @@ public class PrintDomains {
     // get a list of all available readers
     IFormatReader[] readers = new ImageReader().getReaders();
 
-    Hashtable<String, Vector<IFormatReader>> domains =
-      new Hashtable<String, Vector<IFormatReader>>();
-
-    for (String domain : FormatTools.ALL_DOMAINS) {
-      domains.put(domain, new Vector<IFormatReader>());
-    }
+    final TreeMultimap<String, String> domains = TreeMultimap.create();
 
     for (IFormatReader reader : readers) {
       try {
         String[] readerDomains = reader.getPossibleDomains("");
         for (String domain : readerDomains) {
-          domains.get(domain).add(reader);
+          domains.put(domain, reader.getFormat());
         }
       }
       catch (FormatException e) {
@@ -74,14 +69,11 @@ public class PrintDomains {
       }
     }
 
-    String[] domainKeys = domains.keySet().toArray(new String[domains.size()]);
-    Arrays.sort(domainKeys);
-
-    for (String domain : domainKeys) {
-      System.out.println(domain + ":");
-      Vector<IFormatReader> r = domains.get(domain);
-      for (IFormatReader reader : r) {
-        System.out.println("  " + reader.getFormat());
+    for (final Map.Entry<String, Collection<String>> domain :
+             domains.asMap().entrySet()) {
+      System.out.println(domain.getKey() + ":");
+      for (final String readerFormat : domain.getValue()) {
+        System.out.println("  " + readerFormat);
       }
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -27,7 +27,8 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import loci.common.DataTools;
 import loci.common.Location;
@@ -64,7 +65,7 @@ public class APLReader extends FormatReader {
   private String[] xmlFiles;
   private transient TiffParser[] parser;
   private IFDList[] ifds;
-  private Vector<String> used;
+  private List<String> used;
 
   // -- Constructor --
 
@@ -112,7 +113,7 @@ public class APLReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     files.addAll(used);
 
     if (getSeries() < xmlFiles.length) {
@@ -255,7 +256,7 @@ public class APLReader extends FormatReader {
     }
 
     String[] columnNames = null;
-    Vector<String[]> rows = null;
+    List<String[]> rows = null;
     try {
       mdb.initialize(mtb);
       rows = mdb.parseDatabase().get(0);
@@ -280,7 +281,7 @@ public class APLReader extends FormatReader {
       }
     }
 
-    used = new Vector<String>();
+    used = new ArrayList<String>();
     used.add(mtb);
     String tnb = mtb.substring(0, mtb.lastIndexOf("."));
     if (tnb.lastIndexOf("_") > tnb.lastIndexOf(File.separator)) {
@@ -354,7 +355,7 @@ public class APLReader extends FormatReader {
       throw new FormatException("Could not find a directory with TIFF files.");
     }
 
-    Vector<Integer> seriesIndexes = new Vector<Integer>();
+    final List<Integer> seriesIndexes = new ArrayList<Integer>();
 
     for (int i=1; i<rows.size(); i++) {
       String file = rows.get(i)[filename].trim();

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -34,7 +34,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import loci.common.Constants;
@@ -78,9 +78,9 @@ public class BDReader extends FormatReader {
     "xyz", "mac", "bmp", "roi", "adf"};
 
   // -- Fields --
-  private Vector<String> metadataFiles = new Vector<String>();
-  private Vector<String> channelNames = new Vector<String>();
-  private Vector<String> wellLabels = new Vector<String>();
+  private List<String> metadataFiles = new ArrayList<String>();
+  private List<String> channelNames = new ArrayList<String>();
+  private List<String> wellLabels = new ArrayList<String>();
   private String plateName, plateDescription;
   private String[][] tiffs;
   private MinimalTiffReader reader;
@@ -95,7 +95,7 @@ public class BDReader extends FormatReader {
   private int fieldCols;
 
   private String[] rootList;
-  private ArrayList<String[]> wellList = new ArrayList<String[]>();
+  private List<String[]> wellList = new ArrayList<String[]>();
 
   // -- Constructor --
 
@@ -155,7 +155,7 @@ public class BDReader extends FormatReader {
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
 
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     files.add(new Location(currentId).getAbsolutePath());
     for (String file : metadataFiles) {
       if (file != null && !files.contains(file)) {
@@ -319,8 +319,8 @@ public class BDReader extends FormatReader {
       addGlobalMeta("Camera binning", binning);
     }
 
-    Vector<String> uniqueRows = new Vector<String>();
-    Vector<String> uniqueColumns = new Vector<String>();
+    final List<String> uniqueRows = new ArrayList<String>();
+    final List<String> uniqueColumns = new ArrayList<String>();
 
     for (String well : wellLabels) {
       String row = well.substring(0, 1).trim();
@@ -710,7 +710,7 @@ public class BDReader extends FormatReader {
   }
 
   private String[][] getTiffs() {
-    Vector<Vector<String>> files = new Vector<Vector<String>>();
+    final List<List<String>> files = new ArrayList<List<String>>();
 
     Pattern p = Pattern.compile(".* - n\\d\\d\\d\\d\\d\\d\\.tif");
 
@@ -719,7 +719,7 @@ public class BDReader extends FormatReader {
       Location file = new Location(filename).getAbsoluteFile();
       if (file.getName().startsWith("Well ") && file.isDirectory()) {
         String[] list = wellList.get(nextWell++);
-        Vector<String> tiffList = new Vector<String>();
+        final List<String> tiffList = new ArrayList<String>();
         for (String tiff : list) {
           if (p.matcher(tiff).matches()) {
             tiffList.add(new Location(file, tiff).getAbsolutePath());

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -28,12 +28,12 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Vector;
 import java.util.ArrayList;
 import java.lang.Math;
 
@@ -71,14 +71,14 @@ public abstract class BaseZeissReader extends FormatReader {
   protected int[] offsets;
   protected int[][] coordinates;
 
-  protected Hashtable<Integer, String> timestamps, exposureTime;
+  protected Map<Integer, String> timestamps, exposureTime;
   protected int cIndex = -1;
   protected boolean isJPEG, isZlib;
 
   protected int realWidth, realHeight;
 
 
-  protected Vector<String> tagsToParse;
+  protected List<String> tagsToParse;
   protected int nextEmWave = 0, nextExWave = 0, nextChName = 0;
   protected Hashtable<Integer, Length> stageX = new Hashtable<Integer, Length>();
   protected Hashtable<Integer, Length> stageY = new Hashtable<Integer, Length>();
@@ -107,7 +107,7 @@ public abstract class BaseZeissReader extends FormatReader {
   protected Set<Integer> timepointIndices = new HashSet<Integer>();
   protected Set<Integer> tileIndices = new HashSet<Integer>();
 
-  protected Vector<String> roiIDs = new Vector<String>();
+  protected List<String> roiIDs = new ArrayList<String>();
 
   // Layer annotations (contain Shapes, i.e. ROIs).
   public ArrayList<Layer> layers = new ArrayList<BaseZeissReader.Layer>();
@@ -143,9 +143,9 @@ public abstract class BaseZeissReader extends FormatReader {
   }
 
   protected void initVars(String id) throws FormatException, IOException {
-    timestamps = new Hashtable<Integer, String>();
-    exposureTime = new Hashtable<Integer, String>();
-    tagsToParse = new Vector<String>();
+    timestamps = new HashMap<Integer, String>();
+    exposureTime = new HashMap<Integer, String>();
+    tagsToParse = new ArrayList<String>();
   }
 
   protected void countImages() {
@@ -383,7 +383,7 @@ public abstract class BaseZeissReader extends FormatReader {
           }
           String exposure = exposureTime.get(expIndex);
           if (exposure == null && exposureTime.size() == 1) {
-            exposure = exposureTime.get(exposureTime.keys().nextElement());
+            exposure = exposureTime.values().iterator().next();
           }
           Double exp = new Double(0.0);
           try { exp = new Double(exposure); }

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -302,7 +302,7 @@ public abstract class BaseZeissReader extends FormatReader {
     for (int i=0; i<getSeriesCount(); i++) {
       long firstStamp = 0;
       if (timestamps.size() > 0) {
-        String timestamp = timestamps.get(new Integer(0));
+        String timestamp = timestamps.get(0);
         firstStamp = parseTimestamp(timestamp);
         firstStamp /= 1600;
         int epoch = timestamps.size() == 1 ? DateTools.ALT_ZVI : DateTools.ZVI;
@@ -373,7 +373,7 @@ public abstract class BaseZeissReader extends FormatReader {
           store.setPixelsPhysicalSizeZ(sizeZ, i);
         }
 
-        long firstStamp = parseTimestamp(timestamps.get(new Integer(0)));
+        long firstStamp = parseTimestamp(timestamps.get(0));
 
         for (int plane=0; plane<getImageCount(); plane++) {
           int[] zct = getZCTCoords(plane);
@@ -818,7 +818,7 @@ public abstract class BaseZeissReader extends FormatReader {
 
         if (key.startsWith("ImageTile") && !(store instanceof DummyMetadata)) {
           if (!tiles.containsKey(new Integer(value))) {
-            tiles.put(new Integer(value), new Integer(1));
+            tiles.put(Integer.valueOf(value), 1);
           }
           else {
             int v = tiles.get(new Integer(value)).intValue() + 1;

--- a/components/formats-gpl/src/loci/formats/in/BioRadReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadReader.java
@@ -27,9 +27,10 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
@@ -140,7 +141,7 @@ public class BioRadReader extends FormatReader {
 
   // -- Fields --
 
-  private Vector<String> used;
+  private List<String> used;
 
   private String[] picFiles;
 
@@ -148,9 +149,9 @@ public class BioRadReader extends FormatReader {
   private int lastChannel = 0;
   private boolean brokenNotes = false;
 
-  private Vector<Note> noteStrings;
+  private List<Note> noteStrings;
 
-  private Vector<Double> offset, gain;
+  private List<Double> offset, gain;
 
   // -- Constructor --
 
@@ -223,7 +224,7 @@ public class BioRadReader extends FormatReader {
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
     if (noPixels) {
-      Vector<String> files = new Vector<String>();
+      final List<String> files = new ArrayList<String>();
       for (String f : used) {
         if (!checkSuffix(f, PIC_SUFFIX)) files.add(f);
       }
@@ -298,15 +299,15 @@ public class BioRadReader extends FormatReader {
     in = new RandomAccessInputStream(id);
     in.order(true);
 
-    offset = new Vector<Double>();
-    gain = new Vector<Double>();
+    offset = new ArrayList<Double>();
+    gain = new ArrayList<Double>();
 
-    used = new Vector<String>();
+    used = new ArrayList<String>();
     used.add(new Location(currentId).getAbsolutePath());
 
     LOGGER.info("Reading image dimensions");
 
-    noteStrings = new Vector<Note>();
+    noteStrings = new ArrayList<Note>();
 
     // read header
     CoreMetadata m = core.get(0);
@@ -404,7 +405,7 @@ public class BioRadReader extends FormatReader {
 
     // look for companion metadata files
 
-    Vector<String> pics = new Vector<String>();
+    final List<String> pics = new ArrayList<String>();
 
     if (isGroupFiles()) {
       Location parent =
@@ -444,7 +445,7 @@ public class BioRadReader extends FormatReader {
 
     boolean multipleFiles = parseNotes(store);
 
-    if (multipleFiles && isGroupFiles() && pics.size() == 0) {
+    if (multipleFiles && isGroupFiles() && pics.isEmpty()) {
       // do file grouping
       used.remove(currentId);
       long length = new Location(currentId).length();
@@ -591,7 +592,7 @@ public class BioRadReader extends FormatReader {
       n.p = n.p.substring(0, ndx).trim();
 
       String value = n.p.replaceAll("=", "");
-      Vector<String> v = new Vector<String>();
+      final List<String> v = new ArrayList<String>();
       StringTokenizer t = new StringTokenizer(value, " ");
       while (t.hasMoreTokens()) {
         String token = t.nextToken().trim();
@@ -673,7 +674,7 @@ public class BioRadReader extends FormatReader {
 
                     if (key.endsWith("OFFSET")) {
                       if (nextDetector < offset.size()) {
-                        offset.setElementAt(new Double(value), nextDetector);
+                        offset.set(nextDetector, Double.parseDouble(value));
                       }
                       else {
                         while (nextDetector > offset.size()) {
@@ -684,7 +685,7 @@ public class BioRadReader extends FormatReader {
                     }
                     else if (key.endsWith("GAIN")) {
                       if (nextDetector < gain.size()) {
-                        gain.setElementAt(new Double(value), nextDetector);
+                        gain.set(nextDetector, Double.parseDouble(value));
                       }
                       else {
                         while (nextDetector > gain.size()) {
@@ -969,7 +970,7 @@ public class BioRadReader extends FormatReader {
 
       if (n.p.indexOf("AXIS") != -1) {
         n.p = n.p.replaceAll("=", "");
-        Vector<String> v = new Vector<String>();
+        final List<String> v = new ArrayList<String>();
         StringTokenizer tokens = new StringTokenizer(n.p, " ");
         while (tokens.hasMoreTokens()) {
           String token = tokens.nextToken().trim();

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -26,10 +26,10 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Vector;
 
 import loci.common.DataTools;
 import loci.common.DateTools;
@@ -129,7 +129,7 @@ public class CellWorxReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     files.add(currentId);
     if (plateLogFile != null && new Location(plateLogFile).exists()) {
       files.add(plateLogFile);

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -26,9 +26,10 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import loci.common.DataTools;
 import loci.common.DateTools;
@@ -163,7 +164,7 @@ public class DeltavisionReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     if (!noPixels) files.add(currentId);
     if (logFile != null) files.add(logFile);
     if (deconvolutionLogFile != null) files.add(deconvolutionLogFile);
@@ -387,8 +388,8 @@ public class DeltavisionReader extends FormatReader {
 
     ndFilters = new Double[getSizeC()];
 
-    final Vector<Length> uniqueTileX = new Vector<Length>();
-    final Vector<Length> uniqueTileY = new Vector<Length>();
+    final List<Length> uniqueTileX = new ArrayList<Length>();
+    final List<Length> uniqueTileY = new ArrayList<Length>();
 
     // Run through every image and fill in the
     // Extended Header information array for that image
@@ -1232,10 +1233,10 @@ public class DeltavisionReader extends FormatReader {
 
       if (doStatistics) {
         String[] keys = line.split("  ");
-        Vector<String> realKeys = new Vector<String>();
+        final List<String> realKeys = new ArrayList<String>();
         for (int i=0; i<keys.length; i++) {
           keys[i] = keys[i].trim();
-          if (keys[i].length() > 0) realKeys.add(keys[i]);
+          if (!keys[i].isEmpty()) realKeys.add(keys[i]);
         }
         keys = realKeys.toArray(new String[0]);
 
@@ -1244,10 +1245,10 @@ public class DeltavisionReader extends FormatReader {
         line = s.readLine().trim();
         while (line != null && line.length() != 0) {
           String[] values = line.split(" ");
-          Vector<String> realValues = new Vector<String>();
+          final List<String> realValues = new ArrayList<String>();
           for (int i=0; i<values.length; i++) {
             values[i] = values[i].trim();
-            if (values[i].length() > 0) { realValues.add(values[i]); }
+            if (!values[i].isEmpty()) { realValues.add(values[i]); }
           }
           values = realValues.toArray(new String[0]);
 

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -32,8 +32,8 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Vector;
+import java.util.List;
+import java.util.Map;
 
 import loci.common.ByteArrayHandle;
 import loci.common.DataTools;
@@ -107,7 +107,7 @@ public class FV1000Reader extends FormatReader {
   private IniParser parser = new IniParser();
 
   /** Names of every TIFF file to open. */
-  private Vector<String> tiffs;
+  private List<String> tiffs;
 
   /** Name of thumbnail file. */
   private String thumbId;
@@ -116,34 +116,34 @@ public class FV1000Reader extends FormatReader {
   private BMPReader thumbReader;
 
   /** Used file list. */
-  private Vector<String> usedFiles;
+  private List<String> usedFiles;
 
   /** Flag indicating this is an OIB dataset. */
   private boolean isOIB;
 
   /** File mappings for OIB file. */
-  private Hashtable<String, String> oibMapping;
+  private Map<String, String> oibMapping;
 
   private String[] code, size;
   private Double[] pixelSize;
   private int imageDepth;
-  private Vector<String> previewNames;
+  private List<String> previewNames;
 
   private String pixelSizeX, pixelSizeY;
   private int validBits;
-  private Vector<String> illuminations;
-  private Vector<Double> wavelengths;
+  private List<String> illuminations;
+  private List<Double> wavelengths;
   private String pinholeSize;
   private String magnification, lensNA, objectiveName, workingDistance;
   private String creationDate;
 
-  private Vector<ChannelData> channels;
-  private Vector<String> lutNames = new Vector<String>();
-  private Hashtable<Integer, String> filenames =
-    new Hashtable<Integer, String>();
-  private Hashtable<Integer, String> roiFilenames =
-    new Hashtable<Integer, String>();
-  private Vector<PlaneData> planes;
+  private List<ChannelData> channels;
+  private List<String> lutNames = new ArrayList<String>();
+  private Map<Integer, String> filenames =
+    new HashMap<Integer, String>();
+  private Map<Integer, String> roiFilenames =
+    new HashMap<Integer, String>();
+  private List<PlaneData> planes;
 
   private transient POIService poi;
 
@@ -305,7 +305,7 @@ public class FV1000Reader extends FormatReader {
       return noPixels ? null : new String[] {currentId};
     }
 
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     if (usedFiles != null) {
       for (String file : usedFiles) {
         String f = file.toLowerCase();
@@ -390,10 +390,10 @@ public class FV1000Reader extends FormatReader {
     // list of associated files.
     boolean mappedOIF = !isOIB && !new File(id).getAbsoluteFile().exists();
 
-    wavelengths = new Vector<Double>();
-    illuminations = new Vector<String>();
-    channels = new Vector<ChannelData>();
-    planes = new Vector<PlaneData>();
+    wavelengths = new ArrayList<Double>();
+    illuminations = new ArrayList<String>();
+    channels = new ArrayList<ChannelData>();
+    planes = new ArrayList<PlaneData>();
 
     String oifName = null;
 
@@ -430,7 +430,7 @@ public class FV1000Reader extends FormatReader {
     size = new String[NUM_DIMENSIONS];
     pixelSize = new Double[NUM_DIMENSIONS];
 
-    previewNames = new Vector<String>();
+    previewNames = new ArrayList<String>();
     boolean laserEnabled = true;
 
     IniList f = getIniFile(oifName);
@@ -480,7 +480,7 @@ public class FV1000Reader extends FormatReader {
       }
     }
 
-    if (filenames.size() == 0) addPtyFiles();
+    if (filenames.isEmpty()) addPtyFiles();
 
     for (int i=0; i<NUM_DIMENSIONS; i++) {
       IniTable commonParams = f.getTable("Axis " + i + " Parameters Common");
@@ -572,7 +572,7 @@ public class FV1000Reader extends FormatReader {
     // populate core metadata for preview series
 
     if (previewNames.size() > 0) {
-      Vector<String> v = new Vector<String>();
+      final List<String> v = new ArrayList<String>();
       for (int i=0; i<previewNames.size(); i++) {
         String ss = previewNames.get(i);
         ss = replaceExtension(ss, "pty", "tif");
@@ -609,7 +609,7 @@ public class FV1000Reader extends FormatReader {
     }
     CoreMetadata ms0 = core.get(0);
     ms0.imageCount = filenames.size();
-    tiffs = new Vector<String>(getImageCount());
+    tiffs = new ArrayList<String>(getImageCount());
 
     thumbReader = new BMPReader();
     if (thumbId != null) {
@@ -625,8 +625,8 @@ public class FV1000Reader extends FormatReader {
 
     ms0.dimensionOrder = "XY";
 
-    Hashtable<String, String> values = new Hashtable<String, String>();
-    Vector<String> baseKeys = new Vector<String>();
+    final Map<String, String> values = new HashMap<String, String>();
+    final List<String> baseKeys = new ArrayList<String>();
 
     for (int i=0, ii=0; ii<getImageCount(); i++, ii++) {
       String file = filenames.get(new Integer(i));
@@ -777,7 +777,7 @@ public class FV1000Reader extends FormatReader {
       ms0.imageCount = tiffs.size();
     }
 
-    usedFiles = new Vector<String>();
+    usedFiles = new ArrayList<String>();
 
     if (tiffPath != null) {
       usedFiles.add(isOIB ? id : oifName);
@@ -1508,7 +1508,7 @@ public class FV1000Reader extends FormatReader {
   private String mapOIBFiles() throws FormatException, IOException {
     String oifName = null;
     String infoFile = null;
-    Vector<String> list = poi.getDocumentList();
+    final List<String> list = poi.getDocumentList();
     for (String name : list) {
       if (name.endsWith("OibInfo.txt")) {
         infoFile = name;
@@ -1520,7 +1520,7 @@ public class FV1000Reader extends FormatReader {
     }
     RandomAccessInputStream ras = poi.getDocumentStream(infoFile);
 
-    oibMapping = new Hashtable<String, String>();
+    oibMapping = new HashMap<String, String>();
 
     // set up file name mappings
 
@@ -1662,7 +1662,7 @@ public class FV1000Reader extends FormatReader {
   private static int[] scanFormat(String pattern, String string)
     throws FormatException
   {
-    Vector<Integer> percentOffsets = new Vector<Integer>();
+    final List<Integer> percentOffsets = new ArrayList<Integer>();
     int offset = -1;
     for (;;) {
       offset = pattern.indexOf('%', offset + 1);

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -108,17 +108,17 @@ public class FlexReader extends FormatReader {
   private int wellRows, wellColumns;
 
   private String[] channelNames;
-  private Vector<Double> xPositions, yPositions;
-  private Vector<Double> xSizes, ySizes;
-  private Vector<String> cameraIDs, objectiveIDs, lightSourceIDs;
-  private HashMap<String, Vector<String>> lightSourceCombinationIDs;
-  private Vector<String> cameraRefs, binnings, objectiveRefs;
-  private Vector<String> lightSourceCombinationRefs;
-  private Vector<String> filterSets;
+  private List<Double> xPositions, yPositions;
+  private List<Double> xSizes, ySizes;
+  private List<String> cameraIDs, objectiveIDs, lightSourceIDs;
+  private HashMap<String, List<String>> lightSourceCombinationIDs;
+  private List<String> cameraRefs, binnings, objectiveRefs;
+  private List<String> lightSourceCombinationRefs;
+  private List<String> filterSets;
   private HashMap<String, FilterGroup> filterSetMap;
   private HashMap<Integer, Timestamp> acquisitionDates;
 
-  private Vector<String> measurementFiles;
+  private List<String> measurementFiles;
 
   private String plateName, plateBarcode;
   private int nRows = 0, nCols = 0;
@@ -169,14 +169,14 @@ public class FlexReader extends FormatReader {
   @Override
   public boolean isSingleFile(String id) throws FormatException, IOException {
     if (!checkSuffix(id, FLEX_SUFFIX)) return false;
-    return serverMap.size() == 0 || !isGroupFiles();
+    return serverMap.isEmpty() || !isGroupFiles();
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     files.addAll(measurementFiles);
 
     if (!noPixels) {
@@ -345,7 +345,7 @@ public class FlexReader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
 
-    measurementFiles = new Vector<String>();
+    measurementFiles = new ArrayList<String>();
     acquisitionDates = new HashMap<Integer, Timestamp>();
 
     if (checkSuffix(id, FLEX_SUFFIX)) {
@@ -406,8 +406,8 @@ public class FlexReader extends FormatReader {
     XMLTools.parseXML(s, handler);
     s.close();
 
-    Vector<String> flex = handler.getFlexFiles();
-    if (flex.size() == 0) {
+    final List<String> flex = handler.getFlexFiles();
+    if (flex.isEmpty()) {
       LOGGER.debug("Could not build .flex list from .mea.");
       LOGGER.info("Building list of valid .flex files");
       String[] files = findFiles(file);
@@ -416,7 +416,7 @@ public class FlexReader extends FormatReader {
           if (checkSuffix(f, FLEX_SUFFIX)) flex.add(f);
         }
       }
-      if (flex.size() == 0) {
+      if (flex.isEmpty()) {
         throw new FormatException(".flex files were not found. " +
           "Did you forget to specify the server names?");
       }
@@ -471,7 +471,7 @@ public class FlexReader extends FormatReader {
       catch (IOException e) {
         LOGGER.debug("", e);
       }
-      if (measurementFiles.size() == 0) {
+      if (measurementFiles.isEmpty()) {
         LOGGER.warn("Measurement files not found.");
       }
       else {
@@ -486,7 +486,7 @@ public class FlexReader extends FormatReader {
     MetadataStore store = makeFilterMetadata();
 
     LOGGER.info("Making sure that all .flex files are valid");
-    Vector<String> flex = new Vector<String>();
+    final List<String> flex = new ArrayList<String>();
     if (doGrouping) {
       // group together .flex files that are in the same directory
 
@@ -622,7 +622,7 @@ public class FlexReader extends FormatReader {
 
         if (seriesIndex < lightSourceCombinationRefs.size()) {
           String lightSourceCombo = lightSourceCombinationRefs.get(seriesIndex);
-          Vector<String> lightSources =
+          List<String> lightSources =
             lightSourceCombinationIDs.get(lightSourceCombo);
 
           for (int c=0; c<getEffectiveSizeC(); c++) {
@@ -785,23 +785,23 @@ public class FlexReader extends FormatReader {
 
     int originalFieldCount = fieldCount;
 
-    if (xPositions == null) xPositions = new Vector<Double>();
-    if (yPositions == null) yPositions = new Vector<Double>();
-    if (xSizes == null) xSizes = new Vector<Double>();
-    if (ySizes == null) ySizes = new Vector<Double>();
-    if (cameraIDs == null) cameraIDs = new Vector<String>();
-    if (lightSourceIDs == null) lightSourceIDs = new Vector<String>();
-    if (objectiveIDs == null) objectiveIDs = new Vector<String>();
+    if (xPositions == null) xPositions = new ArrayList<Double>();
+    if (yPositions == null) yPositions = new ArrayList<Double>();
+    if (xSizes == null) xSizes = new ArrayList<Double>();
+    if (ySizes == null) ySizes = new ArrayList<Double>();
+    if (cameraIDs == null) cameraIDs = new ArrayList<String>();
+    if (lightSourceIDs == null) lightSourceIDs = new ArrayList<String>();
+    if (objectiveIDs == null) objectiveIDs = new ArrayList<String>();
     if (lightSourceCombinationIDs == null) {
-      lightSourceCombinationIDs = new HashMap<String, Vector<String>>();
+      lightSourceCombinationIDs = new HashMap<String, List<String>>();
     }
     if (lightSourceCombinationRefs == null) {
-      lightSourceCombinationRefs = new Vector<String>();
+      lightSourceCombinationRefs = new ArrayList<String>();
     }
-    if (cameraRefs == null) cameraRefs = new Vector<String>();
-    if (objectiveRefs == null) objectiveRefs = new Vector<String>();
-    if (binnings == null) binnings = new Vector<String>();
-    if (filterSets == null) filterSets = new Vector<String>();
+    if (cameraRefs == null) cameraRefs = new ArrayList<String>();
+    if (objectiveRefs == null) objectiveRefs = new ArrayList<String>();
+    if (binnings == null) binnings = new ArrayList<String>();
+    if (filterSets == null) filterSets = new ArrayList<String>();
     if (filterSetMap == null) filterSetMap = new HashMap<String, FilterGroup>();
 
     // parse factors from XML
@@ -820,8 +820,8 @@ public class FlexReader extends FormatReader {
     }
     String xml = XMLTools.sanitizeXML(ifd.getIFDStringValue(FLEX));
 
-    Vector<String> n = new Vector<String>();
-    Vector<String> f = new Vector<String>();
+    final List<String> n = new ArrayList<String>();
+    final List<String> f = new ArrayList<String>();
     DefaultHandler handler =
       new FlexHandler(n, f, store, firstFile, currentWell, field);
     LOGGER.info("Parsing XML in .flex file");
@@ -909,7 +909,7 @@ public class FlexReader extends FormatReader {
 
   /** Populate core metadata using the given list of image names. */
   private void populateCoreMetadata(int wellRow, int wellCol, int field,
-    Vector<String> imageNames)
+    List<String> imageNames)
     throws FormatException
   {
     LOGGER.info("Populating core metadata for well row " + wellRow +
@@ -920,7 +920,7 @@ public class FlexReader extends FormatReader {
         fieldCount = 1;
       }
 
-      Vector<String> uniqueChannels = new Vector<String>();
+      final List<String> uniqueChannels = new ArrayList<String>();
       for (int i=0; i<imageNames.size(); i++) {
         String name = imageNames.get(i);
         String[] tokens = name.split("_");
@@ -1048,7 +1048,7 @@ public class FlexReader extends FormatReader {
 
     LOGGER.info("Looking for files that are in the same dataset as " +
       baseFile.getAbsolutePath());
-    Vector<String> fileList = new Vector<String>();
+    final List<String> fileList = new ArrayList<String>();
 
     Location plateDir = baseFile.getParentFile();
     String[] files = plateDir.list(true);
@@ -1400,7 +1400,7 @@ public class FlexReader extends FormatReader {
 
   /** SAX handler for parsing XML. */
   public class FlexHandler extends BaseHandler {
-    private Vector<String> names, factors;
+    private final List<String> names, factors;
     private MetadataStore store;
     private int thisField = 0;
 
@@ -1428,7 +1428,7 @@ public class FlexReader extends FormatReader {
 
     private StringBuffer charData = new StringBuffer();
 
-    public FlexHandler(Vector<String> names, Vector<String> factors,
+    public FlexHandler(List<String> names, List<String> factors,
       MetadataStore store, boolean populateCore, int well, int thisField)
     {
       this.names = names;
@@ -1641,11 +1641,11 @@ public class FlexReader extends FormatReader {
         level != MetadataLevel.MINIMUM)
       {
         lightSourceID = attributes.getValue("ID");
-        lightSourceCombinationIDs.put(lightSourceID, new Vector<String>());
+        lightSourceCombinationIDs.put(lightSourceID, new ArrayList<String>());
       }
       else if (qName.equals("LightSourceRef") && level != MetadataLevel.MINIMUM)
       {
-        Vector<String> v = lightSourceCombinationIDs.get(lightSourceID);
+        final List<String> v = lightSourceCombinationIDs.get(lightSourceID);
         if (v != null) {
           int id = lightSourceIDs.indexOf(attributes.getValue("ID"));
           String lightSourceID = MetadataTools.createLSID("LightSource", 0, id);
@@ -1784,12 +1784,12 @@ public class FlexReader extends FormatReader {
 
   /** SAX handler for parsing XML from .mea files. */
   public class MeaHandler extends BaseHandler {
-    private Vector<String> flex = new Vector<String>();
+    private List<String> flex = new ArrayList<String>();
     private String[] hostnames = null;
 
     // -- MeaHandler API methods --
 
-    public Vector<String> getFlexFiles() { return flex; }
+    public List<String> getFlexFiles() { return flex; }
 
     // -- DefaultHandler API methods --
 
@@ -1927,7 +1927,7 @@ public class FlexReader extends FormatReader {
         }
         LOGGER.debug("Base server name is {}", baseName);
 
-        Vector<String> names = new Vector<String>();
+        final List<String> names = new ArrayList<String>();
         names.add(realName);
         Location screening =
           new Location(baseName + File.separator + SCREENING);

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -27,7 +27,9 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.text.Collator;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
+
 import loci.common.Constants;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
@@ -77,8 +79,8 @@ public class GatanReader extends FormatReader {
   private long pixelOffset;
 
   /** List of pixel sizes. */
-  private Vector<Double> pixelSizes;
-  private Vector<String> units;
+  private List<Double> pixelSizes;
+  private List<String> units;
 
   private int bytesPerPixel;
 
@@ -163,8 +165,8 @@ public class GatanReader extends FormatReader {
     LOGGER.info("Verifying Gatan format");
 
     m.littleEndian = false;
-    pixelSizes = new Vector<Double>();
-    units = new Vector<String>();
+    pixelSizes = new ArrayList<Double>();
+    units = new ArrayList<String>();
 
     in.order(isLittleEndian());
 

--- a/components/formats-gpl/src/loci/formats/in/L2DReader.java
+++ b/components/formats-gpl/src/loci/formats/in/L2DReader.java
@@ -28,7 +28,7 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Hashtable;
-import java.util.Vector;
+import java.util.List;
 
 import loci.common.DataTools;
 import loci.common.DateTools;
@@ -61,7 +61,7 @@ public class L2DReader extends FormatReader {
   private String[][] tiffs;
 
   /** List of all metadata files in the dataset. */
-  private Vector[] metadataFiles;
+  private List<String>[] metadataFiles;
 
   private MinimalTiffReader reader;
   private int[] tileWidth, tileHeight;
@@ -142,7 +142,7 @@ public class L2DReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     files.add(currentId);
     if (metadataFiles != null && getSeries() < metadataFiles.length) {
       files.addAll(metadataFiles[getSeries()]);
@@ -215,7 +215,7 @@ public class L2DReader extends FormatReader {
       core = new ArrayList<CoreMetadata>(r.getCoreMetadataList());
       metadataStore = r.getMetadataStore();
 
-      Hashtable globalMetadata = r.getGlobalMetadata();
+      final Hashtable<String, Object> globalMetadata = r.getGlobalMetadata();
       for (Object key : globalMetadata.keySet()) {
         addGlobalMeta(key.toString(), globalMetadata.get(key));
       }
@@ -231,7 +231,7 @@ public class L2DReader extends FormatReader {
 
     // remove scan names that do not correspond to existing directories
 
-    Vector<String> validScans = new Vector<String>();
+    final List<String> validScans = new ArrayList<String>();
     for (String s : scans) {
       Location scanDir = new Location(parent, s);
       if (scanDir.exists() && scanDir.isDirectory()) validScans.add(s);
@@ -241,7 +241,7 @@ public class L2DReader extends FormatReader {
     // read metadata from each scan
 
     tiffs = new String[scans.length][];
-    metadataFiles = new Vector[scans.length];
+    metadataFiles = new List[scans.length];
 
     core = new ArrayList<CoreMetadata>(scans.length);
 
@@ -258,7 +258,7 @@ public class L2DReader extends FormatReader {
       CoreMetadata ms = new CoreMetadata();
       core.add(ms);
       setSeries(i);
-      metadataFiles[i] = new Vector();
+      metadataFiles[i] = new ArrayList<String>();
       String scanName = scans[i] + ".scn";
       Location scanDir = new Location(parent, scans[i]);
 

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -71,6 +71,9 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
 /**
  * LIFReader is the file format reader for Leica LIF files.
  *
@@ -86,23 +89,23 @@ public class LIFReader extends FormatReader {
   /** The encoding used in this file.*/
   private static final String ENCODING = "ISO-8859-1";
 
-  private static final HashMap<String, Integer> CHANNEL_PRIORITIES =
+  private static final ImmutableMap<String, Integer> CHANNEL_PRIORITIES =
     createChannelPriorities();
 
-  private static HashMap<String, Integer> createChannelPriorities() {
-    HashMap<String, Integer> h = new HashMap<String, Integer>();
+  private static ImmutableMap<String, Integer> createChannelPriorities() {
+    final Builder<String, Integer> h = ImmutableMap.builder();
 
-    h.put("red", new Integer(0));
-    h.put("green", new Integer(1));
-    h.put("blue", new Integer(2));
-    h.put("cyan", new Integer(3));
-    h.put("magenta", new Integer(4));
-    h.put("yellow", new Integer(5));
-    h.put("black", new Integer(6));
-    h.put("gray", new Integer(7));
-    h.put("", new Integer(8));
+    h.put("red", 0);
+    h.put("green", 1);
+    h.put("blue", 2);
+    h.put("cyan", 3);
+    h.put("magenta", 4);
+    h.put("yellow", 5);
+    h.put("black", 6);
+    h.put("gray", 7);
+    h.put("", 8);
 
-    return h;
+    return h.build();
   }
 
   // -- Fields --

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -27,12 +27,13 @@ package loci.formats.in;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.Stack;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -111,33 +112,33 @@ public class LIFReader extends FormatReader {
   // -- Fields --
 
   /** Offsets to memory blocks, paired with their corresponding description. */
-  private Vector<Long> offsets;
+  private List<Long> offsets;
 
   private int[][] realChannel;
   private int lastChannel = 0;
 
-  private Vector<String> lutNames = new Vector<String>();
-  private Vector<Double> physicalSizeXs = new Vector<Double>();
-  private Vector<Double> physicalSizeYs = new Vector<Double>();
-  private Vector<Length> fieldPosX = new Vector<Length>();
-  private Vector<Length> fieldPosY = new Vector<Length>();
+  private List<String> lutNames = new ArrayList<String>();
+  private List<Double> physicalSizeXs = new ArrayList<Double>();
+  private List<Double> physicalSizeYs = new ArrayList<Double>();
+  private List<Length> fieldPosX = new ArrayList<Length>();
+  private List<Length> fieldPosY = new ArrayList<Length>();
 
   private String[] descriptions, microscopeModels, serialNumber;
   private Double[] pinholes, zooms, zSteps, tSteps, lensNA;
   private Double[][] expTimes, gains, detectorOffsets;
   private String[][] channelNames;
-  private Vector[] detectorModels;
+  private List[] detectorModels;
   private Double[][] exWaves;
-  private Vector[] activeDetector;
+  private List[] activeDetector;
   private HashMap[] detectorIndexes;
 
   private String[] immersions, corrections, objectiveModels;
   private Double[] magnification;
   private Length[] posX, posY, posZ;
   private Double[] refractiveIndex;
-  private Vector[] cutIns, cutOuts, filterModels;
+  private List[] cutIns, cutOuts, filterModels;
   private double[][] timestamps;
-  private Vector[] laserWavelength, laserIntensity;
+  private List[] laserWavelength, laserIntensity;
   private ROI[][] imageROIs;
   private boolean alternateCenter = false;
   private String[] imageNames;
@@ -388,7 +389,7 @@ public class LIFReader extends FormatReader {
     super.initFile(id);
     in = new RandomAccessInputStream(id);
     in.setEncoding(ENCODING);
-    offsets = new Vector<Long>();
+    offsets = new ArrayList<Long>();
 
     in.order(true);
 
@@ -611,15 +612,15 @@ public class LIFReader extends FormatReader {
         }
       }
 
-      Vector lasers = laserWavelength[index];
-      Vector laserIntensities = laserIntensity[index];
+      final List<Double> lasers = laserWavelength[index];
+      final List<Double> laserIntensities = laserIntensity[index];
       int nextChannel = 0;
 
       if (lasers != null) {
         int laserIndex = 0;
         while (laserIndex < lasers.size()) {
           if ((Double) lasers.get(laserIndex) == 0) {
-            lasers.removeElementAt(laserIndex);
+            lasers.remove(laserIndex);
           }
           else {
             laserIndex++;
@@ -638,7 +639,7 @@ public class LIFReader extends FormatReader {
           }
         }
 
-        Vector<Integer> validIntensities = new Vector<Integer>();
+        final List<Integer> validIntensities = new ArrayList<Integer>();
         for (int laser=0; laser<laserIntensities.size(); laser++) {
           double intensity = (Double) laserIntensities.get(laser);
           if (intensity < 100) {
@@ -751,7 +752,7 @@ public class LIFReader extends FormatReader {
         store.setPixelsTimeIncrement(new Time(tSteps[index], UNITS.S), i);
       }
 
-      Vector detectors = detectorModels[index];
+      final List<String> detectors = detectorModels[index];
       if (detectors != null) {
         nextChannel = 0;
         int start = detectors.size() - getEffectiveSizeC();
@@ -783,7 +784,7 @@ public class LIFReader extends FormatReader {
         }
       }
 
-      Vector activeDetectors = activeDetector[index];
+      final List<Boolean> activeDetectors = activeDetector[index];
       int firstDetector = activeDetectors == null ? 0 :
         activeDetectors.size() - getEffectiveSizeC();
       int nextDetector = firstDetector;
@@ -968,10 +969,10 @@ public class LIFReader extends FormatReader {
     core = new ArrayList<CoreMetadata>(imageNodes.getLength());
     acquiredDate = new double[imageNodes.getLength()];
     descriptions = new String[imageNodes.getLength()];
-    laserWavelength = new Vector[imageNodes.getLength()];
-    laserIntensity = new Vector[imageNodes.getLength()];
+    laserWavelength = new List[imageNodes.getLength()];
+    laserIntensity = new List[imageNodes.getLength()];
     timestamps = new double[imageNodes.getLength()][];
-    activeDetector = new Vector[imageNodes.getLength()];
+    activeDetector = new List[imageNodes.getLength()];
     serialNumber = new String[imageNodes.getLength()];
     lensNA = new Double[imageNodes.getLength()];
     magnification = new Double[imageNodes.getLength()];
@@ -982,11 +983,11 @@ public class LIFReader extends FormatReader {
     posY = new Length[imageNodes.getLength()];
     posZ = new Length[imageNodes.getLength()];
     refractiveIndex = new Double[imageNodes.getLength()];
-    cutIns = new Vector[imageNodes.getLength()];
-    cutOuts = new Vector[imageNodes.getLength()];
-    filterModels = new Vector[imageNodes.getLength()];
+    cutIns = new List[imageNodes.getLength()];
+    cutOuts = new List[imageNodes.getLength()];
+    filterModels = new List[imageNodes.getLength()];
     microscopeModels = new String[imageNodes.getLength()];
-    detectorModels = new Vector[imageNodes.getLength()];
+    detectorModels = new List[imageNodes.getLength()];
     detectorIndexes = new HashMap[imageNodes.getLength()];
     zSteps = new Double[imageNodes.getLength()];
     tSteps = new Double[imageNodes.getLength()];
@@ -1021,7 +1022,7 @@ public class LIFReader extends FormatReader {
       translateSingleROIs(image, i);
       translateDetectors(image, i);
 
-      Stack<String> nameStack = new Stack<String>();
+      final Deque<String> nameStack = new ArrayDeque<String>();
       populateOriginalMetadata(image, nameStack);
       addUserCommentMeta(image);
     }
@@ -1040,7 +1041,7 @@ public class LIFReader extends FormatReader {
     core = newCore;
   }
 
-  private void populateOriginalMetadata(Element root, Stack<String> nameStack) {
+  private void populateOriginalMetadata(Element root, Deque<String> nameStack) {
     String name = root.getNodeName();
     if (root.hasAttributes() && !name.equals("Element") &&
       !name.equals("Attachment") && !name.equals("LMSDataContainerHeader"))
@@ -1092,7 +1093,7 @@ public class LIFReader extends FormatReader {
   }
 
   private void translateImageNames(Element imageNode, int image) {
-    Vector<String> names = new Vector<String>();
+    final List<String> names = new ArrayList<String>();
     Element parent = imageNode;
     while (true) {
       parent = (Element) parent.getParentNode();
@@ -1116,7 +1117,7 @@ public class LIFReader extends FormatReader {
     NodeList definitions = getNodes(imageNode, "ATLConfocalSettingDefinition");
     if (definitions == null) return;
 
-    Vector<String> channels = new Vector<String>();
+    final List<String> channels = new ArrayList<String>();
     int nextChannel = 0;
     for (int definition=0; definition<definitions.getLength(); definition++) {
       Element definitionNode = (Element) definitions.item(definition);
@@ -1168,7 +1169,7 @@ public class LIFReader extends FormatReader {
             double cutOut = new Double(multiband.getAttribute("RightWorld"));
             if ((int) cutIn > 0) {
               if (cutIns[image] == null) {
-                cutIns[image] = new Vector<PositiveFloat>();
+                cutIns[image] = new ArrayList<PositiveFloat>();
               }
               Length in =
                 FormatTools.getCutIn((double) Math.round(cutIn));
@@ -1178,7 +1179,7 @@ public class LIFReader extends FormatReader {
             }
             if ((int) cutOut > 0) {
               if (cutOuts[image] == null) {
-                cutOuts[image] = new Vector<PositiveFloat>();
+                cutOuts[image] = new ArrayList<PositiveFloat>();
               }
               Length out =
                 FormatTools.getCutOut((double) Math.round(cutOut));
@@ -1362,8 +1363,8 @@ public class LIFReader extends FormatReader {
     NodeList aotfLists = getNodes(imageNode, "AotfList");
     if (aotfLists == null) return;
 
-    laserWavelength[image] = new Vector<Double>();
-    laserIntensity[image] = new Vector<Double>();
+    laserWavelength[image] = new ArrayList<Double>();
+    laserIntensity[image] = new ArrayList<Double>();
 
     int baseIntensityIndex = 0;
 
@@ -1385,7 +1386,7 @@ public class LIFReader extends FormatReader {
 
         Double wavelength = new Double(laserLine.getAttribute("LaserLine"));
         if (index < laserWavelength[image].size()) {
-          laserWavelength[image].setElementAt(wavelength, index);
+          laserWavelength[image].set(index, wavelength);
         }
         else {
           for (int i=laserWavelength[image].size(); i<index; i++) {
@@ -1401,7 +1402,7 @@ public class LIFReader extends FormatReader {
         int realIndex = baseIntensityIndex + index;
 
         if (realIndex < laserIntensity[image].size()) {
-          laserIntensity[image].setElementAt(realIntensity, realIndex);
+          laserIntensity[image].set(realIndex, realIntensity);
         }
         else {
           while (realIndex < laserIntensity[image].size()) {
@@ -1458,10 +1459,10 @@ public class LIFReader extends FormatReader {
     NodeList filterSettings = getNodes(imageNode, "FilterSettingRecord");
     if (filterSettings == null) return;
 
-    activeDetector[image] = new Vector<Boolean>();
-    cutIns[image] = new Vector<PositiveFloat>();
-    cutOuts[image] = new Vector<PositiveFloat>();
-    filterModels[image] = new Vector<String>();
+    activeDetector[image] = new ArrayList<Boolean>();
+    cutIns[image] = new ArrayList<PositiveFloat>();
+    cutOuts[image] = new ArrayList<PositiveFloat>();
+    filterModels[image] = new ArrayList<String>();
     detectorIndexes[image] = new HashMap<Integer, String>();
 
     int nextChannel = 0;
@@ -1590,7 +1591,7 @@ public class LIFReader extends FormatReader {
     detectorOffsets[image] = new Double[getEffectiveSizeC()];
     channelNames[image] = new String[getEffectiveSizeC()];
     exWaves[image] = new Double[getEffectiveSizeC()];
-    detectorModels[image] = new Vector<String>();
+    detectorModels[image] = new ArrayList<String>();
 
     for (int i=0; i<scannerSettings.getLength(); i++) {
       Element scannerSetting = (Element) scannerSettings.item(i);
@@ -1936,8 +1937,8 @@ public class LIFReader extends FormatReader {
     // -- Fields --
     public int type;
 
-    public Vector<Double> x = new Vector<Double>();
-    public Vector<Double> y = new Vector<Double>();
+    public List<Double> x = new ArrayList<Double>();
+    public List<Double> y = new ArrayList<Double>();
 
     // center point of the ROI
     public double transX, transY;
@@ -2069,13 +2070,13 @@ public class LIFReader extends FormatReader {
       for (int i=0; i<x.size(); i++) {
         double coordinate = x.get(i).doubleValue() * 1000000;
         coordinate *= 1;
-        x.setElementAt(coordinate, i);
+        x.set(i, coordinate);
       }
 
       for (int i=0; i<y.size(); i++) {
         double coordinate = y.get(i).doubleValue() * 1000000;
         coordinate *= 1;
-        y.setElementAt(coordinate, i);
+        y.set(i, coordinate);
       }
 
       normalized = true;

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1386,7 +1386,7 @@ public class LIFReader extends FormatReader {
         }
         else {
           for (int i=laserWavelength[image].size(); i<index; i++) {
-            laserWavelength[image].add(new Double(0));
+            laserWavelength[image].add(Double.valueOf(0));
           }
           laserWavelength[image].add(wavelength);
         }

--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -25,11 +25,14 @@
 
 package loci.formats.in;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.Stack;
+import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
@@ -81,13 +84,13 @@ public class LeicaHandler extends BaseHandler {
 
   // -- Fields --
 
-  private Stack<String> nameStack = new Stack<String>();
+  private Deque<String> nameStack = new ArrayDeque<String>();
 
   private String elementName, collection;
   private int count = 0, numChannels, extras = 1;
 
   private Vector<String> lutNames;
-  private Vector<Length> xPos, yPos, zPos;
+  private List<Length> xPos, yPos, zPos;
   private double physicalSizeX, physicalSizeY;
 
   private int numDatasets = -1;
@@ -97,7 +100,7 @@ public class LeicaHandler extends BaseHandler {
 
   private int nextChannel = 0;
   private Double zoom, pinhole;
-  private Vector<Integer> detectorIndices;
+  private List<Integer> detectorIndices;
   private String filterWheelName;
   private int nextFilter = 0;
   private int nextROI = 0;
@@ -112,12 +115,12 @@ public class LeicaHandler extends BaseHandler {
   private boolean canParse = true;
   private long firstStamp = 0;
 
-  private Hashtable<Integer, String> bytesPerAxis;
-  private Vector<MultiBand> multiBands = new Vector<MultiBand>();
-  private Vector<Detector> detectors = new Vector<Detector>();
-  private Vector<Laser> lasers = new Vector<Laser>();
-  private Hashtable<String, Channel> channels =
-    new Hashtable<String, Channel>();
+  private Map<Integer, String> bytesPerAxis;
+  private List<MultiBand> multiBands = new ArrayList<MultiBand>();
+  private List<Detector> detectors = new ArrayList<Detector>();
+  private List<Laser> lasers = new ArrayList<Laser>();
+  private Map<String, Channel> channels =
+    new HashMap<String, Channel>();
 
   private MetadataLevel level;
   private int laserCount = 0;
@@ -130,11 +133,11 @@ public class LeicaHandler extends BaseHandler {
     lutNames = new Vector<String>();
     this.store = store;
     core = new ArrayList<CoreMetadata>();
-    detectorIndices = new Vector<Integer>();
-    xPos = new Vector<Length>();
-    yPos = new Vector<Length>();
-    zPos = new Vector<Length>();
-    bytesPerAxis = new Hashtable<Integer, String>();
+    detectorIndices = new ArrayList<Integer>();
+    xPos = new ArrayList<Length>();
+    yPos = new ArrayList<Length>();
+    zPos = new ArrayList<Length>();
+    bytesPerAxis = new HashMap<Integer, String>();
     this.level = level;
   }
 
@@ -150,7 +153,7 @@ public class LeicaHandler extends BaseHandler {
 
   @Override
   public void endElement(String uri, String localName, String qName) {
-    if (!nameStack.empty() && nameStack.peek().equals(qName)) nameStack.pop();
+    if (!nameStack.isEmpty() && nameStack.peek().equals(qName)) nameStack.pop();
 
     if (qName.equals("ImageDescription")) {
       CoreMetadata coreMeta = core.get(numDatasets);
@@ -735,7 +738,7 @@ public class LeicaHandler extends BaseHandler {
         // find the corresponding MultiBand and Detector
         MultiBand m = null;
         Detector detector = null;
-        Laser laser = lasers.size() == 0 ? null : lasers.get(lasers.size() - 1);
+        Laser laser = lasers.isEmpty() ? null : lasers.get(lasers.size() - 1);
         String c = attributes.getValue("Channel");
         int channel = c == null ? 0 : Integer.parseInt(c);
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import loci.common.DataTools;
 import loci.common.DateTools;
@@ -116,7 +116,7 @@ public class LeicaReader extends FormatReader {
   protected MinimalTiffReader tiff;
 
   /** Array of image file names. */
-  protected Vector[] files;
+  protected List[] files;
 
   /** Number of series in the file. */
   private int numSeries;
@@ -131,26 +131,26 @@ public class LeicaReader extends FormatReader {
 
   private String[][] timestamps;
 
-  private Vector<String> seriesNames;
-  private Vector<String> seriesDescriptions;
+  private List<String> seriesNames;
+  private List<String> seriesDescriptions;
   private int lastPlane = 0, nameLength = 0;
 
   private double[][] physicalSizes;
   private double[] pinhole, exposureTime;
 
   private int nextDetector = 0, nextChannel = 0;
-  private Vector<Integer> activeChannelIndices = new Vector<Integer>();
+  private List<Integer> activeChannelIndices = new ArrayList<Integer>();
   private boolean sequential = false;
 
-  private Vector[] channelNames;
-  private Vector[] emWaves;
-  private Vector[] exWaves;
+  private List[] channelNames;
+  private List[] emWaves;
+  private List[] exWaves;
 
   private boolean[][] cutInPopulated;
   private boolean[][] cutOutPopulated;
   private boolean[][] filterRefPopulated;
 
-  private Vector<Detector> detectors = new Vector<Detector>();
+  private List<Detector> detectors = new ArrayList<Detector>();
 
   private int[] tileWidth, tileHeight;
 
@@ -292,7 +292,7 @@ public class LeicaReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    Vector<String> v = new Vector<String>();
+    final List<String> v = new ArrayList<String>();
     if (leiFilename != null) v.add(leiFilename);
     if (!noPixels && files != null) {
       for (Object file : files[getSeries()]) {
@@ -381,7 +381,7 @@ public class LeicaReader extends FormatReader {
 
         r.close();
 
-        files = new Vector[] {new Vector()};
+        files = new ArrayList[] {new ArrayList()};
         files[0].add(id);
         tiff = new MinimalTiffReader();
 
@@ -412,7 +412,7 @@ public class LeicaReader extends FormatReader {
 
     MetadataLevel metadataLevel = metadataOptions.getMetadataLevel();
 
-    seriesNames = new Vector<String>();
+    seriesNames = new ArrayList<String>();
 
     byte[] fourBytes = new byte[4];
     in.read(fourBytes);
@@ -464,19 +464,19 @@ public class LeicaReader extends FormatReader {
       core.add(new CoreMetadata());
     }
 
-    files = new Vector[numSeries];
+    files = new List[numSeries];
 
-    channelNames = new Vector[getSeriesCount()];
-    emWaves = new Vector[getSeriesCount()];
-    exWaves = new Vector[getSeriesCount()];
+    channelNames = new List[getSeriesCount()];
+    emWaves = new List[getSeriesCount()];
+    exWaves = new List[getSeriesCount()];
     cutInPopulated = new boolean[getSeriesCount()][];
     cutOutPopulated = new boolean[getSeriesCount()][];
     filterRefPopulated = new boolean[getSeriesCount()][];
 
     for (int i=0; i<getSeriesCount(); i++) {
-      channelNames[i] = new Vector();
-      emWaves[i] = new Vector();
-      exWaves[i] = new Vector();
+      channelNames[i] = new ArrayList();
+      emWaves[i] = new ArrayList();
+      exWaves[i] = new ArrayList();
     }
 
     // determine the length of a filename
@@ -514,10 +514,10 @@ public class LeicaReader extends FormatReader {
       count[i] = core.get(i).imageCount;
     }
 
-    Vector[] tempFiles = files;
+    final List[] tempFiles = files;
     IFDList tempIFDs = headerIFDs;
     core = new ArrayList<CoreMetadata>(numSeries);
-    files = new Vector[numSeries];
+    files = new List[numSeries];
     headerIFDs = new IFDList();
     int index = 0;
 
@@ -546,7 +546,7 @@ public class LeicaReader extends FormatReader {
 
     if (headerIFDs == null) headerIFDs = ifds;
 
-    seriesDescriptions = new Vector<String>();
+    seriesDescriptions = new ArrayList<String>();
 
     physicalSizes = new double[headerIFDs.size()][5];
     pinhole = new double[headerIFDs.size()];
@@ -855,7 +855,7 @@ public class LeicaReader extends FormatReader {
       listing = Location.getIdMap().keySet().toArray(new String[0]);
     }
 
-    Vector<String> list = new Vector<String>();
+    final List<String> list = new ArrayList<String>();
 
     for (int k=0; k<listing.length; k++) {
       if (checkSuffix(listing[k], TiffReader.TIFF_SUFFIXES)) {
@@ -868,7 +868,7 @@ public class LeicaReader extends FormatReader {
 
   private void parseFilenames(int seriesIndex) throws IOException {
     int maxPlanes = 0;
-    Vector<String> f = new Vector<String>();
+    final List<String> f = new ArrayList<String>();
     int tempImages = in.readInt();
 
     if (((long) tempImages * nameLength) > in.length()) {
@@ -915,7 +915,7 @@ public class LeicaReader extends FormatReader {
       String[] listing = getTIFFList();
 
       // grab the file patterns
-      Vector<String> filePatterns = new Vector<String>();
+      final List<String> filePatterns = new ArrayList<String>();
       for (String q : listing) {
         Location l = new Location(q).getAbsoluteFile();
         if (!l.exists()) {
@@ -929,7 +929,7 @@ public class LeicaReader extends FormatReader {
 
         if (guess.getAxisCountS() >= 1) {
           String pre = pattern.getPrefix(guess.getAxisCountS());
-          Vector<String> fileList = new Vector<String>();
+          final List<String> fileList = new ArrayList<String>();
           for (int n=0; n<listing.length; n++) {
             Location p = new Location(dirPrefix, listing[n]);
             if (p.getAbsolutePath().startsWith(pre)) {
@@ -960,7 +960,7 @@ public class LeicaReader extends FormatReader {
           }
 
           if (validPattern) {
-            files[seriesIndex] = new Vector<String>();
+            files[seriesIndex] = new ArrayList<String>();
             files[seriesIndex].addAll(Arrays.asList(pattern));
           }
         }
@@ -1565,7 +1565,7 @@ public class LeicaReader extends FormatReader {
           if (nextChannel < channelNames[series].size()) {
             String name = (String) channelNames[series].get(nextChannel);
             if (name == null || name.trim().equals("") || name.equals("None")) {
-              channelNames[series].setElementAt(detector.name, nextChannel);
+              channelNames[series].set(nextChannel, detector.name);
             }
           }
           else {

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -27,8 +27,9 @@ package loci.formats.in;
 
 import java.io.IOException;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 
 import org.xml.sax.Attributes;
@@ -470,7 +471,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     public ArrayList<Image> imageMap = new ArrayList<Image>();
 
     // Stack of XML elements to keep track of placement in the tree.
-    public Stack<String> nameStack = new Stack<String>();
+    public Deque<String> nameStack = new ArrayDeque<String>();
     // CDATA text stored while parsing.  Note that this is limited to a
     // single span between two tags, and CDATA with embedded elements is
     // not supported.
@@ -482,7 +483,7 @@ public class LeicaSCNReader extends BaseTiffReader {
 
     @Override
     public void endElement(String uri, String localName, String qName) {
-      if (!nameStack.empty() && nameStack.peek().equals(qName)) {
+      if (!nameStack.isEmpty() && nameStack.peek().equals(qName)) {
         nameStack.pop();
       }
 

--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -448,7 +448,7 @@ public class LiFlimReader extends FormatReader {
           store.setImageAcquisitionDate(new Timestamp(date), 0);
         }
         firstStamp = stamp;
-        deltaT = new Double(0);
+        deltaT = Double.valueOf(0);
       }
       else {
         long ms = stamp - firstStamp;

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -1165,8 +1165,8 @@ public class MIASReader extends FormatReader {
 
         String maskID = MetadataTools.createLSID("Shape", roi + nOverlays, 0);
         store.setMaskID(maskID, roi + nOverlays, 0);
-        store.setMaskX(new Double(0), roi + nOverlays, 0);
-        store.setMaskY(new Double(0), roi + nOverlays, 0);
+        store.setMaskX(Double.valueOf(0), roi + nOverlays, 0);
+        store.setMaskY(Double.valueOf(0), roi + nOverlays, 0);
         store.setMaskWidth(new Double(getSizeX()), roi + nOverlays, 0);
         store.setMaskHeight(new Double(getSizeY()), roi + nOverlays, 0);
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -878,7 +878,7 @@ public class MetamorphReader extends BaseTiffReader {
 
       for (int p=0; p<getImageCount(); p++) {
         int[] coords = getZCTCoords(p);
-        Double deltaT = new Double(0);
+        Double deltaT = Double.valueOf(0);
         Double expTime = exposureTime;
         Double xmlZPosition = null;
 

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -27,8 +27,9 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -72,7 +73,7 @@ public class PCIReader extends FormatReader {
   private HashMap<Integer, Double> timestamps;
   private String creationDate;
   private int binning;
-  private Vector<Double> uniqueZ;
+  private List<Double> uniqueZ;
 
   // -- Constructor --
 
@@ -206,7 +207,7 @@ public class PCIReader extends FormatReader {
 
     imageFiles = new HashMap<Integer, String>();
     timestamps = new HashMap<Integer, Double>();
-    uniqueZ = new Vector<Double>();
+    uniqueZ = new ArrayList<Double>();
 
     CoreMetadata m = core.get(0);
 
@@ -214,8 +215,8 @@ public class PCIReader extends FormatReader {
 
     double scaleFactor = 1;
 
-    Vector<String> allFiles = poi.getDocumentList();
-    if (allFiles.size() == 0) {
+    final List<String> allFiles = poi.getDocumentList();
+    if (allFiles.isEmpty()) {
       throw new FormatException(
         "No files were found - the .cxd may be corrupt.");
     }
@@ -351,7 +352,7 @@ public class PCIReader extends FormatReader {
     }
 
     if (getSizeZ() <= 1 || (getImageCount() % getSizeZ()) != 0) {
-      m.sizeZ = uniqueZ.size() == 0 ? 1 : uniqueZ.size();
+      m.sizeZ = uniqueZ.isEmpty() ? 1 : uniqueZ.size();
     }
     m.sizeT = getImageCount() / getSizeZ();
 

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -27,10 +27,10 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Vector;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
@@ -179,7 +179,7 @@ public class ScreenReader extends FormatReader {
     int[] spwIndexes = getSPWIndexes(getSeries());
     int well = spwIndexes[0];
 
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     if (plateMetadataFiles != null) {
       for (String f : plateMetadataFiles) {
         files.add(f);
@@ -227,7 +227,7 @@ public class ScreenReader extends FormatReader {
     else throw new FormatException(id + " is not a valid well name.");
 
     // build the list of plate directories
-    Vector<String> metadataFiles = new Vector<String>();
+    final List<String> metadataFiles = new ArrayList<String>();
 
     Comparator<String> c = new Comparator<String>() {
       @Override
@@ -246,7 +246,7 @@ public class ScreenReader extends FormatReader {
     };
 
     // build the list of well files for each plate
-    Vector<String> tmpWells = new Vector<String>();
+    final List<String> tmpWells = new ArrayList<String>();
 
     String[] plateList = plate.list(true);
     int maxRow = 0, maxCol = 0;

--- a/components/formats-gpl/src/loci/formats/in/VarianFDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VarianFDFReader.java
@@ -26,8 +26,9 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Vector;
+import java.util.List;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
@@ -49,7 +50,7 @@ public class VarianFDFReader extends FormatReader {
 
   // -- Fields --
 
-  private Vector<String> files = new Vector<String>();
+  private final List<String> files = new ArrayList<String>();
   private long[] pixelOffsets;
   private double pixelSizeX;
   private double pixelSizeY;
@@ -81,7 +82,7 @@ public class VarianFDFReader extends FormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     if (noPixels) return null;
-    if (files.size() == 0) return new String[] {currentId};
+    if (files.isEmpty()) return new String[] {currentId};
     return files.toArray(new String[files.size()]);
   }
 
@@ -296,7 +297,7 @@ public class VarianFDFReader extends FormatReader {
       addGlobalMeta(var, value);
     }
 
-    if (multifile && files.size() == 0) {
+    if (multifile && files.isEmpty()) {
       Location thisFile = new Location(file).getAbsoluteFile();
       Location parent = thisFile.getParentFile();
       String[] list = parent.list(true);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -28,10 +28,11 @@ package loci.formats.in;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.Stack;
 import javax.xml.parsers.DocumentBuilder;
 
 import loci.common.ByteArrayHandle;
@@ -1240,7 +1241,7 @@ public class ZeissCZIReader extends FormatReader {
     translateLayers(realRoot);
     translateHardwareSettings(realRoot);
 
-    Stack<String> nameStack = new Stack<String>();
+    final Deque<String> nameStack = new ArrayDeque<String>();
     populateOriginalMetadata(realRoot, nameStack);
   }
 
@@ -2367,7 +2368,7 @@ public class ZeissCZIReader extends FormatReader {
     return null;
   }
 
-  private void populateOriginalMetadata(Element root, Stack<String> nameStack) {
+  private void populateOriginalMetadata(Element root, Deque<String> nameStack) {
     String name = root.getNodeName();
     if (name.equals("DisplaySetting")) {
       return;

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 import loci.common.DataTools;
 import loci.common.Location;
@@ -334,8 +334,8 @@ public class ZeissZVIReader extends BaseZeissReader {
     if (core.size() > 1) {
       Integer[] t = tiles.keySet().toArray(new Integer[tiles.size()]);
       Arrays.sort(t);
-      Vector<Integer> tmpOffsets = new Vector<Integer>();
-      Vector<String> tmpFiles = new Vector<String>();
+      final List<Integer> tmpOffsets = new ArrayList<Integer>();
+      final List<String> tmpFiles = new ArrayList<String>();
       int index = 0;
       for (Integer key : t) {
         int nTiles = tiles.get(key).intValue();
@@ -503,7 +503,7 @@ public class ZeissZVIReader extends BaseZeissReader {
 
     // scan stream for offsets to each ROI
 
-    Vector<Long> roiOffsets = new Vector<Long>();
+    final List<Long> roiOffsets = new ArrayList<Long>();
 
 
     // Bytes 0x0-1 == 0x3

--- a/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
@@ -131,7 +131,7 @@ public class POIServiceImpl extends AbstractService implements POIService {
   @Override
   public int getFileSize(String file) {
     if (fileSizes.containsKey(file)) {
-      return fileSizes.get(file).intValue();
+      return fileSizes.get(file);
     }
     return -1;
   }

--- a/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
@@ -28,11 +28,8 @@ package loci.formats.services;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.Vector;
 
 import loci.common.RandomAccessInputStream;
@@ -55,9 +52,9 @@ public class POIServiceImpl extends AbstractService implements POIService {
   private DirectoryEntry root;
   private RandomAccessInputStream stream;
 
-  private List<String> filePath;
-  private Map<String, Integer> fileSizes;
-  private Map<String, DocumentEntry> files;
+  private Vector<String> filePath;
+  private Hashtable<String, Integer> fileSizes;
+  private Hashtable<String, DocumentEntry> files;
 
   // -- POIService API methods --
 
@@ -90,9 +87,9 @@ public class POIServiceImpl extends AbstractService implements POIService {
     root = fileSystem.getRoot();
 
     // build the list of files in the file system
-    filePath = new ArrayList<String>();
-    fileSizes = new HashMap<String, Integer>();
-    files = new HashMap<String, DocumentEntry>();
+    filePath = new Vector<String>();
+    fileSizes = new Hashtable<String, Integer>();
+    files = new Hashtable<String, DocumentEntry>();
 
     parseFile(root);
   }
@@ -186,7 +183,7 @@ public class POIServiceImpl extends AbstractService implements POIService {
         s.close();
       }
     }
-    filePath.remove(filePath.size() - 1);
+    filePath.removeElementAt(filePath.size() - 1);
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/POIServiceImpl.java
@@ -28,8 +28,11 @@ package loci.formats.services;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Hashtable;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import loci.common.RandomAccessInputStream;
@@ -52,9 +55,9 @@ public class POIServiceImpl extends AbstractService implements POIService {
   private DirectoryEntry root;
   private RandomAccessInputStream stream;
 
-  private Vector<String> filePath;
-  private Hashtable<String, Integer> fileSizes;
-  private Hashtable<String, DocumentEntry> files;
+  private List<String> filePath;
+  private Map<String, Integer> fileSizes;
+  private Map<String, DocumentEntry> files;
 
   // -- POIService API methods --
 
@@ -87,9 +90,9 @@ public class POIServiceImpl extends AbstractService implements POIService {
     root = fileSystem.getRoot();
 
     // build the list of files in the file system
-    filePath = new Vector<String>();
-    fileSizes = new Hashtable<String, Integer>();
-    files = new Hashtable<String, DocumentEntry>();
+    filePath = new ArrayList<String>();
+    fileSizes = new HashMap<String, Integer>();
+    files = new HashMap<String, DocumentEntry>();
 
     parseFile(root);
   }
@@ -178,12 +181,12 @@ public class POIServiceImpl extends AbstractService implements POIService {
 
         DocumentInputStream s =
           new DocumentInputStream((DocumentEntry) o, stream);
-        fileSizes.put(path.toString(), new Integer(s.available()));
+        fileSizes.put(path.toString(), s.available());
         files.put(path.toString(), (DocumentEntry) o);
         s.close();
       }
     }
-    filePath.removeElementAt(filePath.size() - 1);
+    filePath.remove(filePath.size() - 1);
   }
 
 }


### PR DESCRIPTION
This PR is another batch of making the code more idiomatically Java 6, with a focus on switching away from synchronized collections where access is single-threaded, also some attempts to avoid unnecessary heap allocations and other small efficiency tweaks. It should *not* change any reader behaviors.

--no-rebase