### PR TITLE
Prevent test failures when PhysicalSize* units are in pixels

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -468,19 +468,19 @@ public class Configuration {
 
       Length physicalX = retrieve.getPixelsPhysicalSizeX(series);
       if (physicalX != null) {
-        seriesTable.put(PHYSICAL_SIZE_X, physicalX.toString());
+        seriesTable.put(PHYSICAL_SIZE_X, physicalX.value(UNITS.MICROM).toString());
       }
       Length physicalY = retrieve.getPixelsPhysicalSizeY(series);
       if (physicalY != null) {
-        seriesTable.put(PHYSICAL_SIZE_Y, physicalY.toString());
+        seriesTable.put(PHYSICAL_SIZE_Y, physicalY.value(UNITS.MICROM).toString());
       }
       Length physicalZ = retrieve.getPixelsPhysicalSizeZ(series);
       if (physicalZ != null) {
-        seriesTable.put(PHYSICAL_SIZE_Z, physicalZ.toString());
+        seriesTable.put(PHYSICAL_SIZE_Z, physicalZ.value(UNITS.MICROM).toString());
       }
       Time timeIncrement = retrieve.getPixelsTimeIncrement(series);
       if (timeIncrement != null) {
-        seriesTable.put(TIME_INCREMENT, timeIncrement.toString());
+        seriesTable.put(TIME_INCREMENT, timeIncrement.value().toString());
       }
 
       Timestamp acquisition = retrieve.getImageAcquisitionDate(series);
@@ -503,7 +503,7 @@ public class Configuration {
           int plane = reader.getIndex(0, c, 0);
           if (plane < retrieve.getPlaneCount(series)) {
             seriesTable.put(EXPOSURE_TIME + c,
-              retrieve.getPlaneExposureTime(series, plane).toString());
+              retrieve.getPlaneExposureTime(series, plane).value().toString());
           }
         }
         catch (NullPointerException e) { }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -912,9 +912,9 @@ public class FormatReaderTest {
         expectedSize = null;
       }
       Length realSize = retrieve.getPixelsPhysicalSizeX(i);
-      Double size = realSize == null ? null : realSize.value(UNITS.MICROM).doubleValue();
+      Number size = realSize == null ? null : realSize.value(UNITS.MICROM);
 
-      if (!(expectedSize == null && realSize == null) &&
+      if (!(expectedSize == null && size == null) &&
         (expectedSize == null || !expectedSize.equals(size)))
       {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
@@ -937,9 +937,9 @@ public class FormatReaderTest {
         expectedSize = null;
       }
       Length realSize = retrieve.getPixelsPhysicalSizeY(i);
-      Double size = realSize == null ? null : realSize.value(UNITS.MICROM).doubleValue();
+      Number size = realSize == null ? null : realSize.value(UNITS.MICROM);
 
-      if (!(expectedSize == null && realSize == null) &&
+      if (!(expectedSize == null && size == null) &&
         (expectedSize == null || !expectedSize.equals(size)))
       {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
@@ -963,9 +963,9 @@ public class FormatReaderTest {
         expectedSize = null;
       }
       Length realSize = retrieve.getPixelsPhysicalSizeZ(i);
-      Double size = realSize == null ? null : realSize.value(UNITS.MICROM).doubleValue();
+      Number size = realSize == null ? null : realSize.value(UNITS.MICROM);
 
-      if (!(expectedSize == null && realSize == null) &&
+      if (!(expectedSize == null && size == null) &&
         (expectedSize == null || !expectedSize.equals(size)))
       {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");


### PR DESCRIPTION
This should fix the 8 test failures that are not logged in https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-5.1-merge-full-repository-win/3/ and https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-5.1-merge-full-repository/454/.

This issue was exposed by gh-1716; if the physical unit is set to 'pixel', then it won't be convertible to ```Units.MICROM```, which results in hidden NPEs when the tests are run.  No testing needed other than to verify that the failure count is reduce by 8 with this PR merged.