### PR TITLE
LIF: fix user-defined channel name parsing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1643,7 +1643,9 @@ public class LIFReader extends FormatReader {
           }
         }
         // NB: "UesrDefName" is not a typo.
-        else if (id.endsWith("UesrDefName") && !value.equals("None")) {
+        else if ((id.endsWith("UesrDefName") || id.endsWith("UserDefName")) &&
+          !value.equals("None"))
+        {
           if (channelNames[image][c] == null ||
             channelNames[image][c].trim().length() == 0)
           {


### PR DESCRIPTION
The typo ("UesrDefName") that existed in previous versions of LAS AF has
apparently now been fixed.  See QA 10980.

To test, verify that channel names are not present for the file in QA 10980 without this change.  With this change, all series should have channel names ```Test BF```, ```GFP```, and ```mKate``` (just like in LAS AF Lite).