### PR TITLE
Zeiss CZI: do not set indexed for RGB images

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -754,7 +754,7 @@ public class ZeissCZIReader extends FormatReader {
       indexIntoPlanes.put(c, indices);
     }
 
-    if (channels.size() > 0 && channels.get(0).color != null) {
+    if (channels.size() > 0 && channels.get(0).color != null && !isRGB()) {
       for (int i=0; i<seriesCount; i++) {
         core.get(i).indexed = true;
       }


### PR DESCRIPTION
See QA 10987, fixes gh-1719.

To test, verify that opening the file from QA 10987 in Matlab (as described in the issue) or via ```showinf -separate``` no longer throws an exception.  The image is quite large, so you may need to increase the heap size or crop the image to prevent an OOM.