### PR TITLE
Deltavision: fix channel name order for deconvolved data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -1128,13 +1128,7 @@ public class DeltavisionReader extends FormatReader {
         }
         // Plane properties
         else if (key.equals("EM filter")) {
-          int cIndex = 0;
-          try {
-            cIndex = getZCTCoords(currentImage)[1];
-          }
-          catch (IllegalArgumentException e) {
-            LOGGER.debug("", e);
-          }
+          int cIndex = currentImage % getSizeC();
           for (int series=0; series<getSeriesCount(); series++) {
             store.setChannelName(value, series, cIndex);
           }
@@ -1142,7 +1136,7 @@ public class DeltavisionReader extends FormatReader {
         else if (key.equals("ND filter")) {
           value = value.replaceAll("%", "");
           try {
-            int cIndex = getZCTCoords(currentImage)[1];
+            int cIndex = currentImage % getSizeC();
             double nd = Double.parseDouble(value);
             ndFilters[cIndex] = new Double(nd / 100);
           }

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -26,7 +26,9 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
@@ -960,6 +962,9 @@ public class DeltavisionReader extends FormatReader {
 
     int currentImage = 0;
 
+    List<String> channelNames = new ArrayList<String>();
+    List<Double> filters = new ArrayList<Double>();
+
     for (String line : lines) {
       int colon = line.indexOf(":");
       if (colon != -1 && !line.startsWith("Created")) {
@@ -1128,17 +1133,17 @@ public class DeltavisionReader extends FormatReader {
         }
         // Plane properties
         else if (key.equals("EM filter")) {
-          int cIndex = currentImage % getSizeC();
-          for (int series=0; series<getSeriesCount(); series++) {
-            store.setChannelName(value, series, cIndex);
+          if (!channelNames.contains(value)) {
+            channelNames.add(value);
           }
         }
         else if (key.equals("ND filter")) {
           value = value.replaceAll("%", "");
           try {
-            int cIndex = currentImage % getSizeC();
-            double nd = Double.parseDouble(value);
-            ndFilters[cIndex] = new Double(nd / 100);
+            double nd = Double.parseDouble(value) / 100;
+            if (!filters.contains(nd)) {
+              filters.add(nd);
+            }
           }
           catch (NumberFormatException exc) {
             // "BLANK" is the default (e.g. for deconvolved data),
@@ -1146,6 +1151,7 @@ public class DeltavisionReader extends FormatReader {
             if (!value.equals("BLANK")) {
               LOGGER.warn("Could not parse ND filter '{}'", value);
             }
+            filters.add(null);
           }
           catch (IllegalArgumentException e) {
             LOGGER.debug("", e);
@@ -1196,6 +1202,17 @@ public class DeltavisionReader extends FormatReader {
         }
         else {
           LOGGER.warn("Could not parse date '{}'", line);
+        }
+      }
+    }
+
+    for (int series=0; series<getSeriesCount(); series++) {
+      for (int c=0; c<getEffectiveSizeC(); c++) {
+        if (c < channelNames.size()) {
+          store.setChannelName(channelNames.get(c), series, c);
+        }
+        if (c < filters.size()) {
+          ndFilters[c] = filters.get(c);
         }
       }
     }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12807.  To test, use the .dv files from QA 10945 and 10946.  Place both files in the same directory and create a .log file as described in the ticket.

Without this change, ```showinf -nopix -omexml``` on the *R3D_D3D.dv file should show that only the first channel has a name assigned; with this change, the same test should show that every channel has a name.  The names should be the same as shown by ```showinf -nopix -omexml``` on the *R3D.dv file.