### PR TITLE
ImageJ: use series state in open*ImagePlus(String) methods

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -80,6 +80,7 @@ public class LociFunctions extends MacroFunctions {
   // -- Fields --
 
   private ImageProcessorReader r;
+  private int series = 0;
 
   // -- Constructor --
 
@@ -205,7 +206,10 @@ public class LociFunctions extends MacroFunctions {
   public void openImagePlus(String path) {
     ImagePlus[] imps = null;
     try {
-      imps = BF.openImagePlus(path);
+      ImporterOptions options = new ImporterOptions();
+      options.setId(path);
+      options.setSeriesOn(series, true);
+      imps = BF.openImagePlus(options);
       for (ImagePlus imp : imps) imp.show();
     }
     catch (IOException exc) {
@@ -219,7 +223,10 @@ public class LociFunctions extends MacroFunctions {
   public void openThumbImagePlus(String path) {
     ImagePlus[] imps = null;
     try {
-      imps = BF.openThumbImagePlus(path);
+      ImporterOptions options = new ImporterOptions();
+      options.setId(path);
+      options.setSeriesOn(series, true);
+      imps = BF.openThumbImagePlus(options);
       for (ImagePlus imp : imps) imp.show();
     }
     catch (IOException exc) {
@@ -307,7 +314,10 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void setSeries(Double seriesNum) {
-    r.setSeries(seriesNum.intValue());
+    series = seriesNum.intValue();
+    if (r.getCurrentFile() != null) {
+      r.setSeries(series);
+    }
   }
 
   public void getSeries(Double[] seriesNum) {

--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -314,9 +314,11 @@ public class LociFunctions extends MacroFunctions {
   }
 
   public void setSeries(Double seriesNum) {
-    series = seriesNum.intValue();
-    if (r.getCurrentFile() != null) {
-      r.setSeries(series);
+    if (seriesNum != null && seriesNum >= 0) {
+      series = seriesNum.intValue();
+      if (r.getCurrentFile() != null) {
+        r.setSeries(series);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/11145.

To test, use a macro similar to the following in ImageJ:

```
run("Bio-Formats Macro Extensions");
path = "/path/to/multi-series-file";
Ext.setSeries(1);
Ext.openImagePlus(path);
Ext.setSeries(0);
Ext.openImagePlus(path);
```

Verify that without this change, the images for series 0 are opened twice.  With this change, the images for series 1 should be opened first, followed by the images for series 0.
