### PR TITLE
VSI: prevent infinite loop when parsing extended tags

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1386,7 +1386,7 @@ public class CellSensReader extends FormatReader {
             long start = vsi.getFilePointer();
             readTags(vsi, populateMetadata || inDimensionProperties, getVolumeName(tag));
             long end = vsi.getFilePointer();
-            if (start == end) {
+            if (start >= end) {
               break;
             }
           }


### PR DESCRIPTION
The files that demonstrate the problem are unfortunately private, so the only testing necessary is to verify that the builds are/remain green.

/cc @emilroz