### PR TITLE
ICS writer: fix saving of > 2GB of pixel data

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -125,7 +125,7 @@ public class ICSWriter extends FormatWriter {
     int pixelType =
       FormatTools.pixelTypeFromString(meta.getPixelsType(series).toString());
     int bytesPerPixel = FormatTools.getBytesPerPixel(pixelType);
-    int planeSize = sizeX * sizeY * rgbChannels * bytesPerPixel;
+    long planeSize = sizeX * sizeY * rgbChannels * bytesPerPixel;
 
     if (!initialized[series][realIndex]) {
       initialized[series][realIndex] = true;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12602.

To test, use an input file with more than 2GB of pixel data - I used ```large-file&sizeX=2048&sizeY=2048&sizeZ=1000.fake```.  Use bfconvert to convert the input file to an .ics file, and verify that the conversion succeeds without an exception, the output file is larger than 2GB, and the last plane from the output file can be read.  Without this change, the same test would have resulted in an exception during bfconvert.