### PR TITLE
Improvision TIFF: reset image count if ZCT dimensions are incorrect

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -277,7 +277,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
       files = new String[] {currentId};
     }
 
-    if (files.length > 1 && files.length * ifds.size() < getImageCount()) {
+    if (files.length * ifds.size() < getImageCount()) {
       files = new String[] {currentId};
       m.imageCount = ifds.size();
       m.sizeZ = ifds.size();


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12184.

To test, place the TIFF files from QA 8025 and 9163 in the same directory (unzip as necessary and remove extra zip/log files).  Run ```showinf``` on both files, and import both into OMERO - with this change, each of the files should import as a separate fileset, with one plane and no exception.  Without this change, both would have thrown an exception during import as noted in the ticket.