### PR TITLE
ND2: make series names the same length

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1753,9 +1753,11 @@ public class NativeND2Reader extends FormatReader {
     String filename = new Location(getCurrentFile()).getName();
     if (handler != null) {
       ArrayList<String> posNames = handler.getPositionNames();
+      int nameWidth = String.valueOf(getSeriesCount()).length();
       for (int i=0; i<getSeriesCount(); i++) {
-        String suffix =
-          (i < posNames.size() && !posNames.get(i).equals("")) ? posNames.get(i) : "(series " + (i + 1) + ")";
+        String seriesSuffix = String.format("(series %0" + nameWidth + "d)", i + 1);
+        String suffix = (i < posNames.size() && !posNames.get(i).equals("")) ?
+          posNames.get(i) : seriesSuffix;
         String name = filename + " " + suffix;
         store.setImageName(name.trim(), i);
       }


### PR DESCRIPTION
This adds 0-padding to make the index lengths equal, which should make
the series list easier to read when sorted alphanumerically.

Fixes https://trac.openmicroscopy.org/ome/ticket/12809.  To test, check the output of ```showinf -nopix -omexml``` with the .nd2 file from QA 10945.  The Image names should all be the same length with this change.