### PR TITLE
Fix deprecated UpgradeCheck parsing logic (rebased onto develop)

### DIFF
--- a/components/formats-bsd/src/loci/formats/UpgradeChecker.java
+++ b/components/formats-bsd/src/loci/formats/UpgradeChecker.java
@@ -225,35 +225,27 @@ public class UpgradeChecker {
       conn.addRequestProperty("User-Agent", registryID);
       conn.connect();
 
-      // retrieve latest version number from the registry
-
+      // retrieve the string from the registry
       InputStream in = conn.getInputStream();
-      StringBuffer latestVersion = new StringBuffer();
+      StringBuffer sb = new StringBuffer();
       while (true) {
         int data = in.read();
         if (data == -1) {
           break;
         }
-        latestVersion.append((char) data);
+        sb.append((char) data);
       }
       in.close();
 
-      // check to see if the version reported by the registry is greater than
-      // the current version - version numbers are in "x.x.x" format
+      // check if the string is not empty (upgrade available)
 
-      String[] version = latestVersion.toString().split("\\.");
-      String[] thisVersion = FormatTools.VERSION.split("\\.");
-      for (int i=0; i<thisVersion.length; i++) {
-        try {
-          int subVersion = Integer.parseInt(thisVersion[i]);
-          int registrySubVersion = Integer.parseInt(version[i]);
-          if (registrySubVersion != subVersion) {
-            return registrySubVersion > subVersion;
-          }
-        }
-        catch (NumberFormatException e) {
-          return false;
-        }
+      String result = sb.toString();
+      if (sb.length() == 0) {
+        LOGGER.debug("No update needed");
+        return false;
+      } else {
+        LOGGER.debug("UPGRADE AVAILABLE:" + result);
+        return true;
       }
     }
     catch (IOException e) {


### PR DESCRIPTION

This is the same as gh-1741 but rebased onto develop.

----

The UpgradeCheck logic assumed the upgrade check query returns a string
containing the latest version. This commit reproduces the UpgradeChecker logic
implemented in OMERO which only tests for the length of the returned string.

                