### PR TITLE
C++: Add TIFF writer

### DIFF
--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -101,6 +101,7 @@ set(OME_BIOFORMATS_IN_HEADERS
     in/TIFFReader.h)
 
 set(OME_BIOFORMATS_TIFF_SOURCES
+    tiff/Codec.cpp
     tiff/Exception.cpp
     tiff/Field.cpp
     tiff/IFD.cpp
@@ -111,6 +112,7 @@ set(OME_BIOFORMATS_TIFF_SOURCES
     tiff/TileInfo.cpp)
 
 set(OME_BIOFORMATS_TIFF_HEADERS
+    tiff/Codec.h
     tiff/Exception.h
     tiff/Field.h
     tiff/IFD.h

--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -100,6 +100,12 @@ set(OME_BIOFORMATS_IN_HEADERS
     in/OMETIFFReader.h
     in/TIFFReader.h)
 
+set(OME_BIOFORMATS_OUT_SOURCES
+    out/MinimalTIFFWriter.cpp)
+
+set(OME_BIOFORMATS_OUT_HEADERS
+    out/MinimalTIFFWriter.h)
+
 set(OME_BIOFORMATS_TIFF_SOURCES
     tiff/Codec.cpp
     tiff/Exception.cpp
@@ -124,10 +130,6 @@ set(OME_BIOFORMATS_TIFF_HEADERS
     tiff/TileInfo.h
     tiff/Types.h
     tiff/Util.h)
-
-set(OME_BIOFORMATS_OUT_SOURCES)
-
-set(OME_BIOFORMATS_OUT_HEADERS)
 
 set(BIOFORMATS_SOURCES
     ${OME_BIOFORMATS_SOURCES}

--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -109,7 +109,8 @@ set(OME_BIOFORMATS_TIFF_SOURCES
     tiff/Sentry.cpp
     tiff/Tags.cpp
     tiff/TIFF.cpp
-    tiff/TileInfo.cpp)
+    tiff/TileInfo.cpp
+    tiff/Util.cpp)
 
 set(OME_BIOFORMATS_TIFF_HEADERS
     tiff/Codec.h
@@ -121,7 +122,8 @@ set(OME_BIOFORMATS_TIFF_HEADERS
     tiff/Tags.h
     tiff/TIFF.h
     tiff/TileInfo.h
-    tiff/Types.h)
+    tiff/Types.h
+    tiff/Util.h)
 
 set(OME_BIOFORMATS_OUT_SOURCES)
 

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -203,7 +203,7 @@ namespace ome
       isThisType(std::istream& stream) const = 0;
 
       /**
-       * Determine the number of image planes in the current file.
+       * Determine the number of image planes in the current series.
        *
        * @returns the number of image planes.
        */

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -86,57 +86,6 @@ namespace ome
       typedef uint16_t frame_rate_type;
 
     protected:
-      /**
-       * Sentry for saving and restoring writer series state.
-       *
-       * For any FormatWriter method or subclass method which needs to
-       * set and later restore the series/coreIndex/resolution as part
-       * of its operation, this class exists to manage the safe
-       * restoration of the state.  Create an instance of this class
-       * with the writer set to @c *this.  When the instance goes out
-       * of scope, e.g. at the end of a block or method, or when an
-       * exception is thrown, the saved state will be transparently
-       * restored.
-       */
-      class SaveSeries
-      {
-      private:
-        /// Writer for which the state will be saved and restored.
-        const FormatWriter& writer;
-        /// Saved state.
-        dimension_size_type series;
-
-      public:
-        /**
-         * Constructor.
-         *
-         * @param writer the writer to manage.
-         */
-        SaveSeries(const FormatWriter& writer):
-          writer(writer),
-          series(writer.getSeries())
-        {}
-
-        /**
-         * Destructor.
-         *
-         * Saved state will be restored when run.
-         */
-        ~SaveSeries()
-        {
-          try
-            {
-              if (series != writer.getSeries())
-                writer.setSeries(series);
-            }
-          catch (...)
-            {
-              // We can't throw in a destructor.
-            }
-        }
-      };
-
-    protected:
       /// Constructor.
       FormatWriter()
       {}

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -43,6 +43,7 @@
 #include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/FormatTools.h>
 #include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/PixelProperties.h>
 #include <ome/bioformats/XMLTools.h>
 
 #include <ome/compat/regex.h>
@@ -1034,6 +1035,76 @@ namespace ome
         }
 
       return ome::xml::model::enums::DimensionOrder(validorder);
+    }
+
+    storage_size_type
+    pixelSize(const ::ome::xml::meta::MetadataRetrieve& meta,
+              dimension_size_type                       series)
+    {
+      dimension_size_type x = meta.getPixelsSizeX(series);
+      dimension_size_type y = meta.getPixelsSizeY(series);
+      dimension_size_type z = meta.getPixelsSizeZ(series);
+      dimension_size_type t = meta.getPixelsSizeT(series);
+      dimension_size_type c = meta.getPixelsSizeC(series);
+
+      storage_size_type size = bytesPerPixel(meta.getPixelsType(series));
+      size *= x;
+      size *= y;
+      size *= z;
+      size *= t;
+      size *= c;
+
+      return size;
+    }
+
+    storage_size_type
+    pixelSize(const ::ome::xml::meta::MetadataRetrieve& meta)
+    {
+      storage_size_type size = 0;
+
+      for (dimension_size_type  s = 0;
+           s < meta.getImageCount();
+           ++s)
+        {
+          size += pixelSize(meta, s);
+        }
+
+      return size;
+    }
+
+    storage_size_type
+    significantPixelSize(const ::ome::xml::meta::MetadataRetrieve& meta,
+                         dimension_size_type                       series)
+    {
+      dimension_size_type x = meta.getPixelsSizeX(series);
+      dimension_size_type y = meta.getPixelsSizeY(series);
+      dimension_size_type z = meta.getPixelsSizeZ(series);
+      dimension_size_type t = meta.getPixelsSizeT(series);
+      dimension_size_type c = meta.getPixelsSizeC(series);
+
+      storage_size_type size = significantBitsPerPixel(meta.getPixelsType(series));
+      size *= x;
+      size *= y;
+      size *= z;
+      size *= t;
+      size *= c;
+
+      return size;
+    }
+
+    storage_size_type
+    significantPixelSize(const ::ome::xml::meta::MetadataRetrieve& meta)
+    {
+      storage_size_type size = 0;
+
+      for (dimension_size_type  s = 0;
+           s < meta.getImageCount();
+           ++s)
+        {
+          size += pixelSize(meta, s);
+        }
+
+      return size;
     }
 
   }

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -479,6 +479,59 @@ namespace ome
     ome::xml::model::enums::DimensionOrder
     createDimensionOrder(const std::string& order);
 
+    /**
+     * Get the total size of pixel data in a series.
+     *
+     * The size for the pixel type is rounded up to the nearest byte
+     * before multiplying by the dimension sizes.
+     *
+     * @param meta the metadata to use.
+     * @param series the image series to use.
+     * @returns the size (in bytes).
+     */
+    storage_size_type
+    pixelSize(const ::ome::xml::meta::MetadataRetrieve& meta,
+              dimension_size_type                       series);
+
+    /**
+     * Get the total size of pixel data for all series.
+     *
+     * The size for the pixel type is rounded up to the nearest byte
+     * before multiplying by the dimension sizes.
+     *
+     * @param meta the metadata to use.
+     * @returns the size (in bytes).
+     */
+    storage_size_type
+    pixelSize(const ::ome::xml::meta::MetadataRetrieve& meta);
+
+
+    /**
+     * Get the total significant size of pixel data in a series.
+     *
+     * The significant size for the pixel type (in bits) is multiplied
+     * by the dimension sizes before converting to bytes.
+     *
+     * @param meta the metadata to use.
+     * @param series the image series to use.
+     * @returns the size (in bytes).
+     */
+    storage_size_type
+    significantPixelSize(const ::ome::xml::meta::MetadataRetrieve& meta,
+                         dimension_size_type                       series);
+
+    /**
+     * Get the total significant size of pixel data for all series.
+     *
+     * The significant size for the pixel type (in bits) is multiplied
+     * by the dimension sizes before converting to bytes.
+     *
+     * @param meta the metadata to use.
+     * @returns the size (in bytes).
+     */
+    storage_size_type
+    significantPixelSize(const ::ome::xml::meta::MetadataRetrieve& meta);
+
   }
 }
 

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -226,6 +226,20 @@ namespace ome
                  bool                             doImageName = true);
 
     /**
+     * Fill OME-XML metadata store from core metadata.
+     *
+     * The metadata store is expected to be empty.
+     *
+     * @param store the OME-XML metadata store.
+     * @param seriesList the core metadata to use.
+     * @param doPlane create Plane elements if @c true.
+     */
+    void
+    fillMetadata(::ome::xml::meta::MetadataStore&                          store,
+                 const std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList,
+                 bool                                                      doPlane = false);
+
+    /**
      * Fill all OME-XML metadata store Pixels elements from reader core metadata.
      *
      * Set Pixels metadata for all series.
@@ -248,6 +262,20 @@ namespace ome
     void
     fillPixels(::ome::xml::meta::MetadataStore& store,
                const FormatReader&              reader);
+
+    /**
+     * Fill an OME-XML metadata store Pixels element from core metadata.
+     *
+     * Set Pixels metadata for the the specified series.
+     *
+     * @param store the OME-XML metadata store.
+     * @param seriesMetadata the seriesMetadata the metadata to use.
+     * @param series the series to set.
+     */
+    void
+    fillPixels(::ome::xml::meta::MetadataStore& store,
+               const CoreMetadata&              seriesMetadata,
+               dimension_size_type              series);
 
     /**
      * Add a MetadataOnly element to Pixels for the specified series.

--- a/cpp/lib/ome/bioformats/PixelProperties.cpp
+++ b/cpp/lib/ome/bioformats/PixelProperties.cpp
@@ -142,6 +142,51 @@ namespace ome
       return size;
     }
 
+    pixel_size_type
+    significantBitsPerPixel(::ome::xml::model::enums::PixelType pixeltype)
+    {
+      pixel_size_type size = 0;
+
+      switch(pixeltype)
+        {
+        case ::ome::xml::model::enums::PixelType::INT8:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::INT16:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::INT32:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::UINT8:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::UINT16:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::UINT32:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::FLOAT:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::DOUBLE:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::BIT:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::COMPLEX:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_significant_bit_size();
+          break;
+        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
+          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_significant_bit_size();
+          break;
+        }
+
+      return size;
+    }
+
     bool
     isSigned(::ome::xml::model::enums::PixelType pixeltype)
     {

--- a/cpp/lib/ome/bioformats/PixelProperties.h
+++ b/cpp/lib/ome/bioformats/PixelProperties.h
@@ -78,6 +78,7 @@ namespace ome
     {
       /**
        * Get size of pixel type, in bytes.
+       *
        * @returns pixel size, in bytes.
        */
       static pixel_size_type
@@ -88,12 +89,25 @@ namespace ome
 
       /**
        * Get size of pixel type, in bits.
+       *
        * @returns pixel size, in bits.
        */
       static pixel_size_type
       pixel_bit_size()
       {
         return pixel_byte_size() * 8;
+      }
+
+      /**
+       * Get significant (maximum bits used) size of pixel type, in
+       * bits.
+       *
+       * @returns pixel size, in bits.
+       */
+      static pixel_size_type
+      pixel_significant_bit_size()
+      {
+        return pixel_bit_size();
       }
     };
 
@@ -302,6 +316,18 @@ namespace ome
       static const bool is_integer = true;
       /// This pixel type is not complex.
       static const bool is_complex = false;
+
+      /**
+       * Get significant (maximum bits used) size of pixel type, in
+       * bits.
+       *
+       * @returns pixel size, in bits.
+       */
+      static pixel_size_type
+      pixel_significant_bit_size()
+      {
+        return 1;
+      }
     };
 
     /// Properties of COMPLEX pixels.
@@ -408,6 +434,17 @@ namespace ome
      */
     pixel_size_type
     bitsPerPixel(::ome::xml::model::enums::PixelType pixeltype);
+
+    /**
+     * Get the significant (maximum bits used) size of a PixelType, in
+     * bits.
+     *
+     * @param pixeltype the PixelType to query.
+     *
+     * @returns the size, in bits
+     */
+    pixel_size_type
+    significantBitsPerPixel(::ome::xml::model::enums::PixelType pixeltype);
 
     /**
      * Check whether a PixelType is signed.

--- a/cpp/lib/ome/bioformats/Types.h
+++ b/cpp/lib/ome/bioformats/Types.h
@@ -61,6 +61,9 @@ namespace ome
     /// Size type for pixel bit depths.
     typedef uint32_t pixel_size_type;
 
+    /// Size type for storage size.
+    typedef uint64_t storage_size_type;
+
   }
 }
 

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -897,13 +897,21 @@ namespace ome
         void
         operator()(const T& v)
         {
+          // Shape is the same as the source buffer, but with one subchannel.
           ome::compat::array<VariantPixelBuffer::size_type, 9> dest_shape;
           const VariantPixelBuffer::size_type *shape_ptr(v->shape());
           std::copy(shape_ptr, shape_ptr + PixelBufferBase::dimensions,
                     dest_shape.begin());
           dest_shape[DIM_SUBCHANNEL] = 1;
 
-          dest.setBuffer(dest_shape, v->pixelType());
+          // Default to planar ordering; since openByes/saveBytes
+          // don't use ZTC the DimensionOrder doesn't matter here so
+          // long as it matches what the TIFF reader/writer uses.
+          PixelBufferBase::storage_order_type order(PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, false));
+
+          /// @todo Only call setBuffer if the shape and pixel type
+          /// differ, to allow user control over storage order.
+          dest.setBuffer(dest_shape, v->pixelType(), order);
 
           T& destbuf = boost::get<T>(dest.vbuffer());
 

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -921,6 +921,43 @@ namespace ome
         }
       };
 
+      /// Merge a single subchannel into a PixelBuffer.
+      struct MergeSubchannelVisitor : public boost::static_visitor<>
+      {
+        /// Destination pixel buffer.
+        VariantPixelBuffer& dest;
+        /// Subchannel to copy.
+        dimension_size_type subC;
+
+        /**
+         * Constructor.
+         *
+         * @param dest the destination pixel buffer.
+         * @param subC the subchannel to copy.
+         */
+        MergeSubchannelVisitor(VariantPixelBuffer& dest,
+                               dimension_size_type subC):
+          dest(dest),
+          subC(subC)
+        {}
+
+        /**
+         * Merge subchannel.
+         *
+         * @param v the PixelBuffer to use.
+         */
+        template<typename T>
+        void
+        operator()(const T& v)
+        {
+          T& destbuf = boost::get<T>(dest.vbuffer());
+
+          typename boost::multi_array_types::index_gen indices;
+          typedef boost::multi_array_types::index_range range;
+          destbuf->array()[boost::indices[range()][range()][range()][range()][range()][range(subC,subC+1)][range()][range()][range()]] = v->array();
+        }
+      };
+
     }
 
     /// @copydoc VariantPixelBuffer::array()

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -883,7 +883,7 @@ namespace ome
          * @param subC the subchannel to copy.
          */
         CopySubchannelVisitor(VariantPixelBuffer& dest,
-                                dimension_size_type subC):
+                              dimension_size_type subC):
           dest(dest),
           subC(subC)
         {}

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -327,6 +327,76 @@ namespace ome
         return metadataRetrieve;
       }
 
+      dimension_size_type
+      FormatWriter::getImageCount() const
+      {
+        return getSizeZ() * getSizeT() * getSizeC();
+      }
+
+      dimension_size_type
+      FormatWriter::getSizeX() const
+      {
+        dimension_size_type series = getSeries();
+        dimension_size_type sizeX = metadataRetrieve->getPixelsSizeX(series);
+        if (sizeX == 0U)
+          sizeX = 1U;
+        return sizeX;
+      }
+
+      dimension_size_type
+      FormatWriter::getSizeY() const
+      {
+        dimension_size_type series = getSeries();
+        dimension_size_type sizeY = metadataRetrieve->getPixelsSizeY(series);
+        if (sizeY == 0U)
+          sizeY = 1U;
+        return sizeY;
+      }
+
+      dimension_size_type
+      FormatWriter::getSizeZ() const
+      {
+        dimension_size_type series = getSeries();
+        dimension_size_type sizeZ = metadataRetrieve->getPixelsSizeZ(series);
+        if (sizeZ == 0U)
+          sizeZ = 1U;
+        return sizeZ;
+      }
+
+      dimension_size_type
+      FormatWriter::getSizeT() const
+      {
+        dimension_size_type series = getSeries();
+        dimension_size_type sizeT = metadataRetrieve->getPixelsSizeT(series);
+        if (sizeT == 0U)
+          sizeT = 1U;
+        return sizeT;
+      }
+
+      dimension_size_type
+      FormatWriter::getSizeC() const
+      {
+        dimension_size_type series = getSeries();
+        dimension_size_type sizeC = metadataRetrieve->getPixelsSizeC(series);
+        if (sizeC == 0U)
+          sizeC = 1U;
+        return sizeC;
+      }
+
+      ome::xml::model::enums::PixelType
+      FormatWriter::getPixelType() const
+      {
+        dimension_size_type series = getSeries();
+        return metadataRetrieve->getPixelsType(series);
+      }
+
+      pixel_size_type
+      FormatWriter::getBitsPerPixel() const
+      {
+        dimension_size_type series = getSeries();
+        return metadataRetrieve->getPixelsSignificantBits(series);
+      }
+
       const std::string&
       FormatWriter::getFormat() const
       {

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -101,22 +101,6 @@ namespace ome
             if (out)
               out = ome::compat::shared_ptr<std::ostream>();
 
-            SaveSeries sentry(*this);
-
-            ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
-
-            for (dimension_size_type  s = 0;
-                 s < mr->getImageCount();
-                 ++s)
-              {
-                setSeries(s);
-
-                dimension_size_type z = mr->getPixelsSizeZ(s);
-                dimension_size_type t = mr->getPixelsSizeT(s);
-                dimension_size_type c = mr->getPixelsSizeC(s);
-                c /= mr->getChannelSamplesPerPixel(s, 0);
-              }
-
             currentId = id;
           }
       }

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -222,6 +222,82 @@ namespace ome
         ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve();
 
+        /**
+         * Determine the number of image planes in the current series.
+         *
+         * @returns the number of image planes.
+         */
+        virtual
+        dimension_size_type
+        getImageCount() const;
+
+        /**
+         * Get the size of the X dimension.
+         *
+         * @returns the X dimension size.
+         */
+        virtual
+        dimension_size_type
+        getSizeX() const;
+
+        /**
+         * Get the size of the Y dimension.
+         *
+         * @returns the Y dimension size.
+         */
+        virtual
+        dimension_size_type
+        getSizeY() const;
+
+        /**
+         * Get the size of the Z dimension.
+         *
+         * @returns the Z dimension size.
+         */
+        virtual
+        dimension_size_type
+        getSizeZ() const;
+
+        /**
+         * Get the size of the T dimension.
+         *
+         * @returns the T dimension size.
+         */
+        virtual
+        dimension_size_type
+        getSizeT() const;
+
+        /**
+         * Get the size of the C dimension.
+         *
+         * @returns the C dimension size.
+         */
+        virtual
+        dimension_size_type
+        getSizeC() const;
+
+        /**
+         * Get the pixel type.
+         *
+         * @returns the pixel type.
+         */
+        virtual
+        ome::xml::model::enums::PixelType
+        getPixelType() const;
+
+        /**
+         * Get the number of valid bits per pixel.
+         *
+         * The number of valid bits per pixel is always less than or
+         * equal to the number of bits per pixel that correspond to
+         * getPixelType().
+         *
+         * @returns the number of valid bits per pixel.
+         */
+        virtual
+        pixel_size_type
+        getBitsPerPixel() const;
+
         // Documented in superclass.
         void
         setFramesPerSecond(frame_rate_type rate);

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -121,6 +121,9 @@ namespace ome
         /// Current series.
         mutable dimension_size_type series;
 
+        /// Current plane.
+        mutable dimension_size_type plane;
+
         /// The compression type to use.
         boost::optional<std::string> compression;
 
@@ -183,6 +186,25 @@ namespace ome
         // Documented in superclass.
         dimension_size_type
         getSeries() const;
+
+        /**
+         * Set the active plane.
+         *
+         * @param no the plane to activate.
+         *
+         * @todo Remove use of stateful API which requires use of
+         * plane switching in const methods.
+         */
+        virtual void
+        setPlane(dimension_size_type no) const;
+
+        /**
+         * Get the active plane.
+         *
+         * @returns the active plane.
+         */
+        virtual dimension_size_type
+        getPlane() const;
 
         // Documented in superclass.
         bool

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -62,6 +62,9 @@ namespace ome
       namespace
       {
 
+        // Note that tf2, tf8 and btf are all extensions for "bigTIFF"
+        // (2nd generation TIFF, TIFF with 8-byte offsets and big TIFF
+        // respectively).
         const char *suffixes[] = {"tif", "tiff", "tf2", "tf8", "btf"};
         const char *companion_suffixes_array[] = {"txt", "xml"};
 

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -46,6 +46,7 @@
 #include <ome/bioformats/in/MinimalTIFFReader.h>
 #include <ome/bioformats/tiff/IFD.h>
 #include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Util.h>
 
 using ome::bioformats::detail::ReaderProperties;
 using ome::bioformats::tiff::TIFF;
@@ -93,7 +94,7 @@ namespace ome
       MinimalTIFFReader::MinimalTIFFReader():
         ::ome::bioformats::detail::FormatReader(props),
         tiff(),
-        series_ifd_map()
+        seriesIFDRange()
       {
         domains.push_back(getDomain(GRAPHICS_DOMAIN));
       }
@@ -101,7 +102,7 @@ namespace ome
       MinimalTIFFReader::MinimalTIFFReader(const ReaderProperties& readerProperties):
         ::ome::bioformats::detail::FormatReader(readerProperties),
         tiff(),
-        series_ifd_map()
+        seriesIFDRange()
       {
         domains.push_back(getDomain(GRAPHICS_DOMAIN));
       }
@@ -119,33 +120,9 @@ namespace ome
       const ome::compat::shared_ptr<const tiff::IFD>
       MinimalTIFFReader::ifdAtIndex(dimension_size_type no) const
       {
-        dimension_size_type series = getSeries();
-
-        if (series >= series_ifd_map.size())
-          {
-            boost::format fmt("Invalid series number ‘%1%’");
-            fmt % series;
-            throw FormatException(fmt.str());
-          }
-        const series_ifd_map_type::value_type range(series_ifd_map.at(series));
-
-        // Compute timepoint and subchannel from plane number.
-        dimension_size_type plane = no;
-        if (isRGB())
-          {
-            plane = no / getSizeC();
-          }
-        dimension_size_type ifdidx = range.first + plane;
-        assert(range.first <= plane && plane < range.second);
-
-        if (plane >= (range.second - range.first))
-          {
-            boost::format fmt("Invalid plane number ‘%1%’ for series ‘%2%’");
-            fmt % plane % series;
-            throw FormatException(fmt.str());
-          }
-
+        dimension_size_type ifdidx = tiff::ifdIndex(seriesIFDRange, getSeries(), no, getSizeC(), isRGB());
         const ome::compat::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
+
         return ifd;
       }
 
@@ -219,13 +196,19 @@ namespace ome
               {
                 ++prev_core->sizeT;
                 prev_core->imageCount = prev_core->sizeT;
-                ++(series_ifd_map.back().second);
+                ++(seriesIFDRange.back().end);
               }
             else
               {
                 prev_core = makeCoreMetadata(**i);
                 core.push_back(prev_core);
-                series_ifd_map.push_back(std::make_pair(current_ifd, current_ifd + 1));
+
+                tiff::IFDRange range;
+                range.filename = *currentId;
+                range.begin = current_ifd;
+                range.end = current_ifd + 1;
+
+                seriesIFDRange.push_back(range);
               }
             prev_ifd = *i;
           }

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -265,13 +265,9 @@ namespace ome
 
         if (isRGB())
           {
-            // Copy the desired subchannel into the destination buffer.
-            VariantPixelBuffer tmp;
-            ifd->readImage(tmp, x, y, w, h);
-
-            dimension_size_type S = no % getSizeC();
-            detail::CopySubchannelVisitor v(buf, S);
-            boost::apply_visitor(v, tmp.vbuffer());
+            // Read single subchannel.
+            dimension_size_type subC = no % getSizeC();
+            ifd->readImage(buf, x, y, w, h, subC);
           }
         else
           ifd->readImage(buf, x, y, w, h);

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -40,6 +40,8 @@
 
 #include <ome/bioformats/detail/FormatReader.h>
 
+#include <ome/bioformats/tiff/Util.h>
+
 #include <vector>
 
 namespace ome
@@ -62,19 +64,16 @@ namespace ome
        * Basic TIFF reader.
        *
        * @note Any derived reader which does not implement its own
-       * openBytesImpl() must fill @c series_ifd_map.
+       * openBytesImpl() must fill @c seriesIFDRange.
        */
       class MinimalTIFFReader : public ::ome::bioformats::detail::FormatReader
       {
       protected:
-        /// Mapping between series index and start and end IFD as a half-open range.
-        typedef std::vector<std::pair<dimension_size_type, dimension_size_type> > series_ifd_map_type;
-
         /// Underlying TIFF file.
         ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
 
         /// Mapping between series index and start and end IFD as a half-open range.
-        series_ifd_map_type series_ifd_map;
+        tiff::SeriesIFDRange seriesIFDRange;
 
       public:
         /// Constructor.

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -43,6 +43,7 @@
 #include <ome/bioformats/tiff/TIFF.h>
 #include <ome/bioformats/tiff/Tags.h>
 #include <ome/bioformats/tiff/Field.h>
+#include <ome/bioformats/tiff/Util.h>
 
 using ome::bioformats::detail::ReaderProperties;
 using ome::bioformats::tiff::TIFF;

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -47,6 +47,8 @@
 #include <ome/bioformats/tiff/IFD.h>
 #include <ome/bioformats/tiff/TIFF.h>
 
+#include <ome/internal/config.h>
+
 using ome::bioformats::detail::WriterProperties;
 using ome::bioformats::tiff::TIFF;
 using ome::bioformats::tiff::IFD;
@@ -102,7 +104,7 @@ namespace ome
         ifd(),
         ifdIndex(0),
         seriesIFDRange(),
-        bigTIFF(false)
+        bigTIFF(boost::none)
       {
       }
 
@@ -113,7 +115,7 @@ namespace ome
         ifd(),
         ifdIndex(0),
         seriesIFDRange(),
-        bigTIFF(false)
+        bigTIFF(boost::none)
       {
       }
 
@@ -128,27 +130,44 @@ namespace ome
 
         std::string flags("w");
 
-        // Get expected size of pixel data
+        // File extension in use.
+        boost::filesystem::path ext = currentId->extension();
+
+        // Get expected size of pixel data.
         ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
         storage_size_type pixelSize = significantPixelSize(*mr);
-        // Multiply by 5% to allow for alignment and TIFF metadata overhead.
+
+        // Enable BigTIFF if using a "big" file extension.
+        bool extBig =
+          (ext == boost::filesystem::path(".tf2") ||
+           ext == boost::filesystem::path(".tf8") ||
+           ext == boost::filesystem::path(".btf"));
+
+        // Enable BigTIFF if the pixel size is sufficiently large.
+        // Multiply by 5% to allow for alignment and TIFF metadata
+        // overhead.
         bool needBig = (pixelSize + pixelSize/20) > storage_size_type(std::numeric_limits<uint32_t>::max());
 
+        boost::optional<bool> wantBig = getBigTIFF();
 #if TIFF_HAVE_BIGTIFF
-        if (getBigTIFF() || needBig)
+        if ((wantBig && *wantBig)     // BigTIFF explicitly requested.
+            || extBig                 // BigTIFF file extension used
+            || (!wantBig && needBig)) // BigTIFF unspecified but needed.
           {
             flags += "8";
 
-            if (!bigTIFF) // Not set manually
-              boost::format fmt
-                ("Pixel data size is %1%, but TIFF without BigTIFF "
-                 "support enabled has a maximum size of %2%; "
-                 "automatically enabling BigTIFF support to prevent potential failure");
-            fmt % pixelSize % std::numeric_limits<uint32_t>::max();
+            if (!wantBig && !extBig) // Not set manually
+              {
+                boost::format fmt
+                  ("Pixel data size is %1%, but TIFF without BigTIFF "
+                   "support enabled has a maximum size of %2%; "
+                   "automatically enabling BigTIFF support to prevent potential failure");
+                fmt % pixelSize % std::numeric_limits<uint32_t>::max();
 
-            BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+                BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+              }
           }
-        else (!getBigTIFF() && needBig)
+        else if (wantBig && !*wantBig && needBig) // BigTIFF explicitly disabled but needed.
           {
             boost::format fmt
               ("Pixel data size is %1%, but TIFF with BigTIFF "
@@ -159,15 +178,23 @@ namespace ome
             BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
           }
 #else // ! TIFF_HAVE_BIGTIFF
-        if (needBig)
+        if (needBig) // BigTIFF needed (but unsupported)
           {
             boost::format fmt
-              ("Pixel data size is %1%, but TIFF without BigTIFF "
+              ("Unable to enable BigTIFF support since libtiff support "
+               " for BigTIFF is unavailable.  "
+               "Pixel data size is %1%, but TIFF without BigTIFF "
                "support enabled has a maximum size of %2%; "
-               "TIFF writing may fail if the limit is exceeded");
+               "TIFF writing may fail if the limit is exceeded; ");
             fmt % pixelSize % std::numeric_limits<uint32_t>::max();
 
             BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+          }
+        else if ((wantBig && *wantBig) || extBig) // BigTIFF explicitly requested (but unsupported)
+          {
+            BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+              << "Unable to enable BigTIFF support since libtiff support "
+              " for BigTIFF is unavailable";
           }
 #endif // TIFF_HAVE_BIGTIFF
 
@@ -292,15 +319,15 @@ namespace ome
       }
 
       void
-      MinimalTIFFWriter::setBigTIFF(bool big)
+      MinimalTIFFWriter::setBigTIFF(boost::optional<bool> big)
       {
         bigTIFF = big;
       }
 
-      bool
+      boost::optional<bool>
       MinimalTIFFWriter::getBigTIFF() const
       {
-        return bigTIFF && *bigTIFF;
+        return bigTIFF;
       }
 
     }

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -148,7 +148,7 @@ namespace ome
 
             BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
           }
-        else (!getBigTIFF && needBig)
+        else (!getBigTIFF() && needBig)
           {
             boost::format fmt
               ("Pixel data size is %1%, but TIFF with BigTIFF "

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -1,0 +1,308 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <cassert>
+
+#include <boost/format.hpp>
+#include <boost/range/size.hpp>
+
+#include <ome/bioformats/FormatException.h>
+#include <ome/bioformats/FormatTools.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/out/MinimalTIFFWriter.h>
+#include <ome/bioformats/tiff/IFD.h>
+#include <ome/bioformats/tiff/TIFF.h>
+
+using ome::bioformats::detail::WriterProperties;
+using ome::bioformats::tiff::TIFF;
+using ome::bioformats::tiff::IFD;
+using ome::xml::model::enums::PixelType;
+using ome::xml::meta::MetadataRetrieve;
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace out
+    {
+
+      namespace
+      {
+
+        // Note that tf2, tf8 and btf are all extensions for "bigTIFF"
+        // (2nd generation TIFF, TIFF with 8-byte offsets and big TIFF
+        // respectively).
+        const char *suffixes[] = {"tif", "tiff", "tf2", "tf8", "btf"};
+
+        WriterProperties
+        tiff_properties()
+        {
+          WriterProperties p("MinimalTIFF",
+                             "Baseline Tagged Image File Format");
+
+          p.suffixes = std::vector<boost::filesystem::path>(suffixes,
+                                                            suffixes + boost::size(suffixes));
+
+
+          const PixelType::value_map_type& pv = PixelType::values();
+          std::set<ome::xml::model::enums::PixelType> pixeltypes;
+          for (PixelType::value_map_type::const_iterator i = pv.begin();
+               i != pv.end();
+               ++i)
+            {
+              pixeltypes.insert(i->first);
+            }
+          p.codec_pixel_types.insert(WriterProperties::codec_pixel_type_map::value_type("default", pixeltypes));
+
+          return p;
+        }
+
+        const WriterProperties props(tiff_properties());
+
+      }
+
+      MinimalTIFFWriter::MinimalTIFFWriter():
+        ::ome::bioformats::detail::FormatWriter(props),
+        logger(ome::common::createLogger("MinimalTIFFWriter")),
+        tiff(),
+        ifd(),
+        ifdIndex(0),
+        seriesIFDRange(),
+        bigTIFF(false)
+      {
+      }
+
+      MinimalTIFFWriter::MinimalTIFFWriter(const WriterProperties& writerProperties):
+        ::ome::bioformats::detail::FormatWriter(writerProperties),
+        logger(ome::common::createLogger("MinimalTIFFWriter")),
+        tiff(),
+        ifd(),
+        ifdIndex(0),
+        seriesIFDRange(),
+        bigTIFF(false)
+      {
+      }
+
+      MinimalTIFFWriter::~MinimalTIFFWriter()
+      {
+      }
+
+      void
+      MinimalTIFFWriter::setId(const boost::filesystem::path& id)
+      {
+        FormatWriter::setId(id);
+
+        std::string flags("w");
+
+        // Get expected size of pixel data
+        ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
+        storage_size_type pixelSize = significantPixelSize(*mr);
+        // Multiply by 5% to allow for alignment and TIFF metadata overhead.
+        bool needBig = (pixelSize + pixelSize/20) > storage_size_type(std::numeric_limits<uint32_t>::max());
+
+#if TIFF_HAVE_BIGTIFF
+        if (getBigTIFF() || needBig)
+          {
+            flags += "8";
+
+            if (!bigTIFF) // Not set manually
+              boost::format fmt
+                ("Pixel data size is %1%, but TIFF without BigTIFF "
+                 "support enabled has a maximum size of %2%; "
+                 "automatically enabling BigTIFF support to prevent potential failure");
+            fmt % pixelSize % std::numeric_limits<uint32_t>::max();
+
+            BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+          }
+        else (!getBigTIFF && needBig)
+          {
+            boost::format fmt
+              ("Pixel data size is %1%, but TIFF with BigTIFF "
+               "support disabled has a maximum size of %2%; "
+               "TIFF writing may fail if the limit is exceeded");
+            fmt % pixelSize % std::numeric_limits<uint32_t>::max();
+
+            BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+          }
+#else // ! TIFF_HAVE_BIGTIFF
+        if (needBig)
+          {
+            boost::format fmt
+              ("Pixel data size is %1%, but TIFF without BigTIFF "
+               "support enabled has a maximum size of %2%; "
+               "TIFF writing may fail if the limit is exceeded");
+            fmt % pixelSize % std::numeric_limits<uint32_t>::max();
+
+            BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
+          }
+#endif // TIFF_HAVE_BIGTIFF
+
+        tiff = TIFF::open(id, flags);
+        ifd = tiff->getCurrentDirectory();
+        setupIFD();
+
+        // Create IFD mapping from metadata.
+        MetadataRetrieve::index_type imageCount = metadataRetrieve->getImageCount();
+        dimension_size_type currentIFD = 0U;
+        for (MetadataRetrieve::index_type i = 0;
+             i < imageCount;
+             ++i)
+          {
+            dimension_size_type planeCount = getImageCount();
+
+            tiff::IFDRange range;
+            range.filename = *currentId;
+            range.begin = currentIFD;
+            range.end = currentIFD + planeCount;
+
+            seriesIFDRange.push_back(range);
+            currentIFD += planeCount;
+          }
+      }
+
+      void
+      MinimalTIFFWriter::close(bool fileOnly)
+      {
+        if (tiff)
+          {
+            tiff->writeCurrentDirectory();
+            tiff->close();
+            ifd.reset();
+            tiff.reset();
+          }
+        if (!fileOnly)
+          {
+            ifdIndex = 0;
+            seriesIFDRange.clear();
+            bigTIFF = boost::none;
+          }
+        detail::FormatWriter::close(fileOnly);
+      }
+
+      void
+      MinimalTIFFWriter::setSeries(dimension_size_type no) const
+      {
+        const dimension_size_type currentSeries = getSeries();
+        detail::FormatWriter::setSeries(no);
+
+        if (currentSeries != no)
+          {
+            nextIFD();
+            setupIFD();
+          }
+      }
+
+      void
+      MinimalTIFFWriter::setPlane(dimension_size_type no) const
+      {
+        const dimension_size_type currentPlane = getPlane();
+        detail::FormatWriter::setPlane(no);
+
+        if (currentPlane != no)
+          {
+            nextIFD();
+            setupIFD();
+          }
+      }
+
+      void
+      MinimalTIFFWriter::nextIFD() const
+      {
+        tiff->writeCurrentDirectory();
+        ifd = tiff->getCurrentDirectory();
+        ++ifdIndex;
+      }
+
+      void
+      MinimalTIFFWriter::setupIFD() const
+      {
+        // Default to single strips for now.
+        ifd->setImageWidth(getSizeX());
+        ifd->setImageHeight(getSizeY());
+
+        ifd->setTileType(tiff::STRIP);
+        ifd->setTileWidth(getSizeX());
+        ifd->setTileHeight(1U);
+
+        ifd->setPixelType(getPixelType());
+        ifd->setBitsPerSample(bitsPerPixel(getPixelType()));
+        ifd->setSamplesPerPixel(1U);
+        ifd->setPlanarConfiguration(tiff::SEPARATE);
+        ifd->setPhotometricInterpretation(tiff::MIN_IS_BLACK);
+      }
+
+      void
+      MinimalTIFFWriter::saveBytes(dimension_size_type no,
+                                   VariantPixelBuffer& buf,
+                                   dimension_size_type x,
+                                   dimension_size_type y,
+                                   dimension_size_type w,
+                                   dimension_size_type h)
+      {
+        assertId(currentId, true);
+
+        setPlane(no);
+
+        dimension_size_type sizeC = metadataRetrieve->getPixelsSizeC(getSeries());
+        dimension_size_type expectedIndex =
+          tiff::ifdIndex(seriesIFDRange, getSeries(), no, sizeC, false);
+
+        if (ifdIndex != expectedIndex)
+          {
+            boost::format fmt("IFD index mismatch: actual is %1% but %2% expected");
+            fmt % ifdIndex % expectedIndex;
+            throw FormatException(fmt.str());
+          }
+
+        ifd->writeImage(buf, x, y, w, h);
+      }
+
+      void
+      MinimalTIFFWriter::setBigTIFF(bool big)
+      {
+        bigTIFF = big;
+      }
+
+      bool
+      MinimalTIFFWriter::getBigTIFF() const
+      {
+        return bigTIFF && *bigTIFF;
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
@@ -1,0 +1,181 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_OUT_MINIMALTIFFWRITER_H
+#define OME_BIOFORMATS_OUT_MINIMALTIFFWRITER_H
+
+#include <ome/bioformats/detail/FormatWriter.h>
+#include <ome/bioformats/tiff/Util.h>
+
+#include <ome/common/log.h>
+
+#include <vector>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace tiff
+    {
+
+      class TIFF;
+      class IFD;
+
+    }
+
+    namespace out
+    {
+
+      /**
+       * Basic TIFF writer.
+       *
+       * @note Any derived writer which does not implement its own
+       * openBytesImpl() must fill @c seriesIFDRange.
+       */
+      class MinimalTIFFWriter : public ::ome::bioformats::detail::FormatWriter
+      {
+      protected:
+        /// Message logger.
+        ome::common::Logger logger;
+
+        /// Underlying TIFF file.
+        mutable ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
+
+        /// Current IFD.
+        mutable ome::compat::shared_ptr<ome::bioformats::tiff::IFD> ifd;
+
+        /// Current plane.
+        mutable dimension_size_type ifdIndex;
+
+        /// Mapping between series index and start and end IFD as a half-open range.
+        tiff::SeriesIFDRange seriesIFDRange;
+
+      private:
+        /// Write a Big TIFF
+        boost::optional<bool> bigTIFF;
+
+      public:
+        /// Constructor.
+        MinimalTIFFWriter();
+
+        /// Constructor with writer properties (for derived writers).
+        MinimalTIFFWriter(const ome::bioformats::detail::WriterProperties& writerProperties);
+
+        /// Destructor.
+        virtual
+        ~MinimalTIFFWriter();
+
+        // Documented in superclass.
+        void
+        setId(const boost::filesystem::path& id);
+
+        // Documented in superclass.
+        void
+        close(bool fileOnly = false);
+
+      public:
+        // Documented in superclass.
+        void
+        setSeries(dimension_size_type no) const;
+
+        // Documented in superclass.
+        void
+        setPlane(dimension_size_type no) const;
+
+      protected:
+        /// Flush current IFD and create new IFD.
+        void
+        nextIFD() const;
+
+        /// Set IFD parameters for the current series.
+        void
+        setupIFD() const;
+
+      public:
+        using FormatWriter::saveBytes;
+
+        // Documented in superclass.
+        void
+        saveBytes(dimension_size_type no,
+                  VariantPixelBuffer& buf,
+                  dimension_size_type x,
+                  dimension_size_type y,
+                  dimension_size_type w,
+                  dimension_size_type h);
+
+        /**
+         * Set use of BigTIFF support.
+         *
+         * Enable or disable use of BigTIFF support for writing files
+         * larger than 4GiB.
+         *
+         * @note libtiff must be compiled with BigTIFF support enabled
+         * for this option to have any effect.
+         *
+         * @param big @c true to enable or @c false to disable BigTIFF
+         * support.
+         */
+        void
+        setBigTIFF(bool big = true);
+
+        /**
+         * Query use of BigTIFF support.
+         *
+         * If setBigTIFF has not been used to enable or disable
+         * BigTIFF explicitly, BigTIFF support will be disabled by
+         * default for data less than 4GiB, unless the data would be
+         * larger than 4GiB, in which case it will be enabled by
+         * default.
+         *
+         * @returns @c true if BigTIFF support are enabled, or @c
+         * false if disabled.
+         */
+        bool
+        getBigTIFF() const;
+      };
+
+    }
+  }
+}
+
+#endif // OME_BIOFORMATS_OUT_MINIMALTIFFWRITER_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
@@ -150,7 +150,7 @@ namespace ome
          * support.
          */
         void
-        setBigTIFF(bool big = true);
+        setBigTIFF(boost::optional<bool> big = true);
 
         /**
          * Query use of BigTIFF support.
@@ -164,7 +164,7 @@ namespace ome
          * @returns @c true if BigTIFF support are enabled, or @c
          * false if disabled.
          */
-        bool
+        boost::optional<bool>
         getBigTIFF() const;
       };
 

--- a/cpp/lib/ome/bioformats/tiff/Codec.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Codec.cpp
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <ome/bioformats/tiff/Codec.h>
+
+#include <ome/compat/memory.h>
+
+#include <tiffio.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace tiff
+    {
+
+      std::vector<Codec>
+      getConfiguredCodecs()
+      {
+        std::vector<Codec> ret;
+
+        ome::compat::shared_ptr<TIFFCodec> codecs(TIFFGetConfiguredCODECs(), _TIFFfree);
+        if (codecs)
+          {
+            for (const TIFFCodec *c = &*codecs; c->name != 0; ++c)
+              {
+                Codec nc;
+                nc.name = c->name;
+                nc.scheme = c->scheme;
+                ret.push_back(nc);
+              }
+          }
+        return ret;
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/bioformats/tiff/Codec.h
+++ b/cpp/lib/ome/bioformats/tiff/Codec.h
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_TIFF_CODEC_H
+#define OME_BIOFORMATS_TIFF_CODEC_H
+
+#include <string>
+#include <vector>
+
+#include <ome/compat/cstdint.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace tiff
+    {
+
+      // Functions to query TIFF codec support.
+
+      /// A TIFF codec.
+      struct Codec
+      {
+        /// Codec name.
+        std::string name;
+        /// Codec number.
+        uint16_t    scheme;
+      };
+
+      /**
+       * Get codecs registered with the TIFF library.
+       *
+       * @returns a list of available codecs.
+       */
+      std::vector<Codec>
+      getConfiguredCodecs();
+
+    }
+  }
+}
+
+#endif // OME_BIOFORMATS_TIFF_CODEC_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -1169,6 +1169,13 @@ namespace ome
       }
 
       void
+      IFD::readImage(VariantPixelBuffer& buf,
+                     dimension_size_type subC) const
+      {
+        readImage(buf, 0, 0, getImageWidth(), getImageHeight(), subC);
+      }
+
+      void
       IFD::readImage(VariantPixelBuffer& dest,
                      dimension_size_type x,
                      dimension_size_type y,
@@ -1208,6 +1215,22 @@ namespace ome
 
         ReadVisitor v(*this, info, region, tiles);
         boost::apply_visitor(v, dest.vbuffer());
+      }
+
+      void
+      IFD::readImage(VariantPixelBuffer& dest,
+                     dimension_size_type x,
+                     dimension_size_type y,
+                     dimension_size_type w,
+                     dimension_size_type h,
+                     dimension_size_type subC) const
+      {
+        // Copy the desired subchannel into the destination buffer.
+        VariantPixelBuffer tmp;
+        readImage(tmp, x, y, w, h);
+
+        detail::CopySubchannelVisitor v(dest, subC);
+        boost::apply_visitor(v, tmp.vbuffer());
       }
 
       void

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -426,6 +426,14 @@ namespace ome
         readImage(VariantPixelBuffer& buf) const;
 
         /**
+         * @copydoc IFD::readImage(VariantPixelBuffer&) const
+         * @param subC the subchannel to read
+         */
+        void
+        readImage(VariantPixelBuffer& buf,
+                  dimension_size_type subC) const;
+
+        /**
          * Read a region of an image plane into a pixel buffer.
          *
          * If the destination pixel buffer is of a different size to
@@ -445,6 +453,18 @@ namespace ome
                   dimension_size_type y,
                   dimension_size_type w,
                   dimension_size_type h) const;
+
+        /**
+         * @copydoc IFD::readImage(VariantPixelBuffer&,dimension_size_type,dimension_size_type,dimension_size_type,dimension_size_type) const
+         * @param subC the subchannel to read
+         */
+        void
+        readImage(VariantPixelBuffer& dest,
+                  dimension_size_type x,
+                  dimension_size_type y,
+                  dimension_size_type w,
+                  dimension_size_type h,
+                  dimension_size_type subC) const;
 
         /**
          * Read a lookup table into a pixel buffer.

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -443,7 +443,7 @@ namespace ome
 
         /**
          * @copydoc IFD::readImage(VariantPixelBuffer&) const
-         * @param subC the subchannel to read
+         * @param subC the subchannel to read.
          */
         void
         readImage(VariantPixelBuffer& buf,
@@ -472,7 +472,7 @@ namespace ome
 
         /**
          * @copydoc IFD::readImage(VariantPixelBuffer&,dimension_size_type,dimension_size_type,dimension_size_type,dimension_size_type) const
-         * @param subC the subchannel to read
+         * @param subC the subchannel to read.
          */
         void
         readImage(VariantPixelBuffer& dest,
@@ -499,6 +499,14 @@ namespace ome
         writeImage(const VariantPixelBuffer& buf);
 
         /**
+         * @copydoc IFD::writeImage(const VariantPixelBuffer&)
+         * @param subC the subchannel to write.
+         */
+        void
+        writeImage(const VariantPixelBuffer& buf,
+                   dimension_size_type       subC);
+
+        /**
          * Write a whole image plane from a pixel buffer.
          *
          * The source pixel buffer must match the size of the region
@@ -519,6 +527,18 @@ namespace ome
                    dimension_size_type       h);
 
         /**
+         * @copydoc IFD::writeImage(const VariantPixelBuffer&,dimension_size_type,dimension_size_type,dimension_size_type,dimension_size_type)
+         * @param subC the subchannel to write.
+         */
+        void
+        writeImage(const VariantPixelBuffer& source,
+                   dimension_size_type       x,
+                   dimension_size_type       y,
+                   dimension_size_type       w,
+                   dimension_size_type       h,
+                   dimension_size_type       subC);
+
+        /**
          * Get next directory.
          *
          * @returns the next directory, or null if this is the last directory.
@@ -534,15 +554,6 @@ namespace ome
         bool
         last() const;
       };
-
-      /**
-       * Create CoreMetadata from an IFD.
-       *
-       * @param ifd the IFD to use.
-       * @returns the CoreMetadata.
-       */
-      ome::compat::shared_ptr<CoreMetadata>
-      makeCoreMetadata(const IFD& ifd);
 
     }
   }

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -370,6 +370,22 @@ namespace ome
         setPixelType(::ome::xml::model::enums::PixelType type);
 
         /**
+         * Get bits per sample.
+         *
+         * @returns the number of bits per sample.
+         */
+        uint16_t
+        getBitsPerSample() const;
+
+        /**
+         * Set bits per sample.
+         *
+         * @param samples the number of bits per sample.
+         */
+        void
+        setBitsPerSample(uint16_t samples);
+
+        /**
          * Get samples per pixel.
          *
          * @returns the number of samples per pixel.

--- a/cpp/lib/ome/bioformats/tiff/Util.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Util.cpp
@@ -1,0 +1,446 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <ome/internal/config.h>
+
+#include <ome/bioformats/CoreMetadata.h>
+#include <ome/bioformats/FormatException.h>
+#include <ome/bioformats/tiff/Field.h>
+#include <ome/bioformats/tiff/IFD.h>
+#include <ome/bioformats/tiff/Tags.h>
+#include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Util.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace tiff
+    {
+
+      namespace
+      {
+
+        // Scalar
+        template<typename T>
+        void
+        setMetadata(CoreMetadata&      core,
+                    const std::string& key,
+                    const T&           value)
+        {
+          core.seriesMetadata.set(key, value);
+        }
+
+        // Vector
+        template <typename T>
+        void
+        setMetadata(CoreMetadata&         core,
+                    const std::string&    key,
+                    const std::vector<T>& value)
+        {
+          std::ostringstream os;
+          for (typename std::vector<T>::const_iterator i = value.begin();
+               i != value.end();
+               ++i)
+            {
+              os << *i;
+              if (i + 1 != value.end())
+                os << ", ";
+            }
+          core.seriesMetadata.set(key, os.str());
+        }
+
+        // Array
+        template <template <typename, std::size_t> class C,
+                  typename T,
+                  std::size_t S>
+        void
+        setMetadata(CoreMetadata&      core,
+                    const std::string& key,
+                    const C<T, S>&     value)
+        {
+          std::ostringstream os;
+          for (typename C<T, S>::const_iterator i = value.begin();
+               i != value.end();
+               ++i)
+            {
+              os << *i;
+              if (i + 1 != value.end())
+                os << ", ";
+            }
+          core.seriesMetadata.set(key, os.str());
+        }
+
+        template<typename TagCategory>
+        bool
+        setMetadata(const IFD&         ifd,
+                    CoreMetadata&      core,
+                    const std::string& key,
+                    TagCategory        tag)
+        {
+          bool set = false;
+
+          typedef typename ::ome::bioformats::detail::tiff::TagProperties<TagCategory>::value_type value_type;
+
+          try
+            {
+              value_type v;
+              ifd.getField(tag).get(v);
+              setMetadata(core, key, v);
+              set = true;
+            }
+          catch (...)
+            {
+            }
+
+          return set;
+        }
+
+      }
+
+      ome::compat::shared_ptr<CoreMetadata>
+      makeCoreMetadata(const IFD& ifd)
+      {
+        ome::compat::shared_ptr<CoreMetadata> m(ome::compat::make_shared<CoreMetadata>());
+        getCoreMetadata(ifd, *m);
+        return m;
+      }
+
+      void
+      getCoreMetadata(const IFD&    ifd,
+                      CoreMetadata& core)
+      {
+        core.dimensionOrder = ome::xml::model::enums::DimensionOrder::XYCZT;
+        core.sizeX = ifd.getImageWidth();
+        core.sizeY = ifd.getImageHeight();
+        core.pixelType = ifd.getPixelType();
+
+        core.bitsPerPixel = significantBitsPerPixel(core.pixelType);
+        pixel_size_type psize = ifd.getBitsPerSample();
+        if (psize < core.bitsPerPixel)
+          core.bitsPerPixel = psize;
+
+        uint16_t samples = ifd.getSamplesPerPixel();
+        tiff::PhotometricInterpretation photometric = ifd.getPhotometricInterpretation();
+
+        // Note that RGB does not mean photometric interpretation is
+        // RGB.  It's a way to force the subchannels into sizeC as
+        // addressable channels in the absence of an nD API.
+        core.rgb = false;
+        core.sizeC = 1U;
+        if (samples > 1 || photometric == tiff::RGB)
+          {
+            core.rgb = true;
+            core.sizeC = samples;
+          }
+        core.sizeZ = core.sizeT = core.imageCount = 1U;
+
+        // libtiff does any needed endian conversion
+        // automatically, so the data is always in the native
+        // byte order.
+#ifdef BOOST_BIG_ENDIAN
+        core.littleEndian = false;
+#else // ! BOOST_BIG_ENDIAN
+        core.littleEndian = true;
+#endif // BOOST_BIG_ENDIAN
+
+        // This doesn't match the reality, but since subchannels are
+        // addressed as planes this is needed.
+        core.interleaved = false;
+
+        // Indexed samples.
+        if (samples == 1 && photometric == tiff::PALETTE)
+          {
+            try
+              {
+                ome::compat::array<std::vector<uint16_t>, 3> cmap;
+                ifd.getField(tiff::COLORMAP).get(cmap);
+                core.indexed = true;
+                core.rgb = false;
+              }
+            catch (...)
+              {
+              }
+          }
+        // Indexed samples for different photometric interpretations;
+        // not currently supported fully.
+        else
+          {
+            try
+              {
+                uint16_t indexed;
+                ifd.getField(tiff::INDEXED).get(indexed);
+                if (indexed)
+                  {
+                    core.indexed = true;
+                    core.rgb = false;
+                  }
+              }
+            catch (...)
+              {
+              }
+          }
+
+        // Add series metadata from tags.
+        setMetadata(ifd, core, "PageName #", PAGENAME);
+        setMetadata(ifd, core, "ImageWidth", IMAGEWIDTH);
+        setMetadata(ifd, core, "ImageLength", IMAGELENGTH);
+        setMetadata(ifd, core, "BitsPerSample", BITSPERSAMPLE);
+
+        /// @todo EXIF IFDs
+
+        setMetadata(ifd, core, "PhotometricInterpretation", PHOTOMETRIC);
+
+        /// @todo Text stream output for Tag enums.
+        /// @todo Metadata type for PhotometricInterpretation.
+
+        try
+          {
+            setMetadata(ifd, core, "Artist", ARTIST);
+            Threshholding th;
+            ifd.getField(THRESHHOLDING).get(th);
+            core.seriesMetadata.set("Threshholding", th);
+            if (th == HALFTONE)
+              {
+                setMetadata(ifd, core, "CellWidth", CELLWIDTH);
+                setMetadata(ifd, core, "CellLength", CELLLENGTH);
+              }
+          }
+        catch (...)
+          {
+          }
+
+        setMetadata(ifd, core, "Orientation", ORIENTATION);
+
+        /// @todo Image orientation (storage order and direction) from
+        /// ORIENTATION; fix up width and length from orientation.
+
+        setMetadata(ifd, core, "SamplesPerPixel", SAMPLESPERPIXEL);
+        setMetadata(ifd, core, "Software", SOFTWARE);
+        setMetadata(ifd, core, "Instrument Make", MAKE);
+        setMetadata(ifd, core, "Instrument Model", MODEL);
+        setMetadata(ifd, core, "Make", MAKE);
+        setMetadata(ifd, core, "Model", MODEL);
+        setMetadata(ifd, core, "Document Name", DOCUMENTNAME);
+        setMetadata(ifd, core, "Date Time", DATETIME);
+        setMetadata(ifd, core, "Artist", ARTIST);
+
+        setMetadata(ifd, core, "Host Computer", HOSTCOMPUTER);
+        setMetadata(ifd, core, "Copyright", COPYRIGHT);
+
+        setMetadata(ifd, core, "Subfile Type", SUBFILETYPE);
+        setMetadata(ifd, core, "Fill Order", FILLORDER);
+
+        setMetadata(ifd, core, "Min Sample Value", MINSAMPLEVALUE);
+        setMetadata(ifd, core, "Max Sample Value", MAXSAMPLEVALUE);
+
+        setMetadata(ifd, core, "XResolution", XRESOLUTION);
+        setMetadata(ifd, core, "YResolution", YRESOLUTION);
+
+        setMetadata(ifd, core, "Planar Configuration", PLANARCONFIG);
+
+        setMetadata(ifd, core, "XPosition", XPOSITION);
+        setMetadata(ifd, core, "YPosition", YPOSITION);
+
+        /// @todo Only set if debugging/verbose.
+        // setMetadata(ifd, core, "FreeOffsets", FREEOFFSETS);
+        // setMetadata(ifd, core, "FreeByteCounts", FREEBYTECOUNTS);
+
+        setMetadata(ifd, core, "GrayResponseUnit", GRAYRESPONSEUNIT);
+        setMetadata(ifd, core, "GrayResponseCurve", GRAYRESPONSECURVE);
+
+        try
+          {
+            Compression cmpr;
+            ifd.getField(COMPRESSION).get(cmpr);
+            core.seriesMetadata.set("Compression", cmpr);
+            if (cmpr == COMPRESSION_CCITT_T4)
+              setMetadata(ifd, core, "T4Options", T4OPTIONS);
+            else if (cmpr == COMPRESSION_CCITT_T6)
+              setMetadata(ifd, core, "T6Options", T6OPTIONS);
+            else if (cmpr == COMPRESSION_LZW)
+              setMetadata(ifd, core, "Predictor", PREDICTOR);
+          }
+        catch (...)
+          {
+          }
+
+        setMetadata(ifd, core, "ResolutionUnit", RESOLUTIONUNIT);
+
+        setMetadata(ifd, core, "PageNumber", PAGENUMBER);
+
+        // TransferRange only valid if TransferFunction set.
+        if (setMetadata(ifd, core, "TransferFunction", TRANSFERFUNCTION))
+          setMetadata(ifd, core, "TransferRange", TRANSFERRANGE);
+
+        setMetadata(ifd, core, "WhitePoint", WHITEPOINT);
+        setMetadata(ifd, core, "PrimaryChromacities", PRIMARYCHROMATICITIES);
+        setMetadata(ifd, core, "HalftoneHints", HALFTONEHINTS);
+
+        setMetadata(ifd, core, "TileWidth", TILEWIDTH);
+        setMetadata(ifd, core, "TileLength", TILELENGTH);
+
+        /// @todo Only set if debugging/verbose.
+        // setMetadata(ifd, core, "TileOffsets", TILEOFFSETS);
+        // setMetadata(ifd, core, "TileByteCounts", TILEBYTECOUNTS);
+
+        setMetadata(ifd, core, "InkSet", INKSET);
+        setMetadata(ifd, core, "InkNames", INKNAMES);
+        setMetadata(ifd, core, "NumberOfInks", NUMBEROFINKS);
+        setMetadata(ifd, core, "DotRange", DOTRANGE);
+        setMetadata(ifd, core, "TargetPrinter", TARGETPRINTER);
+        setMetadata(ifd, core, "ExtraSamples", EXTRASAMPLES);
+
+        setMetadata(ifd, core, "SampleFormat", SAMPLEFORMAT);
+
+        /// @todo sminsamplevalue
+        /// @todo smaxsamplevalue
+
+        /// @todo Only set if debugging/verbose.
+        // setMetadata(ifd, core, "StripOffsets", STRIPOFFSETS);
+        // setMetadata(ifd, core, "StripByteCounts", STRIPBYTECOUNTS);
+
+        /// @todo JPEG tags
+
+        setMetadata(ifd, core, "YCbCrCoefficients", YCBCRCOEFFICIENTS);
+        setMetadata(ifd, core, "YCbCrSubSampling", YCBCRSUBSAMPLING);
+        setMetadata(ifd, core, "YCbCrPositioning", YCBCRPOSITIONING);
+        setMetadata(ifd, core, "ReferenceBlackWhite", REFERENCEBLACKWHITE);
+
+        try
+          {
+            uint16_t samples;
+            ifd.getField(SAMPLESPERPIXEL).get(samples);
+            PhotometricInterpretation photometric;
+            ifd.getField(PHOTOMETRIC).get(photometric);
+            if (photometric == RGB ||
+                photometric == CFA_ARRAY)
+              samples = 3;
+
+            try
+              {
+                std::vector<ExtraSamples> extra;
+                ifd.getField(EXTRASAMPLES).get(extra);
+                samples += static_cast<uint16_t>(extra.size());
+              }
+            catch (...)
+              {
+              }
+
+            core.seriesMetadata.set("NumberOfChannels", samples);
+          }
+        catch (...)
+          {
+          }
+
+        core.seriesMetadata.set("BitsPerSample", bitsPerPixel(ifd.getPixelType()));
+      }
+
+      void
+      setCoreMetadata(IFD&                ifd,
+                      const CoreMetadata& core)
+      {
+        ifd.setImageWidth(core.sizeX);
+        ifd.setImageHeight(core.sizeY);
+        ifd.setPixelType(core.pixelType);
+
+        pixel_size_type psize = significantBitsPerPixel(core.pixelType);
+        if (core.bitsPerPixel < psize)
+          psize = core.bitsPerPixel;
+        ifd.setBitsPerSample(psize);
+
+        // Note that RGB does not mean photometric interpretation is
+        // RGB.  It's a way to force the subchannels into sizeC as
+        // addressable channels in the absence of an nD API.
+        uint16_t samples = 1;
+        if (core.rgb)
+          samples = core.sizeC;
+
+        tiff::PhotometricInterpretation photometric = tiff::MIN_IS_BLACK;
+        if (core.rgb && core.sizeC == 3)
+          photometric = tiff::RGB;
+        else if (!core.rgb && core.indexed && samples == 1)
+          photometric = tiff::PALETTE;
+        ifd.setPhotometricInterpretation(photometric);
+
+        // libtiff does any needed endian conversion automatically, so
+        // the data is always in the native byte order; don't set
+        // anything here.
+
+        // @todo Consider adding getMetadata equivalent to
+        // setMetadata, to allow setting of Baseline TIFF tags from
+        // original metadata, allowing round-trip of Baseline TIFF
+        // tags through Bio-Formats.
+      }
+
+      dimension_size_type
+      ifdIndex(const SeriesIFDRange& seriesIFDRange,
+               dimension_size_type   series,
+               dimension_size_type   plane,
+               dimension_size_type   sizeC,
+               bool                  isRGB)
+      {
+        if (series >= seriesIFDRange.size())
+          {
+            boost::format fmt("Invalid series number ‘%1%’");
+            fmt % series;
+            throw FormatException(fmt.str());
+          }
+        const IFDRange range(seriesIFDRange.at(series));
+
+        // Compute timepoint and subchannel from plane number.
+        dimension_size_type realplane = plane;
+        if (isRGB)
+          {
+            realplane = plane / sizeC;
+          }
+        dimension_size_type ifdidx = range.begin + realplane;
+        assert(range.begin <= realplane && realplane < range.end);
+
+        if (realplane >= (range.end - range.begin))
+          {
+            boost::format fmt("Invalid plane number ‘%1%’ for series ‘%2%’");
+            fmt % realplane % series;
+            throw FormatException(fmt.str());
+          }
+
+        return ifdidx;
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/bioformats/tiff/Util.h
+++ b/cpp/lib/ome/bioformats/tiff/Util.h
@@ -1,0 +1,141 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_TIFF_UTIL_H
+#define OME_BIOFORMATS_TIFF_UTIL_H
+
+#include <string>
+#include <vector>
+
+#include <ome/common/filesystem.h>
+
+#include <ome/compat/memory.h>
+
+#include <ome/bioformats/CoreMetadata.h>
+#include <ome/bioformats/TileCoverage.h>
+#include <ome/bioformats/tiff/TileInfo.h>
+#include <ome/bioformats/tiff/Types.h>
+#include <ome/bioformats/VariantPixelBuffer.h>
+
+#include <ome/xml/model/enums/PixelType.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace tiff
+    {
+
+      class TIFF;
+      class IFD;
+
+      /**
+       * Create CoreMetadata from an IFD.
+       *
+       * @param ifd the IFD to use.
+       * @returns the CoreMetadata.
+       */
+      ome::compat::shared_ptr<CoreMetadata>
+      makeCoreMetadata(const IFD& ifd);
+
+      /**
+       * Get CoreMetadata from an IFD.
+       *
+       * @param ifd the IFD to use.
+       * @param core the CoreMetadata to set.
+       */
+      void
+      getCoreMetadata(const IFD&    ifd,
+                      CoreMetadata& core);
+
+      /**
+       * Set CoreMetadata for an IFD.
+       *
+       * @param ifd the IFD to set.
+       * @param core the CoreMetadata to use.
+       */
+      void
+      setCoreMetadata(IFD&                ifd,
+                      const CoreMetadata& core);
+
+      /**
+       * Range of IFDs for an image series.
+       *
+       * Note the range is half-open, with the end index being one
+       * past the end of the range.
+       */
+      struct IFDRange
+      {
+        /// Filename of TIFF containing the IFDs.
+        boost::filesystem::path filename;
+        /// Start index.
+        dimension_size_type     begin;
+        /// End index.
+        dimension_size_type     end;
+      };
+
+      /// Mapping between series index and IFD range.
+      typedef std::vector<IFDRange> SeriesIFDRange;
+
+      /**
+       * Compute IFD index from IFD map and plane index.
+       *
+       * @param seriesIFDRange the series--IFD range mapping.
+       * @param series the series to use.
+       * @param plane the plane within the series to use.
+       * @param sizeC the number of channels in the series.
+       * @param isRGB the number of subchannels in the series.
+       * @returns the IFD index.
+       */
+      dimension_size_type
+      ifdIndex(const SeriesIFDRange& seriesIFDRange,
+               dimension_size_type   series,
+               dimension_size_type   plane,
+               dimension_size_type   sizeC,
+               bool                  isRGB);
+
+    }
+  }
+}
+
+#endif // OME_BIOFORMATS_TIFF_UTIL_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/test/ome-bioformats/CMakeLists.txt
+++ b/cpp/test/ome-bioformats/CMakeLists.txt
@@ -113,7 +113,7 @@ if(BUILD_TESTS)
 
   bf_add_test(ome-bioformats/planeregion planeregion)
 
-  add_executable(tiff tiff.cpp)
+  add_executable(tiff tiff.cpp tiffsamples.cpp)
   target_link_libraries(tiff ome-bioformats)
   target_link_libraries(tiff ome-test ${PNG_LIBRARIES})
   add_dependencies(tiff gentestimages)

--- a/cpp/test/ome-bioformats/CMakeLists.txt
+++ b/cpp/test/ome-bioformats/CMakeLists.txt
@@ -126,6 +126,12 @@ if(BUILD_TESTS)
 
   bf_add_test(ome-bioformats/minimaltiffreader minimaltiffreader)
 
+  add_executable(minimaltiffwriter minimaltiffwriter.cpp tiffsamples.cpp)
+  target_link_libraries(minimaltiffwriter ome-bioformats)
+  target_link_libraries(minimaltiffwriter ome-test)
+
+  bf_add_test(ome-bioformats/minimaltiffwriter minimaltiffwriter)
+
   add_executable(tiffreader tiffreader.cpp)
   target_link_libraries(tiffreader ome-bioformats)
   target_link_libraries(tiffreader ome-test)

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -453,17 +453,20 @@ TEST_P(FormatWriterTest, OutputPixels)
 
 TEST_P(FormatWriterTest, DefaultSeries)
 {
-  EXPECT_THROW(w.setSeries(0U), std::runtime_error);
-  EXPECT_THROW(w.setSeries(2U), std::runtime_error);
-  EXPECT_THROW(w.setSeries(4U), std::runtime_error);
+  EXPECT_THROW(w.setSeries(0U), std::logic_error);
+  EXPECT_THROW(w.setSeries(2U), std::logic_error);
+  EXPECT_THROW(w.setSeries(4U), std::logic_error);
 }
 
 TEST_P(FormatWriterTest, OutputSeries)
 {
   w.setId("output.test");
 
+  // Current series is OK.
   EXPECT_NO_THROW(w.setSeries(0U));
-  EXPECT_NO_THROW(w.setSeries(2U));
+  // Series is valid but skips series 1.
+  EXPECT_THROW(w.setSeries(2U), std::logic_error);
+  // Series is invalid
   EXPECT_THROW(w.setSeries(4U), std::logic_error);
 }
 

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -1,0 +1,192 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * %%
+ * Copyright © 2013 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <stdexcept>
+#include <vector>
+
+#include <ome/bioformats/CoreMetadata.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/VariantPixelBuffer.h>
+#include <ome/bioformats/out/MinimalTIFFWriter.h>
+#include <ome/bioformats/tiff/Field.h>
+#include <ome/bioformats/tiff/IFD.h>
+#include <ome/bioformats/tiff/Tags.h>
+#include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Util.h>
+
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+#include <ome/test/test.h>
+
+#include "tiffsamples.h"
+
+using ome::bioformats::dimension_size_type;
+using ome::bioformats::CoreMetadata;
+using ome::bioformats::VariantPixelBuffer;
+using ome::bioformats::out::MinimalTIFFWriter;
+using ome::bioformats::tiff::IFD;
+using ome::bioformats::tiff::TIFF;
+
+using namespace boost::filesystem;
+
+class TIFFTestParameters
+{
+public:
+
+  std::string file;
+  dimension_size_type sizeT;
+
+  TIFFTestParameters(const std::string& file,
+                     dimension_size_type sizeT):
+    file(file),
+    sizeT(sizeT)
+  {}
+};
+
+template<class charT, class traits>
+inline std::basic_ostream<charT,traits>&
+operator<< (std::basic_ostream<charT,traits>& os,
+            const TIFFTestParameters& tp)
+{
+  os << tp.file;
+
+  return os;
+}
+
+class TIFFWriterTest : public ::testing::TestWithParam<TileTestParameters>
+{
+public:
+  ome::compat::shared_ptr<TIFF> tiff;
+  uint32_t iwidth;
+  uint32_t iheight;
+  ome::bioformats::tiff::PlanarConfiguration planarconfig;
+  uint16_t samples;
+
+  MinimalTIFFWriter tiffwriter;
+  path testfile;
+
+  void
+  SetUp()
+  {
+    const TileTestParameters& params = GetParam();
+
+    path dir(PROJECT_BINARY_DIR "/cpp/test/ome-bioformats/data");
+    testfile = dir / (std::string("minimaltiffwriter-") + path(params.file).filename().string());
+
+    ASSERT_NO_THROW(tiff = TIFF::open(params.file, "r"));
+    ASSERT_TRUE(static_cast<bool>(tiff));
+    ome::compat::shared_ptr<IFD> ifd;
+    ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
+    ASSERT_TRUE(static_cast<bool>(ifd));
+
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::IMAGEWIDTH).get(iwidth));
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::IMAGELENGTH).get(iheight));
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::PLANARCONFIG).get(planarconfig));
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::SAMPLESPERPIXEL).get(samples));
+  }
+
+  void
+  TearDown()
+  {
+    // Delete file (if any)
+    if (boost::filesystem::exists(testfile))
+      boost::filesystem::remove(testfile);
+  }
+};
+
+TEST_P(TIFFWriterTest, setId)
+{
+  const TileTestParameters& params = GetParam();
+
+  std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList;
+  for (TIFF::const_iterator i = tiff->begin();
+       i != tiff->end();
+       ++i)
+    {
+      ome::compat::shared_ptr<CoreMetadata> c = ome::bioformats::tiff::makeCoreMetadata(**i);
+      seriesList.push_back(c);
+    }
+
+  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  ome::bioformats::fillMetadata(*meta, seriesList);
+  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
+
+  tiffwriter.setMetadataRetrieve(retrieve);
+
+  ASSERT_NO_THROW(tiffwriter.setId(testfile));
+
+  VariantPixelBuffer buf;
+  dimension_size_type currentSeries = 0U;
+  for (dimension_size_type i = 0U; i < seriesList.size(); ++i)
+    {
+      ome::compat::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
+      ASSERT_TRUE(static_cast<bool>(ifd));
+
+      dimension_size_type samples = ifd->getSamplesPerPixel();
+      if (samples == 1)
+        {
+          ifd->readImage(buf);
+          tiffwriter.setSeries(currentSeries);
+          tiffwriter.saveBytes(0, buf);
+        }
+      else
+        {
+          tiffwriter.setSeries(currentSeries);
+          for (dimension_size_type channel = 0U; channel < samples; ++channel)
+            {
+              ifd->readImage(buf, channel);
+              tiffwriter.saveBytes(channel, buf);
+            }
+        }
+      ++currentSeries;
+    }
+  tiffwriter.close();
+}
+
+std::vector<TileTestParameters> params(find_tile_tests());
+
+// Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
+// this is solely to work around a missing prototype in gtest.
+#ifdef __GNUC__
+#  if defined __clang__ || defined __APPLE__
+#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#  endif
+#  pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+
+INSTANTIATE_TEST_CASE_P(TIFFWriterVariants, TIFFWriterTest, ::testing::ValuesIn(params));

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -43,6 +43,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/type_traits.hpp>
 
+#include <ome/bioformats/tiff/Codec.h>
 #include <ome/bioformats/tiff/TileInfo.h>
 #include <ome/bioformats/tiff/TIFF.h>
 #include <ome/bioformats/tiff/IFD.h>
@@ -65,6 +66,7 @@ using ome::bioformats::tiff::directory_index_type;
 using ome::bioformats::tiff::TileInfo;
 using ome::bioformats::tiff::TIFF;
 using ome::bioformats::tiff::IFD;
+using ome::bioformats::tiff::Codec;
 using ome::bioformats::dimension_size_type;
 using ome::bioformats::VariantPixelBuffer;
 using ome::bioformats::PixelBuffer;
@@ -897,6 +899,21 @@ TEST(TIFFTest, PixelType)
   ASSERT_TRUE(static_cast<bool>(ifd));
 
   ASSERT_EQ(PT::UINT8, ifd->getPixelType());
+}
+
+TEST(TIFFCodec, ListCodecs)
+{
+  // Note this list depends upon the codecs provided by libtiff, which
+  // can vary, so we don't attempt to validate specific codecs are
+  // present here.
+
+  std::vector<Codec> codecs = ome::bioformats::tiff::getConfiguredCodecs();
+  for (std::vector<Codec>::const_iterator c = codecs.begin();
+       c != codecs.end();
+       ++c)
+    {
+      // std::cout << "C: " << c->name << " = " << c->scheme << '\n';
+    }
 }
 
 class TIFFTileTest : public ::testing::TestWithParam<TileTestParameters>

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -43,6 +43,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/type_traits.hpp>
 
+#include <ome/bioformats/PixelProperties.h>
 #include <ome/bioformats/tiff/Codec.h>
 #include <ome/bioformats/tiff/TileInfo.h>
 #include <ome/bioformats/tiff/TIFF.h>
@@ -68,6 +69,7 @@ using ome::bioformats::tiff::TIFF;
 using ome::bioformats::tiff::IFD;
 using ome::bioformats::tiff::Codec;
 using ome::bioformats::dimension_size_type;
+using ome::bioformats::significantBitsPerPixel;
 using ome::bioformats::VariantPixelBuffer;
 using ome::bioformats::PixelBuffer;
 using ome::bioformats::PixelProperties;
@@ -899,6 +901,7 @@ TEST(TIFFTest, PixelType)
   ASSERT_TRUE(static_cast<bool>(ifd));
 
   ASSERT_EQ(PT::UINT8, ifd->getPixelType());
+  ASSERT_EQ(8U, ifd->getBitsPerSample());
 }
 
 TEST(TIFFCodec, ListCodecs)
@@ -1503,6 +1506,7 @@ TEST_P(PixelTest, WriteTIFF)
     ASSERT_NO_THROW(wifd->setTileWidth(params.tilewidth));
     ASSERT_NO_THROW(wifd->setTileHeight(params.tileheight));
     ASSERT_NO_THROW(wifd->setPixelType(params.pixeltype));
+    ASSERT_NO_THROW(wifd->setBitsPerSample(significantBitsPerPixel(params.pixeltype)));
     ASSERT_NO_THROW(wifd->setSamplesPerPixel(shape[ome::bioformats::DIM_SUBCHANNEL]));
     ASSERT_NO_THROW(wifd->setPlanarConfiguration(params.planarconfig));
     ASSERT_NO_THROW(wifd->setPhotometricInterpretation(params.photometricinterp));
@@ -1514,6 +1518,7 @@ TEST_P(PixelTest, WriteTIFF)
     EXPECT_EQ(params.tilewidth, wifd->getTileWidth());
     EXPECT_EQ(params.tileheight, wifd->getTileHeight());
     EXPECT_EQ(params.pixeltype, wifd->getPixelType());
+    EXPECT_EQ(significantBitsPerPixel(params.pixeltype), wifd->getBitsPerSample());
     EXPECT_EQ(shape[ome::bioformats::DIM_SUBCHANNEL], wifd->getSamplesPerPixel());
     EXPECT_EQ(params.planarconfig, wifd->getPlanarConfiguration());
 
@@ -1598,6 +1603,7 @@ TEST_P(PixelTest, WriteTIFF)
     EXPECT_EQ(params.tilewidth, ifd->getTileWidth());
     EXPECT_EQ(params.tileheight, ifd->getTileHeight());
     EXPECT_EQ(params.pixeltype, ifd->getPixelType());
+    EXPECT_EQ(significantBitsPerPixel(params.pixeltype), ifd->getBitsPerSample());
     EXPECT_EQ(shape[ome::bioformats::DIM_SUBCHANNEL], ifd->getSamplesPerPixel());
     EXPECT_EQ(params.planarconfig, ifd->getPlanarConfiguration());
     EXPECT_EQ(params.photometricinterp, ifd->getPhotometricInterpretation());

--- a/cpp/test/ome-bioformats/tiffsamples.cpp
+++ b/cpp/test/ome-bioformats/tiffsamples.cpp
@@ -1,0 +1,121 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * %%
+ * Copyright © 2014 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include "tiffsamples.h"
+
+using namespace boost::filesystem;
+
+std::vector<TileTestParameters>
+find_tile_tests()
+{
+  std::vector<TileTestParameters> params;
+
+  path dir(PROJECT_BINARY_DIR "/cpp/test/ome-bioformats/data");
+  if (exists(dir) && is_directory(dir))
+    {
+      for(directory_iterator i(dir); i != directory_iterator(); ++i)
+        {
+          static ome::compat::regex tile_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-tiles-([[:digit:]]+)x([[:digit:]]+)\\.tiff");
+          static ome::compat::regex strip_match(".*/data-layout-([[:digit:]]+)x([[:digit:]]+)-([[:alpha:]]+)-strips-([[:digit:]]+)\\.tiff");
+
+          ome::compat::smatch found;
+          std::string file(i->path().string());
+          path wpath(i->path().parent_path());
+          wpath /= std::string("w-") + i->path().filename().string();
+          std::string wfile(wpath.string());
+          if (ome::compat::regex_match(file, found, tile_match))
+            {
+              TileTestParameters p;
+              p.tile = true;
+              p.file = file;
+              p.wfile = wfile;
+
+              std::istringstream iwid(found[1]);
+              if (!(iwid >> p.imagewidth))
+                continue;
+
+              std::istringstream iht(found[2]);
+              if (!(iht >> p.imagelength))
+                continue;
+
+              p.imageplanar = false;
+              if (found[3] == "planar")
+                p.imageplanar = true;
+
+              std::istringstream twid(found[4]);
+              if (!(twid >> p.tilewidth))
+                continue;
+
+              std::istringstream tht(found[5]);
+              if (!(tht >> p.tilelength))
+                continue;
+
+              params.push_back(p);
+            }
+          else if (ome::compat::regex_match(file, found, strip_match))
+            {
+              TileTestParameters p;
+              p.tile = false;
+              p.file = file;
+              p.wfile = wfile;
+
+              std::istringstream iwid(found[1]);
+              if (!(iwid >> p.imagewidth))
+                continue;
+
+              std::istringstream iht(found[2]);
+              if (!(iht >> p.imagelength))
+                continue;
+
+              p.imageplanar = false;
+              if (found[3] == "planar")
+                p.imageplanar = true;
+
+              p.tilewidth = p.imagewidth;
+
+              std::istringstream srow(found[4]);
+              if (!(srow >> p.tilelength))
+                continue;
+
+              params.push_back(p);
+            }
+        }
+    }
+
+  return params;
+}

--- a/cpp/test/ome-bioformats/tiffsamples.h
+++ b/cpp/test/ome-bioformats/tiffsamples.h
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * %%
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef TEST_TIFFSAMPLES_H
+#define TEST_TIFFSAMPLES_H
+
+#include <boost/filesystem.hpp>
+
+#include <ome/bioformats/Types.h>
+
+#include <ome/compat/regex.h>
+
+#include <ome/internal/config.h>
+
+#include <ome/test/config.h>
+#include <ome/test/test.h>
+
+#include <vector>
+
+struct TileTestParameters
+{
+  bool tile;
+  std::string file;
+  std::string wfile;
+  bool imageplanar;
+  ome::bioformats::dimension_size_type imagewidth;
+  ome::bioformats::dimension_size_type imagelength;
+  ome::bioformats::dimension_size_type tilewidth;
+  ome::bioformats::dimension_size_type tilelength;
+};
+
+template<class charT, class traits>
+inline std::basic_ostream<charT,traits>&
+operator<< (std::basic_ostream<charT,traits>& os,
+            const TileTestParameters& p)
+{
+  return os << p.file << " [" << p.wfile << "] ("
+            << p.imagewidth << "x" << p.imagelength
+            << (p.imageplanar ? " planar" : " chunky")
+            << (p.tile ? " tiled " : " strips ")
+            << p.tilewidth << "x" << p.tilelength
+            << ")";
+}
+
+extern std::vector<TileTestParameters>
+find_tile_tests();
+
+#endif // TEST_TIFFSAMPLES_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */


### PR DESCRIPTION
This PR adds a TIFF writer.  It also adds infrastructure for future work for TIFF and OME-TIFF, including:

- TIFF codec querying
- Reading a single subchannel from a TIFF
- Writing a single subchannel to a TIFF (interface only)
- Minor refactoring/cleanup of FormatWriter implementation, plus addition of helper methods
- Addition of significant bit sizes for PixelProperties
- Adjustment of CopySubchannelVisitor to use planar layout by default
- Addition of MergeSubchannelVisitor
- Helper functions to set up an OMEXMLMetadataStore from CoreMetadata
- Helper functions to compute total per-series and per-file pixel storage sizes
- Addition of a few TIFF/IFD helper methods
- Refactoring of some of the TIFF test logic for reuse by the writers

What it does *not* add:

- TIFF compression (codec stuff is present, but needs exposing and using in the writer)
- Extensive TIFFWriter testcases (currently 8-bit only)
- OME-TIFF writing

These will need adding in following PRs.

-no-rebase

--------

Testing: There is not as yet a `bfconvert` tool to write image, so testing is limited to the unit tests.  By default the test files are deleted, so you will need to:

- edit `cpp/test/ome-bioformats/minimaltiffwriter.cpp`; delete or comment the two lines in `TearDown` which delete the images.
- Make this change to test BigTIFF:
```
-  ASSERT_NO_THROW(tiffwriter.setId(testfile));
+  ASSERT_NO_THROW(tiffwriter.setId(testfile.replace_extension(".btf")));
```
  You can also edit `cpp/lib/ome/internal/config.h` and change the value of `TIFF_HAVE_BIGTIFF` from 1 to 0 to test the ifdefs and messages in combination with a bigTIFF extension.
- build normally, then run `make test` or `bf-test cpp/test/ome-bioformats/minimaltiffwriter` to run just the writing tests
- TIFF files written by the TIFF writer are in `cpp/test/ome-bioformats/data/minimaltiffwriter-*.tiff`; they should all be 64×64 8-bit greyscale with 1 row/strip and three IFDs (for RGB planes), i.e. similar to:

```
TIFF Directory at offset 0x1008 (4104)
  Image Width: 64 Image Length: 64
  Bits/Sample: 8
  Sample Format: unsigned integer
  Compression Scheme: None
  Photometric Interpretation: min-is-black
  Samples/Pixel: 1
  Rows/Strip: 1
  Planar Configuration: separate image planes
```