### PR TITLE
DM3: use the DataType tag to set the pixel type

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -204,7 +204,9 @@ public class GatanReader extends FormatReader {
     }
     int bytes = numPixelBytes / (getSizeX() * getSizeY());
 
-    m.pixelType = FormatTools.pixelTypeFromBytes(bytes, signed, false);
+    if (bytes != FormatTools.getBytesPerPixel(getPixelType())) {
+      m.pixelType = FormatTools.pixelTypeFromBytes(bytes, signed, false);
+    }
     m.sizeZ = 1;
     m.sizeC = 1;
     m.sizeT = 1;
@@ -512,6 +514,35 @@ public class GatanReader extends FormatReader {
         }
         else if (labelString.equals("Sample Time")) {
           sampleTime = Double.parseDouble(value);
+        }
+        else if (labelString.equals("DataType")) {
+          int pixelType = Double.valueOf(value).intValue();
+          switch (pixelType) {
+            case 1:
+              core.get(0).pixelType = FormatTools.INT16;
+              break;
+            case 10:
+              core.get(0).pixelType = FormatTools.UINT16;
+              break;
+            case 2:
+              core.get(0).pixelType = FormatTools.FLOAT;
+              break;
+            case 12:
+              core.get(0).pixelType = FormatTools.DOUBLE;
+              break;
+            case 9:
+              core.get(0).pixelType = FormatTools.INT8;
+              break;
+            case 6:
+              core.get(0).pixelType = FormatTools.UINT8;
+              break;
+            case 7:
+              core.get(0).pixelType = FormatTools.INT32;
+              break;
+            case 11:
+              core.get(0).pixelType = FormatTools.UINT32;
+              break;
+          }
         }
 
         value = null;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12559.

To test, use the file from QA 9526 and verify that the pixel type with this change is int32.  Without this change, it would have been uint32.  Note that a number of other sample .dm3 files (in the ```gatan``` directory) changed sign; while I did check each one in ImageJ with the DM3 reader plugin (http://rsb.info.nih.gov/ij/plugins/DM3_Reader.html), it might also be worth spot-checking a few to make sure that the DM3 reader plugin concurs as to the pixel values.