### PR TITLE
Update version history for 5.1.1

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -12,22 +12,22 @@ Version history
     - fixed upgrade checking to more accurately report when a new version is
       available
     - Zeiss CZI
-      - fixed ordering of multiposition data
-      - improved support for RGB and fused images
+        - fixed ordering of multiposition data
+        - improved support for RGB and fused images
     - Nikon ND2
-      - improved ordering of multiposition data
+        - improved ordering of multiposition data
     - Leica LIF
-      - improved metadata validity checks
-      - improved excitation wavelength detection
+        - improved metadata validity checks
+        - improved excitation wavelength detection
     - Metamorph STK/TIFF
-      - record lens numerical aperture
-      - fixed millisecond values in timestamps
+        - record lens numerical aperture
+        - fixed millisecond values in timestamps
     - Gatan DM3
-      - correctly detect signed pixel data
+        - correctly detect signed pixel data
     - Imaris HDF
-      - fix channel count detection
+        - fix channel count detection
     - ICS export
-      - fix writing of files larger than 2GB
+        - fix writing of files larger than 2GB
 
 5.1.0 (2015 April 2)
 ---------------------

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.1.1 (2015 April 30)
+5.1.1 (2015 April 28)
 ---------------------
 
 * Add TIFF writing support to the native C++ implementation

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,34 @@
 Version history
 ===============
 
+5.1.1 (2015 April 30)
+---------------------
+
+* Add TIFF writing support to the native C++ implementation
+* Fixed remaining functional differences between Windows and Mac/Linux
+* Improved performance of ImageJ plugin when working with ROIs
+* TIFF export: switch to BigTIFF if .tf2, .tf8, or .btf extensions are used
+* Many bug fixes, including:
+    - fixed upgrade checking to more accurately report when a new version is
+      available
+    - Zeiss CZI
+      - fixed ordering of multiposition data
+      - improved support for RGB and fused images
+    - Nikon ND2
+      - improved ordering of multiposition data
+    - Leica LIF
+      - improved metadata validity checks
+      - improved excitation wavelength detection
+    - Metamorph STK/TIFF
+      - record lens numerical aperture
+      - fixed millisecond values in timestamps
+    - Gatan DM3
+      - correctly detect signed pixel data
+    - Imaris HDF
+      - fix channel count detection
+    - ICS export
+      - fix writing of files larger than 2GB
+
 5.1.0 (2015 April 2)
 ---------------------
 


### PR DESCRIPTION
A few of the really minor NPE-type PRs were omitted, but otherwise this should cover everything that is merged, open, or planned before tagging.  Happy to add to it if it looks like anything noteworthy is missing though.