### PR TITLE
C++: Reader and writer channel-related fixes

### DIFF
--- a/cpp/lib/ome/bioformats/CoreMetadata.cpp
+++ b/cpp/lib/ome/bioformats/CoreMetadata.cpp
@@ -46,7 +46,7 @@ namespace ome
       sizeX(1),
       sizeY(1),
       sizeZ(1),
-      sizeC(1),
+      sizeC(),
       sizeT(1),
       thumbSizeX(0),
       thumbSizeY(0),
@@ -58,7 +58,6 @@ namespace ome
       moduloC("C"),
       dimensionOrder(ome::xml::model::enums::DimensionOrder::XYZTC),
       orderCertain(true),
-      rgb(false),
       littleEndian(false),
       interleaved(false),
       indexed(false),
@@ -68,6 +67,7 @@ namespace ome
       thumbnail(false),
       resolutionCount(1)
     {
+      sizeC.push_back(1U);
     }
 
     CoreMetadata::CoreMetadata(const CoreMetadata &copy):
@@ -86,7 +86,6 @@ namespace ome
       moduloC(copy.moduloC),
       dimensionOrder(copy.dimensionOrder),
       orderCertain(copy.orderCertain),
-      rgb(copy.rgb),
       littleEndian(copy.littleEndian),
       interleaved(copy.interleaved),
       indexed(copy.indexed),

--- a/cpp/lib/ome/bioformats/CoreMetadata.h
+++ b/cpp/lib/ome/bioformats/CoreMetadata.h
@@ -39,6 +39,7 @@
 #define OME_BIOFORMATS_COREMETADATA_H
 
 #include <map>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -87,7 +88,7 @@ namespace ome
       dimension_size_type sizeZ;
 
       /// Number of channels.
-      dimension_size_type sizeC;
+      std::vector<dimension_size_type> sizeC;
 
       /// Number of timepoints.
       dimension_size_type sizeT;
@@ -121,9 +122,6 @@ namespace ome
 
       /// Are we confident that the dimension order is correct?
       bool orderCertain;
-
-      /// Are images are stored as RGB (multiple channels per plane)?
-      bool rgb;
 
       /// Is the pixel byte order little endian?
       bool littleEndian;
@@ -187,8 +185,21 @@ namespace ome
       os << "sizeX = " << core.sizeX << '\n'
          << "sizeY = " << core.sizeY << '\n'
          << "sizeZ = " << core.sizeZ << '\n'
-         << "sizeC = " << core.sizeC << '\n'
-         << "sizeT = " << core.sizeT << '\n'
+         << "sizeC = " << std::accumulate(core.sizeC.begin(), core.sizeC.end(), dimension_size_type(0));
+      if (core.sizeC.size() > 1U)
+        {
+          os << " [";
+          for (std::vector<dimension_size_type>::const_iterator i = core.sizeC.begin();
+               i != core.sizeC.end();
+               ++i)
+            {
+              os << *i;
+              if (i + 1 != core.sizeC.end())
+                os << ", ";
+            }
+          os << ']';
+        }
+      os << "\nsizeT = " << core.sizeT << '\n'
          << "thumbSizeX = " << core.thumbSizeX << '\n'
          << "thumbSizeY = " << core.thumbSizeY << '\n'
          << "pixelType = " << core.pixelType << '\n'
@@ -198,9 +209,18 @@ namespace ome
          << "}\nmoduloT = {\n" << core.moduloT
          << "}\nmoduloC = {\n" << core.moduloC
          << "}\ndimensionOrder = " << core.dimensionOrder << '\n'
-         << "orderCertain = " << core.orderCertain << '\n'
-         << "rgb = " << core.rgb << '\n'
-         << "littleEndian = " << core.littleEndian << '\n'
+         << "orderCertain = " << core.orderCertain << '\n';
+      os << "rgb = [";
+      for (std::vector<dimension_size_type>::const_iterator i = core.sizeC.begin();
+           i != core.sizeC.end();
+           ++i)
+        {
+          os << (*i > 1);
+          if (i + 1 != core.sizeC.end())
+            os << ", ";
+        }
+      os << ']';
+      os << "\nlittleEndian = " << core.littleEndian << '\n'
          << "interleaved = " << core.interleaved << '\n'
          << "indexed = " << core.indexed << '\n'
          << "falseColor = " << core.falseColor << '\n'

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -212,15 +212,16 @@ namespace ome
       getImageCount() const = 0;
 
       /**
-       * Check if the image planes in the file have more than one channel per
-       * openBytes() call.
+       * Check if the image planes for a channel have more than one
+       * subchannel per openBytes() call.
        *
+       * @param channel the channel to use.
        * @returns @c true if and only if getRGBChannelCount() returns
        * a value greater than 1, @c false otherwise.
        */
       virtual
       bool
-      isRGB() const = 0;
+      isRGB(dimension_size_type channel = 0U) const = 0;
 
       /**
        * Get the size of the X dimension.
@@ -305,18 +306,19 @@ namespace ome
       getEffectiveSizeC() const = 0;
 
       /**
-       * Get the number of channels returned with each call to openBytes().
+       * Get the number of channels returned for a call to openBytes().
        *
        * The most common case where this value is greater than 1 is for interleaved
        * RGB data, such as a 24-bit color image plane. However, it is possible for
        * this value to be greater than 1 for non-interleaved data, such as an RGB
        * TIFF with Planar rather than Chunky configuration.
        *
+       * @param channel the channel to use.
        * @returns the number of channels.
        */
       virtual
       dimension_size_type
-      getRGBChannelCount() const = 0;
+      getRGBChannelCount(dimension_size_type channel = 0U) const = 0;
 
       /**
        * Get whether the image planes are indexed color.
@@ -1070,21 +1072,23 @@ namespace ome
        * Get the optimal sub-image width.
        * This is intended for use with openBytes().
        *
+       * @param channel the channel to use.
        * @returns the optimal width.
        **/
       virtual
       dimension_size_type
-      getOptimalTileWidth() const = 0;
+      getOptimalTileWidth(dimension_size_type channel = 0U) const = 0;
 
       /**
        * Get the optimal sub-image height.
        * This is intended for use with openBytes().
        *
+       * @param channel the channel to use.
        * @returns the optimal height.
        **/
       virtual
       dimension_size_type
-      getOptimalTileHeight() const = 0;
+      getOptimalTileHeight(dimension_size_type channel = 0U) const = 0;
 
       // Sub-resolution API methods
 

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -221,7 +221,7 @@ namespace ome
        */
       virtual
       bool
-      isRGB(dimension_size_type channel = 0U) const = 0;
+      isRGB(dimension_size_type channel) const = 0;
 
       /**
        * Get the size of the X dimension.
@@ -318,7 +318,7 @@ namespace ome
        */
       virtual
       dimension_size_type
-      getRGBChannelCount(dimension_size_type channel = 0U) const = 0;
+      getRGBChannelCount(dimension_size_type channel) const = 0;
 
       /**
        * Get whether the image planes are indexed color.
@@ -365,7 +365,7 @@ namespace ome
       virtual
       void
       getLookupTable(VariantPixelBuffer& buf,
-                     dimension_size_type plane = 0U) const = 0;
+                     dimension_size_type plane) const = 0;
 
       /**
        * Get the Modulo subdivision of the Z dimension.
@@ -1077,7 +1077,7 @@ namespace ome
        **/
       virtual
       dimension_size_type
-      getOptimalTileWidth(dimension_size_type channel = 0U) const = 0;
+      getOptimalTileWidth(dimension_size_type channel) const = 0;
 
       /**
        * Get the optimal sub-image height.
@@ -1088,7 +1088,7 @@ namespace ome
        **/
       virtual
       dimension_size_type
-      getOptimalTileHeight(dimension_size_type channel = 0U) const = 0;
+      getOptimalTileHeight(dimension_size_type channel) const = 0;
 
       // Sub-resolution API methods
 

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -359,13 +359,13 @@ namespace ome
        * but other sizes are possible.
        *
        * @param buf the destination pixel buffer.
-       * @param no the image index within the file.
+       * @param plane the plane index within the series.
        * @throws FormatException if a lookup table could not be obtained.
        */
       virtual
       void
       getLookupTable(VariantPixelBuffer& buf,
-                     dimension_size_type no = 0U) const = 0;
+                     dimension_size_type plane = 0U) const = 0;
 
       /**
        * Get the Modulo subdivision of the Z dimension.
@@ -531,34 +531,34 @@ namespace ome
       /**
        * Obtain an image plane.
        *
-       * Obtain and copy the image plane from the current file into a
-       * VariantPixelBuffer of size
+       * Obtain and copy the image plane from the current series into
+       * a VariantPixelBuffer of size
        *
        * \code{.cpp}
-       * getSizeX * getSizeY * bytesPerPixel * getRGBChannelCount()
+       * getSizeX * getSizeY * bytesPerPixel * getRGBChannelCount(channel)
        * \endcode
        *
-       * @param no the image index within the file.
+       * @param plane the plane index within the series.
        * @param buf the destination pixel buffer.
        * @throws FormatException if there was a problem parsing the
        *   metadata of the file.
        */
       virtual
       void
-      openBytes(dimension_size_type no,
+      openBytes(dimension_size_type plane,
                 VariantPixelBuffer& buf) const = 0;
 
       /**
        * Obtain a sub-image of an image plane.
        *
        * Obtain and copy the sub-image of an image plane from the
-       * current file into a VariantPixelBuffer of size
+       * current series into a VariantPixelBuffer of size
        *
        * \code{.cpp}
-       * w * h * bytesPerPixel * getRGBChannelCount()
+       * w * h * bytesPerPixel * getRGBChannelCount(channel)
        * \endcode
        *
-       * @param no the image index within the file.
+       * @param plane the plane index within the series.
        * @param buf the destination pixel buffer.
        * @param x the @c X coordinate of the upper-left corner of the sub-image.
        * @param y the @c Y coordinate of the upper-left corner of the sub-image.
@@ -569,7 +569,7 @@ namespace ome
        */
       virtual
       void
-      openBytes(dimension_size_type no,
+      openBytes(dimension_size_type plane,
                 VariantPixelBuffer& buf,
                 dimension_size_type x,
                 dimension_size_type y,
@@ -580,14 +580,14 @@ namespace ome
        * Obtain a thumbnail of an image plane.
        *
        * Obtail and copy the thumbnail for the specified image plane
-       * from the current file into a VariantPixelBuffer.
+       * from the current series into a VariantPixelBuffer.
        *
-       * @param no the image index within the file.
+       * @param plane the plane index within the series.
        * @param buf the destination pixel buffer.
        */
       virtual
       void
-      openThumbBytes(dimension_size_type no,
+      openThumbBytes(dimension_size_type plane,
                      VariantPixelBuffer& buf) const = 0;
 
       /**
@@ -607,7 +607,7 @@ namespace ome
        *
        * @note This also resets the resolution to 0.
        *
-       * @param no the series to activate.
+       * @param series the series to activate.
        *
        * @todo Remove use of stateful API which requires use of
        * series switching in const methods.
@@ -616,7 +616,7 @@ namespace ome
        */
       virtual
       void
-      setSeries(dimension_size_type no) const = 0;
+      setSeries(dimension_size_type series) const = 0;
 
       /**
        * Get the active series.

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -213,9 +213,9 @@ namespace ome
 
       /**
        * Check if the image planes for a channel have more than one
-       * subchannel per openBytes() call.
+       * sub-channel per openBytes() call.
        *
-       * @param channel the channel to use.
+       * @param channel the channel to use, range [0, EffectiveSizeC).
        * @returns @c true if and only if getRGBChannelCount() returns
        * a value greater than 1, @c false otherwise.
        */
@@ -313,7 +313,7 @@ namespace ome
        * this value to be greater than 1 for non-interleaved data, such as an RGB
        * TIFF with Planar rather than Chunky configuration.
        *
-       * @param channel the channel to use.
+       * @param channel the channel to use, range [0, EffectiveSizeC).
        * @returns the number of channels.
        */
       virtual
@@ -353,7 +353,7 @@ namespace ome
        * returns @c false, then this may throw an exception.
        *
        * The VariantPixelBuffer will use the X dimension for the value
-       * index and the subchannel dimension for the color samples
+       * index and the sub-channel dimension for the color samples
        * (order is RGB).  Depending upon the image type, the size of
        * the X dimension may vary.  It will typically be 2^8 or 2^16,
        * but other sizes are possible.
@@ -512,21 +512,21 @@ namespace ome
       isInterleaved() const = 0;
 
       /**
-       * Get whether or not the given sub-channel is interleaved.
+       * Get whether or not the given channel is interleaved.
        *
-       * This method exists because some data with multiple rasterized
-       * sub-dimensions within @c C have one sub-dimension
-       * interleaved, and the other not.  For example, @c SDTReader
-       * handles spectral-lifetime data with interleaved lifetime bins
-       * and non-interleaved spectral channels.
+       * Some data with multiple channels within @c C have the
+       * sub-channels of one sub-dimension interleaved, and the other
+       * not.  For example, @c SDTReader handles spectral-lifetime
+       * data with interleaved lifetime bins and non-interleaved
+       * spectral channels.
        *
-       * @param subC the subchannel index.
+       * @param channel the channel to use, range [0, EffectiveSizeC).
        * @returns @c true if the sub-channel is interleaved, @c false
        * otherwise.
        */
       virtual
       bool
-      isInterleaved(dimension_size_type subC) const = 0;
+      isInterleaved(dimension_size_type channel) const = 0;
 
       /**
        * Obtain an image plane.
@@ -594,7 +594,7 @@ namespace ome
        * Get the number of image series in this file.
        *
        * @returns the number of image series.
-       * @throws std::logic_error if the subresolution metadata (if
+       * @throws std::logic_error if the sub-resolution metadata (if
        * any) is invalid; this will only occur if the reader sets
        * invalid metadata.
        */
@@ -1072,7 +1072,7 @@ namespace ome
        * Get the optimal sub-image width.
        * This is intended for use with openBytes().
        *
-       * @param channel the channel to use.
+       * @param channel the channel to use, range [0, EffectiveSizeC).
        * @returns the optimal width.
        **/
       virtual
@@ -1083,7 +1083,7 @@ namespace ome
        * Get the optimal sub-image height.
        * This is intended for use with openBytes().
        *
-       * @param channel the channel to use.
+       * @param channel the channel to use, range [0, EffectiveSizeC).
        * @returns the optimal height.
        **/
       virtual
@@ -1122,7 +1122,7 @@ namespace ome
       getCoreIndex() const = 0;
 
       /**
-       * Set the current resolution/series (ignoring subresolutions).
+       * Set the current resolution/series (ignoring sub-resolutions).
        *
        * Equivalent to setSeries(), but with flattened resolutions always
        * set to @c false.

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -364,8 +364,8 @@ namespace ome
        */
       virtual
       void
-      getLookupTable(VariantPixelBuffer& buf,
-                     dimension_size_type plane) const = 0;
+      getLookupTable(dimension_size_type plane,
+                     VariantPixelBuffer& buf) const = 0;
 
       /**
        * Get the Modulo subdivision of the Z dimension.

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -1070,6 +1070,7 @@ namespace ome
 
       /**
        * Get the optimal sub-image width.
+       *
        * This is intended for use with openBytes().
        *
        * @param channel the channel to use, range [0, EffectiveSizeC).
@@ -1081,6 +1082,7 @@ namespace ome
 
       /**
        * Get the optimal sub-image height.
+       *
        * This is intended for use with openBytes().
        *
        * @param channel the channel to use, range [0, EffectiveSizeC).
@@ -1089,6 +1091,40 @@ namespace ome
       virtual
       dimension_size_type
       getOptimalTileHeight(dimension_size_type channel) const = 0;
+
+      /**
+       * Get the optimal sub-image width.
+       *
+       * This is intended for use with openBytes().  Note that this
+       * overload does not have a channel argument, and so the value
+       * returned is the smallest width for all channels for
+       * convienience and compatibility with the Java implementation.
+       * If the optimal width varies widely between channels, this may
+       * result in suboptimal performance; specify the channel to get
+       * the optimal width for each channel.
+       *
+       * @returns the optimal width.
+       **/
+      virtual
+      dimension_size_type
+      getOptimalTileWidth() const = 0;
+
+      /**
+       * Get the optimal sub-image height.
+       *
+       * This is intended for use with openBytes().  Note that this
+       * overload does not have a channel argument, and so the value
+       * returned is the smallest height for all channels for
+       * convienience and compatibility with the Java implementation.
+       * If the optimal height varies widely between channels, this
+       * may result in suboptimal performance; specify the channel to
+       * get the optimal height for each channel.
+       *
+       * @returns the optimal height.
+       **/
+      virtual
+      dimension_size_type
+      getOptimalTileHeight() const = 0;
 
       // Sub-resolution API methods
 

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -129,13 +129,13 @@ namespace ome
        *
        * to the current series in the current file.
        *
-       * @param no the image index within the file.
+       * @param plane the plane index within the series.
        * @param buf the source pixel buffer.
        * @throws FormatException if any of the parameters are invalid.
        */
       virtual
       void
-      saveBytes(dimension_size_type no,
+      saveBytes(dimension_size_type plane,
                 VariantPixelBuffer& buf) = 0;
 
       /**
@@ -150,7 +150,7 @@ namespace ome
        *
        * to the current series in the current file.
        *
-       * @param no the image index within the file.
+       * @param plane the plane index within the series.
        * @param buf the source pixel buffer.
        * @param x the @c X coordinate of the upper-left corner of the sub-image.
        * @param y the @c Y coordinate of the upper-left corner of the sub-image.
@@ -160,7 +160,7 @@ namespace ome
        */
       virtual
       void
-      saveBytes(dimension_size_type no,
+      saveBytes(dimension_size_type plane,
                 VariantPixelBuffer& buf,
                 dimension_size_type x,
                 dimension_size_type y,
@@ -170,14 +170,14 @@ namespace ome
       /**
        * Set the active series.
        *
-       * @param no the series to activate.
+       * @param series the series to activate.
        *
        * @todo Remove use of stateful API which requires use of
        * series switching in const methods.
        */
       virtual
       void
-      setSeries(dimension_size_type no) const = 0;
+      setSeries(dimension_size_type series) const = 0;
 
       /**
        * Get the active series.

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -111,11 +111,13 @@ namespace ome
        * If the pixel type of the lookup table is unsupported by the
        * file format, this method will throw an exception.
        *
+       * @param plane the plane index within the series.
        * @param buf the source pixel buffer.
        */
       virtual
       void
-      setLookupTable(const VariantPixelBuffer& buf) = 0;
+      setLookupTable(dimension_size_type       plane,
+                     const VariantPixelBuffer& buf) = 0;
 
       /**
        * Save an image plane.

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -313,6 +313,25 @@ namespace ome
       getCompression() const = 0;
 
       /**
+       * Set subchannel interleaving.
+       *
+       * @param interleaved @c true to enable interleaving (chunky) or
+       * @c false to disable interleaving (planar).
+       */
+      virtual
+      void
+      setInterleaved(bool interleaved) = 0;
+
+      /**
+       * Set subchannel interleaving.
+       *
+       * @returns the current interleaving setting; @c false if unset.
+       */
+      virtual
+      const boost::optional<bool>&
+      getInterleaved() const = 0;
+
+      /**
        * Switch the output file for the current dataset.
        *
        * @param id the new file name.

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -437,7 +437,7 @@ namespace ome
               for (dimension_size_type p = 0; p < (*i)->imageCount; ++p)
                 {
                   dimension_size_type sizeZT = (*i)->sizeZ * (*i)->sizeT;
-                  dimension_size_type effSizeC = 0;
+                  dimension_size_type effSizeC = 1U;
                   if (sizeZT)
                     effSizeC = (*i)->imageCount / sizeZT;
 

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -496,7 +496,7 @@ namespace ome
       for (dimension_size_type c = 0; c < effSizeC; ++c)
         {
           store.setChannelID(createID("Channel", series, c), series, c);
-          store.setChannelSamplesPerPixel(static_cast<PositiveInteger::value_type>(reader.getRGBChannelCount()), series, c);
+          store.setChannelSamplesPerPixel(static_cast<PositiveInteger::value_type>(reader.getRGBChannelCount(c)), series, c);
         }
 
     }
@@ -519,19 +519,15 @@ namespace ome
       store.setPixelsSizeY(static_cast<PositiveInteger::value_type>(seriesMetadata.sizeY), series);
       store.setPixelsSizeZ(static_cast<PositiveInteger::value_type>(seriesMetadata.sizeZ), series);
       store.setPixelsSizeT(static_cast<PositiveInteger::value_type>(seriesMetadata.sizeT), series);
-      store.setPixelsSizeC(static_cast<PositiveInteger::value_type>(seriesMetadata.sizeC), series);
+      store.setPixelsSizeC(static_cast<PositiveInteger::value_type>
+                           (std::accumulate(seriesMetadata.sizeC.begin(), seriesMetadata.sizeC.end(),
+                                            dimension_size_type(0))), series);
 
-      dimension_size_type sizeZT = seriesMetadata.sizeZ * seriesMetadata.sizeT;
-      dimension_size_type effSizeC = 0;
-      if (sizeZT)
-        effSizeC = seriesMetadata.imageCount / sizeZT;
+      dimension_size_type effSizeC = seriesMetadata.sizeC.size();
 
       for (dimension_size_type c = 0; c < effSizeC; ++c)
         {
-
-          dimension_size_type rgbC = 0;
-          if (effSizeC)
-            rgbC = seriesMetadata.sizeC / effSizeC;
+          dimension_size_type rgbC = seriesMetadata.sizeC.at(c);
 
           store.setChannelID(createID("Channel", series, c), series, c);
           store.setChannelSamplesPerPixel(static_cast<PositiveInteger::value_type>(rgbC), series, c);

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -1123,7 +1123,36 @@ namespace ome
         assertId(currentId, true);
         uint32_t bpp = bytesPerPixel(getPixelType());
         dimension_size_type maxHeight = (1024U * 1024U) / (getSizeX() * getRGBChannelCount(channel) * bpp);
+        if (!maxHeight)
+          maxHeight = 1U;
+
         return std::min(maxHeight, getSizeY());
+      }
+
+      dimension_size_type
+      FormatReader::getOptimalTileWidth() const
+      {
+        assertId(currentId, true);
+
+        dimension_size_type csize = getEffectiveSizeC();
+        std::vector<dimension_size_type> widths;
+        widths.reserve(csize);
+        for (dimension_size_type c = 0; c < csize; ++c)
+          widths.push_back(getOptimalTileWidth(c));
+        return *std::min_element(widths.begin(), widths.end());
+      }
+
+      dimension_size_type
+      FormatReader::getOptimalTileHeight() const
+      {
+        assertId(currentId, true);
+
+        dimension_size_type csize = getEffectiveSizeC();
+        std::vector<dimension_size_type> heights;
+        heights.reserve(csize);
+        for (dimension_size_type c = 0; c < csize; ++c)
+          heights.push_back(getOptimalTileHeight(c));
+        return *std::min_element(heights.begin(), heights.end());
       }
 
       dimension_size_type

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -584,7 +584,7 @@ namespace ome
 
       void
       FormatReader::getLookupTable(VariantPixelBuffer& /* buf */,
-                                   dimension_size_type /* no */) const
+                                   dimension_size_type /* plane */) const
       {
         throw std::runtime_error("Reader does not implement lookup tables");
       }
@@ -723,25 +723,25 @@ namespace ome
       }
 
       void
-      FormatReader::openBytes(dimension_size_type no,
+      FormatReader::openBytes(dimension_size_type plane,
                               VariantPixelBuffer& buf) const
       {
-        openBytes(no, buf, 0, 0, getSizeX(), getSizeY());
+        openBytes(plane, buf, 0, 0, getSizeX(), getSizeY());
       }
 
       void
-      FormatReader::openBytes(dimension_size_type no,
+      FormatReader::openBytes(dimension_size_type plane,
                               VariantPixelBuffer& buf,
                               dimension_size_type x,
                               dimension_size_type y,
                               dimension_size_type w,
                               dimension_size_type h) const
       {
-        openBytesImpl(no, buf, x, y, w, h);
+        openBytesImpl(plane, buf, x, y, w, h);
       }
 
       void
-      FormatReader::openThumbBytes(dimension_size_type /* no */,
+      FormatReader::openThumbBytes(dimension_size_type /* plane */,
                                    VariantPixelBuffer& /* buf */) const
       {
         assertId(currentId, true);
@@ -777,11 +777,11 @@ namespace ome
       }
 
       void
-      FormatReader::setSeries(dimension_size_type no) const
+      FormatReader::setSeries(dimension_size_type series) const
       {
-        coreIndex = seriesToCoreIndex(no);
-        series = no;
-        resolution = 0;
+        this->coreIndex = seriesToCoreIndex(series);
+        this->series = series;
+        this->resolution = 0;
       }
 
       dimension_size_type

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -583,9 +583,11 @@ namespace ome
       }
 
       void
-      FormatReader::getLookupTable(VariantPixelBuffer& /* buf */,
-                                   dimension_size_type /* plane */) const
+      FormatReader::getLookupTable(dimension_size_type /* plane */,
+                                   VariantPixelBuffer& /* buf */) const
       {
+        assertId(currentId, true);
+
         throw std::runtime_error("Reader does not implement lookup tables");
       }
 

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -737,6 +737,14 @@ namespace ome
 
         // Documented in superclass.
         dimension_size_type
+        getOptimalTileWidth() const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getOptimalTileHeight() const;
+
+        // Documented in superclass.
+        dimension_size_type
         seriesToCoreIndex(dimension_size_type series) const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -482,7 +482,7 @@ namespace ome
         // Documented in superclass.
         void
         getLookupTable(VariantPixelBuffer& buf,
-                       dimension_size_type no) const;
+                       dimension_size_type plane) const;
 
         // Documented in superclass.
         Modulo&
@@ -553,12 +553,12 @@ namespace ome
 
         // Documented in superclass.
         void
-        openBytes(dimension_size_type no,
+        openBytes(dimension_size_type plane,
                   VariantPixelBuffer& buf) const;
 
         // Documented in superclass.
         void
-        openBytes(dimension_size_type no,
+        openBytes(dimension_size_type plane,
                   VariantPixelBuffer& buf,
                   dimension_size_type x,
                   dimension_size_type y,
@@ -571,7 +571,7 @@ namespace ome
          */
         virtual
         void
-        openBytesImpl(dimension_size_type no,
+        openBytesImpl(dimension_size_type plane,
                       VariantPixelBuffer& buf,
                       dimension_size_type x,
                       dimension_size_type y,
@@ -581,7 +581,7 @@ namespace ome
       public:
         // Documented in superclass.
         void
-        openThumbBytes(dimension_size_type no,
+        openThumbBytes(dimension_size_type plane,
                        VariantPixelBuffer& buf) const;
 
         // Documented in superclass.
@@ -594,7 +594,7 @@ namespace ome
 
         // Documented in superclass.
         void
-        setSeries(dimension_size_type no) const;
+        setSeries(dimension_size_type series) const;
 
         // Documented in superclass.
         dimension_size_type

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -258,6 +258,7 @@ namespace ome
          * @param y the top edge of the plane.
          * @param w the width of the plane.
          * @param h the height of the plane.
+         * @param samples the number of samples per pixel.
          */
         virtual
         void
@@ -266,7 +267,8 @@ namespace ome
                   dimension_size_type x,
                   dimension_size_type y,
                   dimension_size_type w,
-                  dimension_size_type h);
+                  dimension_size_type h,
+                  dimension_size_type samples);
 
         /**
          * Read a raw plane with scanline padding.
@@ -281,6 +283,7 @@ namespace ome
          * @param w the width of the plane.
          * @param h the height of the plane.
          * @param scanlinePad the scanline padding.
+         * @param samples the number of samples per pixel.
          */
         virtual
         void
@@ -290,7 +293,8 @@ namespace ome
                   dimension_size_type y,
                   dimension_size_type w,
                   dimension_size_type h,
-                  dimension_size_type scanlinePad);
+                  dimension_size_type scanlinePad,
+                  dimension_size_type samples);
 
         /**
          * Create a configured FilterMetadata instance.
@@ -429,7 +433,7 @@ namespace ome
 
         // Documented in superclass.
         bool
-        isRGB() const;
+        isRGB(dimension_size_type channel) const;
 
         // Documented in superclass.
         dimension_size_type
@@ -465,7 +469,7 @@ namespace ome
 
         // Documented in superclass.
         dimension_size_type
-        getRGBChannelCount() const;
+        getRGBChannelCount(dimension_size_type channel) const;
 
         // Documented in superclass.
         bool
@@ -725,11 +729,11 @@ namespace ome
 
         // Documented in superclass.
         dimension_size_type
-        getOptimalTileWidth() const;
+        getOptimalTileWidth(dimension_size_type channel) const;
 
         // Documented in superclass.
         dimension_size_type
-        getOptimalTileHeight() const;
+        getOptimalTileHeight(dimension_size_type channel) const;
 
         // Documented in superclass.
         dimension_size_type

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -481,8 +481,8 @@ namespace ome
 
         // Documented in superclass.
         void
-        getLookupTable(VariantPixelBuffer& buf,
-                       dimension_size_type plane) const;
+        getLookupTable(dimension_size_type plane,
+                       VariantPixelBuffer& buf) const;
 
         // Documented in superclass.
         Modulo&

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -148,39 +148,39 @@ namespace ome
       }
 
       void
-      FormatWriter::saveBytes(dimension_size_type no,
+      FormatWriter::saveBytes(dimension_size_type plane,
                               VariantPixelBuffer& buf)
       {
         assertId(currentId, true);
 
         dimension_size_type width = metadataRetrieve->getPixelsSizeX(getSeries());
         dimension_size_type height = metadataRetrieve->getPixelsSizeY(getSeries());
-        saveBytes(no, buf, 0, 0, width, height);
+        saveBytes(plane, buf, 0, 0, width, height);
       }
 
       void
-      FormatWriter::setSeries(dimension_size_type no) const
+      FormatWriter::setSeries(dimension_size_type series) const
       {
         assertId(currentId, true);
 
-        if (no >= metadataRetrieve->getImageCount())
+        if (series >= metadataRetrieve->getImageCount())
           {
             boost::format fmt("Invalid series: %1%");
-            fmt % no;
+            fmt % series;
             throw std::logic_error(fmt.str());
           }
 
         const dimension_size_type currentSeries = getSeries();
-        if (currentSeries != no &&
-            (no > 0 && currentSeries != no - 1))
+        if (currentSeries != series &&
+            (series > 0 && currentSeries != series - 1))
           {
             boost::format fmt("Series set out of order: %1% (currently %2%)");
-            fmt % no % currentSeries;
+            fmt % series % currentSeries;
             throw std::logic_error(fmt.str());
           }
 
-        series = no;
-        plane = 0U;
+        this->series = series;
+        this->plane = 0U;
       }
 
       dimension_size_type
@@ -192,27 +192,27 @@ namespace ome
       }
 
       void
-      FormatWriter::setPlane(dimension_size_type no) const
+      FormatWriter::setPlane(dimension_size_type plane) const
       {
         assertId(currentId, true);
 
-        if (no >= getImageCount())
+        if (plane >= getImageCount())
           {
             boost::format fmt("Invalid plane: %1%");
-            fmt % no;
+            fmt % plane;
             throw std::logic_error(fmt.str());
           }
 
         const dimension_size_type currentPlane = getPlane();
-        if (currentPlane != no &&
-            (no > 0 && currentPlane != no - 1))
+        if (currentPlane != plane &&
+            (plane > 0 && currentPlane != plane - 1))
           {
             boost::format fmt("Plane set out of order: %1% (currently %2%)");
-            fmt % no % currentPlane;
+            fmt % plane % currentPlane;
             throw std::logic_error(fmt.str());
           }
 
-        plane = no;
+        this->plane = plane;
       }
 
       dimension_size_type

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -83,6 +83,7 @@ namespace ome
         series(0),
         plane(0),
         compression(boost::none),
+        interleaved(boost::none),
         sequential(false),
         framesPerSecond(0),
         metadataRetrieve(ome::compat::make_shared<DummyMetadata>())
@@ -282,6 +283,18 @@ namespace ome
       FormatWriter::getCompression() const
       {
         return this->compression;
+      }
+
+      void
+      FormatWriter::setInterleaved(bool interleaved)
+      {
+        this->interleaved = interleaved;
+      }
+
+      const boost::optional<bool>&
+      FormatWriter::getInterleaved() const
+      {
+        return interleaved;
       }
 
       void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -142,9 +142,12 @@ namespace ome
       }
 
       void
-      FormatWriter::setLookupTable(const VariantPixelBuffer& /* buf */)
+      FormatWriter::setLookupTable(dimension_size_type       /* plane */,
+                                   const VariantPixelBuffer& /* buf */)
       {
         assertId(currentId, true);
+
+        throw std::runtime_error("Writer does not implement lookup tables");
       }
 
       void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -166,7 +166,8 @@ namespace ome
 
         // Documented in superclass.
         void
-        setLookupTable(const VariantPixelBuffer& buf);
+        setLookupTable(dimension_size_type       plane,
+                       const VariantPixelBuffer& buf);
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -170,12 +170,12 @@ namespace ome
 
         // Documented in superclass.
         void
-        saveBytes(dimension_size_type no,
+        saveBytes(dimension_size_type plane,
                   VariantPixelBuffer& buf);
 
         // Documented in superclass.
         void
-        saveBytes(dimension_size_type no,
+        saveBytes(dimension_size_type plane,
                   VariantPixelBuffer& buf,
                   dimension_size_type x,
                   dimension_size_type y,
@@ -184,7 +184,7 @@ namespace ome
 
         // Documented in superclass.
         void
-        setSeries(dimension_size_type no) const;
+        setSeries(dimension_size_type series) const;
 
         // Documented in superclass.
         dimension_size_type
@@ -193,13 +193,13 @@ namespace ome
         /**
          * Set the active plane.
          *
-         * @param no the plane to activate.
+         * @param plane the plane to activate.
          *
          * @todo Remove use of stateful API which requires use of
          * plane switching in const methods.
          */
         virtual void
-        setPlane(dimension_size_type no) const;
+        setPlane(dimension_size_type plane) const;
 
         /**
          * Get the active plane.

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -127,6 +127,9 @@ namespace ome
         /// The compression type to use.
         boost::optional<std::string> compression;
 
+        /// Subchannel interleaving enabled.
+        boost::optional<bool> interleaved;
+
         /// Planes are written sequentially.
         bool sequential;
 
@@ -334,6 +337,14 @@ namespace ome
         // Documented in superclass.
         const boost::optional<std::string>&
         getCompression() const;
+
+        // Documented in superclass.
+        void
+        setInterleaved(bool interleaved);
+
+        // Documented in superclass.
+        const boost::optional<bool>&
+        getInterleaved() const;
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -235,6 +235,20 @@ namespace ome
         getImageCount() const;
 
         /**
+         * Does a channel contain subchannels?
+         *
+         * Check if the image planes in the file have more than one subchannel per
+         * openBytes() call for the specified channel.
+         *
+         * @param channel the channel to use.
+         * @returns @c true if and only if @c getRGBChannelCount(channel) returns
+         * a value greater than 1, @c false otherwise.
+         */
+        virtual
+        bool
+        isRGB(dimension_size_type channel) const;
+
+        /**
          * Get the size of the X dimension.
          *
          * @returns the X dimension size.
@@ -300,6 +314,59 @@ namespace ome
         virtual
         pixel_size_type
         getBitsPerPixel() const;
+
+        /**
+         * Get the effective size of the C dimension
+         *
+         * This guarantees that
+         * \code{.cpp}
+         * getEffectiveSizeC() * getSizeZ() * getSizeT() == getImageCount()
+         * \endcode
+         * regardless of the result of isRGB().
+         *
+         * @returns the effective C dimension size.
+         */
+        virtual
+        dimension_size_type
+        getEffectiveSizeC() const;
+
+        /**
+         * Get the number of channels required for a call to saveBytes().
+         *
+         * The most common case where this value is greater than 1 is for interleaved
+         * RGB data, such as a 24-bit color image plane. However, it is possible for
+         * this value to be greater than 1 for non-interleaved data, such as an RGB
+         * TIFF with Planar rather than Chunky configuration.
+         *
+         * @param channel the channel to use.
+         * @returns the number of channels.
+         */
+        virtual
+        dimension_size_type
+        getRGBChannelCount(dimension_size_type channel) const;
+
+        /**
+         * @copydoc ome::bioformats::FormatReader::getDimensionOrder() const
+         */
+        virtual
+        const std::string&
+        getDimensionOrder() const;
+
+        /**
+         * @copydoc ome::bioformats::FormatReader::getIndex(dimension_size_type,dimension_size_type,dimension_size_type) const
+         */
+        virtual
+        dimension_size_type
+        getIndex(dimension_size_type z,
+                 dimension_size_type c,
+                 dimension_size_type t) const;
+
+        /**
+         * @copydoc ome::bioformats::FormatReader::getZCTCoords(dimension_size_type) const
+         */
+        virtual
+        ome::compat::array<dimension_size_type, 3>
+        getZCTCoords(dimension_size_type index) const;
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -241,7 +241,7 @@ namespace ome
          * Check if the image planes in the file have more than one subchannel per
          * openBytes() call for the specified channel.
          *
-         * @param channel the channel to use.
+         * @param channel the channel to use, range [0, EffectiveSizeC).
          * @returns @c true if and only if @c getRGBChannelCount(channel) returns
          * a value greater than 1, @c false otherwise.
          */
@@ -339,7 +339,7 @@ namespace ome
          * this value to be greater than 1 for non-interleaved data, such as an RGB
          * TIFF with Planar rather than Chunky configuration.
          *
-         * @param channel the channel to use.
+         * @param channel the channel to use, range [0, EffectiveSizeC).
          * @returns the number of channels.
          */
         virtual

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -215,8 +215,8 @@ namespace ome
       }
 
       void
-      MinimalTIFFReader::getLookupTable(VariantPixelBuffer& buf,
-                                        dimension_size_type plane) const
+      MinimalTIFFReader::getLookupTable(dimension_size_type plane,
+                                        VariantPixelBuffer& buf) const
       {
         assertId(currentId, true);
 

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -120,7 +120,7 @@ namespace ome
       const ome::compat::shared_ptr<const tiff::IFD>
       MinimalTIFFReader::ifdAtIndex(dimension_size_type no) const
       {
-        dimension_size_type ifdidx = tiff::ifdIndex(seriesIFDRange, getSeries(), no, getSizeC(), isRGB());
+        dimension_size_type ifdidx = tiff::ifdIndex(seriesIFDRange, getSeries(), no);
         const ome::compat::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
 
         return ifd;
@@ -246,14 +246,7 @@ namespace ome
 
         const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
 
-        if (isRGB())
-          {
-            // Read single subchannel.
-            dimension_size_type subC = no % getSizeC();
-            ifd->readImage(buf, x, y, w, h, subC);
-          }
-        else
-          ifd->readImage(buf, x, y, w, h);
+        ifd->readImage(buf, x, y, w, h);
       }
 
       ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -118,9 +118,9 @@ namespace ome
       }
 
       const ome::compat::shared_ptr<const tiff::IFD>
-      MinimalTIFFReader::ifdAtIndex(dimension_size_type no) const
+      MinimalTIFFReader::ifdAtIndex(dimension_size_type plane) const
       {
-        dimension_size_type ifdidx = tiff::ifdIndex(seriesIFDRange, getSeries(), no);
+        dimension_size_type ifdidx = tiff::ifdIndex(seriesIFDRange, getSeries(), plane);
         const ome::compat::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
 
         return ifd;
@@ -216,11 +216,11 @@ namespace ome
 
       void
       MinimalTIFFReader::getLookupTable(VariantPixelBuffer& buf,
-                                        dimension_size_type no) const
+                                        dimension_size_type plane) const
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         try
           {
@@ -235,7 +235,7 @@ namespace ome
       }
 
       void
-      MinimalTIFFReader::openBytesImpl(dimension_size_type no,
+      MinimalTIFFReader::openBytesImpl(dimension_size_type plane,
                                        VariantPixelBuffer& buf,
                                        dimension_size_type x,
                                        dimension_size_type y,
@@ -244,7 +244,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         ifd->readImage(buf, x, y, w, h);
       }

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -105,12 +105,12 @@ namespace ome
         /**
          * Get the IFD index for a plane in the current series.
          *
-         * @param no the image index within the file.
+         * @param plane the plane index within the series.
          * @returns the IFD index.
          * @throws FormatException if out of range.
          */
         const ome::compat::shared_ptr<const tiff::IFD>
-        ifdAtIndex(dimension_size_type no) const;
+        ifdAtIndex(dimension_size_type plane) const;
 
       public:
         // Documented in superclass.
@@ -120,12 +120,12 @@ namespace ome
         // Documented in superclass.
         void
         getLookupTable(VariantPixelBuffer& buf,
-                       dimension_size_type no) const;
+                       dimension_size_type plane) const;
 
       protected:
         // Documented in superclass.
         void
-        openBytesImpl(dimension_size_type no,
+        openBytesImpl(dimension_size_type plane,
                       VariantPixelBuffer& buf,
                       dimension_size_type x,
                       dimension_size_type y,

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -119,8 +119,8 @@ namespace ome
 
         // Documented in superclass.
         void
-        getLookupTable(VariantPixelBuffer& buf,
-                       dimension_size_type plane) const;
+        getLookupTable(dimension_size_type plane,
+                       VariantPixelBuffer& buf) const;
 
       protected:
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -1288,8 +1288,8 @@ namespace ome
       }
 
       void
-      OMETIFFReader::getLookupTable(VariantPixelBuffer& buf,
-                                    dimension_size_type plane) const
+      OMETIFFReader::getLookupTable(dimension_size_type plane,
+                                    VariantPixelBuffer& buf) const
       {
         assertId(currentId, true);
 

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -327,24 +327,24 @@ namespace ome
       }
 
       const ome::compat::shared_ptr<const tiff::IFD>
-      OMETIFFReader::ifdAtIndex(dimension_size_type no) const
+      OMETIFFReader::ifdAtIndex(dimension_size_type plane) const
       {
         ome::compat::shared_ptr<const IFD> ifd;
 
         const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
 
-        if (no < ometa.tiffPlanes.size())
+        if (plane < ometa.tiffPlanes.size())
           {
-            const OMETIFFPlane& plane(ometa.tiffPlanes.at(no));
-            const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(plane.id));
+            const OMETIFFPlane& tiffplane(ometa.tiffPlanes.at(plane));
+            const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(tiffplane.id));
             if (tiff)
-              ifd = ome::compat::shared_ptr<const IFD>(tiff->getDirectoryByIndex(plane.ifd));
+              ifd = ome::compat::shared_ptr<const IFD>(tiff->getDirectoryByIndex(tiffplane.ifd));
           }
 
         if (!ifd)
           {
             boost::format fmt("Failed to open IFD ‘%1%’");
-            fmt % no;
+            fmt % plane;
             throw FormatException(fmt.str());
           }
 
@@ -1289,11 +1289,11 @@ namespace ome
 
       void
       OMETIFFReader::getLookupTable(VariantPixelBuffer& buf,
-                                    dimension_size_type no) const
+                                    dimension_size_type plane) const
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         try
           {
@@ -1308,7 +1308,7 @@ namespace ome
       }
 
       void
-      OMETIFFReader::openBytesImpl(dimension_size_type no,
+      OMETIFFReader::openBytesImpl(dimension_size_type plane,
                                    VariantPixelBuffer& buf,
                                    dimension_size_type x,
                                    dimension_size_type y,
@@ -1317,7 +1317,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(no));
+        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         ifd->readImage(buf, x, y, w, h);
       }

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -196,11 +196,11 @@ namespace ome
 
         // Documented in superclass.
         dimension_size_type
-        getOptimalTileWidth() const;
+        getOptimalTileWidth(dimension_size_type channel) const;
 
         // Documented in superclass.
         dimension_size_type
-        getOptimalTileHeight() const;
+        getOptimalTileHeight(dimension_size_type channel) const;
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -125,11 +125,11 @@ namespace ome
         // Documented in superclass.
         void
         getLookupTable(VariantPixelBuffer& buf,
-                       dimension_size_type no) const;
+                       dimension_size_type plane) const;
 
         // Documented in superclass.
         void
-        openBytesImpl(dimension_size_type no,
+        openBytesImpl(dimension_size_type plane,
                       VariantPixelBuffer& buf,
                       dimension_size_type x,
                       dimension_size_type y,
@@ -139,12 +139,12 @@ namespace ome
         /**
          * Get the IFD index for a plane in the current series.
          *
-         * @param no the image index within the file.
+         * @param plane the plane index within the series.
          * @returns the IFD index.
          * @throws FormatException if out of range.
          */
         const ome::compat::shared_ptr<const tiff::IFD>
-        ifdAtIndex(dimension_size_type no) const;
+        ifdAtIndex(dimension_size_type plane) const;
 
         /**
          * Add a TIFF file to the internal TIFF map.

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -124,8 +124,8 @@ namespace ome
 
         // Documented in superclass.
         void
-        getLookupTable(VariantPixelBuffer& buf,
-                       dimension_size_type plane) const;
+        getLookupTable(dimension_size_type plane,
+                       VariantPixelBuffer& buf) const;
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -116,7 +116,9 @@ namespace ome
 
                 ijm->sizeZ = ijmeta.slices;
                 ijm->sizeT = ijmeta.frames;
-                ijm->sizeC = ijmeta.channels;
+                ijm->sizeC.clear();
+                for (dimension_size_type c = 0; c < ijmeta.channels; ++c)
+                  ijm->sizeC.push_back(1U);
 
                 core.clear();
                 core.push_back(ijm);

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -241,12 +241,12 @@ namespace ome
       }
 
       void
-      MinimalTIFFWriter::setSeries(dimension_size_type no) const
+      MinimalTIFFWriter::setSeries(dimension_size_type series) const
       {
         const dimension_size_type currentSeries = getSeries();
-        detail::FormatWriter::setSeries(no);
+        detail::FormatWriter::setSeries(series);
 
-        if (currentSeries != no)
+        if (currentSeries != series)
           {
             nextIFD();
             setupIFD();
@@ -254,12 +254,12 @@ namespace ome
       }
 
       void
-      MinimalTIFFWriter::setPlane(dimension_size_type no) const
+      MinimalTIFFWriter::setPlane(dimension_size_type plane) const
       {
         const dimension_size_type currentPlane = getPlane();
-        detail::FormatWriter::setPlane(no);
+        detail::FormatWriter::setPlane(plane);
 
-        if (currentPlane != no)
+        if (currentPlane != plane)
           {
             nextIFD();
             setupIFD();
@@ -306,7 +306,7 @@ namespace ome
       }
 
       void
-      MinimalTIFFWriter::saveBytes(dimension_size_type no,
+      MinimalTIFFWriter::saveBytes(dimension_size_type plane,
                                    VariantPixelBuffer& buf,
                                    dimension_size_type x,
                                    dimension_size_type y,
@@ -315,10 +315,10 @@ namespace ome
       {
         assertId(currentId, true);
 
-        setPlane(no);
+        setPlane(plane);
 
         dimension_size_type expectedIndex =
-          tiff::ifdIndex(seriesIFDRange, getSeries(), no);
+          tiff::ifdIndex(seriesIFDRange, getSeries(), plane);
 
         if (ifdIndex != expectedIndex)
           {

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -299,6 +299,9 @@ namespace ome
         else
           ifd->setPlanarConfiguration(tiff::SEPARATE);
 
+        // This isn't necessarily always true; we might want to use a
+        // photometric interpretation other than RGB with three
+        // subchannels.
         if (isRGB(channel) && getRGBChannelCount(channel) == 3)
           ifd->setPhotometricInterpretation(tiff::RGB);
         else

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
@@ -110,11 +110,11 @@ namespace ome
       public:
         // Documented in superclass.
         void
-        setSeries(dimension_size_type no) const;
+        setSeries(dimension_size_type series) const;
 
         // Documented in superclass.
         void
-        setPlane(dimension_size_type no) const;
+        setPlane(dimension_size_type plane) const;
 
       protected:
         /// Flush current IFD and create new IFD.
@@ -130,7 +130,7 @@ namespace ome
 
         // Documented in superclass.
         void
-        saveBytes(dimension_size_type no,
+        saveBytes(dimension_size_type plane,
                   VariantPixelBuffer& buf,
                   dimension_size_type x,
                   dimension_size_type y,

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -42,6 +42,8 @@
 #include <boost/range/size.hpp>
 #include <boost/thread.hpp>
 
+#include <ome/bioformats/tiff/Field.h>
+#include <ome/bioformats/tiff/Tags.h>
 #include <ome/bioformats/tiff/TIFF.h>
 #include <ome/bioformats/tiff/IFD.h>
 #include <ome/bioformats/tiff/Sentry.h>
@@ -51,6 +53,7 @@
 #include <ome/common/string.h>
 
 #include <ome/internal/config.h>
+#include <ome/internal/version.h>
 
 #include <tiffio.h>
 
@@ -282,6 +285,9 @@ namespace ome
       TIFF::writeCurrentDirectory()
       {
         Sentry sentry;
+
+        static const std::string software("OME Bio-Formats (C++) " OME_VERSION_MAJOR_S "." OME_VERSION_MINOR_S "." OME_VERSION_PATCH_S);
+        getCurrentDirectory()->getField(SOFTWARE).set(software);
 
         if (!TIFFWriteDirectory(impl->tiff))
           sentry.error("Failed to write current directory");

--- a/cpp/lib/ome/bioformats/tiff/Util.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Util.cpp
@@ -43,6 +43,7 @@
 #include <ome/bioformats/tiff/IFD.h>
 #include <ome/bioformats/tiff/Tags.h>
 #include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Types.h>
 #include <ome/bioformats/tiff/Util.h>
 
 namespace ome
@@ -172,7 +173,7 @@ namespace ome
 
         // This doesn't match the reality, but since subchannels are
         // addressed as planes this is needed.
-        core.interleaved = false;
+        core.interleaved = (ifd.getPlanarConfiguration() == tiff::CONTIG);
 
         // Indexed samples.
         if (samples == 1 && photometric == tiff::PALETTE)

--- a/cpp/lib/ome/bioformats/tiff/Util.h
+++ b/cpp/lib/ome/bioformats/tiff/Util.h
@@ -83,16 +83,6 @@ namespace ome
                       CoreMetadata& core);
 
       /**
-       * Set CoreMetadata for an IFD.
-       *
-       * @param ifd the IFD to set.
-       * @param core the CoreMetadata to use.
-       */
-      void
-      setCoreMetadata(IFD&                ifd,
-                      const CoreMetadata& core);
-
-      /**
        * Range of IFDs for an image series.
        *
        * Note the range is half-open, with the end index being one
@@ -117,16 +107,12 @@ namespace ome
        * @param seriesIFDRange the series--IFD range mapping.
        * @param series the series to use.
        * @param plane the plane within the series to use.
-       * @param sizeC the number of channels in the series.
-       * @param isRGB the number of subchannels in the series.
        * @returns the IFD index.
        */
       dimension_size_type
       ifdIndex(const SeriesIFDRange& seriesIFDRange,
                dimension_size_type   series,
-               dimension_size_type   plane,
-               dimension_size_type   sizeC,
-               bool                  isRGB);
+               dimension_size_type   plane);
 
     }
   }

--- a/cpp/libexec/info/ImageInfo.cpp
+++ b/cpp/libexec/info/ImageInfo.cpp
@@ -225,7 +225,7 @@ namespace info
         dimension_size_type effC = reader->getEffectiveSizeC();
         for (dimension_size_type c = 0; c < effC; ++c)
           {
-            stream << (reader->isRGB() ? "true" : "false");
+            stream << (reader->isRGB(c) ? "true" : "false");
             if (c + 1 != effC)
               stream << ", ";
           }

--- a/cpp/libexec/info/ImageInfo.cpp
+++ b/cpp/libexec/info/ImageInfo.cpp
@@ -221,8 +221,22 @@ namespace info
           }
 
         stream << "\tImage count = " << reader->getImageCount() << '\n'
-               << "\tRGB = " << (reader->isRGB() ? "true" : "false")
-               << " (" << reader->getRGBChannelCount() << ") "
+               << "\tRGB = [";
+        dimension_size_type effC = reader->getEffectiveSizeC();
+        for (dimension_size_type c = 0; c < effC; ++c)
+          {
+            stream << (reader->isRGB() ? "true" : "false");
+            if (c + 1 != effC)
+              stream << ", ";
+          }
+        stream << "] ([";
+        for (dimension_size_type c = 0; c < effC; ++c)
+          {
+            stream << reader->getRGBChannelCount(c);
+            if (c + 1 != effC)
+              stream << ", ";
+          }
+        stream << "]) "
                << (opts.merge ? "merged" : opts.separate ? "separated" : "") << '\n'
                << "\tInterleaved = " << (reader->isInterleaved() ? "true" : "false") << '\n'
                << "\tIndexed = " << (reader->isIndexed() ? "true" : "false") << '\n'

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -515,7 +515,7 @@ TEST_P(FormatReaderTest, SubresolutionUnflattenedCoreMetadata)
 TEST_P(FormatReaderTest, DefaultLUT)
 {
   VariantPixelBuffer buf;
-  EXPECT_THROW(r.getLookupTable(buf, 0U), std::runtime_error);
+  EXPECT_THROW(r.getLookupTable(0U, buf), std::logic_error);
 }
 
 TEST_P(FormatReaderTest, FlatLUT)
@@ -523,7 +523,7 @@ TEST_P(FormatReaderTest, FlatLUT)
   r.setId("flat");
 
   VariantPixelBuffer buf;
-  EXPECT_THROW(r.getLookupTable(buf, 0U), std::runtime_error);
+  EXPECT_THROW(r.getLookupTable(0U, buf), std::runtime_error);
 }
 
 TEST_P(FormatReaderTest, DefaultSeries)

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -378,6 +378,10 @@ TEST_P(FormatReaderTest, DefaultCoreMetadata)
   EXPECT_THROW(r.isMetadataComplete(), std::logic_error);
   EXPECT_THROW(r.getOptimalTileWidth(0), std::logic_error);
   EXPECT_THROW(r.getOptimalTileHeight(0), std::logic_error);
+  EXPECT_THROW(r.getOptimalTileWidth(1), std::logic_error);
+  EXPECT_THROW(r.getOptimalTileHeight(1), std::logic_error);
+  EXPECT_THROW(r.getOptimalTileWidth(), std::logic_error);
+  EXPECT_THROW(r.getOptimalTileHeight(), std::logic_error);
   EXPECT_THROW(r.getResolutionCount(), std::logic_error);
 }
 
@@ -418,9 +422,17 @@ TEST_P(FormatReaderTest, FlatCoreMetadata)
   EXPECT_FALSE(r.isInterleaved(0));
   EXPECT_FALSE(r.isMetadataComplete());
   EXPECT_EQ(512U, r.getOptimalTileWidth(0));
-  EXPECT_EQ(std::min((1024U * 1024U) / (512U * ::ome::bioformats::bytesPerPixel(params.type)),
-                     1024U),
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(0) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
             r.getOptimalTileHeight(0));
+  EXPECT_EQ(512U, r.getOptimalTileWidth(1));
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(1) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
+            r.getOptimalTileHeight(1));
+  EXPECT_EQ(512U, r.getOptimalTileWidth());
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(1) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
+            r.getOptimalTileHeight());
   EXPECT_EQ(1U, r.getResolutionCount());
 }
 
@@ -462,9 +474,17 @@ TEST_P(FormatReaderTest, SubresolutionFlattenedCoreMetadata)
   EXPECT_FALSE(r.isInterleaved(0));
   EXPECT_FALSE(r.isMetadataComplete());
   EXPECT_EQ(512U, r.getOptimalTileWidth(0));
-  EXPECT_EQ(std::min((1024U * 1024U) / (512U * ::ome::bioformats::bytesPerPixel(params.type)),
-                     1024U),
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(0) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
             r.getOptimalTileHeight(0));
+  EXPECT_EQ(512U, r.getOptimalTileWidth(1));
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(1) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
+            r.getOptimalTileHeight(1));
+  EXPECT_EQ(512U, r.getOptimalTileWidth());
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(1) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
+            r.getOptimalTileHeight());
   EXPECT_EQ(1U, r.getResolutionCount());
 }
 
@@ -506,9 +526,17 @@ TEST_P(FormatReaderTest, SubresolutionUnflattenedCoreMetadata)
   EXPECT_FALSE(r.isInterleaved(0));
   EXPECT_FALSE(r.isMetadataComplete());
   EXPECT_EQ(512U, r.getOptimalTileWidth(0));
-  EXPECT_EQ(std::min((1024U * 1024U) / (512U * ::ome::bioformats::bytesPerPixel(params.type)),
-                     1024U),
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(0) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
             r.getOptimalTileHeight(0));
+  EXPECT_EQ(512U, r.getOptimalTileWidth(1));
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(1) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
+            r.getOptimalTileHeight(1));
+  EXPECT_EQ(512U, r.getOptimalTileWidth());
+  EXPECT_EQ(std::min((1024U * 1024U) / (512U * r.getRGBChannelCount(1) * ::ome::bioformats::bytesPerPixel(params.type)),
+                     dimension_size_type(1024U)),
+            r.getOptimalTileHeight());
   EXPECT_EQ(3U, r.getResolutionCount());
 }
 

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -358,7 +358,7 @@ TEST_P(FormatWriterTest, IsThisType)
 TEST_P(FormatWriterTest, DefaultLUT)
 {
   VariantPixelBuffer buf(boost::extents[256][1][1][1][1][3][1][1][1]);
-  EXPECT_THROW(w.setLookupTable(buf), std::logic_error);
+  EXPECT_THROW(w.setLookupTable(0U, buf), std::logic_error);
 }
 
 TEST_P(FormatWriterTest, OutputLUT)
@@ -366,7 +366,7 @@ TEST_P(FormatWriterTest, OutputLUT)
   w.setId("output.test");
 
   VariantPixelBuffer buf(boost::extents[256][1][1][1][1][3][1][1][1]);
-  EXPECT_NO_THROW(w.setLookupTable(buf));
+  EXPECT_THROW(w.setLookupTable(0U, buf), std::runtime_error);
 }
 
 TEST_P(FormatWriterTest, DefaultPixels)

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -246,15 +246,14 @@ private:
     store->setPixelsSizeY(PositiveInteger(core->sizeY), series);
     store->setPixelsSizeZ(PositiveInteger(core->sizeZ), series);
     store->setPixelsSizeT(PositiveInteger(core->sizeT), series);
-    store->setPixelsSizeC(PositiveInteger(core->sizeC), series);
+    store->setPixelsSizeC(PositiveInteger(std::accumulate(core->sizeC.begin(), core->sizeC.end(), dimension_size_type(0))), series);
 
-    dimension_size_type effSizeC = core->imageCount / (core->sizeZ * core->sizeT);
-    dimension_size_type spp = core->sizeC / effSizeC;
+    dimension_size_type effSizeC = core->sizeC.size();
 
     for (dimension_size_type c = 0; c < effSizeC; ++c)
       {
         store->setChannelID(createID("Channel", series, c), series, c);
-        store->setChannelSamplesPerPixel(PositiveInteger(spp), series, c);
+        store->setChannelSamplesPerPixel(PositiveInteger(core->sizeC.at(c)), series, c);
       }
   }
 
@@ -267,11 +266,14 @@ private:
     c->sizeY = 1024;
     c->sizeZ = 20;
     c->sizeT = 4;
-    c->sizeC = 2;
+
+    c->sizeC.clear();
+    c->sizeC.push_back(1);
+    c->sizeC.push_back(1);
+
     c->pixelType = test_params.type;
-    c->imageCount = c->sizeZ * c->sizeT * c->sizeC;
+    c->imageCount = c->sizeZ * c->sizeT * std::accumulate(c->sizeC.begin(), c->sizeC.end(), dimension_size_type(0));
     c->orderCertain = true;
-    c->rgb = false;
     c->littleEndian = test_params.endian == ::ome::bioformats::ENDIAN_LITTLE;
     c->interleaved = false;
     c->indexed = false;

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -147,7 +147,10 @@ TEST_P(TIFFWriterTest, setId)
   ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
-  tiffwriter.setInterleaved(true);
+
+  bool interleaved = true;
+
+  tiffwriter.setInterleaved(interleaved);
 
   ASSERT_NO_THROW(tiffwriter.setId(testfile));
 
@@ -167,13 +170,13 @@ TEST_P(TIFFWriterTest, setId)
       shape[ome::bioformats::DIM_SPATIAL_Z] = shape[ome::bioformats::DIM_TEMPORAL_T] = shape[ome::bioformats::DIM_CHANNEL] =
         shape[ome::bioformats::DIM_MODULO_Z] = shape[ome::bioformats::DIM_MODULO_T] = shape[ome::bioformats::DIM_MODULO_C] = 1;
 
-      ome::bioformats::PixelBufferBase::storage_order_type order(ome::bioformats::PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, ifd->getSamplesPerPixel() > 1 ? true : false));
+      ome::bioformats::PixelBufferBase::storage_order_type order(ome::bioformats::PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, interleaved));
 
       VariantPixelBuffer src(shape, ifd->getPixelType(), order);
       src = buf;
 
-      tiffwriter.setSeries(currentSeries);
-      tiffwriter.saveBytes(0, src);
+      ASSERT_NO_THROW(tiffwriter.setSeries(currentSeries));
+      ASSERT_NO_THROW(tiffwriter.saveBytes(0, src));
       ++currentSeries;
     }
   tiffwriter.close();

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -147,6 +147,7 @@ TEST_P(TIFFWriterTest, setId)
   ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
+  tiffwriter.setInterleaved(true);
 
   ASSERT_NO_THROW(tiffwriter.setId(testfile));
 
@@ -156,23 +157,23 @@ TEST_P(TIFFWriterTest, setId)
     {
       ome::compat::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
       ASSERT_TRUE(static_cast<bool>(ifd));
+      ifd->readImage(buf);
 
-      dimension_size_type samples = ifd->getSamplesPerPixel();
-      if (samples == 1)
-        {
-          ifd->readImage(buf);
-          tiffwriter.setSeries(currentSeries);
-          tiffwriter.saveBytes(0, buf);
-        }
-      else
-        {
-          tiffwriter.setSeries(currentSeries);
-          for (dimension_size_type channel = 0U; channel < samples; ++channel)
-            {
-              ifd->readImage(buf, channel);
-              tiffwriter.saveBytes(channel, buf);
-            }
-        }
+      // Make a second buffer to ensure correct ordering for saveBytes.
+      ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+      shape[ome::bioformats::DIM_SPATIAL_X] = ifd->getImageWidth();
+      shape[ome::bioformats::DIM_SPATIAL_Y] = ifd->getImageHeight();
+      shape[ome::bioformats::DIM_SUBCHANNEL] = ifd->getSamplesPerPixel();
+      shape[ome::bioformats::DIM_SPATIAL_Z] = shape[ome::bioformats::DIM_TEMPORAL_T] = shape[ome::bioformats::DIM_CHANNEL] =
+        shape[ome::bioformats::DIM_MODULO_Z] = shape[ome::bioformats::DIM_MODULO_T] = shape[ome::bioformats::DIM_MODULO_C] = 1;
+
+      ome::bioformats::PixelBufferBase::storage_order_type order(ome::bioformats::PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, ifd->getSamplesPerPixel() > 1 ? true : false));
+
+      VariantPixelBuffer src(shape, ifd->getPixelType(), order);
+      src = buf;
+
+      tiffwriter.setSeries(currentSeries);
+      tiffwriter.saveBytes(0, src);
       ++currentSeries;
     }
   tiffwriter.close();

--- a/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
@@ -78,10 +78,16 @@ namespace
                << "\n\tZ = " << reader.getSizeZ()
                << "\n\tT = " << reader.getSizeT()
                << "\n\tC = " << reader.getSizeC()
-               << "\n\tEffectiveC = " << reader.getEffectiveSizeC()
-               << "\n\tRGB = " << (reader.isRGB() ? "true" : "false")
-               << "\n\tRGBC = " << reader.getRGBChannelCount()
-               << '\n';
+               << "\n\tEffectiveC = " << reader.getEffectiveSizeC();
+        for (dimension_size_type channel = 0;
+             channel < reader.getEffectiveSizeC();
+             ++channel)
+          {
+            stream << "\n\tChannel " << channel << ':'
+                   << "\n\t\tRGB = " << (reader.isRGB(channel) ? "true" : "false")
+                   << "\n\t\tRGBC = " << reader.getRGBChannelCount(channel);
+          }
+        stream << '\n';
 
         // Get total number of planes (for this image index)
         dimension_size_type pc = reader.getImageCount();


### PR DESCRIPTION
Both the existing readers and writers were making some mistaken assuptions with SizeC/EffectiveSizeC/ImageCount/RGBChannelCount.  This PR corrects these assumptions to use these data correctly, and it also adds some fixes to the API to handle subchannel data and calculations correctly in all circumstances.  I was going to wait on doing this, as discussed, but the impact of getting things wrong is quite severe.  Unlike the Java situation, where using incorrect dimension sizes/indices will at worst give an ArrayOutOfBoundsException, here we will at best immediately segfault or worse, silently corrupt memory and write out junk data.  I thought it better to err on the side of caution rather than give the user incorrect data with potentially catastrophic results.

- CoreMetadata: Make `sizeC` a vector of integers to accurately represent SamplesPerPixel subchannels on a per-channel basis; remove the now redundant `rgb` field.  SizeC is the sum of all subchannels; EffectiveSizeC is the size of the vector.  `imageCount` is retained as a sanity check but otherwise redundant.
- FormatReader: `isRGB`, `getRGBChannelCount`, `getOptimalTileWidth` and `getOptimalTileHeight` have a `channel` parameter to specify the channel to use, and make use of the per-channel subchannel count.  `getSizeC` and `getEffectiveSizeC` updated to use the new calculations.
- FormatWriter already provided a subset of these methods, which are extended to provide an equivalent set (using MetadataStore rather than CoreMetadata)
- MetadataTools updated to use updated channel count calculations
- All readers can now read RGB data with correct plane indexing and buffer sizing
- MinimalTIFFWriter can now write RGB data
- OMETIFFReader initFile logic updated to use subchannels; this has simplified it a bit
- ImageInfo updated to display subchannels
- Testcases updated

Additional minor API fixes:

- Parameter names and API docs updated to replace the generic `no` by `series`, `plane` etc. to make the API more self-describing; similar for sample counts.
- LookupTable parameters swapped to make the API consistent for methods using plane index and buffer arguments; fixed assertions and unit test for default LUT behaviour
- FormatWriter has added interleaving methods, used by the TIFF writer

--------

Question: The addition of the `channel` argument works, but an alternative would be to use a `plane` argument to make the method calls align open/saveBytes where the information is most likely to be used (these would internally call getZCTCoords with the provided plane number to get the channel).  Would that be better than channel, or is channel OK?  From the POV of display/rendering, channel is what's needed, but for the user of openBytes/saveBytes, it saves them doing the getZCTCoords themselves to do the lookup before calling methods with channel arguments.

--------

Testing: All the dimension-related changes are tested by the unit tests.  The TIFF writing changes may be tested by editing `cpp/test/ome-bioformats/minimaltiffwriter.cpp` and changing:

```
diff --git a/cpp/test/ome-bioformats/minimaltiffwriter.cpp b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
index b042a89..9734bc4 100644
--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -124,8 +124,8 @@ public:
   TearDown()
   {
     // Delete file (if any)
-    if (boost::filesystem::exists(testfile))
-      boost::filesystem::remove(testfile);
+    // if (boost::filesystem::exists(testfile))
+    //   boost::filesystem::remove(testfile);
   }
 };
 
@@ -148,7 +148,7 @@ TEST_P(TIFFWriterTest, setId)
 
   tiffwriter.setMetadataRetrieve(retrieve);
 
-  bool interleaved = true;
+  bool interleaved = false;
 
   tiffwriter.setInterleaved(interleaved);
 ```

After running the tests, look at the files in `cpp/test/ome-bioformats/data/minimaltiffwriter-data-layout-*`.  These should be RGB with one IFD (previously greyscale with 3 IFDs), for example:

```
% tiffinfo cpp/test/ome-bioformats/data/minimaltiffwriter-data-layout-64x64-planar-tiles-48x16.tiff
TIFF Directory at offset 0x3008 (12296)
  Image Width: 64 Image Length: 64
  Bits/Sample: 8
  Sample Format: unsigned integer
  Compression Scheme: None
  Photometric Interpretation: RGB color
  Samples/Pixel: 3
  Rows/Strip: 1
  Planar Configuration: single image plane
  Software: OME Bio-Formats (C++) 5.1.0
```

Also, run `./bf-test ./cpp/libexec/info/info /path/to/ome-tiff` with a 2013-06 OME-TIFF; ImageInfo will show the constituent subchannels in the RGB output.
