### PR TITLE
matlab: restore state of the warnings instead of turning all of them 'on'

### DIFF
--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -153,14 +153,14 @@ for s = 1:numSeries
         else
             colorMaps{s, i} = r.get16BitLookupTable()';
         end
-        
-        warning off
+
+        warning_state = warning ('off');
         if ~isempty(colorMaps{s, i})
             newMap = single(colorMaps{s, i});
             newMap(newMap < 0) = newMap(newMap < 0) + bppMax;
             colorMaps{s, i} = newMap / (bppMax - 1);
         end
-        warning on
+        warning (warning_state);
 
 
         % build an informative title for our figure


### PR DESCRIPTION
The existing code was modifying the state of the warnings but was turning them all back on instead of restoring to the previous state.

Ideally, this would also turn off only the specific warning that was causing issues but I can't figure out what warning was that. This was done in 664274bb but the commit message does not give me any hints.