### PR TITLE
Performance updates for working with large pattern filesets

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -38,7 +38,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
@@ -667,7 +667,7 @@ public class FileStitcher extends ReaderWrapper {
     // have to call initFile on each constituent file; but we can only do so
     // when each constituent file does not itself have multiple used files
 
-    Set<String> files = new HashSet<String>();
+    Set<String> files = new LinkedHashSet<String>();
     for (ExternalSeries s : externals) {
       String[] f = s.getFiles();
       for (String file : f) {

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
@@ -666,12 +667,12 @@ public class FileStitcher extends ReaderWrapper {
     // have to call initFile on each constituent file; but we can only do so
     // when each constituent file does not itself have multiple used files
 
-    Vector<String> files = new Vector<String>();
+    Set<String> files = new HashSet<String>();
     for (ExternalSeries s : externals) {
       String[] f = s.getFiles();
       for (String file : f) {
         String path = new Location(file).getAbsolutePath();
-        if (!files.contains(path)) files.add(path);
+        files.add(path);
       }
 
       DimensionSwapper[] readers = s.getReaders();
@@ -681,7 +682,7 @@ public class FileStitcher extends ReaderWrapper {
           String[] used = readers[i].getUsedFiles();
           for (String file : used) {
             String path = new Location(file).getAbsolutePath();
-            if (!files.contains(path)) files.add(path);
+            files.add(path);
           }
           readers[i].close();
         }

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -323,6 +323,18 @@ public class FilePatternReader extends FormatReader {
   }
 
   @Override
+  public String[] getUsedFiles(boolean noPixels) {
+    if (noPixels) {
+      return new String[] {currentId};
+    }
+    String[] helperFiles = helper.getUsedFiles(noPixels);
+    String[] allFiles = new String[helperFiles.length + 1];
+    allFiles[0] = currentId;
+    System.arraycopy(helperFiles, 0, allFiles, 1, helperFiles.length);
+    return allFiles;
+  }
+
+  @Override
   public int getIndex(int z, int c, int t) {
     return helper.getIndex(z, c, t);
   }


### PR DESCRIPTION
To test, run ```echo "test_Z<00000-60000>.fake" > fake.pattern```.  ```time showinf -nopix fake.pattern``` should result in an OOM without this change.  The same test with 4b223c4 should run to completion, but be fairly slow (1m50s locally); the same test with all commits should run to completion and be substantially faster (16s locally).