### PR TITLE
ImageJ: prevent NPE if one of the sub-channel types is null

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -595,7 +595,8 @@ public class ImagePlusReader implements StatusReporter {
       else sb.append("; ");
       int[] subCPos = FormatTools.rasterToPosition(subC, zct[1]);
       for (int i=0; i<subC.length; i++) {
-        boolean ch = subCTypes[i].equals(FormatTools.CHANNEL);
+        boolean ch =
+          subCTypes[i] == null || FormatTools.CHANNEL.equals(subCTypes[i]);
         sb.append(ch ? "c" : subCTypes[i]);
         sb.append(":");
         sb.append(subCPos[i] + 1);


### PR DESCRIPTION
See
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-April/005289.html

I was able to reproduce the original exception by copying the ```ics/anke/``` dataset and replacing the ```ch``` in line 5 of the .ics file with ```p```.  With this change, the same dataset should open in ImageJ without an exception; the labels at the top of the image window should show that there are 4 phases.