### PR TITLE
Changes for Octave compatibility

### DIFF
--- a/components/formats-gpl/matlab/bfCheckJavaMemory.m
+++ b/components/formats-gpl/matlab/bfCheckJavaMemory.m
@@ -33,7 +33,7 @@ function [] = bfCheckJavaMemory(varargin)
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-runtime = java.lang.Runtime.getRuntime();
+runtime = javaMethod('getRuntime', 'java.lang.Runtime');
 maxMemory = runtime.maxMemory() / (1024 * 1024);
 
 ip = inputParser;

--- a/components/formats-gpl/matlab/bfCheckJavaPath.m
+++ b/components/formats-gpl/matlab/bfCheckJavaPath.m
@@ -68,7 +68,7 @@ if ~status && ip.Results.autoloadBioFormats,
     jarPath = getJarPath(bfJarFiles);
     assert(~isempty(jarPath), 'bf:jarNotFound',...
         'Cannot automatically locate a Bio-Formats JAR file');
-    
+
     % Add the Bio-Formats JAR file to dynamic Java class path
     javaaddpath(jarPath);
     status = true;
@@ -76,7 +76,11 @@ end
 
 if status
     % Read Bio-Formats version
-    version = char(loci.formats.FormatTools.VERSION);
+    if is_octave()
+        version = char(java_get('loci.formats.FormatTools', 'VERSION'));
+    else
+        version = char(loci.formats.FormatTools.VERSION);
+    end
 else
     version = '';
 end

--- a/components/formats-gpl/matlab/bfGetFileExtensions.m
+++ b/components/formats-gpl/matlab/bfGetFileExtensions.m
@@ -34,12 +34,20 @@ function fileExt = bfGetFileExtensions
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 % Get all readers and create cell array with suffixes and names
-imageReader = loci.formats.ImageReader();
-readers = imageReader.getReaders();
+readers = javaMethod('getReaders', javaObject('loci.formats.ImageReader'));
 fileExt = cell(numel(readers), 2);
 for i = 1:numel(readers)
     suffixes = readers(i).getSuffixes();
-    fileExt{i, 1} = arrayfun(@char, suffixes, 'Unif', false);
+    if is_octave()
+        %% FIXME when https://savannah.gnu.org/bugs/?42700 gets fixed
+        ExtSuf = cell(numel(suffixes), 1);
+        for j = 1:numel(suffixes)
+            ExtSuf{j} = char(suffixes(j));
+        end
+        fileExt{i, 1} = ExtSuf;
+    else
+        fileExt{i, 1} = arrayfun(@char, suffixes, 'Unif', false);
+    end
     fileExt{i, 2} = char(readers(i).getFormat().toString);
 end
 

--- a/components/formats-gpl/matlab/bfGetPlane.m
+++ b/components/formats-gpl/matlab/bfGetPlane.m
@@ -1,6 +1,6 @@
 function I = bfGetPlane(r, varargin)
 % BFGETPLANE Retrieve the plane data from a reader using Bio-Formats
-% 
+%
 %   I = bfGetPlane(r, iPlane) returns a specified plane from the input
 %   format reader. The index specifying the plane to retrieve should be
 %   contained between 1 and the number of planes for the series. Given a
@@ -70,24 +70,24 @@ assert(ip.Results.y - 1 + ip.Results.height <= r.getSizeY(),...
 
 % Get pixel type
 pixelType = r.getPixelType();
-bpp = loci.formats.FormatTools.getBytesPerPixel(pixelType);
-fp = loci.formats.FormatTools.isFloatingPoint(pixelType);
-sgn = loci.formats.FormatTools.isSigned(pixelType);
+bpp = javaMethod('getBytesPerPixel', 'loci.formats.FormatTools', pixelType);
+fp = javaMethod('isFloatingPoint', 'loci.formats.FormatTools', pixelType);
+sgn = javaMethod('isSigned', 'loci.formats.FormatTools', pixelType);
 little = r.isLittleEndian();
 
 plane = r.openBytes(...
     ip.Results.iPlane - 1, ip.Results.x - 1, ip.Results.y - 1, ...
     ip.Results.width, ip.Results.height);
-    
+
 % convert byte array to MATLAB image
 if sgn
     % can get the data directly to a matrix
-    I = loci.common.DataTools.makeDataArray2D(plane, ...
+    I = javaMethod('makeDataArray2D', 'loci.common.DataTools', plane, ...
         bpp, fp, little, ip.Results.height);
 else
     % get the data as a vector, either because makeDataArray2D
     % is not available, or we need a vector for typecast
-    I = loci.common.DataTools.makeDataArray(plane, ...
+    I = javaMethod('makeDataArray', 'loci.common.DataTools', plane, ...
         bpp, fp, little);
 end
 

--- a/components/formats-gpl/matlab/bfGetReader.m
+++ b/components/formats-gpl/matlab/bfGetReader.m
@@ -66,18 +66,19 @@ end
 if exist('lurawaveLicense', 'var')
     path = fullfile(fileparts(mfilename('fullpath')), 'lwf_jsdk2.6.jar');
     javaaddpath(path);
-    java.lang.System.setProperty('lurawave.license', lurawaveLicense);
+    javaMethod('setProperty', 'java.lang.System', ...
+               'lurawave.license', lurawaveLicense);
 end
 
 % Create a loci.formats.ReaderWrapper object
-r = loci.formats.ChannelFiller();
-r = loci.formats.ChannelSeparator(r);
+r = javaObject('loci.formats.ChannelSeparator', ...
+               javaObject('loci.formats.ChannelFiller'));
 if ip.Results.stitchFiles
-    r = loci.formats.FileStitcher(r);
+    r = javaObject('loci.formats.FileStitcher', r);
 end
 
 % Initialize the metadata store
-OMEXMLService = loci.formats.services.OMEXMLServiceImpl();
+OMEXMLService = javaObject('loci.formats.services.OMEXMLServiceImpl');
 r.setMetadataStore(OMEXMLService.createOMEXMLMetadata());
 
 % Initialize the reader

--- a/components/formats-gpl/matlab/bfUpgradeCheck.m
+++ b/components/formats-gpl/matlab/bfUpgradeCheck.m
@@ -1,9 +1,9 @@
 function bfUpgradeCheck(varargin)
 % Check for new version of Bio-Formats and update it if applicable
-% 
+%
 % SYNOPSIS: bfUpgradeCheck(autoDownload, 'STABLE')
 %
-% Input 
+% Input
 %    autoDownload - Optional. A boolean specifying of the latest version
 %    should be downloaded
 %
@@ -41,12 +41,16 @@ ip.addOptional('version', 'STABLE', @(x) any(strcmpi(x, versions)))
 ip.parse(varargin{:})
 
 % Create UpgradeChecker
-upgrader = loci.formats.UpgradeChecker();
+upgrader = javaObject('loci.formats.UpgradeChecker');
 if upgrader.alreadyChecked(), return; end
 
 % Check for new version of Bio-Formats
-canUpgrade = upgrader.newVersionAvailable('MATLAB');
-if ~canUpgrade,
+if is_octave()
+    caller = 'Octave';
+else
+    caller = 'MATLAB';
+end
+if ~ upgrader.newVersionAvailable(caller)
     fprintf('*** bioformats_package.jar is up-to-date ***\n');
     return;
 end

--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -13,7 +13,7 @@ function [result] = bfopen(id, varargin)
 %    y - (Optional) A scalar giving the y-origin of the tile.
 %    Default: 1
 %
-%    w - (Optional) A scalar giving the width of the tile. 
+%    w - (Optional) A scalar giving the width of the tile.
 %    Set to the width of the plane by default.
 %
 %    h - (Optional) A scalar giving the height of the tile.
@@ -21,8 +21,8 @@ function [result] = bfopen(id, varargin)
 %
 % Output
 %
-%    result - a cell array of cell arrays of (matrix, label) pairs, 
-%    with each matrix representing a single image plane, and each inner 
+%    result - a cell array of cell arrays of (matrix, label) pairs,
+%    with each matrix representing a single image plane, and each inner
 %    list of matrices representing an image series.
 %
 % Portions of this code were adapted from:
@@ -108,16 +108,17 @@ if nargin == 0 || exist(id, 'file') == 0
 end
 
 % initialize logging
-loci.common.DebugTools.enableLogging('INFO');
+javaMethod('enableLogging', 'loci.common.DebugTools', 'INFO');
 
 % Get the channel filler
 r = bfGetReader(id, stitchFiles);
 
 % Test plane size
 if nargin >=4
-    planeSize = loci.formats.FormatTools.getPlaneSize(r, varargin{3}, varargin{4});
+    planeSize = javaMethod('getPlaneSize', 'loci.formats.FormatTools', ...
+                           r, varargin{3}, varargin{4});
 else
-    planeSize = loci.formats.FormatTools.getPlaneSize(r);
+    planeSize = javaMethod('getPlaneSize', 'loci.formats.FormatTools', r);
 end
 
 if planeSize/(1024)^3 >= 2,
@@ -135,7 +136,8 @@ for s = 1:numSeries
     fprintf('Reading series #%d', s);
     r.setSeries(s - 1);
     pixelType = r.getPixelType();
-    bpp = loci.formats.FormatTools.getBytesPerPixel(pixelType);
+    bpp = javaMethod('getBytesPerPixel', 'loci.formats.FormatTools', ...
+                     pixelType);
     bppMax = power(2, bpp * 8);
     numImages = r.getImageCount();
     imageList = cell(numImages, 2);
@@ -214,7 +216,8 @@ for s = 1:numSeries
 
     % extract metadata table for this series
     seriesMetadata = r.getSeriesMetadata();
-    loci.formats.MetadataTools.merge(globalMetadata, seriesMetadata, 'Global ');
+    javaMethod('merge', 'loci.formats.MetadataTools', ...
+               globalMetadata, seriesMetadata, 'Global ');
     result{s, 2} = seriesMetadata;
     result{s, 3} = colorMaps;
     result{s, 4} = r.getMetadataStore();

--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -76,7 +76,7 @@ else
 end
 
 % Create ImageWriter
-writer = loci.formats.ImageWriter();
+writer = javaObject('loci.formats.ImageWriter');
 writer.setWriteSequentially(true);
 writer.setMetadataRetrieve(metadata);
 if ~isempty(ip.Results.Compression)
@@ -92,13 +92,13 @@ switch class(ip.Results.I)
     case {'int8', 'uint8'}
         getBytes = @(x) x(:);
     case {'uint16','int16'}
-        getBytes = @(x) loci.common.DataTools.shortsToBytes(x(:), 0);
+        getBytes = @(x) javaMethod('shortsToBytes', 'loci.common.DataTools', x(:), 0);
     case {'uint32','int32'}
-        getBytes = @(x) loci.common.DataTools.intsToBytes(x(:), 0);
+        getBytes = @(x) javaMethod('intsToBytes', 'loci.common.DataTools', x(:), 0);
     case {'single'}
-        getBytes = @(x) loci.common.DataTools.floatsToBytes(x(:), 0);
+        getBytes = @(x) javaMethod('floatsToBytes', 'loci.common.DataTools', x(:), 0);
     case 'double'
-        getBytes = @(x) loci.common.DataTools.doublesToBytes(x(:), 0);
+        getBytes = @(x) javaMethod('doublesToBytes', 'loci.common.DataTools', x(:), 0);
 end
 
 % Save planes to the writer
@@ -117,9 +117,8 @@ writer.close();
 end
 
 function dimensionOrders = getDimensionOrders()
-
 % List all values of DimensionOrder
-dimensionOrderValues = ome.xml.model.enums.DimensionOrder.values();
+dimensionOrderValues = javaMethod('values', 'ome.xml.model.enums.DimensionOrder');
 dimensionOrders = cell(numel(dimensionOrderValues), 1);
 for i = 1 :numel(dimensionOrderValues),
     dimensionOrders{i} = char(dimensionOrderValues(i).toString());
@@ -127,9 +126,18 @@ end
 end
 
 function compressionTypes = getCompressionTypes()
-
 % List all values of Compression
-writer = loci.formats.ImageWriter();
-compressionTypes = arrayfun(@char, writer.getCompressionTypes(),...
-    'UniformOutput', false);
+writer = javaObject('loci.formats.ImageWriter');
+if is_octave()
+    %% FIXME when https://savannah.gnu.org/bugs/?42700 gets fixed
+    types = writer.getCompressionTypes();
+    nTypes = numel(types);
+    compressionTypes = cell(nTypes, 1);
+    for i = 1:nTypes
+        compressionTypes{i} = char(types(i));
+    end
+else
+    compressionTypes = arrayfun(@char, writer.getCompressionTypes(),...
+                                'UniformOutput', false);
+end
 end

--- a/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
+++ b/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
@@ -46,21 +46,27 @@ ip.addOptional('dimensionOrder', 'XYZCT', @(x) ismember(x, getDimensionOrders())
 ip.parse(varargin{:});
 
 % Create metadata
-toInt = @(x) ome.xml.model.primitives.PositiveInteger(java.lang.Integer(x));
-OMEXMLService = loci.formats.services.OMEXMLServiceImpl();
+toInt = @(x) javaObject('ome.xml.model.primitives.PositiveInteger', ...
+                        javaObject('java.lang.Integer', x));
+OMEXMLService = javaObject('loci.formats.services.OMEXMLServiceImpl');
 metadata = OMEXMLService.createOMEXMLMetadata();
 metadata.createRoot();
 metadata.setImageID('Image:0', 0);
 metadata.setPixelsID('Pixels:0', 0);
-metadata.setPixelsBinDataBigEndian(java.lang.Boolean.TRUE, 0, 0);
+if is_octave()
+    java_true = java_get('java.lang.Boolean', 'TRUE');
+else
+    java_true = java.lang.Boolean.TRUE;
+end
+metadata.setPixelsBinDataBigEndian(java_true, 0, 0);
 
 % Set dimension order
-dimensionOrderEnumHandler = ome.xml.model.enums.handlers.DimensionOrderEnumHandler();
+dimensionOrderEnumHandler = javaObject('ome.xml.model.enums.handlers.DimensionOrderEnumHandler');
 dimensionOrder = dimensionOrderEnumHandler.getEnumeration(ip.Results.dimensionOrder);
 metadata.setPixelsDimensionOrder(dimensionOrder, 0);
 
 % Set pixels type
-pixelTypeEnumHandler = ome.xml.model.enums.handlers.PixelTypeEnumHandler();
+pixelTypeEnumHandler = javaObject('ome.xml.model.enums.handlers.PixelTypeEnumHandler');
 if strcmp(class(I), 'single')
     pixelsType = pixelTypeEnumHandler.getEnumeration('float');
 else
@@ -90,8 +96,7 @@ end
 
 function dimensionOrders = getDimensionOrders()
 % List all values of DimensionOrder
-
-dimensionOrderValues = ome.xml.model.enums.DimensionOrder.values();
+dimensionOrderValues = javaMethod('values', 'ome.xml.model.enums.DimensionOrder');
 dimensionOrders = cell(numel(dimensionOrderValues), 1);
 for i = 1 :numel(dimensionOrderValues),
     dimensionOrders{i} = char(dimensionOrderValues(i).toString());

--- a/components/formats-gpl/matlab/private/is_octave.m
+++ b/components/formats-gpl/matlab/private/is_octave.m
@@ -1,0 +1,3 @@
+function is = is_octave ()
+is = exist ('OCTAVE_VERSION', 'builtin') == 5;
+end


### PR DESCRIPTION
These two commits are required for the code to work with GNU Octave.

The first commit only explicitly ends each of the function blocks (and indents them). This is not really required for Octave compatibility but I believe it to be good form, specially when the file has subfunctions (which bioformats does). It is best viewed locally with the `--ignore-all-space` option.

The second commit is the one that actually changes the code but I believe it to still work in Matlab. More details are on the commit message.

Note that even after this changes, the code will not run on the latest release of Octave (3.8.2). However, I have been working on the Octave side to fix the other incompatibilities (which could be treated as Octave bugs) so that bioformats can work on the upcoming Octave release (which will be 4.0.0 and is currently on rc3).