### PR TITLE
travis: Switch from saucy to trusty (rebased onto dev_5_0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: "BUILD=cppwrap"
 
 before_install:
-  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ saucy main universe"
+  - if [[ $BUILD == 'sphinx' ]]; then sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"; fi
   - sudo apt-get -qq update
   - if [[ $BUILD != 'sphinx' ]]; then sudo apt-get install -qq python-genshi; fi
   - if [[ $BUILD == 'cpp' ]] || [[ $BUILD == 'cppwrap' ]]; then sudo apt-get install -qq build-essential cmake libboost-all-dev; fi


### PR DESCRIPTION

This is the same as gh-1759 but rebased onto dev_5_0.

----

saucy has been removed from the mirrors and was no longer supported.

See https://github.com/openmicroscopy/ome-documentation/pull/1197

                