### PR TITLE
JPEG-2000: fix redundant file parsing

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/JPEG2000MetadataParser.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000MetadataParser.java
@@ -213,6 +213,7 @@ public class JPEG2000MetadataParser {
               headerPixelType = convertPixelType(type);
             }
             parseBoxes();
+            nextPos = in.getFilePointer();
             break;
           }
           case PALETTE:

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000MetadataParser.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000MetadataParser.java
@@ -177,7 +177,7 @@ public class JPEG2000MetadataParser {
         length -= 8;
       }
       if (boxType == null) {
-        LOGGER.warn("Unknown JPEG 2000 box 0x{} at {}",
+        LOGGER.info("Unknown JPEG 2000 box 0x{} at {}",
             Integer.toHexString(boxCode), pos);
         if (pos == originalPos) {
           in.seek(originalPos);

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
@@ -240,6 +240,7 @@ public class JPEG2000Reader extends FormatReader {
     }
 
     ArrayList<String> comments = metadataParser.getComments();
+    LOGGER.debug("Found {} comments", comments.size());
     for (int i=0; i<comments.size(); i++) {
       String comment = comments.get(i);
       int equal = comment.indexOf("=");


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-April/005300.html.

To test, use the .jp2 file from ```jpeg2000/mario```.  With both commits, ```showinf -debug``` should indicate that 88 comments were found.  The same test with d742be2 reverted should show that 176 comments were found, but the output should otherwise be the same.

