### PR TITLE
Adding addition BF related mailing lists/groups

### DIFF
--- a/docs/sphinx/about/index.txt
+++ b/docs/sphinx/about/index.txt
@@ -109,16 +109,23 @@ Other places where questions are commonly asked and/or bugs are reported
 include:
 
 -  `OME Trac <http://trac.openmicroscopy.org.uk/ome>`_
--  `Fiji Bugzilla (for ImageJ/Fiji
-   issues) <http://fiji.sc/cgi-bin/bugzilla/index.cgi>`_
 -  `ome-devel mailing
    list <http://lists.openmicroscopy.org.uk/pipermail/ome-devel>`_
    (searchable using google with 'site:lists.openmicroscopy.org.uk')
 -  `ome-users mailing
    list <http://lists.openmicroscopy.org.uk/pipermail/ome-users>`_
    (searchable using google with 'site:lists.openmicroscopy.org.uk')
--  `ImageJ mailing list (for ImageJ/Fiji
-   issues) <http://imagej.1557.n6.nabble.com/>`_
+-  ImageJ mailing list (for ImageJ/Fiji issues)
+   `forum archive <http://imagej.1557.n6.nabble.com/>`_ and
+   `mailing list <http://imagej.nih.gov/ij/list.html>`_
+-  `ImageJ developer mailing
+   list <http://imagej.net/mailman/listinfo/imagej-devel>`_
+-  `Fiji Bugzilla (for ImageJ/Fiji
+   issues) <http://fiji.sc/cgi-bin/bugzilla/index.cgi>`_
+-  `Fiji developer google
+   group <https://groups.google.com/forum/#!forum/fiji-devel>`_
+-  `Confocal microscopy mailing
+   list <http://lists.umn.edu/cgi-bin/wa?A0=confocalmicroscopy>`_
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
List of places people look for help with BF issues wasn't complete.

Will be staged on https://www.openmicroscopy.org/site/support/bio-formats5.1-staging/about/index.html#help

Also, rearranged order so OME, ImageJ and Fiji items are grouped together.