### PR TITLE
AIM: return blank planes for truncated files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AIMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AIMReader.java
@@ -67,8 +67,13 @@ public class AIMReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    in.seek(pixelOffset + FormatTools.getPlaneSize(this) * (long) no);
-    readPlane(in, x, y, w, h, buf);
+    int planeSize = FormatTools.getPlaneSize(this);
+    long offset = pixelOffset + planeSize * (long) no;
+
+    if (offset < in.length()) {
+      in.seek(offset);
+      readPlane(in, x, y, w, h, buf);
+    }
     return buf;
   }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12785.  To test, verify that opening the file from QA 10907 does not result in an exception.

Note though that the images are likely to look weird/wrong.  The dimensional metadata matches the corresponding unprocessed data from QA 10913, so I think everything is fine there.  The file is much too small for the recorded dimensions, though, which leads me to believe that the file is somehow corrupted.  A request for further information (http://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7762) has gone unanswered so far.