### PR TITLE
RowsPerStrip is equal to image height when saved image is tiled

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -853,8 +853,9 @@ public class IFD extends HashMap<Integer, Object> {
   public long[] getRowsPerStrip() throws FormatException {
     long[] rowsPerStrip = getIFDLongArray(ROWS_PER_STRIP);
     if (rowsPerStrip == null) {
-      // create a fake RowsPerStrip entry if one is not present
-      return new long[] {getImageLength()};
+      // create a fake RowsPerStrip entry if one is not present 
+      long tileLength = getIFDLongValue(TILE_LENGTH, 0);
+      return new long[] {tileLength == 0 ? getImageLength() : tileLength};
     }
 
     // rowsPerStrip should never be more than the total number of rows


### PR DESCRIPTION
The problem is that during the writing of a OME-TIFF which is made tiled by creating a custom IFD with tiles by using following lines of code and passing that ifd to saveBytes():

     IFD ifd = new IFD();
     ifd.put(IFD.TILE_WIDTH,  256);
     ifd.put(IFD.TILE_LENGTH, 256);

Bioformats allocates too much memory because rowsPerTile variable assigned in [TiffSaver.writeImage()](https://github.com/openmicroscopy/bioformats/blob/develop/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java#L312) is equal to an entire image height instead of the height of a tile unless you manually set IFD.ROWS_PER_STRIP in custom ifd.

The extraneous memory is later ignored anyway, so the behaviour does not change. Allocating this extraneous memory only causes performance implications and possibly an out of
memory exception if the image is large enough.

I have changed the IFD.getRowsPerStrip() to return the tile height instead of image height if the image is tiled and the ROWS_PER_STRIP has been not specified manually.