### PR TITLE
C++: Various writer corrections

### DIFF
--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -210,6 +210,24 @@ namespace ome
     validateOMEXML(const std::string& document);
 
     /**
+     * Validate a metadata store.
+     *
+     * Note that unlike validateOMEXML(const std::string&) this does
+     * not perform XML validation.  It will look for missing or
+     * inconsistent metadata and (if specified) attempt to correct the
+     * metadata to make it valid.
+     *
+     * @param meta the metadata store.
+     * @param correct @c true to attempt correction, @c false to leave
+     * unmodified.
+     * @returns @c true if valid, @c false if invalid.
+     * @throws FormatException if correction of invalid metadata fails.
+     */
+    bool
+    validateModel(::ome::xml::meta::Metadata& meta,
+                  bool                        correct);
+
+    /**
      * Fill OME-XML metadata store from reader core metadata.
      *
      * The metadata store is expected to be empty.

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -1330,19 +1330,20 @@ namespace ome
       void
       FormatReader::setId(const boost::filesystem::path& id)
       {
-        //    LOGGER.debug("{} initializing {}", getFormat(), id);
-        if (!currentId || id != currentId.get())
+        // Attempt to canonicalize the path.
+        path canonicalpath = id;
+        try
           {
-            path canonicalID(id);
-            try
-              {
-                // Attempt to canonicalize the path.
-                canonicalID = ome::common::canonical(id);
-              }
-            catch (const std::exception& /* e */)
-              {
-              }
-            initFile(canonicalID);
+            canonicalpath = ome::common::canonical(id);
+          }
+        catch (const std::exception& /* e */)
+          {
+          }
+
+        //    LOGGER.debug("{} initializing {}", getFormat(), id);
+        if (!currentId || canonicalpath != currentId.get())
+          {
+            initFile(canonicalpath);
 
             const ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
               ome::compat::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -151,6 +151,12 @@ namespace ome
                            writerProperties.compression_suffixes);
       }
 
+      dimension_size_type
+      FormatWriter::getSeriesCount() const
+      {
+        return metadataRetrieve->getImageCount();
+      }
+
       void
       FormatWriter::setLookupTable(dimension_size_type       /* plane */,
                                    const VariantPixelBuffer& /* buf */)
@@ -176,7 +182,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        if (series >= metadataRetrieve->getImageCount())
+        if (series >= getSeriesCount())
           {
             boost::format fmt("Invalid series: %1%");
             fmt % series;

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -363,7 +363,7 @@ namespace ome
       dimension_size_type
       FormatWriter::getImageCount() const
       {
-        return getSizeZ() * getSizeT() * getSizeC();
+        return getSizeZ() * getSizeT() * getEffectiveSizeC();
       }
 
       bool
@@ -439,14 +439,8 @@ namespace ome
       dimension_size_type
       FormatWriter::getEffectiveSizeC() const
       {
-        // NB: by definition, imageCount == effectiveSizeC * sizeZ * sizeT
-        dimension_size_type sizeZT = getSizeZ() * getSizeT();
-        dimension_size_type effC = 0;
-
-        if (sizeZT)
-          effC = getImageCount() / sizeZT;
-
-        return effC;
+        dimension_size_type series = getSeries();
+        return metadataRetrieve->getChannelCount(series);
       }
 
       dimension_size_type

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -106,12 +106,22 @@ namespace ome
       void
       FormatWriter::setId(const boost::filesystem::path& id)
       {
-        if (!currentId || id != currentId.get())
+        // Attempt to canonicalize the path.
+        path canonicalpath = id;
+        try
+          {
+            canonicalpath = ome::common::canonical(id);
+          }
+        catch (const std::exception& /* e */)
+          {
+          }
+
+        if (!currentId || canonicalpath != currentId.get())
           {
             if (out)
               out = ome::compat::shared_ptr<std::ostream>();
 
-            currentId = id;
+            currentId = canonicalpath;
           }
       }
 

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -164,6 +164,18 @@ namespace ome
         isThisType(const boost::filesystem::path& name,
                    bool                           open = true) const;
 
+        /**
+         * Get the number of image series in this file.
+         *
+         * @returns the number of image series.
+         * @throws std::logic_error if the sub-resolution metadata (if
+         * any) is invalid; this will only occur if the reader sets
+         * invalid metadata.
+         */
+        virtual
+        dimension_size_type
+        getSeriesCount() const;
+
         // Documented in superclass.
         void
         setLookupTable(dimension_size_type       plane,

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -62,7 +62,7 @@ namespace ome
     {
 
       /**
-       * TIFF reader with support for ImageJ extensions.
+       * TIFF reader with support for OME-XML metadata.
        */
       class OMETIFFReader : public ::ome::bioformats::detail::FormatReader
       {

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -67,6 +67,8 @@ namespace ome
       class OMETIFFReader : public ::ome::bioformats::detail::FormatReader
       {
         using detail::FormatReader::isThisType;
+        using ::ome::bioformats::FormatReader::getOptimalTileWidth;
+        using ::ome::bioformats::FormatReader::getOptimalTileHeight;
 
       protected:
         /// Message logger.

--- a/cpp/lib/ome/bioformats/tiff/Util.h
+++ b/cpp/lib/ome/bioformats/tiff/Util.h
@@ -51,6 +51,8 @@
 #include <ome/bioformats/tiff/Types.h>
 #include <ome/bioformats/VariantPixelBuffer.h>
 
+#include <ome/common/log.h>
+
 #include <ome/xml/model/enums/PixelType.h>
 
 namespace ome
@@ -113,6 +115,33 @@ namespace ome
       ifdIndex(const SeriesIFDRange& seriesIFDRange,
                dimension_size_type   series,
                dimension_size_type   plane);
+
+      /**
+       * Check if BigTIFF should be enabled.
+       *
+       * A number of factors determine if BigTIFF support should be
+       * enabled:
+       * - Does the system libtiff support BigTIFF
+       * - Did the user request it
+       * - Is the pixel data over the size limit for non-BigTIFF and
+       *   the user did not explicitly disable BigTIFF
+       * - Was a BigTIFF file extension used?
+       *
+       * If BigTIFF could not be enabled when requested or needed then
+       * an appropriate warning will be logged.
+       *
+       * @param wantBig user requirement (@c true to enable, @c false
+       * to disable, unset if unspecified).
+       * @param pixelSize the total size of pixel data to be written
+       * @param filename the name of the TIFF file to write (if a
+       * known BigTIFF extension is used, BigTIFF will be enabled).
+       * @returns @c true to enable BigTIFF or @c false to disable.
+       */
+      bool
+      enableBigTIFF(const boost::optional<bool>&   wantBig,
+                    storage_size_type              pixelSize,
+                    const boost::filesystem::path& filename,
+                    ome::common::Logger&           logger);
 
     }
   }

--- a/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome
+++ b/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome
@@ -1,0 +1,262 @@
+<?xml version="1.0"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+     xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+     xmlns:Bin="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-06"
+     xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2013-06"
+     xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-06"
+     xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2013-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06 http://www.openmicroscopy.org/Schemas/OME/2013-06/ome.xsd">
+  <Image ID="Image:0" Name="valid-grey1"><!-- Valid 1-channel greyscale -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:0:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:0" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:1" Name="invalid-grey1a"><!-- Missing channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:1:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:2" Name="invalid-grey1a"><!-- Incorrect channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:2:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:1" SamplesPerPixel="2"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:3" Name="invalid-grey1b"><!-- Incorrect C -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:3:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:2" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:4" Name="valid-grey1"><!-- Missing SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:4:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+
+  <Image ID="Image:5" Name="valid-grey2"><!-- Valid 4-channel greyscale -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:5:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:4" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:5" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:6" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:7" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:6" Name="valid-grey2"><!-- Missing channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:6:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:8" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:9" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:10" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:7" Name="valid-grey2"><!-- Missing channels -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:7:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:8" Name="valid-grey2"><!-- Incorrect channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:8:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:11" SamplesPerPixel="2"/>
+      <OME:Channel Color="-2147483648" ID="Channel:12" SamplesPerPixel="2"/>
+      <OME:Channel Color="-2147483648" ID="Channel:13" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:14" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:9" Name="valid-grey2"><!-- Incorrect C -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:9:0" Type="uint8" SizeC="7" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:15" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:16" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:17" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:18" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:10" Name="valid-grey2"><!-- Missing SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:10:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:19"/>
+      <OME:Channel Color="-2147483648" ID="Channel:20" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:21"/>
+      <OME:Channel Color="-2147483648" ID="Channel:22" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:11" Name="valid-grey2"><!-- Missing all SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:11:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:23"/>
+      <OME:Channel Color="-2147483648" ID="Channel:24"/>
+      <OME:Channel Color="-2147483648" ID="Channel:25"/>
+      <OME:Channel Color="-2147483648" ID="Channel:26"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+
+  <Image ID="Image:12" Name="valid-rgb1"><!-- Valid 1-channel RGB -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:12:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:27" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:13" Name="valid-rgb1"><!-- Missing channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:13:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:14" Name="valid-rgb1"><!-- Incorrect channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:14:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:28" SamplesPerPixel="5"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:15" Name="valid-rgb1"><!-- Incorrect C -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:15:0" Type="uint8" SizeC="2" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:29" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:16" Name="valid-rgb1"><!-- Missing SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:16:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:30"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+
+  <Image ID="Image:17" Name="valid-rgb2"><!-- Valid 2-channel RGB -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:17:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:31" SamplesPerPixel="3"/>
+      <OME:Channel Color="-2147483648" ID="Channel:32" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:18" Name="valid-rgb2"><!-- Missing channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:18:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:33" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:19" Name="valid-rgb2"><!-- Missing channels -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:19s:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>  
+  <Image ID="Image:20" Name="valid-rgb2"><!-- Incorrect channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:20:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:34" SamplesPerPixel="5"/>
+      <OME:Channel Color="-2147483648" ID="Channel:35" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:21" Name="valid-rgb2"><!-- Incorrect C -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:21:0" Type="uint8" SizeC="9" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:36" SamplesPerPixel="3"/>
+      <OME:Channel Color="-2147483648" ID="Channel:37" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:22" Name="valid-rgb2"><!-- Missing SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:22:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:38" SamplesPerPixel="3"/>
+      <OME:Channel Color="-2147483648" ID="Channel:39"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:23" Name="valid-rgb2"><!-- Missing all SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:23:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:40"/>
+      <OME:Channel Color="-2147483648" ID="Channel:41"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+
+  <Image ID="Image:24" Name="valid-mixed1"><!-- Valid mixed greyscale and RGB -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:24:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:42" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:43" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:25" Name="valid-mixed1"><!-- Missing channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:25:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:44" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:26" Name="valid-mixed1"><!-- Missing channels -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:26:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:27" Name="valid-mixed1"><!-- Incorrect channel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:27:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:45" SamplesPerPixel="5"/>
+      <OME:Channel Color="-2147483648" ID="Channel:46" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:28" Name="valid-mixed1"><!-- Incorrect C -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:28:0" Type="uint8" SizeC="2" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:47" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:48" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:29" Name="valid-mixed1"><!-- Missing SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:29:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:49" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:50"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:30" Name="valid-mixed1"><!-- Missing SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:30:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:51"/>
+      <OME:Channel Color="-2147483648" ID="Channel:52" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:31" Name="valid-mixed1"><!-- Missing all SamplesPerPixel -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:31:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:53"/>
+      <OME:Channel Color="-2147483648" ID="Channel:54"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+
+</OME>

--- a/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome
+++ b/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome
@@ -20,21 +20,21 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:2" Name="invalid-grey1a"><!-- Incorrect channel -->
+  <Image ID="Image:2" Name="invalid-grey1b"><!-- Incorrect channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:2:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:1" SamplesPerPixel="2"/>
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:3" Name="invalid-grey1b"><!-- Incorrect C -->
+  <Image ID="Image:3" Name="invalid-grey1c"><!-- Incorrect C -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:3:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:2" SamplesPerPixel="1"/>
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:4" Name="valid-grey1"><!-- Missing SamplesPerPixel -->
+  <Image ID="Image:4" Name="invalid-grey1d"><!-- Missing SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:4:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:3"/>
@@ -52,7 +52,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:6" Name="valid-grey2"><!-- Missing channel -->
+  <Image ID="Image:6" Name="invalid-grey2a"><!-- Missing channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:6:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:8" SamplesPerPixel="1"/>
@@ -61,13 +61,13 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:7" Name="valid-grey2"><!-- Missing channels -->
+  <Image ID="Image:7" Name="invalid-grey2b"><!-- Missing channels -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:7:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:8" Name="valid-grey2"><!-- Incorrect channel -->
+  <Image ID="Image:8" Name="invalid-grey2c"><!-- Incorrect channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:8:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:11" SamplesPerPixel="2"/>
@@ -77,7 +77,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:9" Name="valid-grey2"><!-- Incorrect C -->
+  <Image ID="Image:9" Name="invalid-grey2d"><!-- Incorrect C -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:9:0" Type="uint8" SizeC="7" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:15" SamplesPerPixel="1"/>
@@ -87,7 +87,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:10" Name="valid-grey2"><!-- Missing SamplesPerPixel -->
+  <Image ID="Image:10" Name="invalid-grey2e"><!-- Missing SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:10:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:19"/>
@@ -97,7 +97,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:11" Name="valid-grey2"><!-- Missing all SamplesPerPixel -->
+  <Image ID="Image:11" Name="invalid-grey2f"><!-- Missing all SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:11:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:23"/>
@@ -115,27 +115,27 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:13" Name="valid-rgb1"><!-- Missing channel -->
+  <Image ID="Image:13" Name="invalid-rgb1a"><!-- Missing channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:13:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:14" Name="valid-rgb1"><!-- Incorrect channel -->
+  <Image ID="Image:14" Name="invalid-rgb1b"><!-- Incorrect channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:14:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:28" SamplesPerPixel="5"/>
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:15" Name="valid-rgb1"><!-- Incorrect C -->
+  <Image ID="Image:15" Name="invalid-rgb1c"><!-- Incorrect C -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:15:0" Type="uint8" SizeC="2" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:29" SamplesPerPixel="3"/>
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:16" Name="valid-rgb1"><!-- Missing SamplesPerPixel -->
+  <Image ID="Image:16" Name="invalid-rgb1d"><!-- Missing SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:16:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:30"/>
@@ -151,20 +151,20 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:18" Name="valid-rgb2"><!-- Missing channel -->
+  <Image ID="Image:18" Name="invalid-rgb2a"><!-- Missing channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:18:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:33" SamplesPerPixel="3"/>
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:19" Name="valid-rgb2"><!-- Missing channels -->
+  <Image ID="Image:19" Name="invalid-rgb2b"><!-- Missing channels -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:19s:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <MetadataOnly/>
     </OME:Pixels>
   </Image>  
-  <Image ID="Image:20" Name="valid-rgb2"><!-- Incorrect channel -->
+  <Image ID="Image:20" Name="invalid-rgb2c"><!-- Incorrect channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:20:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:34" SamplesPerPixel="5"/>
@@ -172,7 +172,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:21" Name="valid-rgb2"><!-- Incorrect C -->
+  <Image ID="Image:21" Name="invalid-rgb2d"><!-- Incorrect C -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:21:0" Type="uint8" SizeC="9" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:36" SamplesPerPixel="3"/>
@@ -180,7 +180,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:22" Name="valid-rgb2"><!-- Missing SamplesPerPixel -->
+  <Image ID="Image:22" Name="invalid-rgb2e"><!-- Missing SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:22:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:38" SamplesPerPixel="3"/>
@@ -188,7 +188,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:23" Name="valid-rgb2"><!-- Missing all SamplesPerPixel -->
+  <Image ID="Image:23" Name="invalid-rgb2f"><!-- Missing all SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:23:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:40"/>
@@ -205,20 +205,20 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:25" Name="valid-mixed1"><!-- Missing channel -->
+  <Image ID="Image:25" Name="invalid-mixed1a"><!-- Missing channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:25:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:44" SamplesPerPixel="1"/>
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:26" Name="valid-mixed1"><!-- Missing channels -->
+  <Image ID="Image:26" Name="invalid-mixed1b"><!-- Missing channels -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:26:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:27" Name="valid-mixed1"><!-- Incorrect channel -->
+  <Image ID="Image:27" Name="invalid-mixed1c"><!-- Incorrect channel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:27:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:45" SamplesPerPixel="5"/>
@@ -226,7 +226,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:28" Name="valid-mixed1"><!-- Incorrect C -->
+  <Image ID="Image:28" Name="invalid-mixed1d"><!-- Incorrect C -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:28:0" Type="uint8" SizeC="2" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:47" SamplesPerPixel="1"/>
@@ -234,7 +234,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:29" Name="valid-mixed1"><!-- Missing SamplesPerPixel -->
+  <Image ID="Image:29" Name="invalid-mixed1e"><!-- Missing SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:29:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:49" SamplesPerPixel="1"/>
@@ -242,7 +242,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:30" Name="valid-mixed1"><!-- Missing SamplesPerPixel -->
+  <Image ID="Image:30" Name="invalid-mixed1f"><!-- Missing SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:30:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:51"/>
@@ -250,7 +250,7 @@
       <MetadataOnly/>
     </OME:Pixels>
   </Image>
-  <Image ID="Image:31" Name="valid-mixed1"><!-- Missing all SamplesPerPixel -->
+  <Image ID="Image:31" Name="invalid-mixed1g"><!-- Missing all SamplesPerPixel -->
     <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
     <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:31:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
       <OME:Channel Color="-2147483648" ID="Channel:53"/>

--- a/cpp/test/ome-bioformats/data/brokenchannels-uncorrectable.ome
+++ b/cpp/test/ome-bioformats/data/brokenchannels-uncorrectable.ome
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+     xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+     xmlns:Bin="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-06"
+     xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2013-06"
+     xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-06"
+     xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2013-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06 http://www.openmicroscopy.org/Schemas/OME/2013-06/ome.xsd">
+  <Image ID="Image:0" Name="valid-mixed1"><!-- Missing SamplesPerPixel with unallocatable subchannels (indivisible) -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:0:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:0" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:2"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+</OME>

--- a/cpp/test/ome-bioformats/data/validchannels.ome
+++ b/cpp/test/ome-bioformats/data/validchannels.ome
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+     xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2013-06"
+     xmlns:Bin="http://www.openmicroscopy.org/Schemas/BinaryFile/2013-06"
+     xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2013-06"
+     xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2013-06"
+     xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2013-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06 http://www.openmicroscopy.org/Schemas/OME/2013-06/ome.xsd">
+  <Image ID="Image:0" Name="valid-grey1"><!-- Valid 1-channel greyscale -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:0:0" Type="uint8" SizeC="1" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:0" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:1" Name="valid-grey2"><!-- Valid 4-channel greyscale -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:1:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:1" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:2" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:3" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:4" SamplesPerPixel="1"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:2" Name="valid-rgb1"><!-- Valid 1-channel RGB -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:2:0" Type="uint8" SizeC="3" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:5" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:3" Name="valid-rgb2"><!-- Valid 2-channel RGB -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:3:0" Type="uint8" SizeC="6" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:6" SamplesPerPixel="3"/>
+      <OME:Channel Color="-2147483648" ID="Channel:7" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+  <Image ID="Image:4" Name="valid-mixed1"><!-- Valid mixed greyscale and RGB -->
+    <OME:AcquisitionDate>2015-04-28T11:05:15</OME:AcquisitionDate>
+    <OME:Pixels DimensionOrder="XYZTC" ID="Pixels:4:0" Type="uint8" SizeC="4" SizeT="10" SizeX="10" SizeY="10" SizeZ="10">
+      <OME:Channel Color="-2147483648" ID="Channel:8" SamplesPerPixel="1"/>
+      <OME:Channel Color="-2147483648" ID="Channel:9" SamplesPerPixel="3"/>
+      <MetadataOnly/>
+    </OME:Pixels>
+  </Image>
+
+</OME>

--- a/cpp/test/ome-bioformats/metadatatools.cpp
+++ b/cpp/test/ome-bioformats/metadatatools.cpp
@@ -36,6 +36,9 @@
  * #L%
  */
 
+#include <boost/range/size.hpp>
+
+#include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/MetadataTools.h>
 
 #include <ome/internal/version.h>
@@ -48,9 +51,15 @@
 
 #include <ome/xml/model/enums/EnumerationException.h>
 
+using boost::filesystem::path;
+using ome::bioformats::dimension_size_type;
 using ome::bioformats::createID;
 using ome::bioformats::createDimensionOrder;
+using ome::bioformats::createOMEXMLMetadata;
+using ome::bioformats::validateModel;
+using ome::bioformats::FormatException;
 using ome::xml::model::enums::DimensionOrder;
+using namespace ome::xml::model::primitives;
 
 TEST(MetadataToolsTest, CreateID1)
 {
@@ -136,3 +145,420 @@ TEST(MetadataToolsTest, CreateDimensionOrder)
   EXPECT_THROW(createDimensionOrder("Y"), ome::xml::model::enums::EnumerationException);
   EXPECT_THROW(createDimensionOrder("YC"), ome::xml::model::enums::EnumerationException);
 }
+
+struct ModelState
+{
+  dimension_size_type sizeC;
+  dimension_size_type channelCount;
+  dimension_size_type samples[6];
+};
+
+struct Corrections
+{
+  path filename;
+  bool initiallyValid;
+  bool correctable;
+  dimension_size_type imageIndex;
+  ModelState before;
+  ModelState after;
+};
+
+typedef ModelState MS;
+typedef Corrections Corr;
+
+const Corrections corrections[] =
+  {
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/validchannels.ome"),
+      true,
+      true,
+      0,
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } },
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/validchannels.ome"),
+      true,
+      true,
+      1,
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/validchannels.ome"),
+      true,
+      true,
+      2,
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } },
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/validchannels.ome"),
+      true,
+      true,
+      3,
+      { 6, 2, { 3, 0, 0, 0, 0, 0 } },
+      { 6, 2, { 3, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/validchannels.ome"),
+      true,
+      true,
+      4,
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } },
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      0,
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } },
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      1,
+      { 1, 0, { 0, 0, 0, 0, 0, 0 } },
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      2,
+      { 1, 1, { 2, 0, 0, 0, 0, 0 } },
+      { 2, 1, { 2, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      3,
+      { 4, 1, { 1, 0, 0, 0, 0, 0 } },
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      4,
+      { 1, 1, { 0, 0, 0, 0, 0, 0 } },
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      5,
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      6,
+      { 4, 3, { 1, 1, 1, 0, 0, 0 } },
+      { 3, 3, { 1, 1, 1, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      7,
+      { 4, 0, { 0, 0, 0, 0, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      8,
+      { 4, 4, { 2, 2, 1, 1, 0, 0 } },
+      { 6, 4, { 2, 2, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      9,
+      { 7, 4, { 1, 1, 1, 1, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      10,
+      { 4, 4, { 0, 1, 0, 1, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      11,
+      { 4, 4, { 0, 0, 0, 0, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      12,
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } },
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      13,
+      { 3, 0, { 0, 0, 0, 0, 0, 0 } },
+      { 3, 3, { 1, 1, 1, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      14,
+      { 3, 1, { 5, 0, 0, 0, 0, 0 } },
+      { 5, 1, { 5, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      15,
+      { 2, 1, { 3, 0, 0, 0, 0, 0 } },
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      16,
+      { 3, 1, { 0, 0, 0, 0, 0, 0 } },
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      17,
+      { 6, 2, { 3, 3, 0, 0, 0, 0 } },
+      { 6, 2, { 3, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      18,
+      { 6, 1, { 3, 0, 0, 0, 0, 0 } },
+      { 3, 1, { 3, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      19,
+      { 6, 0, { 0, 0, 0, 0, 0, 0 } },
+      { 6, 6, { 1, 1, 1, 1, 1, 1 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      20,
+      { 6, 2, { 5, 3, 0, 0, 0, 0 } },
+      { 8, 2, { 5, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      21,
+      { 9, 2, { 3, 3, 0, 0, 0, 0 } },
+      { 6, 2, { 3, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      22,
+      { 6, 2, { 3, 0, 0, 0, 0, 0 } },
+      { 6, 2, { 3, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      23,
+      { 6, 2, { 0, 0, 0, 0, 0, 0 } },
+      { 6, 2, { 3, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      24,
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } },
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      25,
+      { 4, 1, { 1, 0, 0, 0, 0, 0 } },
+      { 1, 1, { 1, 0, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      26,
+      { 4, 0, { 0, 0, 0, 0, 0, 0 } },
+      { 4, 4, { 1, 1, 1, 1, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      27,
+      { 4, 2, { 5, 3, 0, 0, 0, 0 } },
+      { 8, 2, { 5, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      28,
+      { 2, 2, { 1, 3, 0, 0, 0, 0 } },
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      29,
+      { 4, 2, { 1, 0, 0, 0, 0, 0 } },
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      30,
+      { 4, 2, { 0, 3, 0, 0, 0, 0 } },
+      { 4, 2, { 1, 3, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-correctable.ome"),
+      false,
+      true,
+      31,
+      { 4, 2, { 0, 0, 0, 0, 0, 0 } },
+      { 4, 2, { 2, 2, 0, 0, 0, 0 } }
+    },
+    {
+      path(PROJECT_SOURCE_DIR "/cpp/test/ome-bioformats/data/brokenchannels-uncorrectable.ome"),
+      false,
+      false,
+      0,
+      { 4, 3, { 1, 0, 0, 0, 0, 0 } },
+      { 4, 3, { 1, 0, 0, 0, 0, 0 } }
+    }
+  };
+
+template<class charT, class traits>
+inline std::basic_ostream<charT,traits>&
+operator<< (std::basic_ostream<charT,traits>& os,
+            const Corrections& params)
+{
+  return os << params.filename << ": Image #" << params.imageIndex;
+}
+
+class CorrectionTest : public ::testing::TestWithParam<Corrections>
+{
+};
+
+TEST_P(CorrectionTest, ValidateAndCorrectModel)
+{
+  ome::common::xml::Platform xmlplat;
+
+  const Corrections& current(GetParam());
+  const dimension_size_type idx(current.imageIndex);
+
+  ome::common::xml::dom::Document doc = ome::common::xml::dom::createDocument(current.filename);
+  ASSERT_TRUE(doc);
+
+  ASSERT_EQ(std::string("2013-06"), ome::bioformats::getModelVersion(doc));
+
+  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(doc));
+
+  {
+    const ModelState& state(current.before);
+
+    EXPECT_EQ(PositiveInteger(state.sizeC), meta->getPixelsSizeC(idx));
+    EXPECT_EQ(state.channelCount, meta->getChannelCount(idx));
+    for (dimension_size_type s = 0; s < boost::size(state.samples); ++s)
+      {
+        if (state.samples[s] > 0)
+          {
+            EXPECT_EQ(PositiveInteger(state.samples[s]),
+                      meta->getChannelSamplesPerPixel(idx, s));
+          }
+      }
+  }
+
+  if (current.initiallyValid)
+    {
+      EXPECT_TRUE(validateModel(*meta, false));
+    }
+  else
+    {
+      EXPECT_FALSE(validateModel(*meta, false));
+      if (current.correctable)
+        {
+          EXPECT_NO_THROW(EXPECT_FALSE(validateModel(*meta, true)));
+        }
+      else
+        {
+          // Totally broken; end test here.
+          EXPECT_THROW(validateModel(*meta, true), FormatException);
+          return;
+        }
+    }
+  // Model should now be valid.
+  EXPECT_TRUE(validateModel(*meta, false));
+
+  {
+    const ModelState& state(current.after);
+
+    EXPECT_EQ(PositiveInteger(state.sizeC), meta->getPixelsSizeC(idx));
+    EXPECT_EQ(state.channelCount, meta->getChannelCount(idx));
+    for (dimension_size_type s = 0; s < boost::size(state.samples); ++s)
+      {
+        if (state.samples[s] > 0)
+          {
+            EXPECT_EQ(PositiveInteger(state.samples[s]),
+                      meta->getChannelSamplesPerPixel(idx, s));
+          }
+      }
+  }
+}
+
+// Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
+// this is solely to work around a missing prototype in gtest.
+#ifdef __GNUC__
+#  if defined __clang__ || defined __APPLE__
+#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#  endif
+#  pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+
+INSTANTIATE_TEST_CASE_P(CorrectionVariants, CorrectionTest, ::testing::ValuesIn(corrections));


### PR DESCRIPTION
Major changes include:

- `setId` methods for both FormatReader and FormatWriter always canonicalise the path, so that comparisons always use the same path; previously there was potential for miscomparison where different paths for the same file could be used (relative vs. absolute vs. canonical absolute)
- BigTIFF checking factored out of MinimalTIFFWriter for use by OMETIFFWriter
- detail::FormatWriter methods using channel calculations corrected, and getSeriesCount() method added
- Addition of MetadataTools `validateModel` function, which can optionally correct some channel inconsistencies.

The model validation and correction currently deals solely with ambiguity between *SizeC*, channel element count and SamplesPerPixel (*SPP*) on channels.  The correction ensures that *SizeC* == sum(*SPP* on each channel).  It aims to handle the common cases (no channel elements, channel elements without *SPP*, *SizeC* mismatch), plus all the corner cases.  The following rules are used:

- If SamplesPerPixel is present on a channel, this is always treated as being more correct than *SizeC* (since it's more specific) and will never be changed
- If no channel elements are defined, then *SizeC* channel elements are created, each with *SPP*=1
- If all channels specify *SPP* but it mismatches with *SizeC*, *SizeC* is set to sum(*SPP* for each channel)
- If channel elements are present but do not specify the *SPP*, the number of channels in *SizeC* which are unaccounted for are divided between these channel elements.  This matches the correction the Java code does, but it also handles the corner case where there may be a mixture of channel elements with and without *SPP* set
- If correction is impossible, then we throw an exception; this is basically when we can't evenly divide the unallocated channels between channel elements with no defined *SPP*.

The testcases detail the input and output state for all the different possible corrections.

--------

Testing: unit tests should continue to pass.  Model validation and correction has a comprehensive set of unit tests in metadatatools.cpp and datafiles in `cpp/test/ome-bioformats/data/*.ome`; the main point for review here is whether the implemented behaviour is acceptable.  The other changes don't all include unit tests--they either already exist or will be tested in the OME-TIFF writer PR to follow.