### PR TITLE
TIFF export: use long arithmetic for BigTIFF check

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -80,7 +80,7 @@ public class TiffWriter extends FormatWriter {
    * This is approximately 3.9 GB instead of 4 GB,
    * to allow space for the IFDs.
    */
-  private static final long BIG_TIFF_CUTOFF = 1024 * 1024 * 3990;
+  private static final long BIG_TIFF_CUTOFF = (long) 1024 * 1024 * 3990;
 
   // -- Fields --
 


### PR DESCRIPTION
This should prevent ```BIG_TIFF_CUTOFF``` from being negative, which caused all TIFF/OME-TIFF files to be written as BigTIFF.

To test, pick any small file (e.g. ```test_images_good/al3d/Iron Plate.al3d```).  Verify that using ```bfconvert``` to convert the file to TIFF without this change produces a message to the effect that BigTIFF is being used; with this change, the same test should not produce a BigTIFF message.  Running ```file``` on the output files should also indicate BigTIFF without this change and plain TIFF with this change.