### PR TITLE
Race condition during writing of TIFF leading to an exception

### DIFF
--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -315,12 +315,9 @@ public abstract class FormatWriter extends FormatHandler
 
     MetadataRetrieve r = getMetadataRetrieve();
     initialized = new boolean[r.getImageCount()][];
-    int oldSeries = series;
     for (int i=0; i<r.getImageCount(); i++) {
-      setSeries(i);
-      initialized[i] = new boolean[getPlaneCount()];
+      initialized[i] = new boolean[getPlaneCount(i)];
     }
-    setSeries(oldSeries);
   }
 
   /* @see IFormatHandler#close() */
@@ -430,6 +427,11 @@ public abstract class FormatWriter extends FormatHandler
 
   /** Retrieve the number of samples per pixel for the current series. */
   protected int getSamplesPerPixel() {
+    return getSamplesPerPixel(series);
+  }
+  
+  /** Retrieve the number of samples per pixel for given series. */
+  protected int getSamplesPerPixel(int series) {
     MetadataRetrieve r = getMetadataRetrieve();
     PositiveInteger samples = r.getChannelSamplesPerPixel(series, 0);
     if (samples == null) {
@@ -437,9 +439,14 @@ public abstract class FormatWriter extends FormatHandler
     }
     return samples == null ? 1 : samples.getValue();
   }
-
+  
   /** Retrieve the total number of planes in the current series. */
   protected int getPlaneCount() {
+    return getPlaneCount(series);
+  }
+  
+  /** Retrieve the total number of planes in given series. */
+  protected int getPlaneCount(int series) {
     MetadataRetrieve r = getMetadataRetrieve();
     int z = r.getPixelsSizeZ(series).getValue().intValue();
     int t = r.getPixelsSizeT(series).getValue().intValue();

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -363,12 +363,9 @@ public class TiffWriter extends FormatWriter {
     ifd.putIFDValue(IFD.SAMPLE_FORMAT, sampleFormat);
 
     int index = no;
-    int realSeries = getSeries();
-    for (int i=0; i<realSeries; i++) {
-      setSeries(i);
-      index += getPlaneCount();
+    for (int i=0; i<getSeries(); i++) {
+      index += getPlaneCount(i);
     }
-    setSeries(realSeries);
     return index;
   }
 
@@ -391,16 +388,21 @@ public class TiffWriter extends FormatWriter {
   /* @see loci.formats.FormatWriter#getPlaneCount() */
   @Override
   public int getPlaneCount() {
+    return getPlaneCount(series);
+  }
+  
+  @Override
+  protected int getPlaneCount(int series) {
     MetadataRetrieve retrieve = getMetadataRetrieve();
-    int c = getSamplesPerPixel();
+    int c = getSamplesPerPixel(series);
     int type = FormatTools.pixelTypeFromString(
       retrieve.getPixelsType(series).toString());
     int bytesPerPixel = FormatTools.getBytesPerPixel(type);
 
     if (bytesPerPixel > 1 && c != 1 && c != 3) {
-      return super.getPlaneCount() * c;
+      return super.getPlaneCount(series) * c;
     }
-    return super.getPlaneCount();
+    return super.getPlaneCount(series);
   }
 
   // -- IFormatWriter API methods --


### PR DESCRIPTION
There is a race condition occurring during multithreaded writing of a (OME-)TIFF file resulting in an exception.

It occurs fairly rare but has occurred to me several times when writing huge OME-TIFF file. It ends with a stack trace similar to this one:

    Caused by: loci.formats.FormatException: X:184320 must be < 13206
    at loci.formats.FormatWriter.checkParams(FormatWriter.java:363)
    at loci.formats.out.TiffWriter.saveBytes(TiffWriter.java:211)
    at loci.formats.out.OMETiffWriter.saveBytes(OMETiffWriter.java:196)

This exception occurs when one thread enters FormatWriter.checkParams() while different one is in [TiffWriter.prepareToWriteImage()](https://github.com/openmicroscopy/bioformats/blob/develop/components/formats-bsd/src/loci/formats/out/TiffWriter.java#L368).

The cause of the problem is that linked block of code in prepareToWriteImage() changes temporarily the current series. While the above function is in synchronized block, checkParams() is not, leading to an exception when another thread changes current series in the middle of params checking.

I have fixed it by modifying the prepareToWriteImage() function so that it does not change current series anymore.