### PR TITLE
Add section about MATLAB testing to the developers documentation

### DIFF
--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -110,38 +110,43 @@ Tests for the Bio-Formats MATLAB toolbox are written using the
 `MATLAB xUnit Test Framework`_ and located under
 :sourcedir:`components/formats-gpl/test/matlab`.
 
-To run these tests, you will need to download the xUnit Framework using the
-link above from the MATLAB Central File Exchange. After adding the xUnit
-framework and the MATLAB toolbox to your MATLAB path, you can run the tests
-using:
+To run these tests, you will need to download `matlab-xunit <https://github.com/psexton/matlab-xunit>`_ which is based on the xUnit
+Framework and adds JUnit-compatible XML output. First add this package together
+with the Bio-Formats MATLAB to your MATLAB path:
 
 .. code-block:: matlab
 
-  runtests components/formats-gpl/test/matlab
+  % Add the xUnit toolbox to the MATLAB path
+  addpath('/path/to/matlab-xunit');
+  % Add the Bio-Formats dependencies from the source code
+  addpath('components/formats-gpl/matlab');
+  addpath('components/artifacts');
 
-Alternatively, you can download `matlab-xunit <https://github.com/psexton/matlab-xunit>`_ which is based on the MATLAB xUnit
-Test Framework and adds JUnit-compatible XML output. After adding it to your
-MATLAB path, you can run the tests using:
-
-.. code-block:: matlab
-
-  runxunit components/formats-gpl/test/matlab
-
-You can run individual test class by passing the name of the class:
+You can run all the MATLAB tests using :command:`runxunit`:
 
 .. code-block:: matlab
 
-  runxunit components/formats-gpl/test/matlab TestBfsave
+  cd components/formats-gpl/test/matlab
+  runxunit
 
-Or run individual test methods by passing the name of the class and the name
-of the method:
+Individual test classes can be run by passing the name of the class:
 
 .. code-block:: matlab
 
-  runxunit components/formats-gpl/test/matlab TestBfsave:testLZW
+  cd components/formats-gpl/test/matlab
+  runxunit TestBfsave
+
+Individual test methods can be run by passing the name of the class and the
+name of the method:
+
+.. code-block:: matlab
+
+  cd components/formats-gpl/test/matlab
+  runxunit TestBfsave:testLZW
 
 Finally to output the test results under XML format, you can use the :option:`-xmlfile` option:
 
 .. code-block:: matlab
 
-  runxunit components/formats-gpl/test/matlab -xmlfile test-output.xml
+  cd components/formats-gpl/test/matlab
+  runxunit -xmlfile test-output.xml

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -104,24 +104,24 @@ branch name, number of failures at the bottom of the Ant output, and the
 
 MATLAB tests
 ------------
-.. _MATLAB xUnit Test Framework: http://uk.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
+.. _matlab-xunit: https://github.com/psexton/matlab-xunit
 
-Tests for the Bio-Formats MATLAB toolbox are written using the
-`MATLAB xUnit Test Framework`_ and located under
-:sourcedir:`components/formats-gpl/test/matlab`.
+Tests for the Bio-Formats MATLAB toolbox are written using the xunit framework
+and located under :sourcedir:`components/formats-gpl/test/matlab`.
 
-To run these tests, you will need to download `matlab-xunit <https://github.com/psexton/matlab-xunit>`_ which is based on the xUnit
-Framework and adds JUnit-compatible XML output. First add this package together
-with the Bio-Formats MATLAB to your MATLAB path:
+To run these tests, you will need to download or clone `matlab-xunit`_, a
+xUnit framework with JUnit-compatible XML output. Then add this package
+together with the Bio-Formats MATLAB to your MATLAB path:
 
 .. code-block:: matlab
 
-  % Add the xUnit toolbox to the MATLAB path
+  % Add the matlab-xunit toolbox to the MATLAB path
   addpath('/path/to/matlab-xunit');
-  % Add the Bio-Formats dependencies from the source code
+  % Add the Bio-Formats MATLAB source to the MATLAB path
+  % For developers working against the source code
   addpath('/path/to/bioformats/components/formats-gpl/matlab');
   addpath('/path/to/bioformats/artifacts');
-  % Alternatively add the Bio-Formats MATLAB toolbox
+  % For developers working against a built artifact, e.g. a release
   % addpath('/path/to/bfmatlab');
 
 You can run all the MATLAB tests using :command:`runxunit`:

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -120,8 +120,8 @@ using:
   runtests components/formats-gpl/test/matlab
 
 Alternatively, you can download `matlab-xunit <https://github.com/psexton/matlab-xunit>`_ which is based on the MATLAB xUnit
-Test Framework and adds JUnit compatible XML output. After adding it to your
-MATLAB path,  you can run the tests using:
+Test Framework and adds JUnit-compatible XML output. After adding it to your
+MATLAB path, you can run the tests using:
 
 .. code-block:: matlab
 

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -107,7 +107,7 @@ MATLAB tests
 .. _matlab-xunit: https://github.com/psexton/matlab-xunit
 
 Tests for the Bio-Formats MATLAB toolbox are written using the xunit framework
-and located under :sourcedir:`components/formats-gpl/test/matlab`.
+and are located under :sourcedir:`components/formats-gpl/test/matlab`.
 
 To run these tests, you will need to download or clone `matlab-xunit`_, a
 xUnit framework with JUnit-compatible XML output. Then add this package

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -1,6 +1,9 @@
 Testing code changes
 ====================
 
+Automated tests
+---------------
+
 At the bottom of many commit messages in
 https://github.com/openmicroscopy/bioformats, you will find a few lines
 similar to this:
@@ -98,3 +101,29 @@ If Ant reports that the build was successful, then there is nothing that
 you need to do. Otherwise, it is helpful if you can provide the command,
 branch name, number of failures at the bottom of the Ant output, and the
 :file:`bio-formats-software-test-\*.log` file.
+
+MATLAB tests
+------------
+.. _MATLAB xUnit Test Framework: http://uk.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
+
+Tests for the Bio-Formats MATLAB toolbox are written using the
+`MATLAB xUnit Test Framework`_ and located under
+:sourcedir:`components/formats-gpl/test/matlab`.
+
+To run these tests, you will need to download the xUnit Framework using the
+link above from the MATLAB Central File Exchange. After adding the xUnit
+framework and the MATLAB toolbox to your MATLAB path, you can run the tests
+using:
+
+.. code-block:: matlab
+
+  runtests components/formats-gpl/test/matlab
+
+Alternatively, you can download `matlab-xunit <https://github.com/psexton/matlab-xunit>`_ which is based on the MATLAB xUnit
+Test Framework and adds JUnit compatible XML output. After adding it to your
+MATLAB path,  you can run the tests using:
+
+.. code-block:: matlab
+
+  runxunit components/formats-gpl/test/matlab
+  runxunit components/formats-gpl/test/matlab -xmlfile test-output.xml

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -126,4 +126,22 @@ MATLAB path,  you can run the tests using:
 .. code-block:: matlab
 
   runxunit components/formats-gpl/test/matlab
+
+You can run individual test class by passing the name of the class:
+
+.. code-block:: matlab
+
+  runxunit components/formats-gpl/test/matlab TestBfsave
+
+Or run individual test methods by passing the name of the class and the name
+of the method:
+
+.. code-block:: matlab
+
+  runxunit components/formats-gpl/test/matlab TestBfsave:testLZW
+
+Finally to output the test results under XML format, you can use the :option:`-xmlfile` option:
+
+.. code-block:: matlab
+
   runxunit components/formats-gpl/test/matlab -xmlfile test-output.xml

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -119,21 +119,23 @@ with the Bio-Formats MATLAB to your MATLAB path:
   % Add the xUnit toolbox to the MATLAB path
   addpath('/path/to/matlab-xunit');
   % Add the Bio-Formats dependencies from the source code
-  addpath('components/formats-gpl/matlab');
-  addpath('components/artifacts');
+  addpath('/path/to/bioformats/components/formats-gpl/matlab');
+  addpath('/path/to/bioformats/components/artifacts');
+  % Alternatively add the Bio-Formats MATLAB toolbox
+  % addpath('/path/to/bfmatlab');
 
 You can run all the MATLAB tests using :command:`runxunit`:
 
 .. code-block:: matlab
 
-  cd components/formats-gpl/test/matlab
+  cd /path/to/bioformats/components/formats-gpl/test/matlab
   runxunit
 
 Individual test classes can be run by passing the name of the class:
 
 .. code-block:: matlab
 
-  cd components/formats-gpl/test/matlab
+  cd /path/to/bioformats/components/formats-gpl/test/matlab
   runxunit TestBfsave
 
 Individual test methods can be run by passing the name of the class and the
@@ -141,12 +143,12 @@ name of the method:
 
 .. code-block:: matlab
 
-  cd components/formats-gpl/test/matlab
+  cd /path/to/bioformats/components/formats-gpl/test/matlab
   runxunit TestBfsave:testLZW
 
 Finally to output the test results under XML format, you can use the :option:`-xmlfile` option:
 
 .. code-block:: matlab
 
-  cd components/formats-gpl/test/matlab
+  cd /path/to/bioformats/components/formats-gpl/test/matlab
   runxunit -xmlfile test-output.xml

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -120,7 +120,7 @@ with the Bio-Formats MATLAB to your MATLAB path:
   addpath('/path/to/matlab-xunit');
   % Add the Bio-Formats dependencies from the source code
   addpath('/path/to/bioformats/components/formats-gpl/matlab');
-  addpath('/path/to/bioformats/components/artifacts');
+  addpath('/path/to/bioformats/artifacts');
   % Alternatively add the Bio-Formats MATLAB toolbox
   % addpath('/path/to/bfmatlab');
 


### PR DESCRIPTION
Document requirements (xUnit framework) and commands to run the MATLAB tests

/cc @bramalingam @manics 