### PR TITLE
Memoizer relocation improvements

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -655,6 +655,21 @@ public class Memoizer extends ReaderWrapper {
       loadedFromMemo = false;
       savedToMemo = false;
 
+      if (memo != null) {
+        // loadMemo has already called handleMetadataStore with non-null
+        try {
+          loadedFromMemo = true;
+          reader = memo;
+          reader.reopenFile();
+        } catch (FileNotFoundException e) {
+          LOGGER.warn("could not reopen file - deleting invalid memo file: {}", memoFile);
+          deleteQuietly(memoFile);
+          memo = null;
+          reader.close();
+          loadedFromMemo = false;
+        }
+      }
+
       if (memo == null) {
         OMEXMLService service = getService();
         super.setMetadataStore(service.createOMEXMLMetadata());
@@ -667,11 +682,6 @@ public class Memoizer extends ReaderWrapper {
           return; // EARLY EXIT!
         }
         savedToMemo = saveMemo(); // Should never throw.
-      } else {
-        // loadMemo has already called handleMetadataStore with non-null
-        loadedFromMemo = true;
-        reader = memo;
-        reader.reopenFile();
       }
     } catch (ServiceException e) {
       LOGGER.error("Could not create OMEXMLMetadata", e);

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -662,7 +662,7 @@ public class Memoizer extends ReaderWrapper {
           reader = memo;
           reader.reopenFile();
         } catch (FileNotFoundException e) {
-          LOGGER.warn("could not reopen file - deleting invalid memo file: {}", memoFile);
+          LOGGER.info("could not reopen file - deleting invalid memo file: {}", memoFile);
           deleteQuietly(memoFile);
           memo = null;
           reader.close();

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -335,6 +335,8 @@ public class MemoizerTest {
     memoizer = new Memoizer(reader, 0);
     memoizer.setId(id);
     memoizer.close();
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertTrue(memoizer.isSavedToMemo());
 
     // Rename the directory (including the file and the memo file)
     String uuid = UUID.randomUUID().toString();
@@ -346,6 +348,8 @@ public class MemoizerTest {
     // Try to reopen the file with the Memoizer
     memoizer.setId(newid);
     memoizer.close();
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertTrue(memoizer.isSavedToMemo());
   }
 
   public static void main(String[] args) throws Exception {

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -329,13 +329,32 @@ public class MemoizerTest {
         memoFile.getAbsolutePath());
   }
 
+  @Test
+  public void testRelocate() throws Exception {
+    // Create an in-place memo file
+    memoizer = new Memoizer(reader, 0);
+    memoizer.setId(id);
+    memoizer.close();
+
+    // Rename the directory (including the file and the memo file)
+    String uuid = UUID.randomUUID().toString();
+    File newidDir = new File(System.getProperty("java.io.tmpdir"), uuid);
+    idDir.renameTo(newidDir);
+    File newtempFile = new File(newidDir, TEST_FILE);
+    String newid = newtempFile.getAbsolutePath();
+
+    // Try to reopen the file with the Memoizer
+    memoizer.setId(newid);
+    memoizer.close();
+  }
+
   public static void main(String[] args) throws Exception {
-      MemoizerTest t = new MemoizerTest();
-      t.setUp();
-      try {
-        t.testSimple();
-      } finally {
-        t.tearDown();
-      }
+    MemoizerTest t = new MemoizerTest();
+    t.setUp();
+    try {
+      t.testSimple();
+    } finally {
+      t.tearDown();
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a bug with the memoization that can be reproduced following two scenarios:

- at the Bio-Formats level, using a memoizer-decorated reader, call `setId` on an image file in a directory and create an in-place memo file. Close the reader, rename the directory containing both the original file and the memo file. Using the same memoized reader, call `setId()` on the new file location.
- at the OMERO level, set up a server and import and image. Then stop the server, rename the `omero.data.dir` folder and modify the `omero.data.dir/BioFormatsCache` hierarchy to match the new naming scheme. After fixing the server configuration, restart the server and try to access the image.

In both cases, the `setId()` call should fail with `FileNotFoundException` leaving both the reader and the memo file in a stale state.

This PR fixes this bug by isolating the `reopenFile()` call and encapsulating it in a `try/catch` statement. `FileNotFoundException` will now effectively invalidate the memo file which will be safely recreated in the follow-up block. A Memoizer unit test has been added to cover the scenario described above.

Within the scope to this PR, we might want to be conservatice and catch all `Throwable` exceptions like we do in `loadMemo()` to prevent stale states. Are there edge cases where we do not want memo invalidation if `reopenFile()` fails?