### PR TITLE
Fix getPlanePosition* macro commands in ImageJ

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -67,6 +67,10 @@ import ome.units.UNITS;
  * {@link loci.formats.IFormatReader} interface, with some additional
  * functions to control the type of format reader used.
  *
+ * Note that public methods in this class can only accept parameters of String,
+ * Double, String[], Double[], and Object[] types.  Anything else will prevent
+ * the method from being usable within a macro.
+ *
  * @author Curtis Rueden ctrueden at wisc.edu
  */
 public class LociFunctions extends MacroFunctions {
@@ -471,7 +475,7 @@ public class LociFunctions extends MacroFunctions {
     exposureTime[0] = val == null ? new Double(Double.NaN) : val;
   }
 
-  public void getPlanePositionX(Length[] positionX, Double no) {
+  public void getPlanePositionX(Double[] positionX, Double no) {
     int imageIndex = r.getSeries();
     int planeIndex = getPlaneIndex(r, no.intValue());
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
@@ -479,13 +483,11 @@ public class LociFunctions extends MacroFunctions {
     if (planeIndex >= 0) {
       val = retrieve.getPlanePositionX(imageIndex, planeIndex);
     }
-    if (val == null) {
-        val = new Length(Double.NaN, UNITS.REFERENCEFRAME);
-    }
-    positionX[0] = val;
+    positionX[0] =
+      val == null ? Double.NaN : val.value(UNITS.REFERENCEFRAME).doubleValue();
   }
 
-  public void getPlanePositionY(Length[] positionY, Double no) {
+  public void getPlanePositionY(Double[] positionY, Double no) {
     int imageIndex = r.getSeries();
     int planeIndex = getPlaneIndex(r, no.intValue());
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
@@ -496,10 +498,11 @@ public class LociFunctions extends MacroFunctions {
     if (val == null) {
         val = new Length(Double.NaN, UNITS.REFERENCEFRAME);
     }
-    positionY[0] = val;
+    positionY[0] =
+      val == null ? Double.NaN : val.value(UNITS.REFERENCEFRAME).doubleValue();
   }
 
-  public void getPlanePositionZ(Length[] positionZ, Double no) {
+  public void getPlanePositionZ(Double[] positionZ, Double no) {
     int imageIndex = r.getSeries();
     int planeIndex = getPlaneIndex(r, no.intValue());
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
@@ -510,7 +513,8 @@ public class LociFunctions extends MacroFunctions {
     if (val == null) {
         val = new Length(Double.NaN, UNITS.REFERENCEFRAME);
     }
-    positionZ[0] = val;
+    positionZ[0] =
+      val == null ? Double.NaN : val.value(UNITS.REFERENCEFRAME).doubleValue();
   }
 
   public void getPixelsPhysicalSizeX(Double[] sizeX) {

--- a/components/bio-formats-plugins/utils/macros/planePositions.txt
+++ b/components/bio-formats-plugins/utils/macros/planePositions.txt
@@ -1,0 +1,26 @@
+// Uses Bio-Formats to print the chosen file's plane positions to the Log.
+
+run("Bio-Formats Macro Extensions");
+
+id = File.openDialog("Choose a file");
+print("Image path: " + id);
+
+Ext.setId(id);
+Ext.getImageCount(imageCount);
+print("Plane count: " + imageCount);
+
+positionX = newArray(imageCount);
+positionY = newArray(imageCount);
+positionZ = newArray(imageCount);
+
+print("Plane positions (relative to microscope reference frame):");
+for (no=0; no<imageCount; no++) {
+  Ext.getPlanePositionX(positionX[no], no);
+  Ext.getPlanePositionY(positionY[no], no);
+  Ext.getPlanePositionZ(positionZ[no], no);
+  print("\tplane #" + (no + 1));
+  print("\t\tX = " + positionX[no]);
+  print("\t\tY = " + positionY[no]);
+  print("\t\tZ = " + positionZ[no]);
+}
+print("Complete.");


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12865.

To test, use the macro added in f074113.  Without ccccf80, running the macro in ImageJ should result in an error - see http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-April/005339.html.

With ccccf80, the macro should run successfully and output the X, Y, and Z positions for each plane.  I was using the .nd2 files from test_images_good to test, but almost any file with populated positions should work.