### PR TITLE
Zeiss CZI: fix ordering of metadata tags

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.Iterator;
 import javax.xml.parsers.DocumentBuilder;
 
 import loci.common.ByteArrayHandle;
@@ -2454,7 +2455,10 @@ public class ZeissCZIReader extends FormatReader {
     nameStack.push(name);
 
     StringBuffer key = new StringBuffer();
-    for (String k : nameStack) {
+    String k = null;
+    Iterator<String> keys = nameStack.descendingIterator();
+    while (keys.hasNext()) {
+      k = keys.next();
       if (!k.equals("Metadata") && (!k.endsWith("s") || k.equals(name))) {
         key.append(k);
         key.append("|");


### PR DESCRIPTION
Switching from a Stack to a Deque reversed the order in which the tags
were built.  This fixes the tags by using the Deque's descending
iterator.

See gh-1782.

To test, use any .czi file.  Verify that the original metadata table entries changed between 5.1.0 and 5.1.1; with this PR included, the 5.1.0 behavior should be restored.