### PR TITLE
Zeiss CZI: fix assembly of overlapping tiles

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -338,6 +338,9 @@ public class ZeissCZIReader extends FormatReader {
 
               outputCol = (intersection.x - x) * pixel;
               outputRow = intersection.y - y;
+              if (validScanDim) {
+                outputRow -= tile.y;
+              }
 
               int rowLen = pixel * (int) Math.min(intersection.width, realX);
               int outputOffset = outputRow * outputRowLen + outputCol;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12843.

To test, import the file from ```zeiss-czi/sebastian/12843``` into OMERO; wait for the pyramid to be generated, then compare the resulting image with what is shown in Zeiss' Zen software.