### PR TITLE
Deltavision: check for valid dimensions in isThisType

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -155,9 +155,14 @@ public class DeltavisionReader extends FormatReader {
   public boolean isThisType(RandomAccessInputStream stream) throws IOException {
     final int blockLen = 98;
     if (!FormatTools.validStream(stream, blockLen, false)) return false;
+    stream.seek(0);
+    int x = stream.readInt();
+    int y = stream.readInt();
+    int count = stream.readInt();
     stream.seek(96);
     int magic = stream.readShort() & 0xffff;
-    return magic == DV_MAGIC_BYTES_1 || magic == DV_MAGIC_BYTES_2;
+    return x > 0 && y > 0 && count > 0 &&
+      magic == DV_MAGIC_BYTES_1 || magic == DV_MAGIC_BYTES_2;
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -154,15 +154,19 @@ public class DeltavisionReader extends FormatReader {
   @Override
   public boolean isThisType(RandomAccessInputStream stream) throws IOException {
     final int blockLen = 98;
-    if (!FormatTools.validStream(stream, blockLen, false)) return false;
+    if (!FormatTools.validStream(stream, blockLen, true)) return false;
+    stream.seek(96);
+    int magic = stream.readShort() & 0xffff;
+    boolean valid = magic == DV_MAGIC_BYTES_1 || magic == DV_MAGIC_BYTES_2;
+    if (!valid) {
+      return false;
+    }
+    stream.order(magic == (LITTLE_ENDIAN & 0xffff));
     stream.seek(0);
     int x = stream.readInt();
     int y = stream.readInt();
     int count = stream.readInt();
-    stream.seek(96);
-    int magic = stream.readShort() & 0xffff;
-    return x > 0 && y > 0 && count > 0 &&
-      magic == DV_MAGIC_BYTES_1 || magic == DV_MAGIC_BYTES_2;
+    return x > 0 && y > 0 && count > 0;
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */


### PR DESCRIPTION
See gh-1785.

To test, check the file from QA 11061 with ```showinf```.  Without this change, a NegativeArraySizeException should be thrown in DeltavisionReader.  With this change, the format should be listed as ```FEI TIFF``` and no exception should be thrown.