### PR TITLE
NDPI: fix tile offsets for files between 2 and 4 GB

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -172,6 +172,11 @@ public class NDPIReader extends BaseTiffReader {
       try {
         service.close();
         long[] markers = ifd.getIFDLongArray(MARKER_TAG);
+        if (!use64Bit) {
+          for (int i=0; i<markers.length; i++) {
+            markers[i] = markers[i] & 0xffffffffL;
+          }
+        }
         if (markers != null) {
           service.setRestartMarkers(markers);
         }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12839.

To test, import the file from ```hamamatsu/qi/``` into OMERO.  Scroll through the zoom levels for the first imported image, pan to the lower right corner, and verify that nothing looks obviously wrong; the tiles should load normally, and there should be no exceptions in the Blitz log.

We have a few other files that may or may not be affected by this change, so it's probably a good idea to import them as well:

```
hamamatsu/tony/2010-02-26 17.39.12.ndpi
hamamatsu/paul/2009-10-29 17.04.12.ndpi
hamamatsu/philippe/fluorescence/PHAS 01.ndpi
```

and also verify that viewing/zooming/panning works without missing tiles or Blitz exceptions.