### PR TITLE
OME-TIFF: allow BigTIFF extensions during export

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -84,7 +84,8 @@ public class OMETiffWriter extends TiffWriter {
   // -- Constructor --
 
   public OMETiffWriter() {
-    super("OME-TIFF", new String[] {"ome.tif", "ome.tiff"});
+    super("OME-TIFF",
+      new String[] {"ome.tif", "ome.tiff", "ome.tf2", "ome.tf8", "ome.btf"});
   }
 
   // -- IFormatHandler API methods --


### PR DESCRIPTION
This allows switching to BigTIFF without using the setBigTiff API method.
See https://trello.com/c/1q2GATUh/171-bigtiff-extensions-for-ome-tiff.

To test, verify that converting any file to a file with the ```.ome.btf```, ```.ome.tf2```, or ```.ome.tf8``` extension via bfconvert or ImageJ results in a BigTIFF file.  When using bfconvert, the output should show a message similar to ```Switching to BigTIFF based on extension```.  The converted files should be readable, and showinf should identify them as being OME-TIFF files.