### PR TITLE
C++: Add OME-TIFF writer

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -73,7 +73,6 @@ public class OMETiffWriter extends TiffWriter {
 
   // -- Fields --
 
-  private List<Integer> seriesMap;
   private String[][] imageLocations;
   private OMEXMLMetadata omeMeta;
   private OMEXMLService service;
@@ -156,7 +155,6 @@ public class OMETiffWriter extends TiffWriter {
       }
 
       if (canReallyClose) {
-        seriesMap = null;
         imageLocations = null;
         omeMeta = null;
         service = null;
@@ -188,11 +186,6 @@ public class OMETiffWriter extends TiffWriter {
   public void saveBytes(int no, byte[] buf, IFD ifd, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    if (seriesMap == null) seriesMap = new ArrayList<Integer>();
-    if (!seriesMap.contains(series)) {
-      seriesMap.add(new Integer(series));
-    }
-
     super.saveBytes(no, buf, ifd, x, y, w, h);
 
     int index = no;
@@ -310,7 +303,6 @@ public class OMETiffWriter extends TiffWriter {
     int sizeT = omeMeta.getPixelsSizeT(series).getValue().intValue();
 
     int imageCount = getPlaneCount();
-    int ifdCount = seriesMap.size();
 
     if (imageCount == 0) {
       omeMeta.setTiffDataPlaneCount(new NonNegativeInteger(0), series, 0);

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -456,6 +456,8 @@ ${customContent[obj.name][prop.name]}
 
 #include <ome/common/xml/Platform.h>
 
+#include <ome/internal/url.h>
+
 #include <ome/xml/meta/OMEXMLMetadata.h>
 
 {% for header in fu.OBJECT_HEADERS %}\
@@ -628,6 +630,16 @@ namespace ome
         resolveReferences();
 
         ome::common::xml::dom::Document doc(ome::common::xml::dom::createEmptyDocument("${model.getObjectByName("OME").namespace}", "OME"));
+
+        ome::common::xml::dom::Node comment
+          (doc.createComment
+           (" Warning: this comment is within an OME-XML metadata block, which "
+            "contains crucial dimensional parameters and other important metadata. "
+            "Please edit cautiously (if at all), and back up the original data "
+            "before doing so. For more information, see the OME-TIFF web site: "
+            URL_OME_TIFF " "));
+        doc.getDocumentElement().appendChild(comment);
+
         ome::common::xml::dom::Element ome = root->asXMLElement(doc);
 
         std::string text;

--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -102,10 +102,12 @@ set(OME_BIOFORMATS_IN_HEADERS
     in/TIFFReader.h)
 
 set(OME_BIOFORMATS_OUT_SOURCES
-    out/MinimalTIFFWriter.cpp)
+    out/MinimalTIFFWriter.cpp
+    out/OMETIFFWriter.cpp)
 
 set(OME_BIOFORMATS_OUT_HEADERS
-    out/MinimalTIFFWriter.h)
+    out/MinimalTIFFWriter.h
+    out/OMETIFFWriter.h)
 
 set(OME_BIOFORMATS_TIFF_SOURCES
     tiff/Codec.cpp
@@ -155,6 +157,7 @@ add_library(ome-bioformats SHARED
             ${BIOFORMATS_SOURCES}
             ${BIOFORMATS_HEADERS})
 target_link_libraries(ome-bioformats ome-compat ome-common ome-xml
+                      ${Boost_IOSTREAMS_LIBRARY_RELEASE}
                       ${Boost_FILESYSTEM_LIBRARY_RELEASE}
                       ${Boost_SYSTEM_LIBRARY_RELEASE}
                       ${TIFF_LIBRARIES})

--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -88,7 +88,8 @@ set(OME_BIOFORMATS_DETAIL_SOURCES
 
 set(OME_BIOFORMATS_DETAIL_HEADERS
     detail/FormatReader.h
-    detail/FormatWriter.h)
+    detail/FormatWriter.h
+    detail/OMETIFF.h)
 
 set(OME_BIOFORMATS_IN_SOURCES
     in/MinimalTIFFReader.cpp

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -542,6 +542,8 @@ namespace ome
         {
           std::string pixelType = (*i)->pixelType;
 
+          store.setImageID(createID("Image", s), s);
+
           fillPixels(store, **i, s);
 
           try

--- a/cpp/lib/ome/bioformats/PixelProperties.h
+++ b/cpp/lib/ome/bioformats/PixelProperties.h
@@ -376,14 +376,6 @@ namespace ome
       static const bool is_complex = true;
     };
 
-    /// Endianness.
-    enum EndianType
-      {
-        ENDIAN_BIG,    ///< Big endian.
-        ENDIAN_LITTLE, ///< Little endian.
-        ENDIAN_NATIVE  ///< Native endian.
-      };
-
     /**
      * Map the given PixelPropertiesType and Endian enums to the
      * corresponding endian-specific language type.

--- a/cpp/lib/ome/bioformats/Types.h
+++ b/cpp/lib/ome/bioformats/Types.h
@@ -64,6 +64,14 @@ namespace ome
     /// Size type for storage size.
     typedef uint64_t storage_size_type;
 
+    /// Endianness.
+    enum EndianType
+      {
+        ENDIAN_BIG,    ///< Big endian.
+        ENDIAN_LITTLE, ///< Little endian.
+        ENDIAN_NATIVE  ///< Native endian.
+      };
+
   }
 }
 

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -181,19 +181,12 @@ namespace ome
         setLookupTable(dimension_size_type       plane,
                        const VariantPixelBuffer& buf);
 
-        // Documented in superclass.
-        void
-        saveBytes(dimension_size_type plane,
-                  VariantPixelBuffer& buf);
+        using bioformats::FormatWriter::saveBytes;
 
         // Documented in superclass.
         void
         saveBytes(dimension_size_type plane,
-                  VariantPixelBuffer& buf,
-                  dimension_size_type x,
-                  dimension_size_type y,
-                  dimension_size_type w,
-                  dimension_size_type h) = 0;
+                  VariantPixelBuffer& buf);
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/detail/OMETIFF.h
+++ b/cpp/lib/ome/bioformats/detail/OMETIFF.h
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_DETAIL_OMETIFF_H
+#define OME_BIOFORMATS_DETAIL_OMETIFF_H
+
+#include <ome/bioformats/Types.h>
+
+#include <ome/common/filesystem.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace detail
+    {
+
+      /**
+       * Metadata for a single plane within an OME-TIFF file set.
+       */
+      class OMETIFFPlane
+      {
+      public:
+        /// Status of the file associated with this plane.
+        enum Status
+          {
+            UNKNOWN, ///< Not known.
+            PRESENT, ///< File exists.
+            ABSENT   ///< File is missing.
+          };
+
+        /// File containing this plane.
+        boost::filesystem::path id;
+        /// IFD index.
+        dimension_size_type ifd;
+        /// Certainty flag, for dealing with unspecified NumPlanes.
+        bool certain;
+        /// File status.
+        Status status;
+
+        /**
+         * Default constructor.
+         *
+         * File and IFD are default constructed; order is uncertain;
+         * status is unknown.
+         */
+        OMETIFFPlane():
+          id(),
+          ifd(),
+          certain(false),
+          status(UNKNOWN)
+        {
+        }
+
+        /**
+         * Construct with filename.
+         *
+         * @param id the TIFF file containing this plane.
+         *
+         * IFD is default constructed; order is uncertain; status is
+         * unknown.
+         */
+        OMETIFFPlane(const boost::filesystem::path& id):
+          id(id),
+          ifd(),
+          certain(false),
+          status(UNKNOWN)
+        {
+        }
+      };
+
+    }
+  }
+}
+
+#endif // OME_BIOFORMATS_DETAIL_OMETIFF_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -45,6 +45,7 @@
 #include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/FormatTools.h>
 #include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/detail/OMETIFF.h>
 #include <ome/bioformats/in/OMETIFFReader.h>
 #include <ome/bioformats/tiff/IFD.h>
 #include <ome/bioformats/tiff/TIFF.h>
@@ -132,43 +133,9 @@ namespace ome
             }
         }
 
-        class OMETIFFPlane
-        {
-        public:
-          /// Status of the file associated with this plane.
-          enum Status
-            {
-              UNKNOWN, ///< Not known.
-              PRESENT, ///< File exists.
-              ABSENT   ///< File is missing.
-            };
+        typedef ome::bioformats::detail::OMETIFFPlane OMETIFFPlane;
 
-          /// File containing this plane.
-          path id;
-          /// IFD index.
-          dimension_size_type ifd;
-          /// Certainty flag, for dealing with unspecified NumPlanes.
-          bool certain;
-          /// File status.
-          Status status;
-
-          OMETIFFPlane():
-            id(),
-            ifd(),
-            certain(false),
-            status(UNKNOWN)
-          {
-          }
-
-          OMETIFFPlane(const std::string& id):
-            id(id),
-            ifd(),
-            certain(false),
-            status(UNKNOWN)
-          {
-          }
-        };
-
+        /// OME-TIFF-specific core metadata.
         class OMETIFFMetadata : public CoreMetadata
         {
         public:

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -168,7 +168,8 @@ namespace ome
       {
         if (tiff)
           {
-            tiff->writeCurrentDirectory();
+            // Flush last IFD.
+            nextIFD();
             tiff->close();
             ifd.reset();
             tiff.reset();

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -1,0 +1,906 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <cassert>
+
+#include <boost/format.hpp>
+#include <boost/range/size.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+#include <ome/bioformats/FormatException.h>
+#include <ome/bioformats/FormatTools.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/out/OMETIFFWriter.h>
+#include <ome/bioformats/tiff/Field.h>
+#include <ome/bioformats/tiff/IFD.h>
+#include <ome/bioformats/tiff/Tags.h>
+#include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Util.h>
+
+#include <ome/common/endian.h>
+#include <ome/common/filesystem.h>
+
+#include <ome/internal/config.h>
+
+#include <ome/xml/meta/Convert.h>
+
+#include <tiffio.h>
+
+using boost::filesystem::path;
+
+using ome::bioformats::getOMEXML;
+using ome::bioformats::detail::WriterProperties;
+using ome::bioformats::tiff::TIFF;
+using ome::bioformats::tiff::IFD;
+using ome::bioformats::tiff::enableBigTIFF;
+
+using ome::common::make_relative;
+
+using ome::xml::model::enums::DimensionOrder;
+using ome::xml::model::enums::PixelType;
+using ome::xml::meta::convert;
+using ome::xml::meta::MetadataRetrieve;
+using ome::xml::meta::OMEXMLMetadata;
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace out
+    {
+
+      namespace
+      {
+
+        // Note that tf2, tf8 and btf are all extensions for "bigTIFF"
+        // (2nd generation TIFF, TIFF with 8-byte offsets and big TIFF
+        // respectively).
+        const char *suffixes[] = {"ome.tif", "ome.tiff", "ome.tf2", "ome.tf8", "ome.btf"};
+        const char *companion_suffixes_array[] = {"companion.ome"};
+
+        WriterProperties
+        tiff_properties()
+        {
+          WriterProperties p("OME-TIFF",
+                             "Open Microscopy Environment TIFF");
+
+          p.suffixes = std::vector<boost::filesystem::path>(suffixes,
+                                                            suffixes + boost::size(suffixes));
+
+
+          const PixelType::value_map_type& pv = PixelType::values();
+          std::set<ome::xml::model::enums::PixelType> pixeltypes;
+          for (PixelType::value_map_type::const_iterator i = pv.begin();
+               i != pv.end();
+               ++i)
+            {
+              pixeltypes.insert(i->first);
+            }
+          p.codec_pixel_types.insert(WriterProperties::codec_pixel_type_map::value_type("default", pixeltypes));
+
+          return p;
+        }
+
+        const WriterProperties props(tiff_properties());
+
+        std::vector<path> companion_suffixes(companion_suffixes_array,
+                                             companion_suffixes_array + boost::size(companion_suffixes_array));
+
+        const std::string default_description("OME-TIFF");
+
+        /**
+         * @todo Move these stream helpers to a proper location,
+         * i.e. to replicate the equivalent Java helpers.
+         */
+
+        // No switch default to avoid -Wunreachable-code errors.
+        // However, this then makes -Wswitch-default complain.  Disable
+        // temporarily.
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
+        template<typename T,
+                 typename B,
+                 typename L,
+                 typename N>
+        T
+        read_raw(std::istream&  in,
+                 EndianType     endian)
+        {
+          T ret;
+
+          switch(endian)
+            {
+            case ENDIAN_BIG:
+              {
+                B big_val;
+                in.read(reinterpret_cast<char *>(&big_val), sizeof(big_val));
+                ret = big_val;
+                break;
+              }
+            case ENDIAN_LITTLE:
+              {
+                L little_val;
+                in.read(reinterpret_cast<char *>(&little_val), sizeof(little_val));
+                ret = little_val;
+                break;
+              }
+            case ENDIAN_NATIVE:
+              {
+                N native_val;
+                in.read(reinterpret_cast<char *>(&native_val), sizeof(native_val));
+                ret = native_val;
+                break;
+              }
+            }
+
+          if (!in)
+            throw std::runtime_error("Failed to read value from stream");
+
+          return ret;
+        }
+
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
+
+        template<typename T,
+                 typename B,
+                 typename L,
+                 typename N>
+        T
+        read_raw(std::istream&  in,
+                 std::streamoff off,
+                 EndianType     endian)
+        {
+          if (in)
+            {
+              in.seekg(off, std::ios::beg);
+              if (in)
+                return read_raw<T, B, L, N>(in, endian);
+              else
+                throw std::runtime_error("Bad istream offset");
+            }
+          else
+            throw std::runtime_error("Bad istream");
+        }
+
+        uint16_t
+        read_raw_uint16(std::istream&  in,
+                        EndianType     endian)
+        {
+          return read_raw<uint16_t,
+                          boost::endian::big_uint16_t,
+                          boost::endian::little_uint16_t,
+                          boost::endian::native_uint16_t>(in, endian);
+        }
+
+        uint32_t
+        read_raw_uint32(std::istream&  in,
+                        EndianType     endian)
+        {
+          return read_raw<uint32_t,
+                          boost::endian::big_uint32_t,
+                          boost::endian::little_uint32_t,
+                          boost::endian::native_uint32_t>(in, endian);
+        }
+
+        uint64_t
+        read_raw_uint64(std::istream&  in,
+                        EndianType     endian)
+        {
+          return read_raw<uint64_t,
+                          boost::endian::big_uint64_t,
+                          boost::endian::little_uint64_t,
+                          boost::endian::native_uint64_t>(in, endian);
+        }
+
+        uint16_t
+        read_raw_uint16(std::istream&  in,
+                        std::streamoff off,
+                        EndianType     endian)
+        {
+          return read_raw<uint16_t,
+                          boost::endian::big_uint16_t,
+                          boost::endian::little_uint16_t,
+                          boost::endian::native_uint16_t>(in, off, endian);
+        }
+
+        uint32_t
+        read_raw_uint32(std::istream&  in,
+                        std::streamoff off,
+                        EndianType     endian)
+        {
+          return read_raw<uint32_t,
+                          boost::endian::big_uint32_t,
+                          boost::endian::little_uint32_t,
+                          boost::endian::native_uint32_t>(in, off, endian);
+        }
+
+        uint64_t
+        read_raw_uint64(std::istream&  in,
+                        std::streamoff off,
+                        EndianType     endian)
+        {
+          return read_raw<uint64_t,
+                          boost::endian::big_uint64_t,
+                          boost::endian::little_uint64_t,
+                          boost::endian::native_uint64_t>(in, off, endian);
+        }
+
+        // No switch default to avoid -Wunreachable-code errors.
+        // However, this then makes -Wswitch-default complain.  Disable
+        // temporarily.
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
+        template<typename T,
+                 typename B,
+                 typename L,
+                 typename N>
+        void
+        write_raw(std::ostream& in,
+                  EndianType    endian,
+                  const T&      value)
+        {
+          switch(endian)
+            {
+            case ENDIAN_BIG:
+              {
+                B big_val(value);
+                in.write(reinterpret_cast<char *>(&big_val), sizeof(big_val));
+                break;
+              }
+            case ENDIAN_LITTLE:
+              {
+                L little_val(value);
+                in.write(reinterpret_cast<char *>(&little_val), sizeof(little_val));
+                break;
+              }
+            case ENDIAN_NATIVE:
+              {
+                N native_val(value);
+                in.write(reinterpret_cast<char *>(&native_val), sizeof(native_val));
+                break;
+              }
+            }
+
+          if (!in)
+            throw std::runtime_error("Failed to write value to stream");
+        }
+
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
+
+        template<typename T,
+                 typename B,
+                 typename L,
+                 typename N>
+        void
+        write_raw(std::ostream&  in,
+                  std::streamoff off,
+                  EndianType     endian,
+                  const T&       value)
+        {
+          if (in)
+            {
+              in.seekp(off, std::ios::beg);
+              if (in)
+                write_raw<T, B, L, N>(in, endian, value);
+              else
+                throw std::runtime_error("Bad ostream offset");
+            }
+          else
+            throw std::runtime_error("Bad ostream");
+        }
+
+        void
+        write_raw_uint16(std::ostream& in,
+                         EndianType    endian,
+                         uint16_t      value)
+        {
+          return write_raw<uint16_t,
+                           boost::endian::big_uint16_t,
+                           boost::endian::little_uint16_t,
+                           boost::endian::native_uint16_t>(in, endian, value);
+        }
+
+        void
+        write_raw_uint32(std::ostream& in,
+                         EndianType    endian,
+                         uint32_t      value)
+        {
+          return write_raw<uint32_t,
+                           boost::endian::big_uint32_t,
+                           boost::endian::little_uint32_t,
+                           boost::endian::native_uint32_t>(in, endian, value);
+        }
+
+        void
+        write_raw_uint64(std::ostream& in,
+                         EndianType    endian,
+                         uint64_t      value)
+        {
+          return write_raw<uint64_t,
+                           boost::endian::big_uint64_t,
+                           boost::endian::little_uint64_t,
+                           boost::endian::native_uint64_t>(in, endian, value);
+        }
+
+        void
+        write_raw_uint16(std::ostream&  in,
+                         std::streamoff off,
+                         EndianType     endian,
+                         uint16_t       value)
+        {
+          write_raw<uint16_t,
+                    boost::endian::big_uint16_t,
+                    boost::endian::little_uint16_t,
+                    boost::endian::native_uint16_t>(in, off, endian, value);
+        }
+
+        void
+        write_raw_uint32(std::ostream&  in,
+                         std::streamoff off,
+                         EndianType     endian,
+                         uint32_t       value)
+        {
+          write_raw<uint32_t,
+                    boost::endian::big_uint32_t,
+                    boost::endian::little_uint32_t,
+                    boost::endian::native_uint32_t>(in, off, endian, value);
+        }
+
+        void
+        write_raw_uint64(std::ostream&  in,
+                         std::streamoff off,
+                         EndianType     endian,
+                         uint64_t       value)
+        {
+          write_raw<uint64_t,
+                    boost::endian::big_uint64_t,
+                    boost::endian::little_uint64_t,
+                    boost::endian::native_uint64_t>(in, off, endian, value);
+        }
+
+      }
+
+      OMETIFFWriter::TIFFState::TIFFState(ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>& tiff):
+        uuid(boost::uuids::to_string(boost::uuids::random_generator()())),
+        tiff(tiff),
+        ifdCount(0U)
+      {
+      }
+
+      OMETIFFWriter::TIFFState::~TIFFState()
+      {
+      }
+
+      OMETIFFWriter::OMETIFFWriter():
+        ome::bioformats::detail::FormatWriter(props),
+        logger(ome::common::createLogger("OMETIFFWriter")),
+        files(),
+        tiffs(),
+        currentTIFF(tiffs.end()),
+        flags(),
+        seriesState(),
+        originalMetadataRetrieve(),
+        omeMeta(),
+        bigTIFF(boost::none)
+      {
+      }
+
+      OMETIFFWriter::~OMETIFFWriter()
+      {
+      }
+
+      void
+      OMETIFFWriter::setId(const boost::filesystem::path& id)
+      {
+        // Attempt to canonicalize the path.
+        path canonicalpath = id;
+        try
+          {
+            canonicalpath = ome::common::canonical(id);
+          }
+        catch (const std::exception& /* e */)
+          {
+          }
+
+        if (currentId && *currentId == canonicalpath)
+          return;
+
+        if (seriesState.empty()) // First call to setId.
+          {
+            baseDir = (canonicalpath.parent_path());
+
+            // Create OME-XML metadata.
+            originalMetadataRetrieve = metadataRetrieve;
+            omeMeta = ome::compat::make_shared<OMEXMLMetadata>();
+            convert(*metadataRetrieve, *omeMeta);
+            omeMeta->resolveReferences();
+            metadataRetrieve = omeMeta;
+
+            // Try to fix up OME-XML metadata if inconsistent.
+            if (!validateModel(*omeMeta, false))
+              {
+                validateModel(*omeMeta, true);
+                if (validateModel(*omeMeta, false))
+                  {
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                      << "Correction of model SizeC/ChannelCount/SamplesPerPixel inconsistency attempted";
+                  }
+                else
+                  {
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::error)
+                      << "Correction of model SizeC/ChannelCount/SamplesPerPixel inconsistency attempted (but inconsistencies remain)";
+                  }
+              }
+
+            // Set up initial TIFF plane state for all planes in each series.
+            dimension_size_type seriesCount = metadataRetrieve->getImageCount();
+            seriesState.resize(seriesCount);
+            for (dimension_size_type series = 0U; series < seriesCount; ++series)
+              {
+                dimension_size_type sizeZ = metadataRetrieve->getPixelsSizeZ(series);
+                dimension_size_type sizeT = metadataRetrieve->getPixelsSizeT(series);
+                dimension_size_type effC = metadataRetrieve->getChannelCount(series);
+                dimension_size_type planeCount = sizeZ * sizeT * effC;
+
+                SeriesState& seriesMeta(seriesState.at(series));
+                seriesMeta.planes.resize(planeCount);
+
+                for (dimension_size_type plane = 0U; plane < planeCount; ++plane)
+                  {
+                    detail::OMETIFFPlane& planeMeta(seriesMeta.planes.at(plane));
+                    planeMeta.certain = true;
+                    planeMeta.status = detail::OMETIFFPlane::ABSENT; // Not written yet.
+                  }
+              }
+          }
+
+        if (flags.empty())
+          {
+            flags += 'w';
+
+            // Get expected size of pixel data.
+            ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
+            storage_size_type pixelSize = significantPixelSize(*mr);
+
+            if (enableBigTIFF(bigTIFF, pixelSize, canonicalpath, logger))
+              flags += '8';
+          }
+
+        tiff_map::iterator i = tiffs.find(canonicalpath);
+        if (i == tiffs.end())
+          {
+            detail::FormatWriter::setId(canonicalpath);
+            ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff(TIFF::open(canonicalpath, flags));
+            std::pair<tiff_map::iterator,bool> result =
+              tiffs.insert(tiff_map::value_type(*currentId, TIFFState(tiff)));
+            if (result.second) // should always be true
+              currentTIFF = result.first;
+            detail::FormatWriter::setId(id);
+            setupIFD();
+          }
+        else
+          {
+            detail::FormatWriter::setId(i->first);
+            currentTIFF = i;
+          }
+      }
+
+      void
+      OMETIFFWriter::close(bool fileOnly)
+      {
+        if (currentId)
+          {
+            // Flush last IFD.
+            nextIFD();
+
+            // Remove any BinData elements.
+            removeBinData(*omeMeta);
+            // Create UUID and TiffData elements for each series.
+            fillMetadata();
+
+            for (tiff_map::const_iterator t = tiffs.begin();
+                 t != tiffs.end();
+                 ++t)
+              {
+                // Get OME-XML for this TIFF file.
+                std::string xml = getOMEXML(t->first);
+                // Make sure file is closed before we modify it outside libtiff.
+                t->second.tiff->close();
+
+                // Save OME-XML in the TIFF.
+                saveComment(t->first, xml);
+              }
+          }
+
+        // Close any open TIFFs.
+        for (tiff_map::const_iterator t = tiffs.begin();
+             t != tiffs.end();
+             ++t)
+          t->second.tiff->close();
+        if (!fileOnly)
+          {
+            files.clear();
+            tiffs.clear();
+            currentTIFF = tiffs.end();
+            flags.clear();
+            seriesState.clear();
+            originalMetadataRetrieve.reset();
+            omeMeta.reset();
+            bigTIFF = boost::none;
+          }
+
+        ome::bioformats::detail::FormatWriter::close(fileOnly);
+      }
+
+      void
+      OMETIFFWriter::setSeries(dimension_size_type series) const
+      {
+        const dimension_size_type currentSeries = getSeries();
+        detail::FormatWriter::setSeries(series);
+
+        if (currentSeries != series)
+          {
+            nextIFD();
+            setupIFD();
+          }
+      }
+
+      void
+      OMETIFFWriter::setPlane(dimension_size_type plane) const
+      {
+        const dimension_size_type currentPlane = getPlane();
+        detail::FormatWriter::setPlane(plane);
+
+        if (currentPlane != plane)
+          {
+            nextIFD();
+            setupIFD();
+          }
+      }
+
+      void
+      OMETIFFWriter::nextIFD() const
+      {
+        currentTIFF->second.tiff->writeCurrentDirectory();
+        ++currentTIFF->second.ifdCount;
+      }
+
+      void
+      OMETIFFWriter::setupIFD() const
+      {
+        // Get current IFD.
+        ome::compat::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
+
+        // Default to single strips for now.
+        ifd->setImageWidth(getSizeX());
+        ifd->setImageHeight(getSizeY());
+
+        ifd->setTileType(tiff::STRIP);
+        ifd->setTileWidth(getSizeX());
+        ifd->setTileHeight(1U);
+
+        ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
+
+        dimension_size_type channel = coords[1];
+
+        ifd->setPixelType(getPixelType());
+        ifd->setBitsPerSample(bitsPerPixel(getPixelType()));
+        ifd->setSamplesPerPixel(getRGBChannelCount(channel));
+
+        const boost::optional<bool> interleaved(getInterleaved());
+        if (isRGB(channel) && interleaved && *interleaved)
+          ifd->setPlanarConfiguration(tiff::CONTIG);
+        else
+          ifd->setPlanarConfiguration(tiff::SEPARATE);
+
+        // This isn't necessarily always true; we might want to use a
+        // photometric interpretation other than RGB with three
+        // subchannels.
+        if (isRGB(channel) && getRGBChannelCount(channel) == 3)
+          ifd->setPhotometricInterpretation(tiff::RGB);
+        else
+          ifd->setPhotometricInterpretation(tiff::MIN_IS_BLACK);
+
+        if (currentTIFF->second.ifdCount == 0)
+          ifd->getField(ome::bioformats::tiff::IMAGEDESCRIPTION).set(default_description);
+      }
+
+      void
+      OMETIFFWriter::saveBytes(dimension_size_type plane,
+                               VariantPixelBuffer& buf,
+                               dimension_size_type x,
+                               dimension_size_type y,
+                               dimension_size_type w,
+                               dimension_size_type h)
+      {
+        assertId(currentId, true);
+
+        setPlane(plane);
+
+        // Get current IFD.
+        ome::compat::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
+
+        // Get plane metadata.
+        detail::OMETIFFPlane& planeMeta(seriesState.at(getSeries()).planes.at(plane));
+
+        ifd->writeImage(buf, x, y, w, h);
+
+        // Set plane metadata.
+        planeMeta.id = currentTIFF->first;
+        planeMeta.ifd = currentTIFF->second.ifdCount;
+        planeMeta.certain = true;
+        planeMeta.status = detail::OMETIFFPlane::PRESENT; // Plane now written.
+      }
+
+      void
+      OMETIFFWriter::fillMetadata()
+      {
+        if (!omeMeta)
+          throw std::logic_error("OMEXMLMetadata null");
+
+        dimension_size_type badPlanes = 0U;
+        for (series_list::const_iterator series = seriesState.begin();
+             series != seriesState.end();
+             ++series)
+          {
+            for (std::vector<detail::OMETIFFPlane>::const_iterator plane = series->planes.begin();
+                 plane != series->planes.end();
+                 ++plane)
+              {
+                if (plane->status != detail::OMETIFFPlane::PRESENT) // Plane not written.
+                  ++badPlanes;
+              }
+          }
+        if (badPlanes)
+          {
+            boost::format fmt
+              ("Inconsistent writer state: %1% planes have not been written");
+            fmt % badPlanes;
+            throw FormatException(fmt.str());
+          }
+
+        dimension_size_type seriesCount = getSeriesCount();
+
+        dimension_size_type nextPlane = 0U;
+        for (dimension_size_type series = 0U; series < seriesCount; ++series)
+          {
+            DimensionOrder dimOrder = metadataRetrieve->getPixelsDimensionOrder(series);
+            dimension_size_type sizeZ = metadataRetrieve->getPixelsSizeZ(series);
+            dimension_size_type sizeT = metadataRetrieve->getPixelsSizeT(series);
+            dimension_size_type effC = metadataRetrieve->getChannelCount(series);
+            dimension_size_type imageCount = sizeZ * sizeT * effC;
+
+            if (imageCount == 0)
+              {
+                omeMeta->setTiffDataPlaneCount(0, series, 0);
+              }
+
+            for (dimension_size_type plane = 0U; plane < imageCount; ++plane)
+              {
+                ome::compat::array<dimension_size_type, 3> coords =
+                  ome::bioformats::getZCTCoords(dimOrder, sizeZ, effC, sizeT, imageCount, plane);
+                const detail::OMETIFFPlane& planeState(seriesState.at(series).planes.at(plane));
+
+                tiff_map::const_iterator t = tiffs.find(planeState.id);
+                if (t != tiffs.end())
+                  {
+                    path relative(make_relative(baseDir, planeState.id));
+                    std::string uuid("urn:uuid:");
+                    uuid += t->second.uuid;
+                    omeMeta->setUUIDFileName(relative.generic_string(), series, nextPlane);
+                    omeMeta->setUUIDValue(uuid, series, nextPlane);
+
+                    // Fill in non-default TiffData attributes.
+                    omeMeta->setTiffDataFirstZ(coords[0], series, plane);
+                    omeMeta->setTiffDataFirstT(coords[2], series, plane);
+                    omeMeta->setTiffDataFirstC(coords[1], series, plane);
+                    omeMeta->setTiffDataIFD(planeState.ifd, series, plane);
+                    omeMeta->setTiffDataPlaneCount(1, series, plane);
+
+                    // The Java writer updates the TIFF IFD count
+                    // here, but not sure it's appropriate for us.
+                    ++nextPlane;
+                  }
+                else
+                  {
+                    boost::format fmt
+                      ("Inconsistent writer state: TIFF file %1% not registered with a UUID");
+                    fmt % planeState.id;
+                    throw FormatException(fmt.str());
+                  }
+              }
+          }
+      }
+
+      std::string
+      OMETIFFWriter::getOMEXML(const boost::filesystem::path& id)
+      {
+        tiff_map::const_iterator t = tiffs.find(id);
+
+        if (t == tiffs.end())
+          {
+            boost::format fmt
+              ("Inconsistent writer state: TIFF file %1% not registered with a UUID");
+            fmt % id;
+            throw FormatException(fmt.str());
+          }
+
+        path relative(make_relative(baseDir, id));
+        std::string uuid("urn:uuid:");
+        uuid += t->second.uuid;
+        omeMeta->setUUID(uuid);
+
+        return bioformats::getOMEXML(*omeMeta, true);
+      }
+
+      void
+      OMETIFFWriter::saveComment(const boost::filesystem::path& id,
+                                 const std::string&             xml)
+      {
+        // Open TIFF as a raw stream.
+        boost::iostreams::stream<boost::iostreams::file_descriptor> in(id);
+        in.imbue(std::locale::classic());
+
+        // Check endianness.
+        EndianType endian = ENDIAN_NATIVE;
+        char endianchars[2];
+        in >> endianchars[0] >> endianchars[1];
+
+        if (endianchars[0] == 'I' && endianchars[1] == 'I')
+          endian = ENDIAN_LITTLE;
+        else if (endianchars[0] == 'M' && endianchars[1] == 'M')
+          endian = ENDIAN_BIG;
+        else
+          {
+            boost::format fmt
+              ("%1% is not a valid TIFF file: Invalid endian header \"%2%%3%\"");
+            fmt % id % endianchars[0] % endianchars[1];
+            throw FormatException(fmt.str());
+          }
+
+        // Check version.
+        uint16_t version = read_raw_uint16(in, endian);
+
+        bool bigOffsets;
+        if (version == 0x2A)
+          bigOffsets = false;
+        else if (version == 0x2B)
+          bigOffsets = true;
+        else
+          {
+            boost::format fmt
+              ("%1% is not a valid TIFF file: Invalid version %2%");
+            fmt % id % version;
+            throw FormatException(fmt.str());
+          }
+
+        // Check offset size and bail out if unusual.
+        uint16_t offsetSize = bigOffsets ? read_raw_uint16(in, endian) : 4U;
+        if (offsetSize != 4U && offsetSize != 8U)
+          {
+            boost::format fmt
+              ("%1% uses a nonstandard offset size of %2% bytes");
+            fmt % id % offsetSize;
+            throw FormatException(fmt.str());
+          }
+
+        // Get offset of IFD 0 for later use.
+        uint64_t ifd0Offset = bigOffsets ? read_raw_uint64(in, 8, endian) : read_raw_uint32(in, 4, endian);
+
+        // Append XML text with a NUL terminator at end of file, noting the offset.
+        in.seekp(0, std::ios::end);
+        uint64_t descOffset = in.tellp();
+        in << xml << '\0';
+
+        // Get number of directory entries for IFD 0.
+        uint64_t entries = bigOffsets ? read_raw_uint64(in, ifd0Offset, endian) : read_raw_uint16(in, ifd0Offset, endian);
+
+        // Has ImageDescription been found?
+        bool found = false;
+        // Loop over directory entries to find ImageDescription.
+        for (uint64_t i = 0; i < entries; ++i)
+          {
+            const uint64_t tagOff = bigOffsets ? ifd0Offset + 8 + (i * 20) : ifd0Offset + 2 + (i * 12);
+            const uint16_t tagid = read_raw_uint16(in, tagOff + 0, endian);
+            const uint16_t tagtype = read_raw_uint16(in, tagOff + 2, endian);
+
+            if (tagid != TIFFTAG_IMAGEDESCRIPTION)
+              continue;
+            found = true;
+
+            if (tagtype != TIFF_ASCII)
+            {
+              boost::format fmt
+                ("Invalid TIFF ImageDescription type %1%");
+              fmt % tagtype;
+              throw FormatException(fmt.str());
+            }
+
+            uint64_t count = bigOffsets ? read_raw_uint64(in, tagOff + 4, endian) : read_raw_uint32(in, tagOff + 4, endian);
+            if (count != default_description.size() + 1)
+              throw FormatException("TIFF ImageDescription size is incorrect");
+
+            // Overwrite count and offset for the ImageDescription text.
+            if (bigOffsets)
+              {
+                write_raw_uint64(in, tagOff + 4, endian, xml.size() + 1);
+                write_raw_uint64(in, tagOff + 12, endian, descOffset);
+              }
+            else
+              {
+                write_raw_uint32(in, tagOff + 4, endian, xml.size() + 1);
+                write_raw_uint32(in, tagOff + 8, endian, descOffset);
+              }
+          }
+
+        if (!found)
+          throw FormatException("Could not find TIFF ImageDescription tag");
+        if (!in)
+          throw FormatException("Error writing TIFF ImageDescription tag");
+
+        in.close();
+      }
+
+      void
+      OMETIFFWriter::setBigTIFF(boost::optional<bool> big)
+      {
+        bigTIFF = big;
+      }
+
+      boost::optional<bool>
+      OMETIFFWriter::getBigTIFF() const
+      {
+        return bigTIFF;
+      }
+
+    }
+  }
+}

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -518,7 +518,7 @@ namespace ome
         if (i == tiffs.end())
           {
             detail::FormatWriter::setId(canonicalpath);
-            ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff(TIFF::open(canonicalpath, flags));
+            ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff(ome::bioformats::tiff::TIFF::open(canonicalpath, flags));
             std::pair<tiff_map::iterator,bool> result =
               tiffs.insert(tiff_map::value_type(*currentId, TIFFState(tiff)));
             if (result.second) // should always be true

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
@@ -1,0 +1,253 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2006 - 2014 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_OUT_OMETIFFWRITER_H
+#define OME_BIOFORMATS_OUT_OMETIFFWRITER_H
+
+#include <ome/bioformats/detail/FormatWriter.h>
+#include <ome/bioformats/detail/OMETIFF.h>
+
+#include <ome/common/filesystem.h>
+#include <ome/common/log.h>
+
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+    namespace tiff
+    {
+
+      class TIFF;
+      class IFD;
+
+    }
+
+    namespace out
+    {
+
+      /**
+       * TIFF writer with support for OME-XML metadata.
+       */
+      class OMETIFFWriter : public ::ome::bioformats::detail::FormatWriter
+      {
+      protected:
+        /// Message logger.
+        ome::common::Logger logger;
+
+        /// Map filename to UUID.
+        typedef std::map<boost::filesystem::path, std::string> file_uuid_map;
+
+        // In the Java reader, this is uuids + ifdCounts
+        /// State of TIFF file.
+        struct TIFFState
+        {
+          /// UUID of file.
+          std::string uuid;
+          /// TIFF file handle.
+          ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
+          /// Number of IFDs written.
+          dimension_size_type ifdCount;
+
+          /**
+           * Constructor.
+           *
+           * @param tiff the TIFF file for which to cache state.
+           */
+          TIFFState(ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>& tiff);
+
+          /// Destructor.
+          ~TIFFState();
+        };
+
+        /// Map filename to TIFF state.
+        typedef std::map<boost::filesystem::path, TIFFState> tiff_map;
+
+        // In the Java reader, this is imageLocations.
+        /// Current state of an image series.
+        struct SeriesState
+        {
+          /// Current state of each plane in an image series.
+          std::vector<detail::OMETIFFPlane> planes;
+        };
+
+        /// Vector of SeriesState objects.
+        typedef std::vector<SeriesState> series_list;
+
+        /// Base path for computing relative paths in the OME-XML.
+        boost::filesystem::path baseDir;
+
+        /// UUID to filename mapping.
+        file_uuid_map files;
+
+        // Mutable to allow opening TIFFs when const.
+        /// Open TIFF files
+        mutable tiff_map tiffs;
+
+        /// Current TIFF file.
+        tiff_map::iterator currentTIFF;
+
+        /// TIFF flags.
+        std::string flags;
+        
+        /// State of each series.
+        series_list seriesState;
+
+        /**
+         * Original MetadataRetrieve.
+         *
+         * We replace it with the generated OME-XML metadata store.
+         *
+         * @todo Overriding getMetadataRetrieve will be a cleaner
+         * solution, but need to eliminate all direct use of
+         * metadataRetrieve in all writers first.
+         */
+        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> originalMetadataRetrieve;
+
+        /// OME-XML metadata for embedding in the TIFF.
+        ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> omeMeta;
+
+      private:
+        /// Write a Big TIFF
+        boost::optional<bool> bigTIFF;
+
+      public:
+        /// Constructor.
+        OMETIFFWriter();
+
+        /// Destructor.
+        virtual
+        ~OMETIFFWriter();
+
+        // Documented in superclass.
+        void
+        setId(const boost::filesystem::path& id);
+
+        // Documented in superclass.
+        void
+        close(bool fileOnly = false);
+
+        using FormatWriter::saveBytes;
+
+        // Documented in superclass.
+        void
+        setSeries(dimension_size_type series) const;
+
+        // Documented in superclass.
+        void
+        setPlane(dimension_size_type plane) const;
+
+      protected:
+        /// Flush current IFD and create new IFD.
+        void
+        nextIFD() const;
+
+        /// Set IFD parameters for the current series.
+        void
+        setupIFD() const;
+
+      public:
+        // Documented in superclass.
+        void
+        saveBytes(dimension_size_type plane,
+                  VariantPixelBuffer& buf,
+                  dimension_size_type x,
+                  dimension_size_type y,
+                  dimension_size_type w,
+                  dimension_size_type h);
+
+      private:
+        /**
+         * Fill MetadataStore with cached metadata.
+         *
+         * Set Image, Channel and TiffData elements.
+         */
+        void
+        fillMetadata();
+
+        /**
+         * Get OME-XML for embedding into the specified TIFF file.
+         *
+         * @param id the TIFF in which to embed the OME-XML.
+         * @returns the OME-XML text for embedding.
+         */
+        std::string
+        getOMEXML(const boost::filesystem::path& id);
+
+        /**
+         * Save OME-XML text in the first IFD of the specified TIFF file.
+         *
+         * @param id the TIFF in which to embed the OME-XML.
+         * @param xml the OME-XML text to embed.
+         */
+        void
+        saveComment(const boost::filesystem::path& id,
+                    const std::string&             xml);
+
+        // Java getUUID unimplemented; see uuid member of TIFFState.
+
+        // Java planeCount() unimplemented; use getImageCount()
+        // instead.  Note the java implementation special-cases
+        // certain behaviour such as interleaving for certain pixel
+        // types; here the caller can specify exactly what they want.
+
+      public:
+        /**
+         * @copydoc MinimalTIFFWriter::setBigTIFF(boost::optional<bool>)
+         */
+        void
+        setBigTIFF(boost::optional<bool> big = true);
+
+        /**
+         * @copydoc MinimalTIFFWriter::getBigTIFF() const
+         */
+        boost::optional<bool>
+        getBigTIFF() const;
+      };
+
+    }
+  }
+}
+
+#endif // OME_BIOFORMATS_OUT_OMETIFFWRITER_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/bioformats/tiff/Util.h
+++ b/cpp/lib/ome/bioformats/tiff/Util.h
@@ -135,6 +135,7 @@ namespace ome
        * @param pixelSize the total size of pixel data to be written
        * @param filename the name of the TIFF file to write (if a
        * known BigTIFF extension is used, BigTIFF will be enabled).
+       * @param logger the logger to use to log errors.
        * @returns @c true to enable BigTIFF or @c false to disable.
        */
       bool

--- a/cpp/lib/ome/common/filesystem.h
+++ b/cpp/lib/ome/common/filesystem.h
@@ -133,6 +133,47 @@ namespace ome
         }
     }
 # endif // OME_HAVE_BOOST_FILESYSTEM_CANONICAL
+
+    /**
+     * Make a relative path.
+     *
+     * @param from the start (reference) path.
+     * @param to the end path (to make relative to the start path).
+     * @returns the relative path.
+     */
+    inline
+    boost::filesystem::path
+    make_relative(boost::filesystem::path from,
+                  boost::filesystem::path to)
+    {
+      from = absolute(from);
+      to = absolute(to);
+      boost::filesystem::path ret;
+      boost::filesystem::path::const_iterator itrFrom(from.begin());
+      boost::filesystem::path::const_iterator itrTo(to.begin());
+
+      // Find common base
+      for(boost::filesystem::path::const_iterator toEnd(to.end()), fromEnd(from.end());
+          itrFrom != fromEnd && itrTo != toEnd && *itrFrom == *itrTo;
+          ++itrFrom, ++itrTo);
+
+      // Navigate backwards in directory to reach previously found base
+      for(boost::filesystem::path::const_iterator fromEnd(from.end());
+          itrFrom != fromEnd;
+          ++itrFrom )
+        {
+          if((*itrFrom) != ".")
+            ret /= "..";
+        }
+      // Now navigate down the directory branch
+      for (boost::filesystem::path::iterator begin = itrTo;
+           begin != to.end();
+           ++begin)
+        ret /= *begin;
+
+      return ret;
+    }
+
   }
 }
 

--- a/cpp/lib/ome/common/xml/dom/Document.h
+++ b/cpp/lib/ome/common/xml/dom/Document.h
@@ -46,7 +46,9 @@
 #include <string>
 #include <ostream>
 
+#include <xercesc/dom/DOMComment.hpp>
 #include <xercesc/dom/DOMDocument.hpp>
+#include <xercesc/dom/DOMNode.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
 
 #include <ome/common/filesystem.h>
@@ -154,6 +156,7 @@ namespace ome
             return *this;
           }
 
+          
           /**
            * Create Element with namespace.
            *
@@ -169,6 +172,21 @@ namespace ome
             common::xml::String xname(name);
 
             return Element((*this)->createElementNS(xns, xname), false);
+          }
+
+          /**
+           * Create Comment.
+           *
+           * @param comment the comment text.
+           * @returns the created Node.
+           */
+          Node
+          createComment(const std::string& comment)
+          {
+            common::xml::String text(comment);
+
+            xercesc::DOMNode *node = dynamic_cast<xercesc::DOMNode *>((*this)->createComment(text));
+            return Node(node, false);
           }
 
           /**

--- a/cpp/lib/ome/internal/CMakeLists.txt
+++ b/cpp/lib/ome/internal/CMakeLists.txt
@@ -39,11 +39,12 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 
-set(ome_internal_static_headers)
+set(ome_internal_static_headers
+    url.h)
 
 set(ome_internal_generated_headers
-   ${CMAKE_CURRENT_BINARY_DIR}/config.h
-   ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h
+    ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 
 # Dump header list for testing
 header_include_list_write(ome_internal_static_headers ome_internal_generated_headers ome/internal ${PROJECT_BINARY_DIR}/cpp/test/ome-internal)

--- a/cpp/lib/ome/internal/url.h
+++ b/cpp/lib/ome/internal/url.h
@@ -1,0 +1,53 @@
+/*
+ * #%L
+ * OME-INTERNAL C++ headers for internal use only
+ * %%
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_INTERNAL_URL_H
+#define OME_INTERNAL_URL_H
+
+// Public URLs for embedding in messages, metadata, etc.
+ 
+/// URL of Bio-Formats web page.
+#define URL_BIO_FORMATS "http://www.openmicroscopy.org/site/products/bio-formats"
+
+/// URL of 'Bio-Formats C++ overview' web page.
+#define URL_BIO_FORMATS_LIBRARIES "http://www.openmicroscopy.org/site/support/bio-formats/developers/cpp/overview.html"
+
+/// URL of OME-TIFF web page.
+#define URL_OME_TIFF "http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/"
+
+#endif // OME_INTERNAL_URL_H

--- a/cpp/lib/ome/qtwidgets/GLView2D.cpp
+++ b/cpp/lib/ome/qtwidgets/GLView2D.cpp
@@ -56,7 +56,9 @@
 #include <iostream>
 
 // Only Microsoft issue warnings about correct behaviour...
+#ifdef _MSVC_VER
 #pragma warning(disable : 4351)
+#endif
 
 namespace ome
 {
@@ -323,6 +325,14 @@ namespace ome
       lastPos = event->pos();
     }
 
+    // No switch default to avoid -Wunreachable-code errors.
+    // However, this then makes -Wswitch-default complain.  Disable
+    // temporarily.
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
     void
     GLView2D::mouseMoveEvent(QMouseEvent *event)
     {
@@ -346,6 +356,10 @@ namespace ome
       }
       lastPos = event->pos();
     }
+
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
 
     void
     GLView2D::timerEvent (QTimerEvent *event)

--- a/cpp/lib/ome/test/test.h
+++ b/cpp/lib/ome/test/test.h
@@ -45,6 +45,7 @@
 // for INSTANTIATE_TEST_CASE_P.
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wvariadic-macros"
 #  pragma GCC diagnostic ignored "-Wctor-dtor-privacy"
 #endif
 

--- a/cpp/test/ome-bioformats/CMakeLists.txt
+++ b/cpp/test/ome-bioformats/CMakeLists.txt
@@ -132,6 +132,12 @@ if(BUILD_TESTS)
 
   bf_add_test(ome-bioformats/minimaltiffwriter minimaltiffwriter)
 
+  add_executable(ometiffwriter ometiffwriter.cpp tiffsamples.cpp)
+  target_link_libraries(ometiffwriter ome-bioformats)
+  target_link_libraries(ometiffwriter ome-test)
+
+  bf_add_test(ome-bioformats/ometiffwriter ometiffwriter)
+
   add_executable(tiffreader tiffreader.cpp)
   target_link_libraries(tiffreader ome-bioformats)
   target_link_libraries(tiffreader ome-test)

--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -1,0 +1,197 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * %%
+ * Copyright © 2013 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <stdexcept>
+#include <vector>
+
+#include <ome/bioformats/CoreMetadata.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/VariantPixelBuffer.h>
+#include <ome/bioformats/out/OMETIFFWriter.h>
+#include <ome/bioformats/tiff/Field.h>
+#include <ome/bioformats/tiff/IFD.h>
+#include <ome/bioformats/tiff/Tags.h>
+#include <ome/bioformats/tiff/TIFF.h>
+#include <ome/bioformats/tiff/Util.h>
+
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+#include <ome/test/test.h>
+
+#include "tiffsamples.h"
+
+using ome::bioformats::dimension_size_type;
+using ome::bioformats::CoreMetadata;
+using ome::bioformats::VariantPixelBuffer;
+using ome::bioformats::out::OMETIFFWriter;
+using ome::bioformats::tiff::IFD;
+using ome::bioformats::tiff::TIFF;
+
+using namespace boost::filesystem;
+
+class TIFFTestParameters
+{
+public:
+
+  std::string file;
+  dimension_size_type sizeT;
+
+  TIFFTestParameters(const std::string& file,
+                     dimension_size_type sizeT):
+    file(file),
+    sizeT(sizeT)
+  {}
+};
+
+template<class charT, class traits>
+inline std::basic_ostream<charT,traits>&
+operator<< (std::basic_ostream<charT,traits>& os,
+            const TIFFTestParameters& tp)
+{
+  os << tp.file;
+
+  return os;
+}
+
+class TIFFWriterTest : public ::testing::TestWithParam<TileTestParameters>
+{
+public:
+  ome::compat::shared_ptr<TIFF> tiff;
+  uint32_t iwidth;
+  uint32_t iheight;
+  ome::bioformats::tiff::PlanarConfiguration planarconfig;
+  uint16_t samples;
+
+  OMETIFFWriter tiffwriter;
+  path testfile;
+
+  void
+  SetUp()
+  {
+    const TileTestParameters& params = GetParam();
+
+    path dir(PROJECT_BINARY_DIR "/cpp/test/ome-bioformats/data");
+    testfile = dir / (std::string("ometiffwriter-") + path(params.file).filename().string());
+    testfile.replace_extension(".ome.tiff");
+
+    ASSERT_NO_THROW(tiff = TIFF::open(params.file, "r"));
+    ASSERT_TRUE(static_cast<bool>(tiff));
+    ome::compat::shared_ptr<IFD> ifd;
+    ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
+    ASSERT_TRUE(static_cast<bool>(ifd));
+
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::IMAGEWIDTH).get(iwidth));
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::IMAGELENGTH).get(iheight));
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::PLANARCONFIG).get(planarconfig));
+    ASSERT_NO_THROW(ifd->getField(ome::bioformats::tiff::SAMPLESPERPIXEL).get(samples));
+  }
+
+  void
+  TearDown()
+  {
+    // Delete file (if any)
+    // if (boost::filesystem::exists(testfile))
+    //   boost::filesystem::remove(testfile);
+  }
+};
+
+TEST_P(TIFFWriterTest, setId)
+{
+  const TileTestParameters& params = GetParam();
+
+  std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList;
+  for (TIFF::const_iterator i = tiff->begin();
+       i != tiff->end();
+       ++i)
+    {
+      ome::compat::shared_ptr<CoreMetadata> c = ome::bioformats::tiff::makeCoreMetadata(**i);
+      seriesList.push_back(c);
+    }
+
+  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  ome::bioformats::fillMetadata(*meta, seriesList);
+  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
+
+  tiffwriter.setMetadataRetrieve(retrieve);
+
+  bool interleaved = true;
+
+  tiffwriter.setInterleaved(interleaved);
+
+  ASSERT_NO_THROW(tiffwriter.setId(testfile));
+
+  VariantPixelBuffer buf;
+  dimension_size_type currentSeries = 0U;
+  for (dimension_size_type i = 0U; i < seriesList.size(); ++i)
+    {
+      ome::compat::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
+      ASSERT_TRUE(static_cast<bool>(ifd));
+      ifd->readImage(buf);
+
+      // Make a second buffer to ensure correct ordering for saveBytes.
+      ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+      shape[ome::bioformats::DIM_SPATIAL_X] = ifd->getImageWidth();
+      shape[ome::bioformats::DIM_SPATIAL_Y] = ifd->getImageHeight();
+      shape[ome::bioformats::DIM_SUBCHANNEL] = ifd->getSamplesPerPixel();
+      shape[ome::bioformats::DIM_SPATIAL_Z] = shape[ome::bioformats::DIM_TEMPORAL_T] = shape[ome::bioformats::DIM_CHANNEL] =
+        shape[ome::bioformats::DIM_MODULO_Z] = shape[ome::bioformats::DIM_MODULO_T] = shape[ome::bioformats::DIM_MODULO_C] = 1;
+
+      ome::bioformats::PixelBufferBase::storage_order_type order(ome::bioformats::PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, interleaved));
+
+      VariantPixelBuffer src(shape, ifd->getPixelType(), order);
+      src = buf;
+
+      ASSERT_NO_THROW(tiffwriter.setSeries(currentSeries));
+      ASSERT_NO_THROW(tiffwriter.saveBytes(0, src));
+      ++currentSeries;
+    }
+  tiffwriter.close();
+}
+
+std::vector<TileTestParameters> params(find_tile_tests());
+
+// Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
+// this is solely to work around a missing prototype in gtest.
+#ifdef __GNUC__
+#  if defined __clang__ || defined __APPLE__
+#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#  endif
+#  pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+
+INSTANTIATE_TEST_CASE_P(TIFFWriterVariants, TIFFWriterTest, ::testing::ValuesIn(params));

--- a/cpp/test/ome-common/CMakeLists.txt
+++ b/cpp/test/ome-common/CMakeLists.txt
@@ -56,6 +56,12 @@ if(BUILD_TESTS)
 
   bf_add_test(ome-common/endian endian)
 
+  add_executable(filesystem filesystem.cpp)
+  target_link_libraries(filesystem ome-common)
+  target_link_libraries(filesystem ome-test)
+
+  bf_add_test(ome-common/filesystem filesystem)
+
   add_executable(module module.cpp)
   target_link_libraries(module ome-common)
   target_link_libraries(module ome-test)

--- a/cpp/test/ome-common/filesystem.cpp
+++ b/cpp/test/ome-common/filesystem.cpp
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * %%
+ * Copyright © 2006 - 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <ome/common/filesystem.h>
+
+#include <ome/test/test.h>
+
+using boost::filesystem::path;
+
+using ome::common::make_relative;
+
+TEST(Filesystem, Relative)
+{
+  path basepath(PROJECT_BINARY_DIR "/cpp/test/ome-common/data");
+  boost::filesystem::create_directories(basepath / "testdir1/lib");
+  boost::filesystem::create_directories(basepath / "testdir1/include");
+  boost::filesystem::create_directories(basepath / "testdir2/share");
+
+  path a(basepath / "testdir1" / "include");
+  path b(basepath / "testdir1" / "lib");
+  path c(basepath / "testdir1");
+  path d(basepath / "testdir2");
+
+  ASSERT_TRUE(path("../lib")          == make_relative(a, b));
+  ASSERT_TRUE(path("lib")             == make_relative(c, b));
+  ASSERT_TRUE(path("../testdir1/lib") == make_relative(d, b));
+}

--- a/cpp/test/ome-common/variant.cpp
+++ b/cpp/test/ome-common/variant.cpp
@@ -38,7 +38,7 @@
 
 #include <ome/common/variant.h>
 
-#include <gtest/gtest.h>
+#include <ome/test/test.h>
 
 typedef boost::variant<int,double,std::string> var;
 


### PR DESCRIPTION
- Minor refactoring to allow code sharing between reader and writer
- Some additional small warning cleanups
- Add writer and tests

--------

Notable differences from the Java OMETiffWriter implementation:

- `close()` does not have a `canReallyClose` finally block; since by this point we already validated and written out all pixel data and metadata, it's not clear what this is for given that there's nothing we can really do.  What's the rationale for this, given that closing should be terminal and unconditional, particularly resetting the IFD counts which looks like it might screw up the metadata?
- Channel count/Channel objects are fixed up if broken, so some of the special casing isn't needed here, e.g. the equivalent of `planeIndex` in `populateImage`.
- The IFD object isn't currently exposed to the user, so strip/tile sizes etc. aren't settable.  We could either add specific methods to control this, or expose setPlane in the public API (you need to set the current plane before getting the current IFD, since this forces the flushing of the old IFD for which the metadata and pixel data are already set and written).

--------

Testing:

- Build normally and run `make test` or `./bf-test ./cpp/test/ome-bioformats/ometiffwriter` to run just the writer tests.
- Look at cpp/test/ome-bioformats/data/ometiffwriter-*.ome.tiff.  These should all be valid OME-TIFF files which should work with `bf-test info`, `showinf` and `tiffinfo`, and import into OMERO.
- Make the following edit:

```
% git diff
diff --git a/cpp/test/ome-bioformats/ometiffwriter.cpp b/cpp/test/ome-bioformats/ometiffwriter.cpp
index e633d39..e38d3df 100644
--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -148,6 +148,7 @@ TEST_P(TIFFWriterTest, setId)
   ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
+  tiffwriter.setBigTIFF(true);
 
   bool interleaved = true;
 
```

Run `make && ./cpp/test/ome-bioformats/ometiffwriter` and retest as above.  This should work, but test that it's working with BigTIFF files as well.

Example:

```
% file /tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff 
/tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff: Big TIFF image data, little-endian

% tiffinfo /tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff
TIFF Directory at offset 0x3010 (12304)
  Image Width: 64 Image Length: 64
  Bits/Sample: 8
  Sample Format: unsigned integer
  Compression Scheme: None
  Photometric Interpretation: RGB color
  Samples/Pixel: 3
  Rows/Strip: 1
  Planar Configuration: single image plane
  ImageDescription: <?xml version="1.0" encoding="UTF-8" standalone="no" ?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" UUID="urn:uuid:7b3b0eb8-686e-48c0-bb00-8c896e64f32e" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06 http://www.openmicroscopy.org/Schemas/OME/2013-06/ome.xsd"><!-- Warning: this comment is within an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/ --><Image ID="Image:0"><Pixels BigEndian="false" DimensionOrder="XYCZT" ID="Pixels:0" Interleaved="true" SignificantBits="8" SizeC="3" SizeT="1" SizeX="64" SizeY="64" SizeZ="1" Type="uint8"><Channel ID="Channel:0:0" SamplesPerPixel="3"/><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1"><UUID FileName="ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff">urn:uuid:7b3b0eb8-686e-48c0-bb00-8c896e64f32e</UUID></TiffData></Pixels></Image></OME>
  Software: OME Bio-Formats (C++) 5.1.1

% ./bf-test info /tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff 
Image: /tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff
Using reader: OME-TIFF (Open Microscopy Environment TIFF)
Reader setup took 00:00:00.046091

Filename = "/tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff"
Used files = ["/tmp/b/cpp/test/ome-bioformats/data/ometiffwriter-data-layout-64x64-chunky-strips-01.ome.tiff"]

Reading core metadata
Series count = 1

Series #0:
        Image count = 1
        RGB = [true] ([3]) 
        Interleaved = false
        Indexed = false
        Width = 64
        Height = 64
        SizeZ = 1 (effectively 1)
        SizeT = 1 (effectively 1)
        SizeC = 3 (effectively 1)
        Thumbnail size = 64 × 64
        Endianness = little
        DimensionOrder = XYCZT (certain)
        PixelType = uint8
        Bits per Pixel = 8
        MetadataComplete = true
        ThumbnailSeries = false

No global metadata
```