### PR TITLE
fix iteration order for nameStack in Leica readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -1054,7 +1055,9 @@ public class LIFReader extends FormatReader {
         suffix = root.getAttribute("Description");
       }
       StringBuffer key = new StringBuffer();
-      for (String k : nameStack) {
+      final Iterator<String> nameStackIterator = nameStack.descendingIterator();
+      while (nameStackIterator.hasNext()) {
+        final String k = nameStackIterator.next();
         key.append(k);
         key.append("|");
       }

--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -299,7 +300,9 @@ public class LeicaHandler extends BaseHandler {
     if (!canParse) return;
 
     StringBuffer key = new StringBuffer();
-    for (String k : nameStack) {
+    final Iterator<String> nameStackIterator = nameStack.descendingIterator();
+    while (nameStackIterator.hasNext()) {
+      final String k = nameStackIterator.next();
       key.append(k);
       key.append("|");
     }


### PR DESCRIPTION
https://github.com/openmicroscopy/bioformats/commit/7345a479d072953d6669c9d8cde140311d136afa introduced a possible bug wherein the natural iteration order for `nameStack` is reversed. This PR reverts that change, following the pattern of #1784.

--no-rebase