### PR TITLE
fixing link & typo

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1763,14 +1763,14 @@ developer = ZSoft Corporation
 bsd = yes
 export = no
 weHave = * several .pcx files \n
-* the ability to generate additional .pcx filse
+* the ability to generate additional .pcx files
 pixelsRating = Very good
 metadataRating = Poor
 opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = PCXReader.java
-notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com.au/microscopy/en_au/downloads/lsm-5-series.html>`_.
+notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_.
 
 [PCORAW]
 extensions = .pcoraw, .rec


### PR DESCRIPTION
Australian link has been giving a 404 since 6th May so I've updated with the international English language link. Also fixed a typo I spotted.

This should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-5.1-merge-docs/ green again once it's been built by the autogen job.