### PR TITLE
cpp: common: Add workaround for broken header in Boost 1.58

### DIFF
--- a/cpp/lib/ome/common/variant.h
+++ b/cpp/lib/ome/common/variant.h
@@ -69,6 +69,11 @@
 #include <boost/mpl/transform_view.hpp>
 #include <boost/mpl/vector.hpp>
 
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105800
+# include <boost/type_traits/remove_cv.hpp>
+#endif
+
 #include <boost/variant/apply_visitor.hpp>
 //#include <boost/variant/multivisitors.hpp>
 #include <boost/variant/get.hpp>


### PR DESCRIPTION
See https://svn.boost.org/trac/boost/ticket/11283
`boost/variant/detail/element_index.hpp` uses `boost::remove_cv` from type_traits, but does not include `boost/type_traits/remove_cv.hpp`, leading to build failure.  Include this header before including variant headers to work around this.

--------

Testing: Builds should remain green.  Should build with current homebrew on MacOS X using Boost 1.58.  Note: Building with -Dcxxstd-autodetect=ON will fail due to https://svn.boost.org/trac/boost/ticket/11285 for which I don't yet have a workaround (other than setting it to OFF, which is the default).