### PR TITLE
TIFF: reduce memory required for large files

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -63,6 +63,7 @@ public class EPSReader extends FormatReader {
 
   private boolean isTiff;
   private IFDList ifds;
+  private int[] map;
 
   // -- Constructor --
 
@@ -117,7 +118,6 @@ public class EPSReader extends FormatReader {
       long[] offsets = ifds.get(0).getStripOffsets();
       in.seek(offsets[0]);
 
-      int[] map = ifds.get(0).getIFDIntArray(IFD.COLOR_MAP);
       if (map == null) {
         readPlane(in, x, y, w, h, buf);
         return buf;
@@ -194,6 +194,7 @@ public class EPSReader extends FormatReader {
       start = 0;
       binary = isTiff = false;
       ifds = null;
+      map = null;
     }
   }
 
@@ -228,6 +229,7 @@ public class EPSReader extends FormatReader {
       ifds = tp.getIFDs();
 
       IFD firstIFD = ifds.get(0);
+      map = tp.getColorMap(firstIFD);
 
       m.sizeX = (int) firstIFD.getImageWidth();
       m.sizeY = (int) firstIFD.getImageLength();

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -348,6 +348,12 @@ public class MinimalTiffReader extends FormatReader {
     return buf;
   }
 
+  /* @see loci.formats.IFormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    initTiffParser();
+  }
+
   /* @see loci.formats.IFormatReader#close(boolean) */
   @Override
   public void close(boolean fileOnly) throws IOException {

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -54,6 +54,7 @@ import loci.formats.tiff.IFD;
 import loci.formats.tiff.IFDList;
 import loci.formats.tiff.PhotoInterp;
 import loci.formats.tiff.TiffCompression;
+import loci.formats.tiff.TiffIFDEntry;
 import loci.formats.tiff.TiffParser;
 
 /**
@@ -147,16 +148,17 @@ public class MinimalTiffReader extends FormatReader {
     IFD lastIFD = ifds.get(lastPlane);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 8) {
-      int[] colorMap = lastIFD.getIFDIntArray(IFD.COLOR_MAP);
-      if (colorMap == null) {
+      TiffIFDEntry map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
+      if (map == null) {
         // it's possible that the LUT is only present in the first IFD
         if (lastPlane != 0) {
           lastIFD = ifds.get(0);
-          colorMap = lastIFD.getIFDIntArray(IFD.COLOR_MAP);
-          if (colorMap == null) return null;
+          map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
+          if (map == null) return null;
         }
         else return null;
       }
+      int[] colorMap = (int[]) tiffParser.getIFDValue(map);
 
       byte[][] table = new byte[3][colorMap.length / 3];
       int next = 0;
@@ -184,16 +186,17 @@ public class MinimalTiffReader extends FormatReader {
     IFD lastIFD = ifds.get(lastPlane);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 16 && bits[0] > 8) {
-      int[] colorMap = lastIFD.getIFDIntArray(IFD.COLOR_MAP);
-      if (colorMap == null || colorMap.length < 65536 * 3) {
+      TiffIFDEntry map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
+      if (map == null || map.getValueCount() < 65536 * 3) {
         // it's possible that the LUT is only present in the first IFD
         if (lastPlane != 0) {
           lastIFD = ifds.get(0);
-          colorMap = lastIFD.getIFDIntArray(IFD.COLOR_MAP);
-          if (colorMap == null || colorMap.length < 65536 * 3) return null;
+          map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
+          if (map == null || map.getValueCount() < 65536 * 3) return null;
         }
         else return null;
       }
+      int[] colorMap = (int[]) tiffParser.getIFDValue(map);
 
       short[][] table = new short[3][colorMap.length / 3];
       int next = 0;

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -148,17 +148,16 @@ public class MinimalTiffReader extends FormatReader {
     IFD lastIFD = ifds.get(lastPlane);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 8) {
-      TiffIFDEntry map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
-      if (map == null) {
+      int[] colorMap = tiffParser.getColorMap(lastIFD);
+      if (colorMap == null) {
         // it's possible that the LUT is only present in the first IFD
         if (lastPlane != 0) {
           lastIFD = ifds.get(0);
-          map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
-          if (map == null) return null;
+          colorMap = tiffParser.getColorMap(lastIFD);
+          if (colorMap == null) return null;
         }
         else return null;
       }
-      int[] colorMap = (int[]) tiffParser.getIFDValue(map);
 
       byte[][] table = new byte[3][colorMap.length / 3];
       int next = 0;
@@ -186,17 +185,16 @@ public class MinimalTiffReader extends FormatReader {
     IFD lastIFD = ifds.get(lastPlane);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 16 && bits[0] > 8) {
-      TiffIFDEntry map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
-      if (map == null || map.getValueCount() < 65536 * 3) {
+      int[] colorMap = tiffParser.getColorMap(lastIFD);
+      if (colorMap == null || colorMap.length < 65536 * 3) {
         // it's possible that the LUT is only present in the first IFD
         if (lastPlane != 0) {
           lastIFD = ifds.get(0);
-          map = (TiffIFDEntry) lastIFD.get(IFD.COLOR_MAP);
-          if (map == null || map.getValueCount() < 65536 * 3) return null;
+          colorMap = tiffParser.getColorMap(lastIFD);
+          if (colorMap == null || colorMap.length < 65536 * 3) return null;
         }
         else return null;
       }
-      int[] colorMap = (int[]) tiffParser.getIFDValue(map);
 
       short[][] table = new short[3][colorMap.length / 3];
       int next = 0;

--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -197,6 +197,8 @@ public class IFD extends HashMap<Integer, Object> {
   public static final int SHARPNESS = 41994;
   public static final int SUBJECT_DISTANCE_RANGE = 41996;
 
+  private transient TiffCompression compression;
+
   // -- Constructors --
 
   public IFD() {
@@ -390,6 +392,14 @@ public class IFD extends HashMap<Integer, Object> {
       int[] integers = (int[]) value;
       results = new long[integers.length];
       for (int i=0; i<integers.length; i++) results[i] = integers[i];
+    }
+    else if (value instanceof OnDemandLongArray) {
+      try {
+        results = ((OnDemandLongArray) value).toArray();
+      }
+      catch (IOException e) {
+        throw new FormatException(e);
+      }
     }
     else if (value != null) {
       throw new FormatException(getIFDTagName(tag) +
@@ -658,8 +668,11 @@ public class IFD extends HashMap<Integer, Object> {
    * @throws FormatException if there is a problem parsing the IFD metadata.
    */
   public TiffCompression getCompression() throws FormatException {
-    return TiffCompression.get(getIFDIntValue(
+    if (compression == null) {
+      compression = TiffCompression.get(getIFDIntValue(
         COMPRESSION, TiffCompression.UNCOMPRESSED.getCode()));
+    }
+    return compression;
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -197,8 +197,6 @@ public class IFD extends HashMap<Integer, Object> {
   public static final int SHARPNESS = 41994;
   public static final int SUBJECT_DISTANCE_RANGE = 41996;
 
-  private transient TiffCompression compression;
-
   // -- Constructors --
 
   public IFD() {
@@ -668,11 +666,8 @@ public class IFD extends HashMap<Integer, Object> {
    * @throws FormatException if there is a problem parsing the IFD metadata.
    */
   public TiffCompression getCompression() throws FormatException {
-    if (compression == null) {
-      compression = TiffCompression.get(getIFDIntValue(
+    return TiffCompression.get(getIFDIntValue(
         COMPRESSION, TiffCompression.UNCOMPRESSED.getCode()));
-    }
-    return compression;
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/tiff/OnDemandLongArray.java
+++ b/components/formats-bsd/src/loci/formats/tiff/OnDemandLongArray.java
@@ -54,6 +54,14 @@ public class OnDemandLongArray {
     this.size = size;
   }
 
+  public RandomAccessInputStream getStream() {
+    return stream;
+  }
+
+  public void setStream(RandomAccessInputStream in) {
+    stream = in;
+  }
+
   public long get(int index) throws IOException {
     long fp = stream.getFilePointer();
     stream.seek(start + index * 8);
@@ -66,8 +74,18 @@ public class OnDemandLongArray {
     return size;
   }
 
+  public long[] toArray() throws IOException {
+    long[] arr = new long[size];
+    for (int i=0; i<arr.length; i++) {
+      arr[i] = get(i);
+    }
+    return arr;
+  }
+
   public void close() throws IOException {
-    stream.close();
+    if (stream != null) {
+      stream.close();
+    }
     stream = null;
     size = 0;
     start = 0;

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -630,6 +630,24 @@ public class TiffParser {
     return firstIFD.getComment();
   }
 
+  /**
+   * Retrieve the color map associated with the given IFD.
+   */
+  public int[] getColorMap(IFD ifd) throws IOException {
+    Object map = ifd.get(IFD.COLOR_MAP);
+    if (map == null) {
+      return null;
+    }
+    int[] colorMap = null;
+    if (map instanceof TiffIFDEntry) {
+      colorMap = (int[]) getIFDValue((TiffIFDEntry) map);
+    }
+    else if (map instanceof int[]) {
+      colorMap = (int[]) map;
+    }
+    return colorMap;
+  }
+
   // -- TiffParser methods - image reading --
 
   public byte[] getTile(IFD ifd, byte[] buf, int row, int col)

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -452,7 +452,9 @@ public class TiffParser {
     }
 
     for (TiffIFDEntry entry : entries) {
-      if (entry.getValueCount() < 10 * 1024 * 1024 || entry.getTag() < 32768) {
+      if ((entry.getValueCount() < 10 * 1024 * 1024 || entry.getTag() < 32768) &&
+        entry.getTag() != IFD.COLOR_MAP)
+      {
         ifd.put(new Integer(entry.getTag()), getIFDValue(entry));
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/IPWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPWReader.java
@@ -99,8 +99,10 @@ public class IPWReader extends FormatReader {
     IFD firstIFD = tp.getFirstIFD();
     int[] bits = firstIFD.getBitsPerSample();
     if (bits[0] <= 8) {
-      int[] colorMap = (int[]) firstIFD.getIFDValue(IFD.COLOR_MAP);
-      if (colorMap == null) return null;
+      int[] colorMap = tp.getColorMap(firstIFD);
+      if (colorMap == null) {
+        return null;
+      }
 
       byte[][] table = new byte[3][colorMap.length / 3];
       int next = 0;

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -944,7 +944,7 @@ public class MIASReader extends FormatReader {
     IFD ifd = tp.getFirstIFD();
     s.close();
     if (ifd == null) return null;
-    int[] colorMap = ifd.getIFDIntArray(IFD.COLOR_MAP);
+    int[] colorMap = tp.getColorMap(ifd);
     if (colorMap == null) return null;
 
     int nEntries = colorMap.length / 3;


### PR DESCRIPTION
See https://trello.com/c/dxVTjrxb/235-logbot-out-of-memory-detected-nightshade.

This makes better use of the ```OnDemandLongArray``` class to prevent keeping all tile/strip offsets and byte counts in memory.  The amount of memory required during setId with or without memoization should be greatly reduced for files with a large number of strips or tiles.
