### PR TITLE
CellSens VSI: fix channel count when multiple pyramids exist

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1362,8 +1362,8 @@ public abstract class FormatReader extends FormatHandler
     if (no < 0 || no >= core.size()) {
       throw new IllegalArgumentException("Invalid series: " + no);
     }
-    coreIndex = no;
     series = coreIndexToSeries(no);
+    coreIndex = no;
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1364,6 +1364,7 @@ public abstract class FormatReader extends FormatHandler
     }
     series = coreIndexToSeries(no);
     coreIndex = no;
+    resolution = no - seriesToCoreIndex(series);
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -762,6 +762,7 @@ public class CellSensReader extends FormatReader {
 
     int nextPyramid = 0;
     for (int i=0; i<core.size();) {
+      setCoreIndex(i);
       Pyramid pyramid = null;
       if (nextPyramid < pyramids.size()) {
         pyramid = pyramids.get(nextPyramid++);
@@ -864,6 +865,7 @@ public class CellSensReader extends FormatReader {
 
       i += core.get(i).resolutionCount;
     }
+    setCoreIndex(0);
   }
 
   // -- Helper methods --
@@ -1105,6 +1107,14 @@ public class CellSensReader extends FormatReader {
       int tIndex = tv == null ? -1 : tv + 2;
       int zIndex = zv == null ? -1 : zv + 2;
       int cIndex = cv == null ? -1 : cv + 2;
+
+      if ((tIndex < 0 || tIndex > 2) && (zIndex < 0 || zIndex > 2 ) ||
+        (cIndex < 0 || cIndex > 2))
+      {
+        tIndex--;
+        zIndex--;
+        cIndex--;
+      }
 
       if (tv == null && zv == null) {
         if (t.coordinate.length > 4 && cv == null) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -387,9 +387,6 @@ public class CellSensReader extends FormatReader {
   private boolean foundChannelTag = false;
   private int dimensionTag;
 
-  private HashMap<String, Integer> dimensionOrdering =
-    new HashMap<String, Integer>();
-
   private HashMap<Integer, byte[]> backgroundColor = new HashMap<Integer, byte[]>();
 
   private int metadataIndex = -1;
@@ -584,7 +581,6 @@ public class CellSensReader extends FormatReader {
       inDimensionProperties = false;
       foundChannelTag = false;
       dimensionTag = 0;
-      dimensionOrdering.clear();
       backgroundColor.clear();
       metadataIndex = -1;
       previousTag = 0;
@@ -889,8 +885,27 @@ public class CellSensReader extends FormatReader {
     t.coordinate[0] = col;
     t.coordinate[1] = row;
 
-    for (String dim : dimensionOrdering.keySet()) {
-      int index = dimensionOrdering.get(dim) + 2;
+    int resIndex = getResolution();
+    int pyramidIndex = getSeries();
+    if (hasFlattenedResolutions()) {
+      int index = 0;
+      pyramidIndex = 0;
+      for (int i=0; i<core.size(); ) {
+        if (index + core.get(i).resolutionCount <= getSeries()) {
+          index += core.get(i).resolutionCount;
+          i += core.get(i).resolutionCount;
+          pyramidIndex++;
+        }
+        else {
+          resIndex = getSeries() - index;
+          break;
+        }
+      }
+    }
+
+    Pyramid pyramid = pyramids.get(pyramidIndex);
+    for (String dim : pyramid.dimensionOrdering.keySet()) {
+      int index = pyramid.dimensionOrdering.get(dim) + 2;
 
       if (dim.equals("Z")) {
         t.coordinate[index] = zct[0];
@@ -900,21 +915,6 @@ public class CellSensReader extends FormatReader {
       }
       else if (dim.equals("T")) {
         t.coordinate[index] = zct[2];
-      }
-    }
-
-    int resIndex = getResolution();
-    if (hasFlattenedResolutions()) {
-      int index = 0;
-      for (int i=0; i<core.size(); ) {
-        if (index + core.get(i).resolutionCount <= getSeries()) {
-          index += core.get(i).resolutionCount;
-          i += core.get(i).resolutionCount;
-        }
-        else {
-          resIndex = getSeries() - index;
-          break;
-        }
       }
     }
 
@@ -1097,29 +1097,51 @@ public class CellSensReader extends FormatReader {
     int[] maxC = new int[maxResolution];
     int[] maxT = new int[maxResolution];
 
+    HashMap<String, Integer> dimOrder = pyramids.get(s).dimensionOrdering;
+
     for (TileCoordinate t : tmpTiles) {
       int resolution = usePyramid ? t.coordinate[t.coordinate.length - 1] : 0;
 
-      Integer tv = dimensionOrdering.get("T");
-      Integer zv = dimensionOrdering.get("Z");
-      Integer cv = dimensionOrdering.get("C");
+      Integer tv = dimOrder.get("T");
+      Integer zv = dimOrder.get("Z");
+      Integer cv = dimOrder.get("C");
 
       int tIndex = tv == null ? -1 : tv + 2;
       int zIndex = zv == null ? -1 : zv + 2;
       int cIndex = cv == null ? -1 : cv + 2;
 
-      if ((tIndex < 0 || tIndex > 2) && (zIndex < 0 || zIndex > 2 ) ||
-        (cIndex < 0 || cIndex > 2))
+      if (usePyramid && tIndex == t.coordinate.length - 1) {
+        tv = null;
+        tIndex = -1;
+      }
+      if (usePyramid && zIndex == t.coordinate.length - 1) {
+        zv = null;
+        zIndex = -1;
+      }
+
+      int upperLimit = usePyramid ? t.coordinate.length - 1 : t.coordinate.length;
+      if ((tIndex < 0 || tIndex >= upperLimit) &&
+        (zIndex < 0 || zIndex >= upperLimit) &&
+        (cIndex < 0 || cIndex >= upperLimit))
       {
         tIndex--;
         zIndex--;
         cIndex--;
+        if (dimOrder.containsKey("T")) {
+          dimOrder.put("T", tIndex - 2);
+        }
+        if (dimOrder.containsKey("Z")) {
+          dimOrder.put("Z", zIndex - 2);
+        }
+        if (dimOrder.containsKey("C")) {
+          dimOrder.put("C", cIndex - 2);
+        }
       }
 
       if (tv == null && zv == null) {
         if (t.coordinate.length > 4 && cv == null) {
           cIndex = 2;
-          dimensionOrdering.put("C", cIndex - 2);
+          dimOrder.put("C", cIndex - 2);
         }
 
         if (t.coordinate.length > 4) {
@@ -1130,7 +1152,7 @@ public class CellSensReader extends FormatReader {
             tIndex = cIndex + 2;
           }
           if (tIndex < t.coordinate.length) {
-            dimensionOrdering.put("T", tIndex - 2);
+            dimOrder.put("T", tIndex - 2);
           }
           else {
             tIndex = -1;
@@ -1145,7 +1167,7 @@ public class CellSensReader extends FormatReader {
             zIndex = cIndex + 1;
           }
           if (zIndex < t.coordinate.length) {
-            dimensionOrdering.put("Z", zIndex - 2);
+            dimOrder.put("Z", zIndex - 2);
           }
           else {
             zIndex = -1;
@@ -1676,22 +1698,24 @@ public class CellSensReader extends FormatReader {
         }
 
         if (inDimensionProperties) {
-          if (tag == Z_START && !dimensionOrdering.containsValue(dimensionTag)) {
-            dimensionOrdering.put("Z", dimensionTag);
+          Pyramid p = pyramids.get(metadataIndex);
+          if (tag == Z_START && !p.dimensionOrdering.containsValue(dimensionTag)) {
+            p.dimensionOrdering.put("Z", dimensionTag);
           }
           else if ((tag == TIME_START || tag == DIMENSION_VALUE_ID) &&
-            !dimensionOrdering.containsValue(dimensionTag))
+            !p.dimensionOrdering.containsValue(dimensionTag))
           {
-            dimensionOrdering.put("T", dimensionTag);
+            p.dimensionOrdering.put("T", dimensionTag);
           }
-          else if (tag == LAMBDA_START && !dimensionOrdering.containsValue(dimensionTag))
+          else if (tag == LAMBDA_START &&
+            !p.dimensionOrdering.containsValue(dimensionTag))
           {
-            dimensionOrdering.put("L", dimensionTag);
+            p.dimensionOrdering.put("L", dimensionTag);
           }
           else if (tag == CHANNEL_PROPERTIES && foundChannelTag &&
-            !dimensionOrdering.containsValue(dimensionTag))
+            !p.dimensionOrdering.containsValue(dimensionTag))
           {
-            dimensionOrdering.put("C", dimensionTag);
+            p.dimensionOrdering.put("C", dimensionTag);
           }
           else if (tag == CHANNEL_PROPERTIES) {
             foundChannelTag = true;
@@ -2246,35 +2270,6 @@ public class CellSensReader extends FormatReader {
     }
 
     @Override
-    public int hashCode() {
-      int[] lengths = new int[coordinate.length];
-      lengths[0] = 0;
-      lengths[1] = 0;
-
-      for (String dim : dimensionOrdering.keySet()) {
-        int index = dimensionOrdering.get(dim) + 2;
-
-        if (dim.equals("Z")) {
-          lengths[index] = getSizeZ();
-        }
-        else if (dim.equals("C")) {
-          lengths[index] = getEffectiveSizeC();
-        }
-        else if (dim.equals("T")) {
-          lengths[index] = getSizeT();
-        }
-      }
-
-      for (int i=0; i<lengths.length; i++) {
-        if (lengths[i] == 0) {
-          lengths[i] = 1;
-        }
-      }
-
-      return FormatTools.positionToRaster(lengths, coordinate);
-    }
-
-    @Override
     public String toString() {
       StringBuffer b = new StringBuffer("{");
       for (int p : coordinate) {
@@ -2331,6 +2326,9 @@ public class CellSensReader extends FormatReader {
 
     public Hashtable<String, Object> originalMetadata =
       new Hashtable<String, Object>();
+
+    public HashMap<String, Integer> dimensionOrdering =
+      new HashMap<String, Integer>();
   }
 
 }

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -1322,8 +1322,8 @@ namespace ome
             fmt % index;
             throw std::logic_error(fmt.str());
           }
-        this->coreIndex = index;
         this->series = coreIndexToSeries(index);
+        this->coreIndex = index;
         this->resolution = index - seriesToCoreIndex(this->series);
       }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12848.

To test, import the following .vsi files into OMERO:

```
cellsens/qa-11039/Image_01.vsi
cellsens/olivier/small-tiles/*.vsi
cellsens/olivier/14-09-2012/Image_07.vsi
```

Verify that each results in multiple pyramids, some of which will have a single channel and some of which will have multiple channels.  Open each pyramid in the full viewer and zoom/pan to verify that there is nothing obviously wrong with the image.

When reading through the code, please pay special attention to 76b37a2, as this is a very subtle change to how ```FormatReader.setCoreIndex(int)``` works.
