### PR TITLE
ND2: better timestamp and plane position population

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -111,6 +111,7 @@ public class ND2Handler extends BaseHandler {
   private ArrayList<Boolean> validLoopState = new ArrayList<Boolean>();
 
   private boolean canAdjustDimensions = true;
+  private boolean firstTimeLoop = true;
 
   // -- Constructor --
 
@@ -926,8 +927,9 @@ public class ND2Handler extends BaseHandler {
       }
       else if (key.equals("Time Loop")) {
         int v = Integer.parseInt(value);
-        if (v <= nImages) {
+        if (v <= nImages && firstTimeLoop) {
           core.get(0).sizeT = v;
+          firstTimeLoop = false;
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1861,15 +1861,19 @@ public class NativeND2Reader extends FormatReader {
     for (int i=0; i<getSeriesCount(); i++) {
       if (tsT.size() > 0) {
         setSeries(i);
+        int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());
         for (int n=0; n<getImageCount(); n++) {
           int[] coords = getZCTCoords(n);
-          int stampIndex = coords[2] + i * getSizeT();
+          int stampIndex = getIndex(coords[0], split ? 0 : coords[1], 0);
+          stampIndex += (coords[2] * getSeriesCount() + i) * zcPlanes;
           if (tsT.size() == getImageCount()) stampIndex = n;
           else if (tsT.size() == getSizeZ()) {
             stampIndex = coords[0];
           }
-          double stamp = tsT.get(stampIndex).doubleValue();
-          store.setPlaneDeltaT(new Time(stamp, UNITS.S), i, n);
+          if (stampIndex < tsT.size()) {
+            double stamp = tsT.get(stampIndex).doubleValue();
+            store.setPlaneDeltaT(new Time(stamp, UNITS.S), i, n);
+          }
 
           int index = i * getSizeC() + coords[1];
           if (exposureTime.size() == getSizeC()) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1858,10 +1858,10 @@ public class NativeND2Reader extends FormatReader {
     if (handler != null && handler.getExposureTimes().size() > 0) {
       exposureTime = handler.getExposureTimes();
     }
+    int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());
     for (int i=0; i<getSeriesCount(); i++) {
       if (tsT.size() > 0) {
         setSeries(i);
-        int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());
         for (int n=0; n<getImageCount(); n++) {
           int[] coords = getZCTCoords(n);
           int stampIndex = getIndex(coords[0], split ? 0 : coords[1], 0);
@@ -1893,11 +1893,9 @@ public class NativeND2Reader extends FormatReader {
 
       String pos = "for position";
       for (int n=0; n<getImageCount(); n++) {
-        int index = n * getSeriesCount() + i;
-        if (split) {
-          int planes = getImageCount() / getSizeC();
-          index = (n / getSizeC()) * getSeriesCount() + i;
-        }
+        int[] coords = getZCTCoords(n);
+        int index = coords[0];
+        index += (coords[2] * getSeriesCount() + i) * zcPlanes;
         if (posX != null) {
           if (index >= posX.size()) index = i;
           if (index < posX.size()) {

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -100,6 +100,10 @@ public class Configuration {
   private static final String SERIES_COUNT = "series_count";
   private static final String CHANNEL_COUNT = "channel_count";
   private static final String DATE = "Date";
+  private static final String DELTA_T = "DeltaT_";
+  private static final String X_POSITION = "PositionX_";
+  private static final String Y_POSITION = "PositionY_";
+  private static final String Z_POSITION = "PositionZ_";
 
   // -- Fields --
 
@@ -291,6 +295,15 @@ public class Configuration {
   public Time getExposureTime(int channel) {
     String exposure = currentTable.get(EXPOSURE_TIME + channel);
     return exposure == null ? null : new Time(new Double(exposure), UNITS.S);
+  }
+
+  public boolean hasDeltaT(int plane) {
+    return currentTable.containsKey(DELTA_T + plane);
+  }
+
+  public Double getDeltaT(int plane) {
+    String deltaT = currentTable.get(DELTA_T + plane);
+    return deltaT == null ? null : new Double(deltaT);
   }
 
   public Double getEmissionWavelength(int channel) {
@@ -522,6 +535,25 @@ public class Configuration {
             retrieve.getDetectorSettingsID(series, c));
         }
         catch (NullPointerException e) { }
+      }
+
+      for (int p=0; p<reader.getImageCount(); p++) {
+        Time deltaT = retrieve.getPlaneDeltaT(series, p);
+        if (deltaT != null) {
+          seriesTable.put(DELTA_T + p, deltaT.value(UNITS.S).toString());
+        }
+        Length xPos = retrieve.getPlanePositionX(series, p);
+        if (xPos != null) {
+          seriesTable.put(X_POSITION + p, xPos.value(UNITS.REFERENCEFRAME).toString());
+        }
+        Length yPos = retrieve.getPlanePositionY(series, p);
+        if (yPos != null) {
+          seriesTable.put(Y_POSITION + p, yPos.value(UNITS.REFERENCEFRAME).toString());
+        }
+        Length zPos = retrieve.getPlanePositionZ(series, p);
+        if (zPos != null) {
+          seriesTable.put(Z_POSITION + p, zPos.value(UNITS.REFERENCEFRAME).toString());
+        }
       }
 
       ini.add(seriesTable);

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -297,13 +297,24 @@ public class Configuration {
     return exposure == null ? null : new Time(new Double(exposure), UNITS.S);
   }
 
-  public boolean hasDeltaT(int plane) {
-    return currentTable.containsKey(DELTA_T + plane);
-  }
-
   public Double getDeltaT(int plane) {
     String deltaT = currentTable.get(DELTA_T + plane);
     return deltaT == null ? null : new Double(deltaT);
+  }
+
+  public Double getPositionX(int plane) {
+    String pos = currentTable.get(X_POSITION + plane);
+    return pos == null ? null : new Double(pos);
+  }
+
+  public Double getPositionY(int plane) {
+    String pos = currentTable.get(Y_POSITION + plane);
+    return pos == null ? null : new Double(pos);
+  }
+
+  public Double getPositionZ(int plane) {
+    String pos = currentTable.get(Z_POSITION + plane);
+    return pos == null ? null : new Double(pos);
   }
 
   public Double getEmissionWavelength(int channel) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1132,6 +1132,88 @@ public class FormatReaderTest {
   }
 
   @Test(groups = {"all", "fast", "automated"})
+  public void testPlanePositions() {
+    if (config == null) throw new SkipException("No config tree");
+    String testName = "PlanePositions";
+    if (!initFile()) result(testName, false, "initFile");
+    IMetadata retrieve = (IMetadata) reader.getMetadataStore();
+
+    for (int i=0; i<reader.getSeriesCount(); i++) {
+      config.setSeries(i);
+
+      for (int p=0; p<reader.getImageCount(); p++) {
+        Length posX = null;
+        Length posY = null;
+        Length posZ = null;
+        try {
+          posX = retrieve.getPlanePositionX(i, p);
+        }
+        catch (IndexOutOfBoundsException e) { }
+        try {
+          posY = retrieve.getPlanePositionY(i, p);
+        }
+        catch (IndexOutOfBoundsException e) { }
+        try {
+          posZ = retrieve.getPlanePositionZ(i, p);
+        }
+        catch (IndexOutOfBoundsException e) { }
+
+        Double expectedX = config.getPositionX(p);
+        Double expectedY = config.getPositionY(p);
+        Double expectedZ = config.getPositionZ(p);
+
+        if (posX == null && expectedX == null) {
+        }
+        else if (posX == null) {
+          result(testName, false, "missing X position for series " + i + ", plane " + p);
+          return;
+        }
+        else if (expectedX != null) {
+          Double x = posX.value(UNITS.REFERENCEFRAME).doubleValue();
+          if (Math.abs(x - expectedX) > Constants.EPSILON) {
+            result(testName, false, "X position series " + i + ", plane " + p +
+              " (expected " + expectedX + ", actual " + x + ")");
+            return;
+          }
+        }
+
+        if (posY == null && expectedY == null) {
+        }
+        else if (posY == null) {
+          result(testName, false, "missing Y position for series " + i + ", plane " + p);
+          return;
+        }
+        else if (expectedY != null) {
+          Double y = posY.value(UNITS.REFERENCEFRAME).doubleValue();
+          if (Math.abs(y - expectedY) > Constants.EPSILON) {
+            result(testName, false, "Y position series " + i + ", plane " + p +
+              " (expected " + expectedY + ", actual " + y + ")");
+            return;
+          }
+        }
+
+        if (posZ == null && expectedZ == null) {
+        }
+        else if (posZ == null) {
+          result(testName, false, "missing Z position for series " + i + ", plane " + p);
+          return;
+        }
+        else if (expectedZ != null) {
+          Double z = posZ.value(UNITS.REFERENCEFRAME).doubleValue();
+          if (Math.abs(z - expectedZ) > Constants.EPSILON) {
+            result(testName, false, "Z position series " + i + ", plane " + p +
+              " (expected " + expectedZ + ", actual " + z + ")");
+            return;
+          }
+        }
+      }
+    }
+    result(testName, true);
+  }
+
+
+
+  @Test(groups = {"all", "fast", "automated"})
   public void testEmissionWavelengths() {
     if (config == null) throw new SkipException("No config tree");
     String testName = "EmissionWavelengths";

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1093,6 +1093,40 @@ public class FormatReaderTest {
   }
 
   @Test(groups = {"all", "fast", "automated"})
+  public void testDeltaT() {
+    if (config == null) throw new SkipException("No config tree");
+    String testName = "DeltaT";
+    if (!initFile()) result(testName, false, "initFile");
+    IMetadata retrieve = (IMetadata) reader.getMetadataStore();
+
+    for (int i=0; i<reader.getSeriesCount(); i++) {
+      config.setSeries(i);
+
+      for (int p=0; p<reader.getImageCount(); p++) {
+        Time deltaT = retrieve.getPlaneDeltaT(i, p);
+        Double expectedDeltaT = config.getDeltaT(p);
+
+        if (deltaT == null && expectedDeltaT == null) {
+          continue;
+        }
+
+        if (deltaT == null) {
+          result(testName, false, "missing series " + i + ", plane " + p);
+          return;
+        }
+
+        Double seconds = deltaT.value(UNITS.S).doubleValue();
+        if (Math.abs(seconds - expectedDeltaT) > Constants.EPSILON) {
+          result(testName, false, "series " + i + ", plane " + p +
+            " (expected " + expectedDeltaT + ", actual " + seconds + ")");
+          return;
+        }
+      }
+    }
+    result(testName, true);
+  }
+
+  @Test(groups = {"all", "fast", "automated"})
   public void testEmissionWavelengths() {
     if (config == null) throw new SkipException("No config tree");
     String testName = "EmissionWavelengths";

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1103,7 +1103,11 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       for (int p=0; p<reader.getImageCount(); p++) {
-        Time deltaT = retrieve.getPlaneDeltaT(i, p);
+        Time deltaT = null;
+        try {
+          deltaT = retrieve.getPlaneDeltaT(i, p);
+        }
+        catch (IndexOutOfBoundsException e) { }
         Double expectedDeltaT = config.getDeltaT(p);
 
         if (deltaT == null && expectedDeltaT == null) {
@@ -1114,12 +1118,13 @@ public class FormatReaderTest {
           result(testName, false, "missing series " + i + ", plane " + p);
           return;
         }
-
-        Double seconds = deltaT.value(UNITS.S).doubleValue();
-        if (Math.abs(seconds - expectedDeltaT) > Constants.EPSILON) {
-          result(testName, false, "series " + i + ", plane " + p +
-            " (expected " + expectedDeltaT + ", actual " + seconds + ")");
-          return;
+        if (expectedDeltaT != null) {
+          Double seconds = deltaT.value(UNITS.S).doubleValue();
+          if (Math.abs(seconds - expectedDeltaT) > Constants.EPSILON) {
+            result(testName, false, "series " + i + ", plane " + p +
+              " (expected " + expectedDeltaT + ", actual " + seconds + ")");
+            return;
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12880.

To test, use each of the .nd2 files from QA 11064.  Compare the DeltaT, PositionX, PositionY, and PositionZ values from ```showinf -nopix -omexml``` with the Time, X, Y, and Z values in the ```Recorded Data``` tab of NIS Elements Viewer's ```Image Properties``` window.  Also verify that the Z, C, T, and series counts match the Z, C, T, and XY position counts in NIS Elements.

This does also add DeltaT and Position* automated tests, so that going forward we'll have an easier time of catching and fixing these sorts of problems.  I have not gone through all of the .nd2 samples and updated configuration files to include the correct DeltaT and Position* values (it's only been done for ```nd2/qa-11064```).  Follow-up Trello card is https://trello.com/c/ZTCDiSU9/181-deltat-position-configuration-updates, likely for 5.1.3.