### PR TITLE
cpp: ome-xml: Correct intermittent incorrect Timestamp timezone offset parsing

### DIFF
--- a/cpp/lib/ome/xml/model/primitives/Timestamp.h
+++ b/cpp/lib/ome/xml/model/primitives/Timestamp.h
@@ -131,84 +131,90 @@ namespace ome
         operator>> (std::basic_istream<charT,traits>& is,
                     Timestamp& timestamp)
         {
-          Timestamp::value_type value;
-
-          // Save locale.
-          std::locale savedlocale = is.getloc();
-
-          try
+          std::istream::sentry s(is);
+          if (s)
             {
-              boost::posix_time::time_input_facet *input_facet =
-                new boost::posix_time::time_input_facet();
-              input_facet->set_iso_extended_format();
-              std::locale iso8601_loc(std::locale::classic(), input_facet);
+              Timestamp::value_type value;
 
-              is.imbue(iso8601_loc);
-              is >> value;
+              // Save locale.
+              std::locale savedlocale = is.getloc();
 
-              if (is)
+              try
                 {
-                  // Check for zone offset
-                  std::char_traits<char>::int_type tztype = is.peek();
-                  if(tztype != std::char_traits<char>::eof())
-                    {
-                      if (tztype == 'Z')
-                        {
-                          is.ignore(); // Drop above from istream
-                          // If Z, we're already using UTC, so don't apply numeric offsets
-                        }
-                      else if (tztype == '-' || tztype == '+')
-                        {
-                          is.ignore(); // Drop above from istream
-                          if (is.rdbuf()->in_avail() >= 4) // Need 4 numeric chars
-                            {
-                              // Check that the next 4 characters are only numeric
-                              char inchars[4];
-                              is.read(&inchars[0], 4);
-                              for (int i=0; i < 4; ++i)
-                                if (inchars[i] < '0' || inchars[i] > '9')
-                                  is.setstate(std::ios::failbit);
+                  boost::posix_time::time_input_facet *input_facet =
+                    new boost::posix_time::time_input_facet();
+                  input_facet->set_iso_extended_format();
+                  std::locale iso8601_loc(std::locale::classic(), input_facet);
 
-                              if (is)
-                                {
-                                  // Get offset value
-                                  int offset;
-                                  std::istringstream valueis(inchars);
-                                  valueis >> offset;
-                                  if (valueis)
-                                    {
-                                      if (tztype == '+')
-                                        offset = -offset;
-                                      // Offset in                       hours,      minutes,    seconds
-                                      boost::posix_time::time_duration d(offset/100, offset%100, 0);
-                                      // Apply offset
-                                      value += d;
-                                    }
-                                  else
-                                    is.setstate(std::ios::failbit);
-                                }
-                            }
-                          else
+                  is.imbue(iso8601_loc);
+                  is >> value;
+
+                  if (is)
+                    {
+                      // Check for zone offset
+                      std::char_traits<char>::int_type tztype = is.peek();
+                      if(tztype != std::char_traits<char>::eof())
+                        {
+                          if (tztype == 'Z')
                             {
-                              is.setstate(std::ios::failbit);
+                              is.ignore(); // Drop above from istream
+                              // If Z, we're already using UTC, so don't apply numeric offsets
+                            }
+                          else if (tztype == '-' || tztype == '+')
+                            {
+                              is.ignore(); // Drop above from istream
+                              if (is.rdbuf()->in_avail() >= 4) // Need 4 numeric chars
+                                {
+                                  // Check that the next 4 characters are only numeric
+                                  std::string inchars(4, ' ');
+                                  is.read(&inchars[0], 4);
+                                  for (std::string::const_iterator i = inchars.begin();
+                                       i != inchars.end();
+                                       ++i)
+                                    if (*i < '0' || *i > '9')
+                                      is.setstate(std::ios::failbit);
+
+                                  if (is)
+                                    {
+                                      // Get offset value
+                                      int offset;
+                                      std::istringstream valueis(inchars);
+                                      valueis >> offset;
+                                      if (valueis)
+                                        {
+                                          if (tztype == '+')
+                                            offset = -offset;
+                                          // Offset in                       hours,      minutes,    seconds
+                                          boost::posix_time::time_duration d(offset/100, offset%100, 0);
+                                          // Apply offset
+                                          value += d;
+                                        }
+                                      else
+                                        is.setstate(std::ios::failbit);
+                                    }
+                                }
+                              else
+                                {
+                                  is.setstate(std::ios::failbit);
+                                }
                             }
                         }
                     }
+
+                  if (is)
+                    timestamp = Timestamp(value);
+                  else
+                    throw std::runtime_error("Failed to parse timestamp");
+                }
+              catch (const std::exception& e)
+                {
+                  is.imbue(savedlocale);
+                  throw;
                 }
 
-              if (is)
-                timestamp = Timestamp(value);
-              else
-                throw std::runtime_error("Failed to parse timestamp");
-            }
-          catch (const std::exception& e)
-            {
               is.imbue(savedlocale);
-              throw;
+              return is;
             }
-
-          is.imbue(savedlocale);
-          return is;
         }
 
       }


### PR DESCRIPTION
- Add sentry (not for this bug, just for general correctness)
- Use a string rather than a character array for the TZ offset;
  the use of a character array led to inconsistent behaviour since
  it decays to a char* and hence requires NUL termination, which
  may or may not occur depending on whether the memory has been
  used before, which is unpredictable.

Note: whitespace-only diff: https://github.com/openmicroscopy/bioformats/pull/1799/files?w=1

--------

Testing:

I've used Ubuntu 14.04 to reproduce and test.  Do a build like normal, then run

```
while ./bf-test ./cpp/test/ome-xml/timestamp ; do : ; done
```

Without this PR, you should see the tests fail intermittently if you run this a few times.  With the PR, no failures should be apparent.

Note that you can test on other platforms, but I can't reproduce on e.g. current MacOS or FreeBSD--the compiler and libc obviously use different memory allocation patterns which don't cause the parsing code to trip up, so the above is recommended.