### PR TITLE
Use native kHz units for DeltavisionReader read-out rate

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -1114,13 +1114,13 @@ public class DeltavisionReader extends FormatReader {
         else if (key.equals("Speed")) {
           value = value.replaceAll("KHz", "");
           try {
-            double mhz = Double.parseDouble(value) / 1000;
+            double khz = Double.parseDouble(value);
             String detectorID = MetadataTools.createLSID("Detector", 0, 0);
             store.setDetectorID(detectorID, 0, 0);
             for (int series=0; series<getSeriesCount(); series++) {
               for (int c=0; c<getSizeC(); c++) {
                 store.setDetectorSettingsReadOutRate(
-                        new Frequency(mhz, UNITS.HZ), series, c);
+                        new Frequency(khz, UNITS.KHZ), series, c);
                 store.setDetectorSettingsID(detectorID, series, c);
               }
             }


### PR DESCRIPTION
This should use the native kHz unit included in the log file. Additionally this fixes a bug introduced in 5.1.0 with an incorrect conversion.