### PR TITLE
C++: Document and correct use of qtwidgets namespace

### DIFF
--- a/cpp/lib/ome/qtwidgets/GLView2D.h
+++ b/cpp/lib/ome/qtwidgets/GLView2D.h
@@ -54,6 +54,7 @@
 
 namespace ome
 {
+  /// Qt5 widgets for image display with OpenGL.
   namespace qtwidgets
   {
 

--- a/cpp/lib/ome/qtwidgets/TexelProperties.cpp
+++ b/cpp/lib/ome/qtwidgets/TexelProperties.cpp
@@ -41,7 +41,7 @@
 
 namespace ome
 {
-  namespace bioformats
+  namespace qtwidgets
   {
 
     // No switch default to avoid -Wunreachable-code errors.

--- a/cpp/lib/ome/qtwidgets/TexelProperties.h
+++ b/cpp/lib/ome/qtwidgets/TexelProperties.h
@@ -35,8 +35,8 @@
  * #L%
  */
 
-#ifndef OME_BIOFORMATS_TEXELPROPERTIES_H
-#define OME_BIOFORMATS_TEXELPROPERTIES_H
+#ifndef OME_QTWIDGETS_TEXELPROPERTIES_H
+#define OME_QTWIDGETS_TEXELPROPERTIES_H
 
 #include <ome/bioformats/PixelProperties.h>
 
@@ -46,7 +46,7 @@
 
 namespace ome
 {
-  namespace bioformats
+  namespace qtwidgets
   {
 
     /**
@@ -442,7 +442,7 @@ namespace ome
   }
 }
 
-#endif // OME_BIOFORMATS_TEXELPROPERTIES_H
+#endif // OME_QTWIDGETS_TEXELPROPERTIES_H
 
 /*
  * Local Variables:


### PR DESCRIPTION
- Document the namespace
- Make TexelProperties use the namespace (it was using the bioformats namespace incorrectly)

--------

Testing: None; check job is green.