### PR TITLE
Add TRACE logging to loci.common.Location

### DIFF
--- a/components/formats-common/src/loci/common/Location.java
+++ b/components/formats-common/src/loci/common/Location.java
@@ -353,6 +353,7 @@ public class Location {
    * @see java.io.File#list()
    */
   public String[] list(boolean noHiddenFiles) {
+    LOGGER.trace("list({})", noHiddenFiles);
     String key = getAbsolutePath() + Boolean.toString(noHiddenFiles);
     String [] result = null;
     if (cacheListings) {
@@ -419,6 +420,7 @@ public class Location {
     if (cacheListings) {
       fileListings.put(key, new ListingsResult(result, System.nanoTime()));
     }
+    LOGGER.trace("  returning {} files", files.size());
     return result;
   }
 
@@ -432,6 +434,7 @@ public class Location {
    * @see java.io.File#canRead()
    */
   public boolean canRead() {
+    LOGGER.trace("canRead()");
     return isURL ? (isDirectory() || isFile() || exists()) : file.canRead();
   }
 
@@ -442,6 +445,7 @@ public class Location {
    * @see java.io.File#canWrite()
    */
   public boolean canWrite() {
+    LOGGER.trace("canWrite()");
     return isURL ? false : file.canWrite();
   }
 
@@ -529,6 +533,7 @@ public class Location {
    * @see java.io.File#exists()
    */
   public boolean exists() {
+    LOGGER.trace("exists()");
     if (isURL) {
       try {
         url.getContent();
@@ -553,6 +558,7 @@ public class Location {
 
   /* @see java.io.File#getAbsolutePath() */
   public String getAbsolutePath() {
+    LOGGER.trace("getAbsolutePath()");
     return isURL ? url.toExternalForm() : file.getAbsolutePath();
   }
 
@@ -578,6 +584,7 @@ public class Location {
    * @see java.io.File#getName()
    */
   public String getName() {
+    LOGGER.trace("getName()");
     if (isURL) {
       String name = url.getFile();
       name = name.substring(name.lastIndexOf("/") + 1);
@@ -594,6 +601,7 @@ public class Location {
    * @see java.io.File#getParent()
    */
   public String getParent() {
+    LOGGER.trace("getParent()");
     if (isURL) {
       String absPath = getAbsolutePath();
       absPath = absPath.substring(0, absPath.lastIndexOf("/"));
@@ -619,6 +627,7 @@ public class Location {
    * @see java.io.File#isAbsolute()
    */
   public boolean isAbsolute() {
+    LOGGER.trace("isAbsolute()");
     return isURL ? true : file.isAbsolute();
   }
 
@@ -628,6 +637,7 @@ public class Location {
    * @see java.io.File#isDirectory()
    */
   public boolean isDirectory() {
+    LOGGER.trace("isDirectory()");
     if (isURL) {
       String[] list = list();
       return list != null;
@@ -641,6 +651,7 @@ public class Location {
    * @see java.io.File#exists()
    */
   public boolean isFile() {
+    LOGGER.trace("isFile()");
     return isURL ? (!isDirectory() && exists()) : file.isFile();
   }
 
@@ -651,6 +662,7 @@ public class Location {
    * @see java.io.File#isHidden()
    */
   public boolean isHidden() {
+    LOGGER.trace("isHidden()");
     if (isURL) {
       return false;
     }
@@ -670,6 +682,7 @@ public class Location {
    * @see java.net.URLConnection#getLastModified()
    */
   public long lastModified() {
+    LOGGER.trace("lastModified()");
     if (isURL) {
       try {
         return url.openConnection().getLastModified();
@@ -687,6 +700,7 @@ public class Location {
    * @see java.net.URLConnection#getContentLength()
    */
   public long length() {
+    LOGGER.trace("length()");
     if (isURL) {
       try {
         return url.openConnection().getContentLength();

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -181,6 +181,7 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
+      <jvmarg value="-Dlogback.configurationFile=${logback.configurationFile}"/>
     </testng>
     <fail if="failedTest"/>
   </target>

--- a/components/test-suite/logback-trace.xml
+++ b/components/test-suite/logback-trace.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="true">
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+  <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+       <level>INFO</level>
+   </filter>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>[%d] [%t] %m%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <timeout>60 minutes</timeout>
+    <discriminator class="loci.tests.testng.ThreadNameBasedDiscriminator"/>
+    <sift>
+      <appender name="logfile-${threadName}" class="loci.tests.testng.TimestampedLogFileAppender">
+	    <File>target/bio-formats-test-${threadName}.log</File>
+	    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+	      <pattern>[%d] %level  %m%n</pattern>
+	    </encoder>
+	  </appender>
+	</sift>
+  </appender>
+  <logger name="loci.tests.testng" level="DEBUG"/>
+  <root level="INFO">
+    <appender-ref ref="SIFT"/>
+  </root>
+  <logger name="loci.tests.testng">
+    <appender-ref ref="stdout"/>
+  </logger>
+  <logger name="loci.common.Location" level="TRACE"/>
+</configuration>

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -275,7 +275,7 @@ public class TestTools {
         LOGGER.debug("\tdirectory");
         getFiles(subs[i], files, config, null, null, configFileSuffix);
       }
-      else if (!subs[i].endsWith("readme.txt")) {
+      else if (!subs[i].endsWith("readme.txt") && !subs[i].endsWith("test_setup.ini")) {
         if (typeTester.isThisType(subs[i])) {
           LOGGER.debug("\tOK");
           files.add(file.getAbsolutePath());


### PR DESCRIPTION
Related to https://trac.openmicroscopy.org/ome/ticket/6586 and https://trello.com/c/0Rdx4AMl/113-nfs-on-windows - this will hopefully help to see the speed and number of calls in Location.

To test, compare the log files generated by ```ant -Dtestng.directory=/path/to/test_images_good test-automated``` and ```ant -Dlogback.configurationFile=logback-trace.xml -Dtestng.directory=/path/to/test_images_good test-automated```.  The latter should produce log files that include copious quantities of TRACE lines from loci.common.Location; the former should not have any TRACE-level logging.

If this is acceptable, the next step is to temporarily add ```-Dlogback.configurationFile=logback-trace.xml``` to one or more of the Windows merge jobs.