### PR TITLE
Improve memo file invalidation error handling

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.ArrayIndexOutOfBoundsException;
 
 import loci.common.Constants;
 import loci.common.Location;
@@ -898,6 +899,10 @@ public class Memoizer extends ReaderWrapper {
         memoFile, memoFile.length());
       return copy;
     } catch (KryoException e) {
+      LOGGER.warn("deleting invalid memo file: {}", memoFile, e);
+      deleteQuietly(memoFile);
+      return null;
+    } catch (ArrayIndexOutOfBoundsException e) {
       LOGGER.warn("deleting invalid memo file: {}", memoFile, e);
       deleteQuietly(memoFile);
       return null;


### PR DESCRIPTION
When the reader is significantly modified (e.g. during major releases), the `loadMemo` logic usually throws an ArrayIndexOutOfBoundsException which results in an ERROR message. Similarly to KryoException, this commit "whitelists" these exceptions and decrease the log level to WARN.

A typical testing workflow for this PR is via an OMERO use case:
- start an OMERO 5.0.x server and import a file which underwent major changes between 5.0.x and 5.1.x (`Deltavision`)
- stop the server and upgrade it to a 5.1.x server with this PR included
- access the same file again to regenerate the memo file, e.g. via the clients
- check Blitz.log shows a WARN-level invalidation message, e.g.

 ```
2015-05-20 16:20:52,655 WARN  [                   loci.formats.Memoizer] (l.Server-3) deleting invalid memo file: /OMERO/BioFormatsCache/OMERO/ManagedRepository/root_0/2015-05/20/14-33-08.950/.very_small.d3d.dv.bfmemo
```

/cc @kennethgillen 