### PR TITLE
Java: Unify plane state handling

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -527,7 +527,7 @@ public class ImportProcess implements StatusReporter {
       options.setId(fileStitcher.getFilePattern().getPattern());
     }
 
-    final byte[][] lut8 = r.get8BitLookupTable();
+    final byte[][] lut8 = r.get8BitLookupTable(0);
     final int sizeC = r.getSizeC();
     r = channelFiller = new ChannelFiller(r);
     if (channelFiller.isFilled()) {

--- a/components/bio-formats-plugins/src/loci/plugins/util/ImageProcessorReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ImageProcessorReader.java
@@ -286,8 +286,8 @@ public class ImageProcessorReader extends ReaderWrapper {
     // regardless of the value of isIndexed.
     //if (!isIndexed()) return null;
 
-    byte[][] byteTable = get8BitLookupTable();
-    if (byteTable == null) byteTable = convertTo8Bit(get16BitLookupTable());
+    byte[][] byteTable = get8BitLookupTable(getPlane());
+    if (byteTable == null) byteTable = convertTo8Bit(get16BitLookupTable(getPlane()));
     if (byteTable == null || byteTable.length == 0) return null;
 
     // extract red, green and blue elements

--- a/components/bio-formats-plugins/utils/Read_Image.java
+++ b/components/bio-formats-plugins/utils/Read_Image.java
@@ -65,7 +65,7 @@ public class Read_Image implements PlugIn {
         ImageProcessor ip = r.openProcessors(i)[0];
         stack.addSlice("" + (i + 1), ip);
         int channel = r.getZCTCoords(i)[1];
-        lookupTable[channel] = r.get8BitLookupTable();
+        lookupTable[channel] = r.get8BitLookupTable(r.getPlane());
       }
       IJ.showStatus("Constructing image");
       ImagePlus imp = new ImagePlus(name, stack);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -843,14 +843,14 @@ public final class ImageConverter {
   private void applyLUT(IFormatWriter writer)
     throws FormatException, IOException
   {
-    byte[][] lut = reader.get8BitLookupTable();
+    byte[][] lut = reader.get8BitLookupTable(reader.getPlane());
     if (lut != null) {
       IndexColorModel model = new IndexColorModel(8, lut[0].length,
         lut[0], lut[1], lut[2]);
       writer.setColorModel(model);
     }
     else {
-      short[][] lut16 = reader.get16BitLookupTable();
+      short[][] lut16 = reader.get16BitLookupTable(reader.getPlane());
       if (lut16 != null) {
         Index16ColorModel model = new Index16ColorModel(16, lut16[0].length,
           lut16, reader.isLittleEndian());

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -563,8 +563,8 @@ public class ImageInfo {
       int rgbChanCount = reader.getRGBChannelCount();
       boolean indexed = reader.isIndexed();
       boolean falseColor = reader.isFalseColor();
-      byte[][] table8 = reader.get8BitLookupTable();
-      short[][] table16 = reader.get16BitLookupTable();
+      byte[][] table8 = reader.get8BitLookupTable(0);
+      short[][] table16 = reader.get16BitLookupTable(0);
       Modulo moduloZ = reader.getModuloZ();
       Modulo moduloC = reader.getModuloC();
       Modulo moduloT = reader.getModuloT();
@@ -859,8 +859,8 @@ public class ImageInfo {
       if (images[i - start] == null) {
         LOGGER.warn("\t************ Failed to read plane #{} ************", i);
       }
-      if (reader.isIndexed() && reader.get8BitLookupTable() == null &&
-        reader.get16BitLookupTable() == null)
+      if (reader.isIndexed() && reader.get8BitLookupTable(0) == null &&
+        reader.get16BitLookupTable(0) == null)
       {
         LOGGER.warn("\t************ no LUT for plane #{} ************", i);
       }

--- a/components/formats-api/src/loci/formats/DelegateReader.java
+++ b/components/formats-api/src/loci/formats/DelegateReader.java
@@ -197,6 +197,24 @@ public abstract class DelegateReader extends FormatReader {
     legacyReader.setMetadataStore(store);
   }
 
+  /* @see IFormatReader#get8BitLookupTable(int) */
+  @Override
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+      return legacyReader.get8BitLookupTable(no);
+    }
+    return nativeReader.get8BitLookupTable(no);
+  }
+
+  /* @see IFormatReader#get16BitLookupTable(int) */
+  @Override
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+      return legacyReader.get16BitLookupTable(no);
+    }
+    return nativeReader.get16BitLookupTable(no);
+  }
+
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {

--- a/components/formats-api/src/loci/formats/DelegateReader.java
+++ b/components/formats-api/src/loci/formats/DelegateReader.java
@@ -125,6 +125,14 @@ public abstract class DelegateReader extends FormatReader {
     if (legacyReaderInitialized) legacyReader.setSeries(no);
   }
 
+  /* @see IFormatReader#setPlane(int) */
+  @Override
+  public void setPlane(int no) {
+    super.setPlane(no);
+    if (nativeReaderInitialized) nativeReader.setPlane(no);
+    if (legacyReaderInitialized) legacyReader.setPlane(no);
+  }
+
   /* @see IFormatReader#setCoreIndex(int) */
   @Override
   public void setCoreIndex(int no) {
@@ -221,6 +229,7 @@ public abstract class DelegateReader extends FormatReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
+    setPlane(no);
     if (callLegacyReader()) {
       return legacyReader.openBytes(no, buf, x, y, w, h);
     }

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -779,16 +779,28 @@ public abstract class FormatReader extends FormatHandler
     return core.get(getCoreIndex()).falseColor;
   }
 
+  /* @see IFormatReader#get8BitLookupTable(int) */
+  @Override
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    return null;
+  }
+
+  /* @see IFormatReader#get16BitLookupTable(int) */
+  @Override
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    return null;
+  }
+
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
-    return null;
+    return get8BitLookupTable(getPlane());
   }
 
   /* @see IFormatReader#get16BitLookupTable() */
   @Override
   public short[][] get16BitLookupTable() throws FormatException, IOException {
-    return null;
+    return get16BitLookupTable(getPlane());
   }
 
   /* @see IFormatReader#getModuloZ() */

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -136,6 +136,9 @@ public abstract class FormatReader extends FormatHandler
   /** The number of the current series (non flat). */
   protected int series = 0;
 
+  /** The number of the current plane. */
+  protected int plane = 0;
+
   /** Core metadata values. */
   protected List<CoreMetadata> core;
 
@@ -234,6 +237,7 @@ public abstract class FormatReader extends FormatHandler
 
     coreIndex = 0;
     series = 0;
+    plane = 0;
     close();
     currentId = id;
     metadata = new Hashtable<String, Object>();
@@ -904,6 +908,8 @@ public abstract class FormatReader extends FormatHandler
   public byte[] openBytes(int no, int x, int y, int w, int h)
     throws FormatException, IOException
   {
+    setPlane(no);
+
     int ch = getRGBChannelCount();
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     byte[] newBuffer;
@@ -938,6 +944,7 @@ public abstract class FormatReader extends FormatHandler
   @Override
   public byte[] openThumbBytes(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
+    setPlane(no);
     return FormatTools.openThumbBytes(this, no);
   }
 
@@ -970,12 +977,29 @@ public abstract class FormatReader extends FormatHandler
     coreIndex = seriesToCoreIndex(no);
     series = no;
     resolution = 0;
+    plane = 0;
   }
 
   /* @see IFormatReader#getSeries() */
   @Override
   public int getSeries() {
     return series;
+  }
+
+  /* @see IFormatReader#setPlane(int) */
+  @Override
+  public void setPlane(int no) {
+    if (plane < 0 || plane >= getImageCount()) {
+      throw new IllegalArgumentException("Invalid plane: " + plane);
+    }
+
+    plane = no;
+  }
+
+  /* @see IFormatReader#getPlane() */
+  @Override
+  public int getPlane() {
+    return plane;
   }
 
   /* @see IFormatReader#setGroupFiles(boolean) */
@@ -1365,6 +1389,7 @@ public abstract class FormatReader extends FormatHandler
     }
     coreIndex = seriesToCoreIndex(getSeries()) + no;
     resolution = no;
+    plane = 0;
   }
 
   /* @see IFormatReader#getResolution() */
@@ -1400,6 +1425,7 @@ public abstract class FormatReader extends FormatHandler
     series = coreIndexToSeries(no);
     coreIndex = no;
     resolution = no - seriesToCoreIndex(series);
+    plane = 0;
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -933,7 +933,7 @@ public final class FormatTools {
     int bufLength, int x, int y, int w, int h) throws FormatException
   {
     assertId(r.getCurrentFile(), true, 2);
-    checkPlaneNumber(r, no);
+    r.setPlane(no);
     checkTileSize(r, x, y, w, h);
     if (bufLength >= 0) checkBufferSize(r, bufLength, w, h);
   }

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -175,7 +175,7 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
    * anything other than {@link FormatTools#INT8} or {@link FormatTools#UINT8},
    * this method will return null.
    *
-   * @deprecated Superseded by stateless get8BitLookupTable(int).
+   * @deprecated Superseded by stateless {@link #get8BitLookupTable(int)}.
    */
   byte[][] get8BitLookupTable() throws FormatException, IOException;
 
@@ -187,7 +187,7 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
    * anything other than {@link FormatTools#INT16} or {@link
    * FormatTools#UINT16}, this method will return null.
    *
-   * @deprecated Superseded by stateless get16BitLookupTable(int).
+   * @deprecated Superseded by stateless {@link #get16BitLookupTable(int)}.
    */
   short[][] get16BitLookupTable() throws FormatException, IOException;
 

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -302,11 +302,21 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
   /** Gets the number of series in this file. */
   int getSeriesCount();
 
-  /** Activates the specified series. This also resets the resolution to 0. */
+  /** Activates the specified series. This also resets the resolution
+   * and current plane to 0.
+   */
   void setSeries(int no);
 
   /** Gets the currently active series. */
   int getSeries();
+
+  /** Activates the specified plane. This also resets the resolution
+   * to 0.
+   */
+  void setPlane(int no);
+
+  /** Gets the currently active plane. */
+  int getPlane();
 
   /** Specifies whether or not to normalize float data. */
   void setNormalized(boolean normalize);

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -143,11 +143,39 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
 
   /**
    * Gets the 8-bit color lookup table associated with
+   * the most recently opened image plane.
+   * If {@link #isIndexed()} returns false, then this may return
+   * null. Also, if {@link #getPixelType()} returns anything other
+   * than {@link FormatTools#INT8} or {@link FormatTools#UINT8}, this
+   * method will return null.
+   *
+   * @param no the image index within the file.
+   * @return the 8-bit LUT.
+   */
+  byte[][] get8BitLookupTable(int no) throws FormatException, IOException;
+
+  /**
+   * Gets the 16-bit color lookup table associated with
+   * the most recently opened image plane.
+   * If {@link #isIndexed()} returns false, then this may return
+   * null. Also, if {@link #getPixelType()} returns anything other
+   * than {@link FormatTools#INT16} or {@link FormatTools#UINT16},
+   * this method will return null.
+   *
+   * @param no the image index within the file.
+   * @return the 16-bit LUT.
+   */
+  short[][] get16BitLookupTable(int no) throws FormatException, IOException;
+
+  /**
+   * Gets the 8-bit color lookup table associated with
    * the most recently opened image.
    * If no image planes have been opened, or if {@link #isIndexed()} returns
    * false, then this may return null. Also, if {@link #getPixelType()} returns
    * anything other than {@link FormatTools#INT8} or {@link FormatTools#UINT8},
    * this method will return null.
+   *
+   * @deprecated Superseded by stateless get8BitLookupTable(int).
    */
   byte[][] get8BitLookupTable() throws FormatException, IOException;
 
@@ -158,6 +186,8 @@ public interface IFormatReader extends IFormatHandler, IMetadataConfigurable {
    * false, then this may return null. Also, if {@link #getPixelType()} returns
    * anything other than {@link FormatTools#INT16} or {@link
    * FormatTools#UINT16}, this method will return null.
+   *
+   * @deprecated Superseded by stateless get16BitLookupTable(int).
    */
   short[][] get16BitLookupTable() throws FormatException, IOException;
 

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -485,6 +485,18 @@ public class ImageReader implements IFormatReader {
     return getReader().getSeries();
   }
 
+  /* @see IFormatReader#setPlane(int) */
+  @Override
+  public void setPlane(int no) {
+    getReader().setPlane(no);
+  }
+
+  /* @see IFormatReader#getPlane() */
+  @Override
+  public int getPlane() {
+    return getReader().getPlane();
+  }
+
   /* @see IFormatReader#getUsedFiles() */
   @Override
   public String[] getUsedFiles() {

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -347,6 +347,18 @@ public class ImageReader implements IFormatReader {
 
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    return getReader().get8BitLookupTable(no);
+  }
+
+  /* @see IFormatReader#get16BitLookupTable() */
+  @Override
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    return getReader().get16BitLookupTable(no);
+  }
+
+  /* @see IFormatReader#get8BitLookupTable() */
+  @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
     return getReader().get8BitLookupTable();
   }

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -259,6 +259,16 @@ public abstract class ReaderWrapper implements IFormatReader {
   }
 
   @Override
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    return reader.get8BitLookupTable(no);
+  }
+
+  @Override
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    return reader.get16BitLookupTable(no);
+  }
+
+  @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
     return reader.get8BitLookupTable();
   }

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -382,6 +382,16 @@ public abstract class ReaderWrapper implements IFormatReader {
   }
 
   @Override
+  public void setPlane(int no) {
+    reader.setPlane(no);
+  }
+
+  @Override
+  public int getPlane() {
+    return reader.getPlane();
+  }
+
+  @Override
   public void setGroupFiles(boolean group) {
     reader.setGroupFiles(group);
   }

--- a/components/formats-bsd/src/loci/formats/ChannelFiller.java
+++ b/components/formats-bsd/src/loci/formats/ChannelFiller.java
@@ -110,6 +110,20 @@ public class ChannelFiller extends ReaderWrapper {
     return false;
   }
 
+  /* @see IFormatReader#get8BitLookupTable(int) */
+  @Override
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    if (!isFilled()) return reader.get8BitLookupTable(no);
+    return null;
+  }
+
+  /* @see IFormatReader#get16BitLookupTable(int) */
+  @Override
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    if (!isFilled()) return reader.get16BitLookupTable(no);
+    return null;
+  }
+
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
@@ -165,7 +179,7 @@ public class ChannelFiller extends ReaderWrapper {
 
     byte[] pix = reader.openBytes(no, x, y, w, h);
     if (getPixelType() == FormatTools.UINT8) {
-      byte[][] b = ImageTools.indexedToRGB(reader.get8BitLookupTable(), pix);
+      byte[][] b = ImageTools.indexedToRGB(reader.get8BitLookupTable(no), pix);
       if (isInterleaved()) {
         int pt = 0;
         for (int i=0; i<b[0].length; i++) {
@@ -181,7 +195,7 @@ public class ChannelFiller extends ReaderWrapper {
       }
       return buf;
     }
-    short[][] s = ImageTools.indexedToRGB(reader.get16BitLookupTable(),
+    short[][] s = ImageTools.indexedToRGB(reader.get16BitLookupTable(no),
       pix, isLittleEndian());
 
     if (isInterleaved()) {
@@ -233,13 +247,13 @@ public class ChannelFiller extends ReaderWrapper {
   private int getLookupTableComponentCount()
     throws FormatException, IOException
   {
-    byte[][] lut8 = reader.get8BitLookupTable();
+    byte[][] lut8 = reader.get8BitLookupTable(0);
     if (lut8 != null) return lut8.length;
-    short[][] lut16 = reader.get16BitLookupTable();
+    short[][] lut16 = reader.get16BitLookupTable(0);
     if (lut16 != null) return lut16.length;
-    lut8 = reader.get8BitLookupTable();
+    lut8 = reader.get8BitLookupTable(0);
     if (lut8 != null) return lut8.length;
-    lut16 = reader.get16BitLookupTable();
+    lut16 = reader.get16BitLookupTable(0);
     if (lut16 != null) return lut16.length;
     return 0; // LUTs are missing
   }

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -371,6 +371,22 @@ public class FileStitcher extends ReaderWrapper {
     return noStitch ? reader.isFalseColor() : core.get(getCoreIndex()).falseColor;
   }
 
+  /* @see IFormatReader#get8BitLookupTable(int) */
+  @Override
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    return noStitch ? reader.get8BitLookupTable(no) :
+      getReader(getCoreIndex(), 0).get8BitLookupTable(getAdjustedIndex(no));
+  }
+
+  /* @see IFormatReader#get16BitLookupTable(int) */
+  @Override
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    return noStitch ? reader.get16BitLookupTable(no) :
+      getReader(getCoreIndex(), 0).get16BitLookupTable(getAdjustedIndex(no));
+  }
+
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
@@ -507,6 +523,8 @@ public class FileStitcher extends ReaderWrapper {
     throws FormatException, IOException
   {
     FormatTools.assertId(getCurrentFile(), true, 2);
+
+    setPlane(no);
 
     IFormatReader r = getReader(no);
     int ino = getAdjustedIndex(no);

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -93,6 +93,9 @@ public class FileStitcher extends ReaderWrapper {
   /** The number of the current series (non flat). */
   private int series;
 
+  /** The number of the current plane. */
+  private int plane;
+
   private boolean noStitch;
   private boolean group = true;
 
@@ -478,6 +481,8 @@ public class FileStitcher extends ReaderWrapper {
   {
     FormatTools.assertId(getCurrentFile(), true, 2);
 
+    setPlane(no);
+
     int[] pos = computeIndices(no);
     IFormatReader r = getReader(getCoreIndex(), pos[0]);
     int ino = pos[1];
@@ -551,6 +556,7 @@ public class FileStitcher extends ReaderWrapper {
       core.clear();
       coreIndex = 0;
       series = 0;
+      plane = 0;
       store = null;
     }
   }
@@ -571,6 +577,7 @@ public class FileStitcher extends ReaderWrapper {
     else {
       coreIndex = no;
       series = no;
+      plane = no;
     }
   }
 
@@ -579,6 +586,24 @@ public class FileStitcher extends ReaderWrapper {
   public int getSeries() {
     FormatTools.assertId(getCurrentFile(), true, 2);
     return reader.getSeries() > 0 ? reader.getSeries() : series;
+  }
+
+  /* @see IFormatReader#setPlane(int) */
+  @Override
+  public void setPlane(int no) {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    int n = reader.getSeriesCount();
+    if (n > 1 || noStitch) reader.setPlane(no);
+    else {
+      plane = no;
+    }
+  }
+
+  /* @see IFormatReader#getPlane() */
+  @Override
+  public int getPlane() {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    return reader.getPlane() > 0 ? reader.getPlane() : plane;
   }
 
   /* @see IFormatReader#seriesToCoreIndex(int) */

--- a/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
@@ -786,7 +786,7 @@ public final class AWTImageTools {
 
     if (indexed && rgbChanCount == 1) {
       if (pixelType == FormatTools.UINT8 || pixelType == FormatTools.INT8) {
-        byte[][] table = r.get8BitLookupTable();
+        byte[][] table = r.get8BitLookupTable(0);
         if (table != null && table.length > 0 && table[0] != null) {
           int len = table[0].length;
           byte[] dummy = table.length < 3 ? new byte[len] : null;
@@ -799,7 +799,7 @@ public final class AWTImageTools {
       else if (pixelType == FormatTools.UINT16 ||
         pixelType == FormatTools.INT16)
       {
-        short[][] table = r.get16BitLookupTable();
+        short[][] table = r.get16BitLookupTable(0);
         if (table != null && table.length > 0 && table[0] != null) {
           model = new Index16ColorModel(16, table[0].length, table,
             r.isLittleEndian());

--- a/components/formats-bsd/src/loci/formats/in/APNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/APNGReader.java
@@ -119,9 +119,9 @@ public class APNGReader extends FormatReader {
     return true;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     return lut;
   }

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -170,9 +170,9 @@ public class AVIReader extends FormatReader {
     return type.equals(AVI_MAGIC_STRING) && format.equals("AVI ");
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     return isRGB() ? null : lut;
   }

--- a/components/formats-bsd/src/loci/formats/in/BMPReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BMPReader.java
@@ -101,10 +101,11 @@ public class BMPReader extends FormatReader {
     return stream.readString(blockLen).startsWith(BMP_MAGIC_STRING);
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
+    openBytes(no);
     return palette;
   }
 

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -196,9 +196,9 @@ public class DicomReader extends FormatReader {
     return false;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (getPixelType() != FormatTools.INT8 &&
       getPixelType() != FormatTools.UINT8)
@@ -208,9 +208,9 @@ public class DicomReader extends FormatReader {
     return lut;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() {
+  public short[][] get16BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (getPixelType() != FormatTools.INT16 &&
       getPixelType() != FormatTools.UINT16)

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -194,9 +194,6 @@ public class FakeReader extends FormatReader {
   /** For indexed color, mapping from indices to values and vice versa. */
   private int[][] indexToValue = null, valueToIndex = null;
 
-  /** Channel of last opened image plane. */
-  private int ac = 0;
-
   /** Properties companion file which can be associated with this fake file */
   private String iniFile;
 
@@ -286,13 +283,17 @@ public class FakeReader extends FormatReader {
   // -- IFormatReader API methods --
 
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
-    return ac < 0 || lut8 == null ? null : lut8[ac];
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    openBytes(no);
+    final int ac = getZCTCoords(no)[1];
+    return lut8 == null ? null : lut8[ac];
   }
 
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
-    return ac < 0 || lut16 == null ? null : lut16[ac];
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    openBytes(no);
+    final int ac = getZCTCoords(no)[1];
+    return lut16 == null ? null : lut16[ac];
   }
 
   @Override
@@ -313,7 +314,6 @@ public class FakeReader extends FormatReader {
 
     final int[] zct = getZCTCoords(no);
     final int zIndex = zct[0], cIndex = zct[1], tIndex = zct[2];
-    ac = cIndex;
 
     // integer types start gradient at the smallest value
     long min = signed ? (long) -Math.pow(2, 8 * bpp - 1) : 0;
@@ -356,8 +356,8 @@ public class FakeReader extends FormatReader {
 
           // if indexed color with non-null LUT, convert value to index
           if (indexed) {
-            if (lut8 != null) pixel = valueToIndex[ac][(int) (pixel % 256)];
-            if (lut16 != null) pixel = valueToIndex[ac][(int) (pixel % 65536)];
+            if (lut8 != null) pixel = valueToIndex[cIndex][(int) (pixel % 256)];
+            if (lut16 != null) pixel = valueToIndex[cIndex][(int) (pixel % 65536)];
           }
 
           // scale pixel value by the scale factor

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -149,19 +149,19 @@ public class FilePatternReader extends FormatReader {
   }
 
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     if (getCurrentFile() == null) {
       return null;
     }
-    return helper.get8BitLookupTable();
+    return helper.get8BitLookupTable(no);
   }
 
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     if (getCurrentFile() == null) {
       return null;
     }
-    return helper.get16BitLookupTable();
+    return helper.get16BitLookupTable(no);
   }
 
   @Override

--- a/components/formats-bsd/src/loci/formats/in/GIFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/GIFReader.java
@@ -119,9 +119,9 @@ public class GIFReader extends FormatReader {
     return stream.readString(blockLen).startsWith(GIF_MAGIC_STRING);
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     byte[][] table = new byte[3][act.length];
     for (int i=0; i<act.length; i++) {

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
@@ -105,9 +105,9 @@ public class JPEG2000Reader extends FormatReader {
     return validStart && validEnd;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (lut == null || FormatTools.getBytesPerPixel(getPixelType()) != 1) {
       return null;
@@ -122,9 +122,9 @@ public class JPEG2000Reader extends FormatReader {
     return byteLut;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() {
+  public short[][] get16BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (lut == null || FormatTools.getBytesPerPixel(getPixelType()) != 2) {
       return null;

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -91,8 +91,6 @@ public class MinimalTiffReader extends FormatReader {
 
   protected boolean use64Bit = false;
 
-  protected int lastPlane = 0;
-
   protected boolean noSubresolutions = false;
 
   /** Number of JPEG 2000 resolution levels. */
@@ -140,18 +138,18 @@ public class MinimalTiffReader extends FormatReader {
     return new TiffParser(stream).isValidHeader();
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (ifds == null || lastPlane < 0 || lastPlane >= ifds.size()) return null;
-    IFD lastIFD = ifds.get(lastPlane);
+    if (ifds == null || no >= ifds.size()) return null;
+    IFD lastIFD = ifds.get(no);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 8) {
       int[] colorMap = tiffParser.getColorMap(lastIFD);
       if (colorMap == null) {
         // it's possible that the LUT is only present in the first IFD
-        if (lastPlane != 0) {
+        if (no != 0) {
           lastIFD = ifds.get(0);
           colorMap = tiffParser.getColorMap(lastIFD);
           if (colorMap == null) return null;
@@ -177,18 +175,18 @@ public class MinimalTiffReader extends FormatReader {
     return null;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (ifds == null || lastPlane < 0 || lastPlane >= ifds.size()) return null;
-    IFD lastIFD = ifds.get(lastPlane);
+    if (ifds == null || no >= ifds.size()) return null;
+    IFD lastIFD = ifds.get(no);
     int[] bits = lastIFD.getBitsPerSample();
     if (bits[0] <= 16 && bits[0] > 8) {
       int[] colorMap = tiffParser.getColorMap(lastIFD);
       if (colorMap == null || colorMap.length < 65536 * 3) {
         // it's possible that the LUT is only present in the first IFD
-        if (lastPlane != 0) {
+        if (no != 0) {
           lastIFD = ifds.get(0);
           colorMap = tiffParser.getColorMap(lastIFD);
           if (colorMap == null || colorMap.length < 65536 * 3) return null;
@@ -281,7 +279,6 @@ public class MinimalTiffReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     IFD firstIFD = ifds.get(0);
-    lastPlane = no;
     IFD ifd = ifds.get(no);
     if ((firstIFD.getCompression() == TiffCompression.JPEG_2000
         || firstIFD.getCompression() == TiffCompression.JPEG_2000_LOSSY)
@@ -375,7 +372,6 @@ public class MinimalTiffReader extends FormatReader {
       ifds = null;
       thumbnailIFDs = null;
       subResolutionIFDs = null;
-      lastPlane = 0;
       tiffParser = null;
       resolutionLevels = null;
       j2kCodecOptions = null;
@@ -557,7 +553,7 @@ public class MinimalTiffReader extends FormatReader {
     ms0.pixelType = firstIFD.getPixelType();
     ms0.metadataComplete = true;
     ms0.indexed = photo == PhotoInterp.RGB_PALETTE &&
-      (get8BitLookupTable() != null || get16BitLookupTable() != null);
+      (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
     if (isIndexed()) {
       ms0.sizeC = 1;
       ms0.rgb = false;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -86,7 +86,6 @@ public class OMETiffReader extends FormatReader {
   /** List of used files. */
   protected String[] used;
 
-  private int lastPlane = 0;
   private boolean hasSPW;
 
   private int[] tileWidth;
@@ -276,32 +275,33 @@ public class OMETiffReader extends FormatReader {
       FormatTools.NON_SPECIAL_DOMAINS;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     int series = getSeries();
-    if (info[series][lastPlane] == null ||
-      info[series][lastPlane].reader == null ||
-      info[series][lastPlane].id == null)
+    if (info[series][no] == null ||
+      info[series][no].reader == null ||
+      info[series][no].id == null)
     {
       return null;
     }
-    info[series][lastPlane].reader.setId(info[series][lastPlane].id);
-    return info[series][lastPlane].reader.get8BitLookupTable();
+    info[series][no].reader.setId(info[series][no].id);
+    return info[series][no].reader.get8BitLookupTable(0);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     int series = getSeries();
-    if (info[series][lastPlane] == null ||
-      info[series][lastPlane].reader == null ||
-      info[series][lastPlane].id == null)
+    if (info[series][no] == null ||
+      info[series][no].reader == null ||
+      info[series][no].id == null)
     {
       return null;
     }
-    info[series][lastPlane].reader.setId(info[series][lastPlane].id);
-    return info[series][lastPlane].reader.get16BitLookupTable();
+    info[series][no].reader.setId(info[series][no].id);
+    info[series][no].reader.setPlane(info[series][no].ifd);
+    return info[series][no].reader.get16BitLookupTable(0);
   }
 
   /* @see loci.formats.IFormatReader#reopenFile() */
@@ -329,7 +329,6 @@ public class OMETiffReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
     int series = getSeries();
-    lastPlane = no;
     int i = info[series][no].ifd;
 
     if (!info[series][no].exists) {
@@ -341,7 +340,6 @@ public class OMETiffReader extends FormatReader {
     if (r.getCurrentFile() == null) {
       r.setId(info[series][no].id);
     }
-    r.lastPlane = i;
     IFDList ifdList = r.getIFDs();
     if (i >= ifdList.size()) {
       LOGGER.warn("Error untangling IFDs; the OME-TIFF file may be malformed (IFD #{} missing).", i);
@@ -420,7 +418,6 @@ public class OMETiffReader extends FormatReader {
     if (!fileOnly) {
       info = null;
       used = null;
-      lastPlane = 0;
       tileWidth = null;
       tileHeight = null;
       metadataFile = null;

--- a/components/formats-bsd/src/loci/formats/in/PCXReader.java
+++ b/components/formats-bsd/src/loci/formats/in/PCXReader.java
@@ -82,9 +82,9 @@ public class PCXReader extends FormatReader {
     return stream.read() == PCX_MAGIC_BYTE;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     return lut;
   }

--- a/components/formats-bsd/src/loci/formats/in/PictReader.java
+++ b/components/formats-bsd/src/loci/formats/in/PictReader.java
@@ -122,10 +122,11 @@ public class PictReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
+    openBytes(no);
     return lookup;
   }
 

--- a/components/formats-bsd/src/loci/formats/in/ZipReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ZipReader.java
@@ -67,16 +67,16 @@ public class ZipReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
-    return reader.get8BitLookupTable();
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    return reader.get8BitLookupTable(no);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
-    return reader.get16BitLookupTable();
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    return reader.get16BitLookupTable(no);
   }
 
   /* @see loci.formats.IFormatReader#setGroupFiles(boolean) */

--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -151,9 +151,9 @@ for s = 1:numSeries
 
         % retrieve color map data
         if bpp == 1
-            colorMaps{s, i} = r.get8BitLookupTable()';
+            colorMaps{s, i} = r.get8BitLookupTable(0)';
         else
-            colorMaps{s, i} = r.get16BitLookupTable()';
+            colorMaps{s, i} = r.get16BitLookupTable(0)';
         end
 
         warning_state = warning ('off');

--- a/components/formats-gpl/src/loci/formats/TileStitcher.java
+++ b/components/formats-gpl/src/loci/formats/TileStitcher.java
@@ -127,6 +127,8 @@ public class TileStitcher extends ReaderWrapper {
   {
     FormatTools.assertId(getCurrentFile(), true, 2);
 
+    setPlane(no);
+
     if (tileX == 1 && tileY == 1) {
       return super.openBytes(no, buf, x, y, w, h);
     }

--- a/components/formats-gpl/src/loci/formats/in/AmiraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AmiraReader.java
@@ -278,9 +278,9 @@ public class AmiraReader extends FormatReader {
     return amiraMeshDef.find();
   }
 
-  /* @see IFormatReader#get8BitLookupTable() */
+  /* @see IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true ,1);
     return lut;
   }

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -82,7 +82,6 @@ public abstract class BaseZeissReader extends FormatReader {
   protected int timepoint = 0;
 
   protected int[] channelColors;
-  protected int lastPlane = 0;
   protected final Map<Integer, Integer> tiles =
       new HashMap<Integer, Integer>();
 
@@ -684,9 +683,9 @@ public abstract class BaseZeissReader extends FormatReader {
     }
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     int pixelType = getPixelType();
     if ((pixelType != FormatTools.INT8 && pixelType != FormatTools.UINT8) ||
         !isIndexed())
@@ -694,7 +693,7 @@ public abstract class BaseZeissReader extends FormatReader {
       return null;
     }
     byte[][] lut = new byte[3][256];
-    int channel = getZCTCoords(lastPlane)[1];
+    int channel = getZCTCoords(no)[1];
     if (channel >= channelColors.length) return null;
     int color = channelColors[channel];
 
@@ -711,9 +710,9 @@ public abstract class BaseZeissReader extends FormatReader {
     return lut;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     int pixelType = getPixelType();
     if ((pixelType != FormatTools.INT16 && pixelType != FormatTools.UINT16) ||
         !isIndexed())
@@ -721,7 +720,7 @@ public abstract class BaseZeissReader extends FormatReader {
       return null;
     }
     short[][] lut = new short[3][65536];
-    int channel = getZCTCoords(lastPlane)[1];
+    int channel = getZCTCoords(no)[1];
     if (channel >= channelColors.length) return null;
     int color = channelColors[channel];
 
@@ -756,7 +755,6 @@ public abstract class BaseZeissReader extends FormatReader {
       stageX.clear();
       stageY.clear();
       channelColors = null;
-      lastPlane = 0;
       tiles.clear();
       detectorGain.clear();
       detectorOffset.clear();

--- a/components/formats-gpl/src/loci/formats/in/BioRadReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadReader.java
@@ -146,7 +146,6 @@ public class BioRadReader extends FormatReader {
   private String[] picFiles;
 
   private byte[][][] lut;
-  private int lastChannel = 0;
   private boolean brokenNotes = false;
 
   private List<Note> noteStrings;
@@ -212,11 +211,11 @@ public class BioRadReader extends FormatReader {
     return FormatTools.CAN_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
-    return lut == null ? null : lut[lastChannel];
+    return lut == null ? null : lut[getZCTCoords(no)[1]];
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
@@ -242,7 +241,6 @@ public class BioRadReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    lastChannel = getZCTCoords(no)[1];
 
     if (picFiles != null) {
       int file = no % picFiles.length;
@@ -268,7 +266,6 @@ public class BioRadReader extends FormatReader {
       used = null;
       picFiles = null;
       lut = null;
-      lastChannel = 0;
       noteStrings = null;
       offset = gain = null;
       brokenNotes = false;

--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -107,7 +107,6 @@ public class CellH5Reader extends FormatReader {
   private transient JHDFService jhdf;
 
   private MetadataStore store;
-  private int lastChannel = 0;
 
   private List<CellH5Coordinate> CellH5PositionList = new ArrayList<CellH5Coordinate>();
   private List<String> CellH5PathsToImageData = new ArrayList<String>();
@@ -161,17 +160,15 @@ public class CellH5Reader extends FormatReader {
     return stream.readString(blockLen).contains(HDF_MAGIC_STRING);
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (getPixelType() != FormatTools.UINT8 || !isIndexed()) {
       return null;
     }
 
-    if (lastChannel < 0) {
-      return null;
-    }
+    int lastChannel = getZCTCoords(no)[1];
 
     byte[][] lut = new byte[3][256];
     for (int i = 0; i < 256; i++) {
@@ -221,7 +218,6 @@ public class CellH5Reader extends FormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
-    lastChannel = getZCTCoords(no)[1];
 
     // pixel data is stored in XYZ blocks
     Object image = getImageData(no, y, h);
@@ -280,7 +276,6 @@ public class CellH5Reader extends FormatReader {
         jhdf.close();
       }
       jhdf = null;
-      lastChannel = 0;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -710,7 +710,7 @@ public class CellSensReader extends FormatReader {
         ms.sizeC = ms.rgb ? samples : 1;
         ms.littleEndian = ifd.isLittleEndian();
         ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-          (get8BitLookupTable() != null || get16BitLookupTable() != null);
+          (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
         ms.imageCount = 1;
         ms.pixelType = ifd.getPixelType();
         ms.interleaved = false;

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -148,7 +148,6 @@ public class FV1000Reader extends FormatReader {
   private transient POIService poi;
 
   private short[][][] lut;
-  private int lastChannel = 0;
   private double pixelSizeZ = 1, pixelSizeT = 1;
 
   private String ptyStart = null, ptyEnd = null, ptyPattern = null, line = null;
@@ -253,10 +252,16 @@ public class FV1000Reader extends FormatReader {
     return FormatTools.MUST_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() {
+  public short[][] get16BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
+
+    int nFiles = getSeries() == 0 ? tiffs.size() : previewNames.size();
+    int image = no % (getImageCount() / nFiles);
+    int[] coords = getZCTCoords(image);
+    int lastChannel = coords[1];
+
     return lut == null || !isIndexed() ? null : lut[lastChannel];
   }
 
@@ -272,9 +277,7 @@ public class FV1000Reader extends FormatReader {
     int nFiles = getSeries() == 0 ? tiffs.size() : previewNames.size();
     int image = no % (getImageCount() / nFiles);
     int file = no / (getImageCount() / nFiles);
-
     int[] coords = getZCTCoords(image);
-    lastChannel = coords[1];
 
     RandomAccessInputStream plane = getPlane(getSeries(), no);
 
@@ -345,7 +348,6 @@ public class FV1000Reader extends FormatReader {
       previewNames = null;
       if (poi != null) poi.close();
       poi = null;
-      lastChannel = 0;
       wavelengths = null;
       illuminations = null;
       oibMapping = null;

--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -158,6 +158,8 @@ public class FluoviewReader extends BaseTiffReader {
   {
     int image = getImageIndex(no);
 
+    setPlane(no);
+
     if (tiffParser == null) {
       initTiffParser();
     }

--- a/components/formats-gpl/src/loci/formats/in/GelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GelReader.java
@@ -103,6 +103,8 @@ public class GelReader extends BaseTiffReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
+    setPlane(no);
+
     IFD ifd = ifds.get(no);
 
     if (fmt == SQUARE_ROOT) {

--- a/components/formats-gpl/src/loci/formats/in/IPWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPWReader.java
@@ -90,9 +90,9 @@ public class IPWReader extends FormatReader {
     return stream.readInt() == IPW_MAGIC_BYTES;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     RandomAccessInputStream stream = poi.getDocumentStream(imageFiles.get(0));
     TiffParser tp = new TiffParser(stream);

--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -70,7 +70,6 @@ public class ImarisHDFReader extends FormatReader {
   private List<String> emWave, exWave, channelMin, channelMax;
   private List<String> gain, pinhole, channelName, microscopyMode;
   private List<double[]> colors;
-  private int lastChannel = 0;
 
   // -- Constructor --
 
@@ -103,13 +102,14 @@ public class ImarisHDFReader extends FormatReader {
     return stream.readString(blockLen).indexOf(HDF_MAGIC_STRING) >= 0;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (getPixelType() != FormatTools.UINT8 || !isIndexed()) return null;
 
-    if (lastChannel < 0 || lastChannel >= colors.size()) {
+    int lastChannel = getZCTCoords(no)[1];
+    if (lastChannel >= colors.size()) {
       return null;
     }
 
@@ -125,13 +125,14 @@ public class ImarisHDFReader extends FormatReader {
     return lut;
   }
 
-  /* @see loci.formats.IFormatReaderget16BitLookupTable() */
+  /* @see loci.formats.IFormatReaderget16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() {
+  public short[][] get16BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (getPixelType() != FormatTools.UINT16 || !isIndexed()) return null;
 
-    if (lastChannel < 0 || lastChannel >= colors.size()) {
+    int lastChannel = getZCTCoords(no)[1];
+    if (lastChannel >= colors.size()) {
       return null;
     }
 
@@ -155,8 +156,6 @@ public class ImarisHDFReader extends FormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
-
-    lastChannel = getZCTCoords(no)[1];
 
     // pixel data is stored in XYZ blocks
 
@@ -230,7 +229,6 @@ public class ImarisHDFReader extends FormatReader {
       emWave = exWave = channelMin = channelMax = null;
       gain = pinhole = channelName = microscopyMode = null;
       colors = null;
-      lastChannel = 0;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -64,8 +64,6 @@ public class ImprovisionTiffReader extends BaseTiffReader {
   private String[] files;
   private MinimalTiffReader[] readers;
 
-  private int lastFile = 0;
-
   // -- Constructor --
 
   public ImprovisionTiffReader() {
@@ -100,7 +98,6 @@ public class ImprovisionTiffReader extends BaseTiffReader {
       }
       readers = null;
       files = null;
-      lastFile = 0;
     }
   }
 
@@ -111,28 +108,38 @@ public class ImprovisionTiffReader extends BaseTiffReader {
     return noPixels ? null : files;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (readers == null || lastFile < 0 || lastFile >= readers.length ||
+
+    int[] zct = getZCTCoords(no);
+    int lastFile = FormatTools.getIndex("XYZCT", getSizeZ(), getEffectiveSizeC(),
+      getSizeT(), getImageCount(), zct[0], zct[1], zct[2]) % files.length;
+
+    if (readers == null || lastFile >= readers.length ||
       readers[lastFile] == null)
     {
-      return super.get8BitLookupTable();
+      return super.get8BitLookupTable(0);
     }
-    return readers[lastFile].get8BitLookupTable();
+    return readers[lastFile].get8BitLookupTable(0);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (readers == null || lastFile < 0 || lastFile >= readers.length ||
+
+    int[] zct = getZCTCoords(no);
+    int lastFile = FormatTools.getIndex("XYZCT", getSizeZ(), getEffectiveSizeC(),
+      getSizeT(), getImageCount(), zct[0], zct[1], zct[2]) % files.length;
+
+    if (readers == null || lastFile >= readers.length ||
       readers[lastFile] == null)
     {
-      return super.get16BitLookupTable();
+      return super.get16BitLookupTable(0);
     }
-    return readers[lastFile].get16BitLookupTable();
+    return readers[lastFile].get16BitLookupTable(0);
   }
 
   /**
@@ -148,7 +155,6 @@ public class ImprovisionTiffReader extends BaseTiffReader {
     int file = FormatTools.getIndex("XYZCT", getSizeZ(), getEffectiveSizeC(),
       getSizeT(), getImageCount(), zct[0], zct[1], zct[2]) % files.length;
     int plane = no / files.length;
-    lastFile = file;
 
     return readers[file].openBytes(plane, buf, x, y, w, h);
   }

--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -113,12 +113,16 @@ public class ImprovisionTiffReader extends BaseTiffReader {
   public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
 
+    if (readers == null)
+    {
+      return super.get8BitLookupTable(0);
+    }
+
     int[] zct = getZCTCoords(no);
     int lastFile = FormatTools.getIndex("XYZCT", getSizeZ(), getEffectiveSizeC(),
       getSizeT(), getImageCount(), zct[0], zct[1], zct[2]) % files.length;
 
-    if (readers == null || lastFile >= readers.length ||
-      readers[lastFile] == null)
+    if (lastFile >= readers.length || readers[lastFile] == null)
     {
       return super.get8BitLookupTable(0);
     }
@@ -130,12 +134,16 @@ public class ImprovisionTiffReader extends BaseTiffReader {
   public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
 
+    if (readers == null)
+    {
+      return super.get16BitLookupTable(0);
+    }
+
     int[] zct = getZCTCoords(no);
     int lastFile = FormatTools.getIndex("XYZCT", getSizeZ(), getEffectiveSizeC(),
       getSizeT(), getImageCount(), zct[0], zct[1], zct[2]) % files.length;
 
-    if (readers == null || lastFile >= readers.length ||
-      readers[lastFile] == null)
+    if (lastFile >= readers.length || readers[lastFile] == null)
     {
       return super.get16BitLookupTable(0);
     }

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -153,18 +153,18 @@ public class InCellReader extends FormatReader {
     return FormatTools.MUST_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    return tiffReader == null ? null : tiffReader.get8BitLookupTable();
+    return tiffReader == null ? null : tiffReader.get8BitLookupTable(0);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    return tiffReader == null ? null : tiffReader.get16BitLookupTable();
+    return tiffReader == null ? null : tiffReader.get16BitLookupTable(0);
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/JPKReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JPKReader.java
@@ -106,7 +106,7 @@ public class JPKReader extends BaseTiffReader {
       ms.sizeC = ms.rgb ? samples : 1;
       ms.littleEndian = ifd.isLittleEndian();
       ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+        (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
       ms.imageCount = s == 0 ? 1 : ifds.size() - 1;
       ms.pixelType = ifd.getPixelType();
       ms.metadataComplete = true;

--- a/components/formats-gpl/src/loci/formats/in/JPXReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JPXReader.java
@@ -92,9 +92,9 @@ public class JPXReader extends FormatReader {
     return validStart && validEnd;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (lut == null || FormatTools.getBytesPerPixel(getPixelType()) != 1) {
       return null;
@@ -109,9 +109,9 @@ public class JPXReader extends FormatReader {
     return byteLut;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() {
+  public short[][] get16BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (lut == null || FormatTools.getBytesPerPixel(getPixelType()) != 2) {
       return null;

--- a/components/formats-gpl/src/loci/formats/in/KhorosReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KhorosReader.java
@@ -70,9 +70,9 @@ public class KhorosReader extends FormatReader {
     return stream.readShort() == KHOROS_MAGIC_BYTES;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     return lut;
   }

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -136,7 +136,7 @@ public class LeicaReader extends FormatReader {
 
   private List<String> seriesNames;
   private List<String> seriesDescriptions;
-  private int lastPlane = 0, nameLength = 0;
+  private int nameLength = 0;
 
   private double[][] physicalSizes;
   private double[] pinhole, exposureTime;
@@ -216,14 +216,14 @@ public class LeicaReader extends FormatReader {
     return ifd.containsKey(new Integer(LEICA_MAGIC_TAG));
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     try {
-      int index = (int) Math.min(lastPlane, files[getSeries()].size() - 1);
+      int index = (int) Math.min(no, files[getSeries()].size() - 1);
       tiff.setId(files[getSeries()].get(index));
-      return tiff.get8BitLookupTable();
+      return tiff.get8BitLookupTable(0);
     }
     catch (FormatException e) {
       LOGGER.debug("Failed to retrieve lookup table", e);
@@ -234,14 +234,14 @@ public class LeicaReader extends FormatReader {
     return null;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     try {
-      int index = (int) Math.min(lastPlane, files[getSeries()].size() - 1);
+      int index = (int) Math.min(no, files[getSeries()].size() - 1);
       tiff.setId(files[getSeries()].get(index));
-      return tiff.get16BitLookupTable();
+      return tiff.get16BitLookupTable(0);
     }
     catch (FormatException e) {
       LOGGER.debug("Failed to retrieve lookup table", e);
@@ -266,8 +266,6 @@ public class LeicaReader extends FormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
-
-    lastPlane = no;
 
     int fileIndex = no < files[getSeries()].size() ? no : 0;
     int planeIndex = no < files[getSeries()].size() ? 0 : no;
@@ -319,7 +317,6 @@ public class LeicaReader extends FormatReader {
       tiff = null;
       seriesNames = null;
       numSeries = 0;
-      lastPlane = 0;
       physicalSizes = null;
       seriesDescriptions = null;
       pinhole = exposureTime = null;

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -278,7 +278,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     ms.orderCertain = true;
     ms.littleEndian = ifd.isLittleEndian();
     ms.indexed = pi == PhotoInterp.RGB_PALETTE &&
-      (get8BitLookupTable() != null || get16BitLookupTable() != null);
+      (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
     ms.imageCount = i.pixels.sizeZ * i.pixels.sizeC;
     ms.pixelType = ifd.getPixelType();
     ms.metadataComplete = true;

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -212,24 +212,24 @@ public class MIASReader extends FormatReader {
     return FormatTools.MUST_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     if (readers == null || readers[0][0].getCurrentFile() == null) {
       return null;
     }
-    return readers[0][0].get8BitLookupTable();
+    return readers[0][0].get8BitLookupTable(0);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     if (readers == null || readers[0][0].getCurrentFile() == null) {
       return null;
     }
-    return readers[0][0].get16BitLookupTable();
+    return readers[0][0].get16BitLookupTable(0);
   }
 
   /**
@@ -1210,7 +1210,7 @@ public class MIASReader extends FormatReader {
     byte[][] planes = null;
 
     if (r.isIndexed()) {
-      planes = ImageTools.indexedToRGB(r.get8BitLookupTable(), plane);
+      planes = ImageTools.indexedToRGB(r.get8BitLookupTable(0), plane);
     }
     else {
       int bpp = FormatTools.getBytesPerPixel(r.getPixelType());

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -257,6 +257,8 @@ public class MetamorphReader extends BaseTiffReader {
     throws FormatException, IOException
   {
     FormatTools.assertId(currentId, true, 1);
+    setPlane(plane);
+
     if (stks == null) {
       return super.openBytes(no, buf, x, y, w, h);
     }

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -431,7 +431,7 @@ public class NDPIReader extends BaseTiffReader {
       ms.sizeC = ms.rgb ? samples : 1;
       ms.littleEndian = ifd.isLittleEndian();
       ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+        (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
       ms.imageCount = ms.sizeZ * ms.sizeT;
       ms.pixelType = ifd.getPixelType();
       ms.metadataComplete = true;

--- a/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OpenlabReader.java
@@ -107,7 +107,6 @@ public class OpenlabReader extends FormatReader {
   private int[][] planeOffsets;
 
   private Vector<byte[][]> luts;
-  private int lastPlane = 0;
 
   private String gain, detectorOffset, xPos, yPos, zPos;
   private boolean specialPlateNames = false;
@@ -138,17 +137,19 @@ public class OpenlabReader extends FormatReader {
     return stream.readLong() == LIFF_MAGIC_BYTES;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     if (luts != null) {
+
+      openBytes(no);
+
       if (getSeries() < planeOffsets.length &&
-        lastPlane < planeOffsets[getSeries()].length)
-      {
-        return luts.get(planeOffsets[getSeries()][lastPlane]);
+          no < planeOffsets[getSeries()].length) {
+        return luts.get(planeOffsets[getSeries()][no]);
       }
-      else if (lastPlane < luts.size()) {
-        return luts.get(lastPlane);
+      else if (no < luts.size()) {
+        return luts.get(no);
       }
     }
     return null;
@@ -162,8 +163,6 @@ public class OpenlabReader extends FormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
-
-    lastPlane = no;
 
     PlaneInfo planeInfo = null;
     if (specialPlateNames) {
@@ -246,9 +245,9 @@ public class OpenlabReader extends FormatReader {
           if (isIndexed()) {
             int index = no;
             if (getSeries() < planeOffsets.length) {
-              index = planeOffsets[getSeries()][lastPlane];
+              index = planeOffsets[getSeries()][no];
             }
-            luts.setElementAt(pict.get8BitLookupTable(), index);
+            luts.setElementAt(pict.get8BitLookupTable(0), index);
           }
 
           r.openBytes(0, buf, x, y, w, h);
@@ -319,7 +318,6 @@ public class OpenlabReader extends FormatReader {
     if (!fileOnly) {
       planes = null;
       luts = null;
-      lastPlane = 0;
       version = 0;
       numSeries = 0;
       xcal = ycal = 0f;

--- a/components/formats-gpl/src/loci/formats/in/PDSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PDSReader.java
@@ -92,9 +92,9 @@ public class PDSReader extends FormatReader {
     return stream.readString(blockLen).equals(PDS_MAGIC_STRING);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     if (lutIndex < 0 || lutIndex >= 3) return null;
     short[][] lut = new short[3][65536];

--- a/components/formats-gpl/src/loci/formats/in/PSDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PSDReader.java
@@ -78,9 +78,9 @@ public class PSDReader extends FormatReader {
     return stream.readString(blockLen).startsWith(PSD_MAGIC_STRING);
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() {
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     return lut;
   }

--- a/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
@@ -175,21 +175,33 @@ public class PerkinElmerReader extends FormatReader {
     return FormatTools.MUST_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
-    if (isTiff && tiff != null) {
-      return tiff.get8BitLookupTable();
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    String file = getFile(no);
+    int index = getFileIndex(no);
+
+    if (isTiff) {
+      tiff.setId(file);
+      tiff.setPlane(index);
+      return tiff.get8BitLookupTable(0);
     }
+
     return null;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
-    if (isTiff && tiff != null) {
-      return tiff.get16BitLookupTable();
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    String file = getFile(no);
+    int index = getFileIndex(no);
+
+    if (isTiff) {
+      tiff.setId(file);
+      tiff.setPlane(index);
+      return tiff.get16BitLookupTable(0);
     }
+
     return null;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -150,7 +150,7 @@ public class PyramidTiffReader extends BaseTiffReader {
       ms.sizeC = ms.rgb ? samples : 1;
       ms.littleEndian = ifd.isLittleEndian();
       ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+        (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
       ms.imageCount = 1;
       ms.pixelType = ifd.getPixelType();
       ms.metadataComplete = true;

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -340,7 +340,7 @@ public class SVSReader extends BaseTiffReader {
       ms.sizeC = ms.rgb ? samples : 1;
       ms.littleEndian = ifd.isLittleEndian();
       ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+        (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
       ms.imageCount = 1;
       ms.pixelType = ifd.getPixelType();
       ms.metadataComplete = true;

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -143,24 +143,24 @@ public class ScreenReader extends FormatReader {
     return FormatTools.MUST_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     if (readers == null || readers[0].getCurrentFile() == null) {
       return null;
     }
-    return readers[0].get8BitLookupTable();
+    return readers[0].get8BitLookupTable(0);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     if (readers == null || readers[0].getCurrentFile() == null) {
       return null;
     }
-    return readers[0].get16BitLookupTable();
+    return readers[0].get16BitLookupTable(0);
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/SlidebookTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlidebookTiffReader.java
@@ -60,7 +60,6 @@ public class SlidebookTiffReader extends BaseTiffReader {
 
   // -- Fields --
 
-  private int lastFile = 0;
   private MinimalTiffReader[] readers;
   private String[] files;
   private ArrayList<String> channelNames = new ArrayList<String>();
@@ -102,7 +101,6 @@ public class SlidebookTiffReader extends BaseTiffReader {
           }
         }
       }
-      lastFile = 0;
       readers = null;
       files = null;
       channelNames.clear();
@@ -116,26 +114,30 @@ public class SlidebookTiffReader extends BaseTiffReader {
     return noPixels ? null : files;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (readers == null || lastFile < 0 || lastFile >= readers.length ||
+    int lastFile = no / getSizeT();
+
+    if (readers == null || lastFile >= readers.length ||
       readers[lastFile] == null)
     {
-      return super.get8BitLookupTable();
+      return super.get8BitLookupTable(no);
     }
-    return readers[lastFile].get8BitLookupTable();
+    return readers[lastFile].get8BitLookupTable(0);
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
-    if (readers == null || lastFile < 0 || lastFile >= readers.length ||
+    int lastFile = no / getSizeT();
+
+    if (readers == null || lastFile >= readers.length ||
       readers[lastFile] == null)
     {
-      return super.get16BitLookupTable();
+      return super.get16BitLookupTable(0);
     }
     return readers[lastFile].get16BitLookupTable();
   }
@@ -151,8 +153,6 @@ public class SlidebookTiffReader extends BaseTiffReader {
 
     int file = no / getSizeT();
     int plane = no % getSizeT();
-
-    lastFile = file;
 
     return readers[file].openBytes(plane, buf, x, y, w, h);
   }

--- a/components/formats-gpl/src/loci/formats/in/TargaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TargaReader.java
@@ -61,9 +61,9 @@ public class TargaReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
     FormatTools.assertId(currentId, true, 1);
     return isRGB() ? null : colorMap;
   }

--- a/components/formats-gpl/src/loci/formats/in/TrestleReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TrestleReader.java
@@ -267,7 +267,7 @@ public class TrestleReader extends BaseTiffReader {
       ms.sizeC = ms.rgb ? samples : 1;
       ms.littleEndian = ifd.isLittleEndian();
       ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+        (get8BitLookupTable(0) != null || get16BitLookupTable(0) != null);
       ms.imageCount = 1;
       ms.pixelType = ifd.getPixelType();
       ms.metadataComplete = true;

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -150,8 +150,6 @@ public class ZeissCZIReader extends FormatReader {
   private Length[] positionsY;
   private Length[] positionsZ;
 
-  private int previousChannel = 0;
-
   private Boolean prestitched = null;
   private String objectiveSettingsID;
   private boolean hasDetectorSettings = false;
@@ -206,11 +204,13 @@ public class ZeissCZIReader extends FormatReader {
     return files;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
   @Override
-  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+  public byte[][] get8BitLookupTable(int no) throws FormatException, IOException {
+    int previousChannel = getZCTCoords(no)[1];
+
     if ((getPixelType() != FormatTools.INT8 &&
-      getPixelType() != FormatTools.UINT8) || previousChannel == -1 ||
+      getPixelType() != FormatTools.UINT8) ||
       previousChannel >= channels.size())
     {
       return null;
@@ -243,11 +243,13 @@ public class ZeissCZIReader extends FormatReader {
     else return null;
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.IFormatReader#get16BitLookupTable(int) */
   @Override
-  public short[][] get16BitLookupTable() throws FormatException, IOException {
+  public short[][] get16BitLookupTable(int no) throws FormatException, IOException {
+    int previousChannel = getZCTCoords(no)[1];
+
     if ((getPixelType() != FormatTools.INT16 &&
-      getPixelType() != FormatTools.UINT16) || previousChannel == -1 ||
+      getPixelType() != FormatTools.UINT16) ||
       previousChannel >= channels.size())
     {
       return null;
@@ -293,7 +295,7 @@ public class ZeissCZIReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    previousChannel = getZCTCoords(no)[1];
+    int currentChannel = getZCTCoords(no)[1];
 
     int currentSeries = getSeries();
 
@@ -317,7 +319,7 @@ public class ZeissCZIReader extends FormatReader {
       int minTileX = Integer.MAX_VALUE, minTileY = Integer.MAX_VALUE;
       for (SubBlock plane : planes) {
         if ((plane.seriesIndex == currentSeries && plane.planeIndex == no) ||
-          (plane.planeIndex == previousChannel && validScanDim))
+          (plane.planeIndex == currentChannel && validScanDim))
         {
           if (plane.row < minTileY) {
             minTileY = plane.row;
@@ -329,7 +331,7 @@ public class ZeissCZIReader extends FormatReader {
       }
       for (SubBlock plane : planes) {
         if ((plane.seriesIndex == currentSeries && plane.planeIndex == no) ||
-          (plane.planeIndex == previousChannel && validScanDim))
+          (plane.planeIndex == currentChannel && validScanDim))
         {
           if ((prestitched != null && prestitched) || validScanDim) {
             int realX = plane.x;
@@ -455,7 +457,6 @@ public class ZeissCZIReader extends FormatReader {
       detectorRefs.clear();
       timestamps.clear();
 
-      previousChannel = 0;
       prestitched = null;
       objectiveSettingsID = null;
       imageName = null;

--- a/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
@@ -72,8 +72,8 @@ public class ZeissLMSReader extends FormatReader {
     return stream.readString(checkLen).indexOf(CHECK) >= 0;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
-  public byte[][] get8BitLookupTable() {
+  /* @see loci.formats.IFormatReader#get8BitLookupTable(int) */
+  public byte[][] get8BitLookupTable(int no) {
     FormatTools.assertId(currentId, true, 1);
     if (isIndexed()) {
       return lut;

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -92,7 +92,6 @@ public class ZeissZVIReader extends BaseZeissReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
-    lastPlane = no;
 
     if (poi == null) {
       initPOIService();


### PR DESCRIPTION
The current `FormatReader` interface and implementation contain some suboptimal aspects:
- `openBytes` takes a plane index, while `get*LookupTable` rely on the *previous* plane rather than taking a plane index as well
- The plane index must be cached by the reader; some readers do this, but the state can be easily invalidated by either calling `get*LookupTable` before `openBytes`, or changing the current series/resolution (most readers don't reset the cached plane index)

This PR corrects these defects by:
- Adding a plane index to `FormatReader` as for the coreIndex/series, and keeping it updated
- Adding `getPlane` and `setPlane` methods to `FormatReader` to expose the plane state to the user
- Converting the readers to use the cached plane state in place of each reader implementing this logic independently and potentially inconsistently
- Adding `get*LookupTable` methods which take a plane index explicitly (readers which rely on `openBytes` calling first are updated accordingly so that all `openBytes`/`get*LookupTable` method calls are idempotent)
- All use of `get*LookupTable` updated to use explicit plane indexes; this clearly documents exactly which plane is needed; this potentially unclear/ambigious in several places, where it could behave inconsistently depending upon which methods the user previously called
- Deprecating `getLookupTable` methods which don't use a plane index
- C++ interfaces also provide the same methods, and the sentry saves and restores the plane state along with the coreIndex/series

--breaking

Note that the unit tests don't currently pass--there's an indexing bounds failure testing LUTs; marking breaking.  I'm not sure why this is happening--I suspect I'm not doing something right in the `ReaderWrapper` and/or other wrapper classes in getting/setting/caching the plane state correctly, but not sure exactly what.  It might also be that I've exposed a latent bug which was previously not encountered.  Or it might be the unit tests themselves at fault.  Any thoughts here would be much appreciated.

--------

Testing: All tests should remain green.  Lookup table functionality should not have changed; the behaviour of the existing get*LookupTable functions should remain unchanged (this should not be a breaking change).