### PR TITLE
C++: Add plane state introspection and manipulation to reader and writer interfaces

### DIFF
--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -99,8 +99,10 @@ namespace ome
       private:
         /// Reader for which the state will be saved and restored.
         const FormatReader& reader;
-        /// Saved state.
+        /// Saved core index.
         dimension_size_type coreIndex;
+        /// Saved plane index.
+        dimension_size_type plane;
 
       public:
         /**
@@ -110,7 +112,8 @@ namespace ome
          */
         SaveSeries(const FormatReader& reader):
           reader(reader),
-          coreIndex(reader.getCoreIndex())
+          coreIndex(reader.getCoreIndex()),
+          plane(reader.getPlane())
         {}
 
         /**
@@ -124,6 +127,8 @@ namespace ome
             {
               if (coreIndex != reader.getCoreIndex())
                 reader.setCoreIndex(coreIndex);
+              if (plane != reader.getPlane())
+                reader.setCoreIndex(plane);
             }
           catch (...)
             {

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -605,7 +605,8 @@ namespace ome
       /**
        * Set the active series.
        *
-       * @note This also resets the resolution to 0.
+       * @note This also resets the resolution to 0 and the current
+       * plane to 0.
        *
        * @param series the series to activate.
        *
@@ -626,6 +627,25 @@ namespace ome
       virtual
       dimension_size_type
       getSeries() const = 0;
+
+      /**
+       * Set the active plane.
+       *
+       * @param plane the plane to activate.
+       *
+       * @todo Remove use of stateful API which requires use of
+       * plane switching in const methods.
+       */
+      virtual void
+      setPlane(dimension_size_type plane) const = 0;
+
+      /**
+       * Get the active plane.
+       *
+       * @returns the active plane.
+       */
+      virtual dimension_size_type
+      getPlane() const = 0;
 
       /**
        * Set float normalization.
@@ -1189,6 +1209,8 @@ namespace ome
 
       /**
        * Set the active resolution level.
+       *
+       * @note This also resets the current plane to 0.
        *
        * @param resolution the resolution to set.
        *

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -128,7 +128,7 @@ namespace ome
               if (coreIndex != reader.getCoreIndex())
                 reader.setCoreIndex(coreIndex);
               if (plane != reader.getPlane())
-                reader.setCoreIndex(plane);
+                reader.setPlane(plane);
             }
           catch (...)
             {

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -191,6 +191,25 @@ namespace ome
       getSeries() const = 0;
 
       /**
+       * Set the active plane.
+       *
+       * @param plane the plane to activate.
+       *
+       * @todo Remove use of stateful API which requires use of
+       * plane switching in const methods.
+       */
+      virtual void
+      setPlane(dimension_size_type plane) const = 0;
+
+      /**
+       * Get the active plane.
+       *
+       * @returns the active plane.
+       */
+      virtual dimension_size_type
+      getPlane() const = 0;
+
+      /**
        * Get whether or not the writer can save multiple images in a
        * single file.
        *

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -84,6 +84,7 @@ namespace ome
         metadata(),
         coreIndex(0),
         series(0),
+        plane(0),
         core(),
         resolution(0),
         flattenedResolutions(true),
@@ -739,6 +740,7 @@ namespace ome
                               dimension_size_type w,
                               dimension_size_type h) const
       {
+        setPlane(plane);
         openBytesImpl(plane, buf, x, y, w, h);
       }
 
@@ -762,7 +764,7 @@ namespace ome
         if (!fileOnly)
           {
             currentId = boost::none;
-            coreIndex = series = resolution = 0;
+            coreIndex = series = resolution = plane = 0;
             core.clear();
           }
       }
@@ -784,12 +786,36 @@ namespace ome
         this->coreIndex = seriesToCoreIndex(series);
         this->series = series;
         this->resolution = 0;
+        this->plane = 0;
       }
 
       dimension_size_type
       FormatReader::getSeries() const
       {
         return series;
+      }
+
+      void
+      FormatReader::setPlane(dimension_size_type plane) const
+      {
+        assertId(currentId, true);
+
+        if (plane >= getImageCount())
+          {
+            boost::format fmt("Invalid plane: %1%");
+            fmt % plane;
+            throw std::logic_error(fmt.str());
+          }
+
+        this->plane = plane;
+      }
+
+      dimension_size_type
+      FormatReader::getPlane() const
+      {
+        assertId(currentId, true);
+
+        return plane;
       }
 
       void
@@ -1286,6 +1312,7 @@ namespace ome
         this->coreIndex = seriesToCoreIndex(getSeries()) + resolution;
         // this->series unchanged.
         this->resolution = resolution;
+        this->plane = 0;
       }
 
       dimension_size_type
@@ -1325,6 +1352,7 @@ namespace ome
         this->series = coreIndexToSeries(index);
         this->coreIndex = index;
         this->resolution = index - seriesToCoreIndex(this->series);
+        this->plane = 0;
       }
 
       void

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -141,6 +141,14 @@ namespace ome
          */
         mutable dimension_size_type series;
 
+        /**
+         * The number of the current plane in the current series.
+         *
+         * @todo Remove use of stateful API which requires use of
+         * series switching in const methods.
+         */
+        mutable dimension_size_type plane;
+
         /// Core metadata values.
         coremetadata_list_type core;
 
@@ -599,6 +607,14 @@ namespace ome
         // Documented in superclass.
         dimension_size_type
         getSeries() const;
+
+        // Documented in superclass.
+        void
+        setPlane(dimension_size_type plane) const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getPlane() const;
 
         // Documented in superclass.
         void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -241,6 +241,7 @@ namespace ome
 
         return plane;
       }
+
       void
       FormatWriter::setFramesPerSecond(frame_rate_type rate)
       {

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -196,23 +196,12 @@ namespace ome
         dimension_size_type
         getSeries() const;
 
-        /**
-         * Set the active plane.
-         *
-         * @param plane the plane to activate.
-         *
-         * @todo Remove use of stateful API which requires use of
-         * plane switching in const methods.
-         */
-        virtual void
+        // Documented in superclass.
+        void
         setPlane(dimension_size_type plane) const;
 
-        /**
-         * Get the active plane.
-         *
-         * @returns the active plane.
-         */
-        virtual dimension_size_type
+        // Documented in superclass.
+        dimension_size_type
         getPlane() const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -1260,6 +1260,8 @@ namespace ome
       {
         assertId(currentId, true);
 
+        setPlane(plane);
+
         const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         try


### PR DESCRIPTION
- Add getPlane and setPlane to FormatReader and FormatWriter, to match getSeries and setSeries.
- FormatReader sentry saves and restores plane state in addition to series state.
- Current plane is set to zero on series change.

This is the C++ part of #1806 

--------

Testing: Jobs should remain green.  The only code currently exercising the plane state is the writers, and these were already using the methods (the change for FormatWriter is simply moving them up to the public interface to expose them)