### PR TITLE
Add memoize functionality to ImageInfo

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -258,7 +258,7 @@ public class ImageInfo {
         }
         else if (args[i].equals("-map")) map = args[++i];
         else if (args[i].equals("-format")) format = args[++i];
-        else if (args[i].equals("-cachedir")) {
+        else if (args[i].equals("-cache-dir")) {
             cache = true;
             cachedir = args[++i];
         }
@@ -288,7 +288,7 @@ public class ImageInfo {
       "    [-resolution num] [-swap inputOrder] [-shuffle outputOrder]",
       "    [-map id] [-preload] [-crop x,y,w,h] [-autoscale] [-novalid]",
       "    [-omexml-only] [-no-sas] [-no-upgrade] [-noflat] [-format Format]",
-      "    [-cache] [-cachedir dir]",
+      "    [-cache] [-cache-dir dir]",
       "",
       "    -version: print the library version and exit",
       "        file: the image file to read",
@@ -327,7 +327,7 @@ public class ImageInfo {
       " -no-upgrade: do not perform the upgrade check",
       "     -format: read file with a particular reader (e.g., ZeissZVI)",
       "      -cache: cache the initialized reader",
-      "   -cachedir: use the specified directory to store the cached",
+      "  -cache-dir: use the specified directory to store the cached",
       "              initialized reader. If unspecified, the cached reader",
       "              will be stored under the same folder as the image file",
       "",

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -57,6 +57,7 @@ import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.ImageTools;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.MinMaxCalculator;
 import loci.formats.MissingLibraryException;
@@ -106,6 +107,7 @@ public class ImageInfo {
   private boolean separate = false;
   private boolean expand = false;
   private boolean omexml = false;
+  private boolean memoize = false;
   private boolean originalMetadata = true;
   private boolean normalize = false;
   private boolean fastBlit = false;
@@ -155,6 +157,7 @@ public class ImageInfo {
     separate = false;
     expand = false;
     omexml = false;
+    memoize = false;
     originalMetadata = true;
     normalize = false;
     fastBlit = false;
@@ -192,6 +195,7 @@ public class ImageInfo {
         else if (args[i].equals("-nogroup")) group = false;
         else if (args[i].equals("-separate")) separate = true;
         else if (args[i].equals("-expand")) expand = true;
+        else if (args[i].equals("-memoize")) memoize = true;
         else if (args[i].equals("-omexml")) omexml = true;
         else if (args[i].equals("-no-sas")) originalMetadata = false;
         else if (args[i].equals("-normalize")) normalize = true;
@@ -277,6 +281,7 @@ public class ImageInfo {
       "    [-resolution num] [-swap inputOrder] [-shuffle outputOrder]",
       "    [-map id] [-preload] [-crop x,y,w,h] [-autoscale] [-novalid]",
       "    [-omexml-only] [-no-sas] [-no-upgrade] [-noflat] [-format Format]",
+      "    [-memoize]",
       "",
       "    -version: print the library version and exit",
       "        file: the image file to read",
@@ -314,6 +319,7 @@ public class ImageInfo {
       "     -no-sas: do not output OME-XML StructuredAnnotation elements",
       " -no-upgrade: do not perform the upgrade check",
       "     -format: read file with a particular reader (e.g., ZeissZVI)",
+      "    -memoize: cache the initialized reader",
       "",
       "* = may result in loss of precision",
       ""
@@ -421,6 +427,7 @@ public class ImageInfo {
     if (expand) reader = new ChannelFiller(reader);
     if (separate) reader = new ChannelSeparator(reader);
     if (merge) reader = new ChannelMerger(reader);
+    if (memoize) reader = new Memoizer(reader, 0);
     minMaxCalc = null;
     if (minmax || autoscale) reader = minMaxCalc = new MinMaxCalculator(reader);
     dimSwapper = null;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -258,7 +258,10 @@ public class ImageInfo {
         }
         else if (args[i].equals("-map")) map = args[++i];
         else if (args[i].equals("-format")) format = args[++i];
-        else if (args[i].equals("-cachedir")) cachedir = args[++i];
+        else if (args[i].equals("-cachedir")) {
+            cache = true;
+            cachedir = args[++i];
+        }
         else if (!args[i].equals(NO_UPGRADE_CHECK)) {
           LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -34,6 +34,7 @@ package loci.formats.tools;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.File;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
 
@@ -107,7 +108,7 @@ public class ImageInfo {
   private boolean separate = false;
   private boolean expand = false;
   private boolean omexml = false;
-  private boolean memoize = false;
+  private boolean cache = false;
   private boolean originalMetadata = true;
   private boolean normalize = false;
   private boolean fastBlit = false;
@@ -127,6 +128,7 @@ public class ImageInfo {
   private String swapOrder = null, shuffleOrder = null;
   private String map = null;
   private String format = null;
+  private String cachedir = null;
   private int xmlSpaces = 3;
 
   private IFormatReader reader;
@@ -157,7 +159,7 @@ public class ImageInfo {
     separate = false;
     expand = false;
     omexml = false;
-    memoize = false;
+    cache = false;
     originalMetadata = true;
     normalize = false;
     fastBlit = false;
@@ -180,6 +182,7 @@ public class ImageInfo {
     swapOrder = null;
     shuffleOrder = null;
     map = null;
+    cachedir = null;
     if (args == null) return false;
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-")) {
@@ -195,7 +198,7 @@ public class ImageInfo {
         else if (args[i].equals("-nogroup")) group = false;
         else if (args[i].equals("-separate")) separate = true;
         else if (args[i].equals("-expand")) expand = true;
-        else if (args[i].equals("-memoize")) memoize = true;
+        else if (args[i].equals("-cache")) cache = true;
         else if (args[i].equals("-omexml")) omexml = true;
         else if (args[i].equals("-no-sas")) originalMetadata = false;
         else if (args[i].equals("-normalize")) normalize = true;
@@ -255,6 +258,7 @@ public class ImageInfo {
         }
         else if (args[i].equals("-map")) map = args[++i];
         else if (args[i].equals("-format")) format = args[++i];
+        else if (args[i].equals("-cachedir")) cachedir = args[++i];
         else if (!args[i].equals(NO_UPGRADE_CHECK)) {
           LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;
@@ -281,7 +285,7 @@ public class ImageInfo {
       "    [-resolution num] [-swap inputOrder] [-shuffle outputOrder]",
       "    [-map id] [-preload] [-crop x,y,w,h] [-autoscale] [-novalid]",
       "    [-omexml-only] [-no-sas] [-no-upgrade] [-noflat] [-format Format]",
-      "    [-memoize]",
+      "    [-cache] [-cachedir dir]",
       "",
       "    -version: print the library version and exit",
       "        file: the image file to read",
@@ -319,7 +323,10 @@ public class ImageInfo {
       "     -no-sas: do not output OME-XML StructuredAnnotation elements",
       " -no-upgrade: do not perform the upgrade check",
       "     -format: read file with a particular reader (e.g., ZeissZVI)",
-      "    -memoize: cache the initialized reader",
+      "      -cache: cache the initialized reader",
+      "   -cachedir: use the specified directory to store the cached",
+      "              initialized reader. If unspecified, the cached reader",
+      "              will be stored under the same folder as the image file",
       "",
       "* = may result in loss of precision",
       ""
@@ -427,7 +434,13 @@ public class ImageInfo {
     if (expand) reader = new ChannelFiller(reader);
     if (separate) reader = new ChannelSeparator(reader);
     if (merge) reader = new ChannelMerger(reader);
-    if (memoize) reader = new Memoizer(reader, 0);
+    if (cache) {
+      if (cachedir != null) {
+        reader  = new Memoizer(reader, 0, new File(cachedir));
+      } else {
+        reader = new Memoizer(reader, 0);
+      }
+    }
     minMaxCalc = null;
     if (minmax || autoscale) reader = minMaxCalc = new MinMaxCalculator(reader);
     dimSwapper = null;
@@ -476,7 +489,7 @@ public class ImageInfo {
     // read basic metadata
     LOGGER.info("");
     LOGGER.info("Reading core metadata");
-    LOGGER.info("{} = {}", stitch ? "File pattern" : "Filename",
+    LOGGER.info("{} = {}", stitch ? "File pattern" : "filename",
       stitch ? id : reader.getCurrentFile());
     if (map != null) LOGGER.info("Mapped filename = {}", map);
     if (usedFiles) {


### PR DESCRIPTION
This should also ease the testing of Memoizer functionalities which can be invoked in the command-line tools via:

```
showinf -cache /path/to/file
showinf -cache-dir /tmp /path/to/file
```