### PR TITLE
Reduce missing library log level

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -89,7 +89,7 @@ public class SlideBook6Reader  extends FormatReader {
 			libraryFound = true;
 		}
 		catch (UnsatisfiedLinkError e) {
-			LOGGER.warn(NO_3I_MSG, e);
+			LOGGER.debug(NO_3I_MSG, e);
 			libraryFound = false;
 		}
 		catch (SecurityException e) {


### PR DESCRIPTION
This should prevent exceptions from being logged at WARN when the SlideBook .dlls are missing.

To test, pick any .sld file from ```test_images_good/slidebook``` or ```from_skyking/slidebook```; verify that ```showinf -nopix``` shows a logged exception without this change, and no exception with this change.