### PR TITLE
Explain JAVA/Matlab relationship in the docs

### DIFF
--- a/docs/sphinx/about/bug-reporting.txt
+++ b/docs/sphinx/about/bug-reporting.txt
@@ -36,7 +36,7 @@ Common issues to check
        suspicious-file: AppleDouble encoded Macintosh file
 -  If you get an ``OutOfMemory`` or ``NegativeArraySize`` error message when
    attempting to open an SVS or JPEG-2000 file then the amount of pixel data
-   in a single image plane exceeds the amount of memory allocated to the JVM
+   in a single image plane exceeds the amount of memory allocated to the |JVM|
    or 2 GB, respectively. For the former, you can increase the amount of
    memory allocated; in the latter case, you will need to open the image in
    sections. If you are using Bio-Formats as a library, this means using the

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -188,6 +188,7 @@ rst_epilog = """
 .. _Hibernate: http://www.hibernate.org
 .. _ZeroC: http://www.zeroc.com
 .. _Ice: http://www.zeroc.com
+.. |JVM| replace:: :abbr:`JVM (Java Virtual Machine)`
 
 .. |Poor| image:: /images/crystal-1.png
            :alt: 1 - Poor

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -44,7 +44,7 @@ On Windows, the arguments to the test command must be quoted:
 
     > ant "-Dtestng.directory=$DATA\metamorph" test-automated
 
-By default, 512 MB of memory are allocated to the JVM. You can increase
+By default, 512 MB of memory are allocated to the |JVM|. You can increase
 this by adding the '-Dtestng.memory=XXXm' option. You should now see
 output similar to this:
 

--- a/docs/sphinx/developers/jace/build-windows.txt
+++ b/docs/sphinx/developers/jace/build-windows.txt
@@ -67,7 +67,7 @@ e.g.:
 
 This step ensures that a directory containing jvm.dll is present in the PATH.
 If you do not perform this step, you will receive a runtime error when
-attempting to initialize a JVM from native code.
+attempting to initialize a |JVM| from native code.
 
 Optionally, you can add the bin subdirectory to the PATH; e.g.:
 

--- a/docs/sphinx/developers/jace/build.txt
+++ b/docs/sphinx/developers/jace/build.txt
@@ -35,7 +35,7 @@ required:
     At runtime, only the Java Runtime Environment (JRE) is necessary to 
     execute the Bio-Formats code. However, the full J2SE development kit is 
     required at compile time on some platforms (Windows in particular), since 
-    it comes bundled with the JVM shared library (jvm.lib) necessary to link 
+    it comes bundled with the |JVM| shared library (jvm.lib) necessary to link 
     with Java.
 
 For information on installing these dependencies, refer to the page for your

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -7,6 +7,10 @@ This section assumes that you have installed the MATLAB toolbox as instructed
 in the :doc:`MATLAB user information page </users/matlab/index>`. Note the
 minimum supported MATLAB version is R2007b (7.5).
 
+As described in `Using Java Libraries <http://uk.mathworks.com/help/matlab/matlab_external/product-overview.html>`_,
+every installation of MATLAB includes a Java Virtual Machine allowing to use
+the Java API and third-party Java libraries.
+
 Increasing JVM memory settings
 ------------------------------
 

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -8,20 +8,20 @@ in the :doc:`MATLAB user information page </users/matlab/index>`. Note the
 minimum supported MATLAB version is R2007b (7.5).
 
 As described in `Using Java Libraries <http://uk.mathworks.com/help/matlab/matlab_external/product-overview.html>`_,
-every installation of MATLAB includes a Java Virtual Machine allowing to use
-the Java API and third-party Java libraries.
+every installation of MATLAB includes a |JVM| allowing to use the Java API and
+third-party Java libraries.
 
-Increasing JVM memory settings
-------------------------------
+Increasing |JVM| memory settings
+--------------------------------
 
-The default JVM settings in MATLAB can result in
+The default |JVM| settings in MATLAB can result in
 ``java.lang.OutOfMemoryError: Java heap space`` exceptions when opening large
 image files using Bio-Formats. Information about the Java heap space usage in
 MATLAB can be retrieved using::
 
 	java.lang.Runtime.getRuntime.maxMemory
 
-Default JVM settings can be increased by creating a :file:`java.opts` file in
+Default |JVM| settings can be increased by creating a :file:`java.opts` file in
 the startup directory and overriding the default memory settings. We recommend
 using ``-Xmx512m`` in your :file:`java.opts` file. Calling::
 

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -8,7 +8,7 @@ in the :doc:`MATLAB user information page </users/matlab/index>`. Note the
 minimum supported MATLAB version is R2007b (7.5).
 
 As described in `Using Java Libraries <http://uk.mathworks.com/help/matlab/matlab_external/product-overview.html>`_,
-every installation of MATLAB includes a |JVM| allowing to use the Java API and
+every installation of MATLAB includes a |JVM| allowing use of the Java API and
 third-party Java libraries. All the helper functions included in the MATLAB
 toolbox make use of the Bio-Formats Java API. Please refer to the
 :javadoc:`Javadocs <>` for more information.

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -9,7 +9,9 @@ minimum supported MATLAB version is R2007b (7.5).
 
 As described in `Using Java Libraries <http://uk.mathworks.com/help/matlab/matlab_external/product-overview.html>`_,
 every installation of MATLAB includes a |JVM| allowing to use the Java API and
-third-party Java libraries.
+third-party Java libraries. All the helper functions included in the MATLAB
+toolbox make use of the Bio-Formats Java API. Please refer to the
+:javadoc:`Javadocs <>` for more information.
 
 Increasing |JVM| memory settings
 --------------------------------


### PR DESCRIPTION
See https://trello.com/c/3tqP1qU9. This PR should hopefully clarify the fact that MATLAB is using the Bio-Formats Java API directly and add an extra link to the Javadocs.