### PR TITLE
Command-line tools: 5.1.2 docs

### DIFF
--- a/docs/sphinx/users/comlinetools/display.txt
+++ b/docs/sphinx/users/comlinetools/display.txt
@@ -96,3 +96,24 @@ Debugging output can also be enabled if more information is needed:
 ::
 
   showinf -debug /path/to/file
+
+Image display can be done as quickly as possible using::
+
+  showinf -fast /path/to/file
+
+Note that this command results in a loss of precision.
+
+In combination with the :option:`-fast` option, the display range can be
+adjusted to the minimum and maximum pixel values::
+
+  showinf -fast -autoscale /path/to/file
+
+After initialization, the reader can be cached under the same directory as the
+input file::
+
+  showinf -cache /path/to/file
+
+It is also possible to specify the base directory under which the reader
+should be cached::
+
+  showinf -cache-dir /tmp/cachedir /path/to/file

--- a/docs/sphinx/users/comlinetools/display.txt
+++ b/docs/sphinx/users/comlinetools/display.txt
@@ -4,7 +4,7 @@ Displaying images and metadata
 The :command:`showinf` :doc:`command line tool <index>` can be used to show the
 images and metadata contained in a file.
 
-If no options are specified, :command:`showinf` displays a summary of available
+If no options are specified, :program:`showinf` displays a summary of available
 options.
 
 .. program:: showinf
@@ -19,101 +19,130 @@ All of the images in the first 'series' (or 5 dimensional stack) will be
 opened and displayed in a simple image viewer.  The number of series, image
 dimensions, and other basic metadata will be printed to the console.
 
-To display a different series, for example the second one:
+.. option:: -series SERIES
 
-::
+    To display a different series, for example the second one:
 
-  showinf -series 1 /path/to/file
+    ::
 
-Note that series numbers begin with 0.
+      showinf -series 1 /path/to/file
 
-To display the OME-XML metadata for a file on the console:
+    Note that series numbers begin with 0.
 
-::
+.. option:: -omexml
 
-  showinf -omexml /path/to/file
+    To display the OME-XML metadata for a file on the console:
 
-Image reading can be suppressed if only the metadata is needed:
+    ::
 
-::
+      showinf -omexml /path/to/file
 
-  showinf -nopix /path/to/file
+.. option:: -nopix
 
-A subset of images can also be opened instead of the entire stack, by
-specifying the start and end plane indices (inclusive):
+    Image reading can be suppressed if only the metadata is needed:
 
-::
+    ::
 
-  showinf -range 0 0 /path/to/file
+      showinf -nopix /path/to/file
 
-That opens only the first image in first series in the file.
+.. option:: -range START END
 
-For very large images, it may also be useful to open a small tile from the
-image instead of reading everything into memory.  To open the upper-left-most
-512x512 tile from the images:
+    A subset of images can also be opened instead of the entire stack, by
+    specifying the start and end plane indices (inclusive):
 
-::
+    ::
 
-  showinf -crop 0,0,512,512 /path/to/file
+      showinf -range 0 0 /path/to/file
 
-The parameter to ``-crop`` is of the format ``x,y,width,height``.  The (x, y)
-coordinate (0, 0) is the upper-left corner of the image; ``x + width`` must be
-less than or equal to the image width and ``y + height`` must be less than or
-equal to the image height.
+    That opens only the first image in first series in the file.
 
-By default, :command:`showinf` will check for a new version of Bio-Formats.  This can
-take several seconds (especially on a slow internet connection); to save time,
-the update check can be disabled:
+.. option:: -crop X,Y,WIDTH,HEIGHT
 
-::
+    For very large images, it may also be useful to open a small tile from the
+    image instead of reading everything into memory.  To open the
+    upper-left-most 512x512 tile from the images:
 
-  showinf -no-update /path/to/file
+    ::
 
-Similarly, if OME-XML is displayed then it will automatically be validated.
-On slow or missing internet connections, this can take some time, and so can
-be disabled:
+      showinf -crop 0,0,512,512 /path/to/file
 
-::
+    The parameter to :option:`-crop` is of the format ``x,y,width,height``.  
+    The (x, y) coordinate (0, 0) is the upper-left corner of the image;
+    ``x + width`` must be less than or equal to the image width and
+    ``y + height`` must be less than or equal to the image height.
 
-  showinf -novalid /path/to/file
+.. option:: -no-upgrade
 
-Most output can be suppressed:
+    By default, :program:`showinf` will check for a new version of
+    Bio-Formats.  This can take several seconds (especially on a slow internet
+    connection); to save time, the update check can be disabled:
 
-::
+    ::
 
-  showinf -nocore /path/to/file
+      showinf -no-upgrade /path/to/file
 
-and to display the OME-XML alone:
+.. option:: -no-valid
 
-::
+    Similarly, if OME-XML is displayed then it will automatically be validated.
+    On slow or missing internet connections, this can take some time, and so
+    can be disabled:
 
-  showinf -omexml-only /path/to/file
+    ::
 
-This is particularly helpful when there are hundreds or thousands of series.
+      showinf -novalid /path/to/file
 
-Debugging output can also be enabled if more information is needed:
+.. option:: -no-core
 
-::
+    Most output can be suppressed:
 
-  showinf -debug /path/to/file
+    ::
 
-Image display can be done as quickly as possible using::
+      showinf -nocore /path/to/file
 
-  showinf -fast /path/to/file
+.. option:: -omexml-only
 
-Note that this command results in a loss of precision.
+    and to display the OME-XML alone:
 
-In combination with the :option:`-fast` option, the display range can be
-adjusted to the minimum and maximum pixel values::
+    ::
 
-  showinf -fast -autoscale /path/to/file
+      showinf -omexml-only /path/to/file
 
-After initialization, the reader can be cached under the same directory as the
-input file::
+    This is particularly helpful when there are hundreds or thousands of
+    series.
 
-  showinf -cache /path/to/file
+.. option:: -debug
 
-It is also possible to specify the base directory under which the reader
-should be cached::
+    Debugging output can also be enabled if more information is needed:
 
-  showinf -cache-dir /tmp/cachedir /path/to/file
+    ::
+
+      showinf -debug /path/to/file
+
+.. option:: -fast
+
+    Image display can be done as quickly as possible using::
+
+      showinf -fast /path/to/file
+
+.. option:: -autoscale
+
+    Note that this command results in a loss of precision.
+
+    In combination with the :option:`-fast` option, the display range can be
+    adjusted to the minimum and maximum pixel values::
+
+      showinf -fast -autoscale /path/to/file
+
+.. option:: -cache
+
+    After initialization, the reader can be cached under the same directory as 
+    the input file::
+
+      showinf -cache /path/to/file
+
+.. option:: -cache-dir DIR
+
+    It is also possible to specify the base directory under which the reader
+    should be cached::
+
+      showinf -cache-dir /tmp/cachedir /path/to/file

--- a/docs/sphinx/users/comlinetools/display.txt
+++ b/docs/sphinx/users/comlinetools/display.txt
@@ -7,6 +7,8 @@ images and metadata contained in a file.
 If no options are specified, :command:`showinf` displays a summary of available
 options.
 
+.. program:: showinf
+
 To simply display images:
 
 ::


### PR DESCRIPTION
Following https://github.com/openmicroscopy/bioformats/pull/1808, this PR:
- adds basic documentation for the `-cache`/`-cache-dir` options of `showinf`
- adds basic documentation fro the `-fast`/`-autoscale` options /cc @mtbc 

The last commit implements a proposal to migrate this page to using the `program/option` markup (similarly to what was done for the CLI). The benefit would be 1- to register these options in the generated index and 2- to allow cross-references across the documentation using :option:`showinf -nopix`. On the flip side, this does not fully matches the way this page was originally written. This proposal was implemented in an isolated commit and can be reverted /cc @hflynn 