### PR TITLE
C++: Minor writer improvements and writer example with documentation

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -48,6 +48,9 @@ target_link_libraries(metadata-io ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INI
 add_executable(metadata-formatreader "${exampledir}/metadata-formatreader.cpp")
 target_link_libraries(metadata-formatreader ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(metadata-formatwriter "${exampledir}/metadata-formatwriter.cpp")
+target_link_libraries(metadata-formatwriter ome-xml ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(pixeldata "${exampledir}/pixeldata.cpp")
 target_link_libraries(pixeldata ome-bioformats ${CMAKE_THREAD_LIBS_INIT})
 
@@ -55,5 +58,6 @@ if(BUILD_TESTS)
   bf_add_test(examples/model-io model-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
   bf_add_test(examples/metadata-io metadata-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
   bf_add_test(examples/metadata-formatreader metadata-formatreader "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/set-1-meta-companion/18x24y5z1t1c8b-text-split-Z1.ome.tiff")
+  bf_add_test(examples/metadata-formatwriter metadata-formatwriter "${CMAKE_CURRENT_BINARY_DIR}/test-write.ome.tiff")
   bf_add_test(examples/pixeldata pixeldata "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
 endif(BUILD_TESTS)

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -113,7 +113,7 @@ namespace ome
 
       /// Type used to index all dimensions in public interfaces.
       typedef ome::compat::array<boost::multi_array_types::index,
-                         PixelBufferBase::dimensions> indices_type;
+                                 PixelBufferBase::dimensions> indices_type;
 
       /// Storage ordering type for controlling pixel memory layout.
       typedef boost::general_storage_order<dimensions> storage_order_type;

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -109,6 +109,13 @@ namespace ome
 
       MinimalTIFFReader::~MinimalTIFFReader()
       {
+        try
+          {
+            close();
+          }
+        catch (...)
+          {
+          }
       }
 
       bool

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -183,6 +183,13 @@ namespace ome
 
       OMETIFFReader::~OMETIFFReader()
       {
+        try
+          {
+            close();
+          }
+        catch (...)
+          {
+          }
       }
 
       void

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -89,6 +89,13 @@ namespace ome
 
       TIFFReader::~TIFFReader()
       {
+        try
+          {
+            close();
+          }
+        catch (...)
+          {
+          }
       }
 
       void

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -123,6 +123,13 @@ namespace ome
 
       MinimalTIFFWriter::~MinimalTIFFWriter()
       {
+        try
+          {
+            close();
+          }
+        catch (...)
+          {
+          }
       }
 
       void

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -435,6 +435,13 @@ namespace ome
 
       OMETIFFWriter::~OMETIFFWriter()
       {
+        try
+          {
+            close();
+          }
+        catch (...)
+          {
+          }
       }
 
       void

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -128,6 +128,7 @@ bf_github_tree = bf_github_root + 'tree/' + source_branch + '/'
 bf_github_blob = bf_github_root + 'blob/' + source_branch + '/'
 gpl_formats = bf_github_blob + 'components/formats-gpl/src/loci/formats/'
 bsd_formats = bf_github_blob + 'components/formats-bsd/src/loci/formats/'
+bf_cpp = bf_github_blob + 'cpp/'
 
 # Variables used to define Jenkins extlinks
 jenkins_root = 'http://ci.openmicroscopy.org'
@@ -158,6 +159,7 @@ extlinks = {
     'bsd-reader' : (bsd_formats + 'in/%s', ''),
     'bfwriter' : (gpl_formats + 'out/' + '%s', ''),
     'bsd-writer' : (bsd_formats + 'out/' + '%s', ''),
+    'bf-cpp-lib': (bf_cpp + 'lib/' + '%s', ''),
     # Jenkins links
     'jenkins' : (jenkins_root + '/%s', ''),
     'jenkinsjob' : (jenkins_job_root + '/%s', ''),

--- a/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
@@ -211,6 +211,9 @@ main(int argc, char *argv[])
 
           // Read pixel data
           readPixelData(*reader, std::cout);
+
+          // Explicitly close reader
+          reader->close();
           /* reader-example-end */
         }
       else

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
@@ -1,0 +1,216 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <iostream>
+
+#include <ome/bioformats/CoreMetadata.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/VariantPixelBuffer.h>
+#include <ome/bioformats/out/OMETIFFWriter.h>
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+#include <ome/compat/memory.h>
+
+#include <ome/common/filesystem.h>
+
+using boost::filesystem::path;
+using ome::compat::make_shared;
+using ome::compat::shared_ptr;
+using ome::bioformats::dimension_size_type;
+using ome::bioformats::fillMetadata;
+using ome::bioformats::CoreMetadata;
+using ome::bioformats::DIM_SPATIAL_X;
+using ome::bioformats::DIM_SPATIAL_Y;
+using ome::bioformats::DIM_SUBCHANNEL;
+using ome::bioformats::FormatWriter;
+using ome::bioformats::MetadataMap;
+using ome::bioformats::out::OMETIFFWriter;
+using ome::bioformats::PixelBuffer;
+using ome::bioformats::PixelBufferBase;
+using ome::bioformats::PixelProperties;
+using ome::bioformats::VariantPixelBuffer;
+using ome::xml::model::enums::PixelType;
+using ome::xml::model::enums::DimensionOrder;
+
+namespace
+{
+
+  /* write-example-start */
+  shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+  createMetadata()
+  {
+    // OME-XML metadata store.
+    shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+
+    // Create simple CoreMetadata and use this to set up the OME-XML
+    // metadata.  This is purely for convenience in this example; a
+    // real writer would typically set up the OME-XML metadata from an
+    // existing MetadataRetrieve instance or by hand.
+    std::vector<shared_ptr<CoreMetadata> > seriesList;
+    shared_ptr<CoreMetadata> core(make_shared<CoreMetadata>());
+    core->sizeX = 512U;
+    core->sizeY = 512U;
+    core->sizeC.clear(); // defaults to 1 channel with 1 subchannel; clear this
+    core->sizeC.push_back(3U); // replace with single RGB channel
+    core->pixelType = ome::xml::model::enums::PixelType::UINT16;
+    core->interleaved = false;
+    core->bitsPerPixel = 12U;
+    core->dimensionOrder = DimensionOrder::XYZTC;
+    seriesList.push_back(core);
+
+    fillMetadata(*meta, seriesList);
+
+    return meta;
+  }
+  /* write-example-end */
+
+  /* pixel-example-start */
+  void
+  writePixelData(FormatWriter& writer,
+                 std::ostream& stream)
+  {
+    // Total number of images (series)
+    dimension_size_type ic = 1;
+    stream << "Image count: " << ic << '\n';
+
+    // Loop over images
+    for (dimension_size_type i = 0 ; i < ic; ++i)
+      {
+        // Change the current series to this index
+        writer.setSeries(i);
+
+        // Total number of planes.
+        dimension_size_type pc = 1;
+        stream << "\tPlane count: " << pc << '\n';
+
+        // Loop over planes (for this image index)
+        for (dimension_size_type p = 0 ; p < pc; ++p)
+          {
+            // Pixel buffer; size 512 × 512 with 3 subchannels of type
+            // uint16_t.  It uses the native endianness and has a
+            // storage order of XYZTC without interleaving
+            // (subchannels are planar).
+            shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> >
+              buffer(make_shared<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> >
+                     (boost::extents[512][512][1][1][1][3][1][1][1],
+                      PixelType::UINT16, ome::bioformats::ENDIAN_NATIVE,
+                      PixelBufferBase::make_storage_order(DimensionOrder::XYZTC, false)));
+
+            // Fill each subchannel with a different intensity ramp in
+            // the 12-bit range.  In a real program, the pixel data
+            // would typically be obtained from data acquisition or
+            // another image.
+            for (dimension_size_type x = 0; x < 512; ++x)
+              for (dimension_size_type y = 0; y < 512; ++y)
+                {
+                  PixelBufferBase::indices_type idx;
+                  std::fill(idx.begin(), idx.end(), 0);
+                  idx[DIM_SPATIAL_X] = x;
+                  idx[DIM_SPATIAL_Y] = y;
+                  
+                  idx[DIM_SUBCHANNEL] = 0;
+                  buffer->at(idx) = (static_cast<float>(x) / 512.0f) * 4096.0f;
+                  idx[DIM_SUBCHANNEL] = 1;
+                  buffer->at(idx) = (static_cast<float>(y) / 512.0f) * 4096.0f;
+                  idx[DIM_SUBCHANNEL] = 2;
+                  buffer->at(idx) = (static_cast<float>(x+y) / 1024.0f) * 4096.0f;
+                }
+
+            VariantPixelBuffer vbuffer(buffer);
+            stream << "PixelBuffer PixelType is " << buffer->pixelType() << '\n';
+            stream << "VariantPixelBuffer PixelType is " << vbuffer.pixelType() << '\n';
+            stream << std::flush;
+
+            // Write the the entire pixel buffer to the plane.
+            writer.saveBytes(p, vbuffer);
+
+            stream << "Wrote " << buffer->num_elements() << ' ' << buffer->pixelType() << " pixels\n";
+          }
+      }
+  }
+  /* pixel-example-end */
+
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      if (argc > 1)
+        {
+          // Portable path
+          path filename(argv[1]);
+
+          /* writer-example-start */
+          // Create metadata for the file to be written.
+          shared_ptr< ::ome::xml::meta::MetadataRetrieve> meta(createMetadata());
+
+          // Create TIFF writer
+          shared_ptr<FormatWriter> writer(make_shared<OMETIFFWriter>());
+
+          // Set writer options before opening a file
+          writer->setMetadataRetrieve(meta);
+          writer->setInterleaved(false);
+
+          // Open the file
+          writer->setId(filename);
+
+          // Write pixel data
+          writePixelData(*writer, std::cout);
+
+          // Explicitly close writer
+          writer->close();
+          /* writer-example-end */
+        }
+      else
+        {
+          std::cerr << "Usage: " << argv[0] << " ome-xml.xml\n";
+          std::exit(1);
+        }
+    }
+  catch (const std::exception& e)
+    {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+      std::exit(1);
+    }
+  catch (...)
+    {
+      std::cerr << "Caught unknown exception\n";
+      std::exit(1);
+    }
+}

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -488,10 +488,11 @@ with OME-XML metadata).
 
 Using a reader involves these steps:
 
-#. Create a reader instance
-#. Set options to control reader behavior
-#. Call :cpp:func:`setId` to specify the image file to read
-#. Retrieve desired metadata and pixel data
+#. Create a reader instance.
+#. Set options to control reader behavior.
+#. Call :cpp:func:`setId` to specify the image file to read.
+#. Retrieve desired metadata and pixel data.
+#. Close the reader.
 
 These steps are illustrated in this example:
 
@@ -539,12 +540,13 @@ OME-TIFF (TIFF with OME-XML metadata).
 
 Using a writer involves these steps:
 
-#. Create a writer instance
-#. Set metadata store to use
-#. Set options to control writer behavior
-#. Call :cpp:func:`setId` to specify the image file to write
+#. Create a writer instance.
+#. Set metadata store to use.
+#. Set options to control writer behavior.
+#. Call :cpp:func:`setId` to specify the image file to write.
 #. Store pixel data for each plane of each image in the specified
-   dimension order
+   dimension order.
+#. Close the writer.
 
 These steps are illustrated in this example:
 

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -50,6 +50,11 @@ certain modifications to the data model may only be made via direct
 access to the model objects, otherwise the higher-level metadata store
 interface should be preferred.
 
+The header :file:`ome/bioformats/MetadataTools.h` provides several
+convenience functions to work with and manipulate the various forms of
+metadata, including conversion of Core metadata to and from a metadata
+store.
+
 Core metadata
 ^^^^^^^^^^^^^
 
@@ -66,7 +71,26 @@ themselves are more of an implementation detail at present.
    :start-after: read-example-start
    :end-before: read-example-end
 
-Full example source: :download:`metadata-formatreader.cpp <examples/metadata-formatreader.cpp>`
+If implementing a reader, it is fairly typical to set the basic image
+metadata in :cpp:class:`CoreMetadata` objects, and then use the
+:cpp:func:`fillMetadata` function in
+:file:`ome/bioformats/MetadataTools.h` to fill the reader's metadata
+store with this information, before filling the metadata store with
+additional (non-core) metadata as required.  When writing an image, a
+metadata store is required in order to provide the writer with all the
+metadata needed to write an image.  If the metadata store was not
+already obtained from a reader, :cpp:func:`fillMetadata` may also be
+used in this situation to create a suitable metadata store:
+
+.. literalinclude:: examples/metadata-formatwriter.cpp
+   :language: cpp
+   :start-after: write-example-start
+   :end-before: write-example-end
+
+Full example source: :download:`metadata-formatreader.cpp
+<examples/metadata-formatreader.cpp>`,
+:download:`metadata-formatreader.cpp
+<examples/metadata-formatwriter.cpp>`
 
 .. seealso::
 
@@ -366,6 +390,14 @@ example, to read all pixel data in an image using
    :start-after: pixel-example-start
    :end-before: pixel-example-end
 
+To perform the reverse process, writing pixel data with
+:cpp:func:`saveBytes`:
+
+.. literalinclude:: examples/metadata-formatwriter.cpp
+   :language: cpp
+   :start-after: pixel-example-start
+   :end-before: pixel-example-end
+
 Both buffer classes provide access to the pixel data so that it may be
 accessed, manipulated and passed elsewhere.  The
 :cpp:class:`PixelBuffer` class provides an :cpp:class:`at` method.
@@ -457,7 +489,7 @@ Using a reader involves these steps:
 
 #. Create a reader instance
 #. Set options to control reader behavior
-#. Call :cpp:func:`setId` to read a specific image file
+#. Call :cpp:func:`setId` to specify the image file to read
 #. Retrieve desired metadata and pixel data
 
 These steps are illustrated in this example:
@@ -493,3 +525,59 @@ Full example source: :download:`metadata-formatreader.cpp <examples/metadata-for
   - :doxygen:`FormatReader <classome_1_1bioformats_1_1FormatReader.html>`
   - :doxygen:`TIFFReader <classome_1_1bioformats_1_1in_1_1TIFFReader.html>`
   - :doxygen:`OMETIFFReader <classome_1_1bioformats_1_1in_1_1OMETIFFReader.html>`
+
+Writing images
+--------------
+
+Image writing is performed using the :cpp:class:`FormatWriter`
+interface.  This is an abstract writer interface implemented by
+file-format-specific writer classes.  Examples of writers include
+:cpp:class:`MinimalTIFFWriter`, which implements writing of Baseline
+TIFF and :cpp:class:`OMETIFFWriter` which implements writing of
+OME-TIFF (TIFF with OME-XML metadata).
+
+Using a writer involves these steps:
+
+#. Create a writer instance
+#. Set metadata store to use
+#. Set options to control writer behavior
+#. Call :cpp:func:`setId` to specify the image file to write
+#. Store pixel data for each plane of each image in the specified
+   dimension order
+
+These steps are illustrated in this example:
+
+.. literalinclude:: examples/metadata-formatwriter.cpp
+   :language: cpp
+   :start-after: writer-example-start
+   :end-before: writer-example-end
+
+Here we create a writer to write OME-TIFF files, set the metadata
+store using metadata we create, then set a writer option (sample
+interleaving), and then call :cpp:func:`setId`.  At this point the
+writer has been set up and initialized, and we can then write the
+pixel data, which we covered in the preceding sections.  Finally we
+call :cpp:func:`close` to flush all data.
+
+.. note::
+
+  Metadata store setting and writer option-setting methods may only be
+  called *before* :cpp:func:`setId`.  Writer state changing and
+  querying methods such as :cpp:func:`setSeries` and
+  :cpp:func:`getSeries`, and pixel data storage methods may only be
+  called *after* :cpp:func:`setId`.  If these constraints are
+  violated, a :cpp:class:`FormatException` will be thrown.
+
+.. note::
+
+  :cpp:func:`close` should be called explicitly to catch any errors.
+  While this will be called by the destructor, the destructor can't
+  throw exceptions and any errors will be silently ignored.
+
+Full example source: :download:`metadata-formatwriter.cpp <examples/metadata-formatwriter.cpp>`
+
+.. seealso::
+
+  - :doxygen:`FormatWriter <classome_1_1bioformats_1_1FormatWriter.html>`
+  - :doxygen:`TIFFWriter <classome_1_1bioformats_1_1in_1_1TIFFWriter.html>`
+  - :doxygen:`OMETIFFWriter <classome_1_1bioformats_1_1in_1_1OMETIFFWriter.html>`

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -579,5 +579,5 @@ Full example source: :download:`metadata-formatwriter.cpp <examples/metadata-for
 .. seealso::
 
   - :doxygen:`FormatWriter <classome_1_1bioformats_1_1FormatWriter.html>`
-  - :doxygen:`TIFFWriter <classome_1_1bioformats_1_1in_1_1TIFFWriter.html>`
-  - :doxygen:`OMETIFFWriter <classome_1_1bioformats_1_1in_1_1OMETIFFWriter.html>`
+  - :doxygen:`TIFFWriter <classome_1_1bioformats_1_1out_1_1MinimalTIFFWriter.html>`
+  - :doxygen:`OMETIFFWriter <classome_1_1bioformats_1_1out_1_1OMETIFFWriter.html>`

--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -50,10 +50,10 @@ certain modifications to the data model may only be made via direct
 access to the model objects, otherwise the higher-level metadata store
 interface should be preferred.
 
-The header :file:`ome/bioformats/MetadataTools.h` provides several
-convenience functions to work with and manipulate the various forms of
-metadata, including conversion of Core metadata to and from a metadata
-store.
+The header file :doxygen:`ome/bioformats/MetadataTools.h
+<MetadataTools_8h_source.html>` provides several convenience functions
+to work with and manipulate the various forms of metadata, including
+conversion of Core metadata to and from a metadata store.
 
 Core metadata
 ^^^^^^^^^^^^^
@@ -74,8 +74,9 @@ themselves are more of an implementation detail at present.
 If implementing a reader, it is fairly typical to set the basic image
 metadata in :cpp:class:`CoreMetadata` objects, and then use the
 :cpp:func:`fillMetadata` function in
-:file:`ome/bioformats/MetadataTools.h` to fill the reader's metadata
-store with this information, before filling the metadata store with
+:doxygen:`ome/bioformats/MetadataTools.h
+<MetadataTools_8h_source.html>` to fill the reader's metadata store
+with this information, before filling the metadata store with
 additional (non-core) metadata as required.  When writing an image, a
 metadata store is required in order to provide the writer with all the
 metadata needed to write an image.  If the metadata store was not


### PR DESCRIPTION
- Minor cleanups (indent, error message detail increased)
- Make close on destruction reliable (readers and writers)
- Minor fix to existing writer example
- Add OME-TIFF writing example
- Add OME-TIFF writing documentation to tutorial


--------

Testing:

- Take a look at the tutorial https://www.openmicroscopy.org/site/support/bio-formats5.1-staging/developers/cpp/tutorial.html
- Run the example and check you get a 512×512 16-bit image (RGB, planar, 12 signif. bits/pixel):

```
% ./bf-test ./cpp/examples/metadata-formatwriter test.ome.tiff
Image count: 1
        Plane count: 1
PixelBuffer PixelType is uint16
VariantPixelBuffer PixelType is uint16
Wrote 786432 uint16 pixels

% tiffinfo test.ome.tiff 
TIFF Directory at offset 0x180008 (1572872)
  Image Width: 512 Image Length: 512
  Bits/Sample: 16
  Sample Format: unsigned integer
  Compression Scheme: None
  Photometric Interpretation: RGB color
  Samples/Pixel: 3
  Rows/Strip: 1
  Planar Configuration: separate image planes
  ImageDescription: <?xml version="1.0" encoding="UTF-8" standalone="no" ?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2013-06" UUID="urn:uuid:8fc8ecfc-3d06-4672-bfbb-82ecb87607c4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06 http://www.openmicroscopy.org/Schemas/OME/2013-06/ome.xsd"><!-- Warning: this comment is within an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/ --><Image ID="Image:0"><Pixels BigEndian="true" DimensionOrder="XYZTC" ID="Pixels:0" Interleaved="false" SignificantBits="12" SizeC="3" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint16"><Channel ID="Channel:0:0" SamplesPerPixel="3"/><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1"><UUID FileName="test.ome.tiff">urn:uuid:8fc8ecfc-3d06-4672-bfbb-82ecb87607c4</UUID></TiffData></Pixels></Image></OME>
  Software: OME Bio-Formats (C++) 5.1.1
```

- View the example with the Java showinf:

```
./tools/showinf -fast -autoscale /path/to/test.ome.tiff
Checking file format [OME-TIFF]
Initializing reader
OMETiffReader initializing /tmp/b/test.ome.tiff
Reading IFDs
Populating metadata
Initialization took 0.085s

Reading core metadata
filename = /tmp/b/test.ome.tiff
Series count = 1
Series #0 :
        Image count = 1
        RGB = true (3) 
        Interleaved = false
        Indexed = false (false color)
        Width = 512
        Height = 512
        SizeZ = 1
        SizeT = 1
        SizeC = 3 (effectively 1)
        Thumbnail size = 128 x 128
        Endianness = intel (little)
        Dimension order = XYZTC (certain)
        Pixel type = uint16
        Valid bits per pixel = 12
        Metadata complete = true
        Thumbnail series = false
        -----
        Plane #0 <=> Z 0, C 0, T 0
```