### PR TITLE
Automated tests: add support for external configuration directory

### DIFF
--- a/components/formats-common/src/loci/common/IniWriter.java
+++ b/components/formats-common/src/loci/common/IniWriter.java
@@ -36,6 +36,9 @@ import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,22 +64,39 @@ public class IniWriter {
   }
 
   /** Saves the given IniList to the given file. */
-  public void saveINI(IniList ini, String path, boolean append)
+  public void saveINI(IniList ini, String path, boolean append, boolean sorted)
     throws IOException
   {
     BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
       new FileOutputStream(path, append), Constants.ENCODING));
 
     for (IniTable table : ini) {
+
       String header = table.get(IniTable.HEADER_KEY);
       out.write("[" + header + "]\n");
-      for (String key : table.keySet()) {
+      Set<String> keys;
+      if (sorted) {
+        Map<String, String> treeMap = new TreeMap<String, String>(table);
+        keys = treeMap.keySet();
+      }
+      else {
+        keys = table.keySet();
+      }
+
+      for (String key : keys) {
         out.write(key + " = " + table.get(key) + "\n");
       }
       out.write("\n");
     }
 
     out.close();
+  }
+
+  /** Saves the given IniList to the given file. */
+  public void saveINI(IniList ini, String path, boolean append)
+    throws IOException
+  {
+    saveINI(ini, path, append, false);
   }
 
 }

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -121,7 +121,7 @@ Type "ant -p" for a list of targets.
     <fail if="failedTest"/>
   </target>
 
-  <target name="test-config" depends="compile"
+  <target name="gen-config" depends="compile"
     description="generate config files for automated test suite">
     <testng groups="config" testname="Config generation"
       listener="loci.tests.testng.DotTestListener"
@@ -149,6 +149,7 @@ Type "ant -p" for a list of targets.
     </testng>
     <fail if="failedTest"/>
   </target>
+  <target name="test-config" depends="gen-config"/>
 
   <target name="test-automated" depends="compile"
     description="run automated tests in group 'automated'">
@@ -309,7 +310,7 @@ Type "ant -p" for a list of targets.
     <fail if="failedTest"/>
   </target>
 
-  <target name="test-config-xml" depends="compile"
+  <target name="gen-config-xml" depends="compile"
     description="generate OME-XML files for automated test suite">
     <testng groups="config-xml" testname="OME-XML generation"
       listener="loci.tests.testng.DotTestListener"
@@ -336,5 +337,6 @@ Type "ant -p" for a list of targets.
     </testng>
     <fail if="failedTest"/>
   </target>
+  <target name="test-config-xml" depends="gen-config-xml"/>
 
 </project>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -109,6 +109,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -175,6 +175,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
@@ -204,6 +205,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
@@ -233,6 +235,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
@@ -262,6 +265,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
@@ -291,6 +295,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -139,6 +139,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
+      <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -354,7 +354,7 @@ public class Configuration {
 
   public void saveToFile() throws IOException {
     IniWriter writer = new IniWriter();
-    writer.saveINI(ini, configFile);
+    writer.saveINI(ini, configFile, false);
   }
 
   public IniList getINI() {

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -354,7 +354,7 @@ public class Configuration {
 
   public void saveToFile() throws IOException {
     IniWriter writer = new IniWriter();
-    writer.saveINI(ini, configFile, false, true);
+    writer.saveINI(ini, configFile, true, true);
   }
 
   public IniList getINI() {

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -354,7 +354,7 @@ public class Configuration {
 
   public void saveToFile() throws IOException {
     IniWriter writer = new IniWriter();
-    writer.saveINI(ini, configFile, false);
+    writer.saveINI(ini, configFile, false, true);
   }
 
   public IniList getINI() {

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -61,6 +61,9 @@ public class ConfigurationTree {
   /** Directory on the file system associated with the tree root. */
   private String rootDir;
 
+  /** Directory on the file system associated with the tree root. */
+  private String configDir;
+
   /**
    * Root of tree structure containing configuration data.
    * Each node's user object is a hashtable of key/value pairs.
@@ -74,7 +77,18 @@ public class ConfigurationTree {
    * the given directory in the file system.
    */
   public ConfigurationTree(String rootDir) {
+    this(rootDir, null);
+  }
+
+  /**
+   * Creates a new configuration tree rooted at
+   * the given directory in the file system.
+   */
+  public ConfigurationTree(String rootDir, String configDir) {
     this.rootDir = new File(rootDir).getAbsolutePath();
+    if (configDir != null) {
+        this.configDir = new File(configDir).getAbsolutePath();
+    }
     root = new DefaultMutableTreeNode();
   }
 
@@ -89,19 +103,13 @@ public class ConfigurationTree {
   }
 
   public void parseConfigFile(String configFile) throws IOException {
-      parseConfigFile(configFile, null, null);
-  }
-
-  public void parseConfigFile(String configFile, String configDir, String rootDir) throws IOException {
     File file = new File(configFile);
     if (file.isDirectory()) {
       return;
     }
-    String root = file.getParent();
-    if (rootDir != null && configDir != null) {
-        configDir = configDir.substring(0,configDir.length()-1);
-        rootDir = rootDir.substring(0,rootDir.length()-1);
-        root = root.replaceAll(configDir, rootDir);
+    String parent = file.getParent();
+    if (configDir != null) {
+        parent = parent.replaceAll(configDir, rootDir);
     }
 
     configFile = file.getAbsolutePath();
@@ -117,7 +125,7 @@ public class ConfigurationTree {
       String id = table.get(IniTable.HEADER_KEY);
       id = id.substring(0, id.lastIndexOf(" "));
 
-      id = new File(file.getParent(), id).getAbsolutePath();
+      id = new File(parent, id).getAbsolutePath();
 
       DefaultMutableTreeNode node = findNode(id, true, configFile);
       if (node == null) {

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -95,6 +95,9 @@ public class ConfigurationTree {
    *
    */
   public ConfigurationTree(String rootDir, String configDir) {
+    if (rootDir == null) {
+      throw new IllegalArgumentException("rootDir cannot be null.");
+    }
     this.rootDir = new File(rootDir).getAbsolutePath();
     if (configDir != null) {
         this.configDir = new File(configDir).getAbsolutePath();

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -61,7 +61,9 @@ public class ConfigurationTree {
   /** Directory on the file system associated with the tree root. */
   private String rootDir;
 
-  /** Directory on the file system associated with the tree root. */
+  /** Base directory on the file system associated with the configuration
+   * files.
+   */
   private String configDir;
 
   /**
@@ -73,23 +75,24 @@ public class ConfigurationTree {
   // -- Constructor --
 
   /**
-   * Creates a new configuration tree rooted at
-   * the given directory in the file system.
+   *  Constructs a new configuration tree rooted at the given directory in the
+   *  file system.
+   *
+   *  @param rootDir a string specifying the root directory
+   *
    */
   public ConfigurationTree(String rootDir) {
     this(rootDir, null);
   }
 
   /**
-   * Returns the configuration directory
-   */
-  public String getConfigDirectory() {
-    return this.configDir;
-  }
-
-  /**
-   * Creates a new configuration tree rooted at
-   * the given directory in the file system.
+   *  Constructs a new configuration tree rooted at the given directory in the
+   *  file system with a custom configuration directory.
+   *
+   *  @param rootDir a string specifying the root directory
+   *
+   *  @param configDir a string specifying the base configuration directory
+   *
    */
   public ConfigurationTree(String rootDir, String configDir) {
     this.rootDir = new File(rootDir).getAbsolutePath();
@@ -100,6 +103,13 @@ public class ConfigurationTree {
   }
 
   // -- ConfigurationTree API methods --
+
+  /**
+   *  Returns the base directory holding the configuration files
+   */
+  public String getConfigDirectory() {
+    return this.configDir;
+  }
 
   /** Retrieves the Configuration object corresponding to the given file. */
   public Configuration get(String id) throws IOException {

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -105,6 +105,13 @@ public class ConfigurationTree {
   // -- ConfigurationTree API methods --
 
   /**
+   *  Returns the toot directory holding the data
+   */
+  public String getRootDirectory() {
+    return this.rootDir;
+  }
+
+  /**
    *  Returns the base directory holding the configuration files
    */
   public String getConfigDirectory() {

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -89,10 +89,21 @@ public class ConfigurationTree {
   }
 
   public void parseConfigFile(String configFile) throws IOException {
+      parseConfigFile(configFile, null, null);
+  }
+
+  public void parseConfigFile(String configFile, String configDir, String rootDir) throws IOException {
     File file = new File(configFile);
     if (file.isDirectory()) {
       return;
     }
+    String root = file.getParent();
+    if (rootDir != null && configDir != null) {
+        configDir = configDir.substring(0,configDir.length()-1);
+        rootDir = rootDir.substring(0,rootDir.length()-1);
+        root = root.replaceAll(configDir, rootDir);
+    }
+
     configFile = file.getAbsolutePath();
     String dir = file.getParentFile().getAbsolutePath();
 

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -81,6 +81,13 @@ public class ConfigurationTree {
   }
 
   /**
+   * Returns the configuration directory
+   */
+  public String getConfigDirectory() {
+    return this.configDir;
+  }
+
+  /**
    * Creates a new configuration tree rooted at
    * the given directory in the file system.
    */

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2386,7 +2386,6 @@ public class FormatReaderTest {
     setupReader();
     if (!initFile(false)) return;
     String file = reader.getCurrentFile();
-    LOGGER.info("Generating configuration: {}", file);
     try {
       String parent = new Location(file).getParent();
       String configDir = configTree.getConfigDirectory();
@@ -2399,6 +2398,7 @@ public class FormatReaderTest {
         }
       }
       File f = new File(parent, ".bioformats");
+      LOGGER.info("Generating configuration: {}", f);
       Configuration newConfig = new Configuration(reader, f.getAbsolutePath());
       newConfig.saveToFile();
       reader.close();

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2388,7 +2388,13 @@ public class FormatReaderTest {
     String file = reader.getCurrentFile();
     LOGGER.info("Generating configuration: {}", file);
     try {
-      File f = new File(new Location(file).getParent(), ".bioformats");
+      String parent = new Location(file).getParent();
+      String configDir = configTree.getConfigDirectory();
+      String rootDir = configTree.getRootDirectory();
+      if (configDir != null) {
+        parent = parent.replaceAll(rootDir, configDir);
+      }
+      File f = new File(parent, ".bioformats");
       Configuration newConfig = new Configuration(reader, f.getAbsolutePath());
       newConfig.saveToFile();
       reader.close();

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2393,6 +2393,10 @@ public class FormatReaderTest {
       String rootDir = configTree.getRootDirectory();
       if (configDir != null) {
         parent = parent.replaceAll(rootDir, configDir);
+        File parentDir = new File(parent);
+        if (!parentDir.exists()) {
+          parentDir.mkdirs();
+        }
       }
       File f = new File(parent, ".bioformats");
       Configuration newConfig = new Configuration(reader, f.getAbsolutePath());

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -89,7 +89,7 @@ public class FormatReaderTestFactory {
       baseDir = getProperty(baseDirProp);
 
       if (baseDir == null) {
-        baseDir = System.getProperty("testng.directory-prefix");
+        baseDir = getProperty("testng.directory-prefix");
         String dirList = System.getProperty("testng.directory-list");
         try {
           validSubdirs = DataTools.readFile(dirList).split("\n");
@@ -99,27 +99,30 @@ public class FormatReaderTestFactory {
         }
       }
 
+      // Return early if no base directory is supplied
+      if (baseDir == null) {
+        LOGGER.error("No base directory specified.");
+        LOGGER.error("Please specify a directory containing files to test:");
+        LOGGER.error("   ant -D{}=\"/path/to/data\" test-all", baseDirProp);
+        return new Object[0];
+      }
+
+      // Test base directory validity
       File baseDirFile = new File(baseDir);
       if (!baseDirFile.isDirectory()) {
         LOGGER.info("Directory: {}", baseDir);
         LOGGER.info("  exists?: {}", baseDirFile.exists());
         LOGGER.info("  readable?: {}", baseDirFile.canRead());
         LOGGER.info("  is a directory?: {}", baseDirFile.isDirectory());
-
-        if (baseDir == null || baseDir.equals("${" + baseDirProp + "}")) {
-          LOGGER.error("No base directory specified.");
-        }
-        else LOGGER.error("Invalid base directory: {}", baseDir);
         LOGGER.error("Please specify a directory containing files to test:");
         LOGGER.error("   ant -D{}=\"/path/to/data\" test-all", baseDirProp);
         return new Object[0];
       }
 
-      LOGGER.info("testng.directory = {}", baseDir);
-
       // check for an alternate configuration directory
       final String configDirProperty = "testng.configDirectory";
       String configDir = getProperty(configDirProperty);
+      LOGGER.info("testng.directory = {}", baseDir);
       if (configDir != null) {
         LOGGER.info("testng.configDirectory = {}", configDir);
       }
@@ -129,9 +132,9 @@ public class FormatReaderTestFactory {
 
     // parse multiplier
     final String multProp = "testng.multiplier";
-    String mult = System.getProperty(multProp);
+    String mult = getProperty(multProp);
     float multiplier = 1;
-    if (mult != null && !mult.equals("${" + multProp + "}")) {
+    if (mult != null) {
       try {
         multiplier = Float.parseFloat(mult);
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -134,14 +134,15 @@ public class FormatReaderTestFactory {
 
     final String toplevelConfig = "testng.toplevel-config";
     String configFile = System.getProperty(toplevelConfig);
-    LOGGER.info("testng.toplevel-config = {}", configFile);
+    if (configFile != null) {
+      LOGGER.info("testng.toplevel-config = {}", configFile);
+    }
 
-    // check for an alternate top level configuration file
-
+    // check for an alternate configuration directory
     final String configDirProperty = "testng.configDirectory";
     String configDir = System.getProperty(configDirProperty);
     if (configDir != null) {
-        LOGGER.info("testng.configDirectory = {}", configDir);
+      LOGGER.info("testng.configDirectory = {}", configDir);
     }
     // check for a configuration file suffix
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -64,7 +64,7 @@ public class FormatReaderTestFactory {
     String value = System.getProperty(key);
     if (value == null || value.equals("${" + key + "}")) {
       return null;
-    };
+    }
     return value;
   }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -62,7 +62,7 @@ public class FormatReaderTestFactory {
    */
   public String getProperty(String key) {
     String value = System.getProperty(key);
-    if (value.equals("${" + key + "}")) {
+    if (value == null || value.equals("${" + key + "}")) {
       return null;
     };
     return value;

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -136,6 +136,13 @@ public class FormatReaderTestFactory {
     String configFile = System.getProperty(toplevelConfig);
     LOGGER.info("testng.toplevel-config = {}", configFile);
 
+    // check for an alternate top level configuration file
+
+    final String configDirProperty = "testng.configDirectory";
+    String configDir = System.getProperty(configDirProperty);
+    if (configDir != null) {
+        LOGGER.info("testng.configDirectory = {}", configDir);
+    }
     // check for a configuration file suffix
 
     final String configSuffixProperty = "testng.configSuffix";
@@ -158,7 +165,7 @@ public class FormatReaderTestFactory {
       long start = System.currentTimeMillis();
       try {
         TestTools.getFiles(baseDir, files, FormatReaderTest.configTree,
-          configFile, validSubdirs, configSuffix);
+          configFile, validSubdirs, configSuffix, configDir);
       }
       catch (Exception e) {
         LOGGER.info("Failed to retrieve complete list of files", e);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -146,7 +146,7 @@ public class FormatReaderTestFactory {
 
     // detect whether or not the map the files into memory
     final String inMemoryProp = "testng.in-memory";
-    String inMemoryValue = System.getProperty(inMemoryProp);
+    String inMemoryValue = getProperty(inMemoryProp);
     boolean inMemory = Boolean.parseBoolean(inMemoryValue);
     LOGGER.info("testng.in-memory = {}", inMemory);
 
@@ -161,7 +161,7 @@ public class FormatReaderTestFactory {
     // check for a configuration file suffix
 
     final String configSuffixProperty = "testng.configSuffix";
-    String configSuffix = System.getProperty(configSuffixProperty);
+    String configSuffix = getProperty(configSuffixProperty);
     if (configSuffix == null) {
       configSuffix = "";
     }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -230,7 +230,7 @@ public class FormatReaderTestFactory {
       String id = (String) files.get(i);
       try {
         if (FormatReaderTest.configTree.get(id) == null) {
-          LOGGER.warn("{} not configured.", id);
+          LOGGER.error("{} not configured.", id);
         }
       }
       catch (Exception e) {

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -244,7 +244,7 @@ public class TestTools {
     LOGGER.debug("\tconfig file");
     try {
       LOGGER.debug("Parsing {}:", subs[0]);
-      config.parseConfigFile(subs[0], configRoot, root);
+      config.parseConfigFile(subs[0]);
     }
     catch (IOException exc) {
       LOGGER.debug("", exc);

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -211,7 +211,7 @@ public class TestTools {
     String configDir = config.getConfigDirectory();
     boolean useConfigDir = (configDir != null);
 
-    ArrayList<String> subsList = new ArrayList<String>();
+    List<String> subsList = new ArrayList<String>();
 
     if (useConfigDir) {
       // Look for a configuration file under the configuration directory

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -195,14 +195,6 @@ public class TestTools {
     final ConfigurationTree config, String toplevelConfig, String[] subdirs,
     String configFileSuffix)
   {
-      getFiles(root, files, config, toplevelConfig, subdirs, configFileSuffix, null);
-  }
-
-  /** Recursively generate a list of files to test. */
-  public static void getFiles(String root, List files,
-    final ConfigurationTree config, String toplevelConfig, String[] subdirs,
-    String configFileSuffix, String configRoot)
-  {
     Location f = new Location(root);
     String[] subs = f.list();
     if (subs == null) subs = new String[0];
@@ -212,7 +204,7 @@ public class TestTools {
 
     boolean isToplevel =
      toplevelConfig != null && new File(toplevelConfig).exists();
-
+    String configDir = config.getConfigDirectory();
     Arrays.sort(subs);
 
     // make sure that if a config file exists, it is first on the list
@@ -223,8 +215,8 @@ public class TestTools {
           (isToplevel && subs[i].equals(toplevelConfig)))
       {
         String tmp = subs[0];
-        if (configRoot != null) {
-            Location configFile = new Location(configRoot, subs[i]);
+        if (configDir != null) {
+            Location configFile = new Location(configDir, subs[i]);
             LOGGER.debug("config file: {}", configFile.getAbsolutePath());
             if (configFile.exists()) {
                 subs[0] = configFile.getAbsolutePath();

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -209,9 +209,11 @@ public class TestTools {
 
     String rootDir = config.getRootDirectory();
     String configDir = config.getConfigDirectory();
+    boolean useConfigDir = (configDir != null);
+
     ArrayList<String> subsList = new ArrayList<String>();
 
-    if (configDir != null) {
+    if (useConfigDir) {
       // Look for a configuration file under the configuration directory
       String configRoot = root.replaceAll(rootDir, configDir);
       Location configFile = new Location(configRoot, baseConfigName);
@@ -228,7 +230,7 @@ public class TestTools {
       if ((!isToplevel && isConfigFile(file, configFileSuffix)) ||
           (isToplevel && subs[i].equals(toplevelConfig)))
       {
-        if (configDir == null) {
+        if (!useConfigDir) {
           LOGGER.debug("adding config file: {}", file.getAbsolutePath());
           subsList.add(0, file.getAbsolutePath());
         }

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -64,6 +64,8 @@ public class TestTools {
   public static final String DIVIDER =
     "----------------------------------------";
 
+  public static final String baseConfigName = ".bioformats";
+
   /** Calculate the SHA-1 of a byte array. */
   public static String sha1(byte[] b, int offset, int len) {
     try {
@@ -162,6 +164,19 @@ public class TestTools {
   }
 
   /** Recursively generate a list of files to test. */
+  public static boolean isConfigFile(Location file, String configFileSuffix)
+  {
+    String configName = baseConfigName;
+    if (configFileSuffix.length() > 0) {
+      configName += ".";
+      configName += configFileSuffix;
+    }
+
+    String filename = file.getName();
+    return (filename.equals(configName) || filename.equals(baseConfigName));
+  }
+
+  /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig)
   {
@@ -175,19 +190,11 @@ public class TestTools {
     getFiles(root, files, config, toplevelConfig, subdirs, "");
   }
 
-
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig, String[] subdirs,
     String configFileSuffix)
   {
-    String configName = ".bioformats";
-    String baseConfigName = configName;
-    if (configFileSuffix.length() > 0) {
-      configName += ".";
-      configName += configFileSuffix;
-    }
-
     Location f = new Location(root);
     String[] subs = f.list();
     if (subs == null) subs = new String[0];
@@ -205,11 +212,8 @@ public class TestTools {
       Location file = new Location(root, subs[i]);
       subs[i] = file.getAbsolutePath();
 
-      String filename = file.getName();
-
-      if ((!isToplevel && (filename.equals(configName) ||
-        filename.equals(baseConfigName))) ||
-        (isToplevel && subs[i].equals(toplevelConfig)))
+      if ((!isToplevel && isConfigFile(file, configFileSuffix)) ||
+          (isToplevel && subs[i].equals(toplevelConfig)))
       {
         String tmp = subs[0];
         subs[0] = subs[i];
@@ -262,9 +266,7 @@ public class TestTools {
       Location file = new Location(subs[i]);
       LOGGER.debug("Checking {}:", subs[i]);
 
-      String filename = file.getName();
-
-      if (filename.equals(configName) || filename.equals(baseConfigName)) {
+      if (isConfigFile(file, configFileSuffix)) {
         continue;
       }
       else if (isIgnoredFile(subs[i], config)) {


### PR DESCRIPTION
Currently automated tests are relying upon configuration files (`.bioformats`) being present under the same tree as the data repository. The goal of this infrastructure PR is to remove this requirement and allow external configuration tree to bee used to test the data repository. Ultimately, this should simplify our workflow when modifying readers and configuration files /cc @jburel

To test this PR:

- check the overall set of changes is sensible. Some refactoring in the test classes to use helper methods and hide parameters of type `${property}` set by `ant`
- check the existing test logic is untouched without specifying a configuration directory
  ```
ant test-config -Dtestng.directory=/path/to/data  # should create/append .bioformats files in-place
ant test-automated -Dtestng.directory=/path/to/data  # should test using local .bioformats files
```
- test the configuration files can be generated under a custom directory using `test-config`
  ```
ant test-config -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config 
```
Check that for each section, the entries of `.bioformats` file should now be sorted by key. This is meant to simplify diff examination when updating these files.
- modify the created `.bioformats` file under `/path/to/config` and test the new ant variable picks up this configuration file instead of the local file under the data directory tree using
  ```
ant test-automated -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config
```

Other scenarios that can be tested:
- test a more complex tree (multiple level of hierarchies under `/path/to/data`)
- test multiple data folders
- test removing the `.bioformats` files under the data directory with the `configDirectory` property set does not affect the tests (for future data repo cleanup)