### PR TITLE
xsd-fu: Add javadocs to Java metadata templates

### DIFF
--- a/components/ome-xml/src/ome/xml/meta/OMEXMLMetadata.java
+++ b/components/ome-xml/src/ome/xml/meta/OMEXMLMetadata.java
@@ -47,6 +47,9 @@ public interface OMEXMLMetadata extends IMetadata {
    */
   String dumpXML();
 
+  /**
+   * Resolve model object cross-references.
+   */
   int resolveReferences();
 
 }

--- a/components/xsd-fu/templates-java/FilterMetadata.template
+++ b/components/xsd-fu/templates-java/FilterMetadata.template
@@ -165,11 +165,19 @@ public class FilterMetadata implements MetadataStore
 {
 	// -- Fields --
 
+        /** The wrapped metadata store. */
 	private MetadataStore store;
+        /** Is filtering enabled? */
 	private boolean filter;
 
 	// -- Constructor --
 
+        /**
+         * Creates a new instance.
+         * @param store the metadata store to wrap.
+         * @param filter true to enable filtering, false to
+         * disable.
+         */
 	public FilterMetadata(MetadataStore store, boolean filter)
 	{
 		this.store = store;

--- a/components/xsd-fu/templates-java/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-java/MetadataRetrieve.template
@@ -13,18 +13,40 @@
 {% if debug %}\
 	// MARKER [A-GET]
 {% end debug %}\
+        /**
+         * Get the ${prop.name} property of ${o.name}.
+         *
+{% for param in indexes %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
+         * @return the ${prop.name} property.
+         */
 	${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)}, ${index_string(prop.name)});\
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
 	// MARKER [B-GET]
 {% end debug %}\
+        /**
+         * Get the ${prop.name} property of ${o.name}.
+         *
+{% for param in indexes %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         * @return the ${prop.name} property.
+         */
 	${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)});\
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
 	// MARKER [C-GET]
 {% end debug %}\
+        /**
+         * Get the ${prop.name} property of ${o.name}.
+         *
+         * @return the ${prop.name} property.
+         */
 	${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}();\
 {% end %}\
 {% end %}\
@@ -132,34 +154,153 @@ import java.util.Map;
  */
 public interface MetadataRetrieve extends BaseMetadata {
 
-	// -- Entity counting (manual definitions) --
+  // -- Entity counting (manual definitions) --
 
-	int getPixelsBinDataCount(int imageIndex);
+  /**
+   * Get the number of BinData elements in Pixels.
+   *
+   * @param imageIndex the Image index.
+   * @return the number of BinData elements.
+   */
+  int getPixelsBinDataCount(int imageIndex);
 
+  /**
+   * Get the number of links to a BooleanAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified BooleanAnnotation held by all model objects.
+   *
+   * @param booleanAnnotationIndex the BooleanAnnotation index.
+   * @return the number of BooleanAnnotation links.
+   */
   int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex);
 
+  /**
+   * Get the number of links to a CommentAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified CommentAnnotation held by all model objects.
+   *
+   * @param commentAnnotationIndex the CommentAnnotation index.
+   * @return the number of CommentAnnotation links.
+   */
   int getCommentAnnotationAnnotationCount(int commentAnnotationIndex);
 
+  /**
+   * Get the number of links to a DoubleAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified DoubleAnnotation held by all model objects.
+   *
+   * @param doubleAnnotationIndex the DoubleAnnotation index.
+   * @return the number of DoubleAnnotation links.
+   */
   int getDoubleAnnotationAnnotationCount(int doubleAnnotationIndex);
 
+  /**
+   * Get the number of links to a FileAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified FileAnnotation held by all model objects.
+   *
+   * @param fileAnnotationIndex the FileAnnotation index.
+   * @return the number of FileAnnotation links.
+   */
   int getFileAnnotationAnnotationCount(int fileAnnotationIndex);
 
+  /**
+   * Get the number of links to a ListAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified ListAnnotation held by all model objects.
+   *
+   * @param listAnnotationIndex the ListAnnotation index.
+   * @return the number of ListAnnotation links.
+   */
   int getListAnnotationAnnotationCount(int listAnnotationIndex);
 
+  /**
+   * Get the number of links to a LongAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified LongAnnotation held by all model objects.
+   *
+   * @param longAnnotationIndex the LongAnnotation index.
+   * @return the number of LongAnnotation links.
+   */
   int getLongAnnotationAnnotationCount(int longAnnotationIndex);
 
+  /**
+   * Get the number of links to a MapAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified MapAnnotation held by all model objects.
+   *
+   * @param mapAnnotationIndex the MapAnnotation index.
+   * @return the number of MapAnnotation links.
+   */
   int getMapAnnotationAnnotationCount(int mapAnnotationIndex);
 
+  /**
+   * Get the number of links to a TagAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified TagAnnotation held by all model objects.
+   *
+   * @param tagAnnotationIndex the TagAnnotation index.
+   * @return the number of TagAnnotation links.
+   */
   int getTagAnnotationAnnotationCount(int tagAnnotationIndex);
 
+  /**
+   * Get the number of links to a TermAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified TermAnnotation held by all model objects.
+   *
+   * @param termAnnotationIndex the TermAnnotation index.
+   * @return the number of TermAnnotation links.
+   */
   int getTermAnnotationAnnotationCount(int termAnnotationIndex);
 
+  /**
+   * Get the number of links to a TimestampAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified TimestampAnnotation held by all model objects.
+   *
+   * @param timestampAnnotationIndex the TimestampAnnotation index.
+   * @return the number of TimestampAnnotation links.
+   */
   int getTimestampAnnotationAnnotationCount(int timestampAnnotationIndex);
 
+  /**
+   * Get the number of links to an XMLAnnotation.
+   *
+   * This method returns the number of references to the
+   * specified XMLAnnotation held by all model objects.
+   *
+   * @param xmlAnnotationIndex the XMLAnnotation index.
+   * @return the number of XMLAnnotation links.
+   */
   int getXMLAnnotationAnnotationCount(int xmlAnnotationIndex);
 
-	String getLightSourceType(int instrumentIndex, int lightSourceIndex);
+  /**
+   * Get the type of a LightSource.
+   *
+   * @param instrumentIndex the Instrument index.
+   * @param lightSourceIndex the LightSource index.
+   * @return the LightSource type.
+   */
+  String getLightSourceType(int instrumentIndex, int lightSourceIndex);
 
+  /**
+   * Get the type of a Shape.
+   *
+   * @param roiIndex the ROI index.
+   * @param shapeIndex the Shape index.
+   * @return the Shape type.
+   */
   String getShapeType(int roiIndex, int shapeIndex);
 
 	// -- Entity counting (code generated definitions) --
@@ -167,15 +308,35 @@ public interface MetadataRetrieve extends BaseMetadata {
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
+{% if debug %}\
 	// Element's text data
 	// ${repr(indexes[o.name])}
+{% end debug %}\
+        /**
+         * Get the text value of ${o.name}.
+         *
+{% for param in indexes[o.name].items()[0][1] %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         * @return the text value.
+         */
 	${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])});
 
 {% end %}\
 {% if parents[o.name] is not None and not o.isAbstract %}\
+{% if debug %}\
 	// ${o.name} entity counting
+{% end debug %}\
 {% for k, v in indexes[o.name].items() %}\
 {% if fu.max_occurs_under_parent(model, k, o.name) > 1 and (k not in fu.METADATA_COUNT_IGNORE or o.type not in fu.METADATA_COUNT_IGNORE[k]) %}\
+        /**
+         * Get the number of ${o.name} elements{% if is_multi_path[o.name] %} in ${k}{% end %}.
+         *
+{% for param in v[:-1] %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         * @return the number of ${o.name} elements.
+         */
 	int get{% if is_multi_path[o.name] %}${k}{% end %}${o.name}Count(${indexes_string(v[:-1])});
 
 {% end %}\
@@ -186,14 +347,44 @@ public interface MetadataRetrieve extends BaseMetadata {
 
 	// -- Entity retrieval (manual definitions) --
 
+        /**
+         * Get the BigEndian property of Pixels.
+         *
+         * @param imageIndex the Image index.
+         * @param binDataIndex BinData index (unused).
+         * @return true if big endian, or false if little endian.
+         */
 	Boolean getPixelsBinDataBigEndian(int imageIndex, int binDataIndex);
 
+        /**
+         * Get the values from a MapAnnotation.
+         *
+         * @param mapAnnotationIndex the MapAnnotation index.
+         * @return the MapAnnotation values.
+         */
 	java.util.List<ome.xml.model.MapPair> getMapAnnotationValue(int mapAnnotationIndex);
 
+        /**
+         * Get the MapAnnotation values from a GenericExcitationSource.
+         *
+         * @param instrumentIndex the Instrument index.
+         * @return the MapAnnotation values.
+         */
 	java.util.List<ome.xml.model.MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex);
 
+        /**
+         * Get the MapAnnotation values from a ImagingEnvironment.
+         *
+         * @param imageIndex the Image index.
+         * @return the MapAnnotation values.
+         */
 	java.util.List<ome.xml.model.MapPair> getImagingEnvironmentMap(int imageIndex);
 
+        /**
+         * Get the UUID associated with this collection of metadata.
+         *
+         * @return the UUID.
+         */
 	/** Gets the UUID associated with this collection of metadata. */
 	String getUUID();
 
@@ -204,12 +395,12 @@ public interface MetadataRetrieve extends BaseMetadata {
 {% if parents[o.name] is not None and not o.isAbstract and not o.isAbstractProprietary %}\
 {% if debug %}\
 	// MARKER [EEE]
-{% end debug %}\
 	//
 	// ${o.name} property storage
 	//
 	// ${repr(parents[o.name])}
 	// Is multi path? ${is_multi_path[o.name]}
+{% end debug %}\
 
 {% choose %}\
 {% when o.isReference %}\
@@ -231,8 +422,6 @@ public interface MetadataRetrieve extends BaseMetadata {
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
 	// MARKER [CCC]
-{% end debug %}\
-{% if debug %}\
 	// Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
@@ -271,8 +460,6 @@ ${getter(k, o, prop, v)}
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
 	// MARKER [FFF]
-{% end debug %}\
-{% if debug %}\
 	// Ignoring ${prop.name} element, unit enumeration property
 {% end debug %}\
 {% end %}\

--- a/components/xsd-fu/templates-java/MetadataStore.template
+++ b/components/xsd-fu/templates-java/MetadataStore.template
@@ -196,7 +196,7 @@ public interface MetadataStore extends BaseMetadata
         /**
          * Set the BigEndian property of Pixels.
          *
-         * @param bigEndian @c true if big endian, or @c false if little endian.
+         * @param bigEndian true if big endian, or false if little endian.
          * @param imageIndex the Image index.
          * @param binDataIndex BinData index (unused).
          */

--- a/components/xsd-fu/templates-java/MetadataStore.template
+++ b/components/xsd-fu/templates-java/MetadataStore.template
@@ -13,18 +13,40 @@
 {% if debug %}\
 	// MARKER [A-GET]
 {% end debug %}\
+	/**
+         * Set the ${prop.name} property of ${o.name}.
+         *
+         * @param ${prop.argumentName} ${prop.name} to set.
+{% for param in indexes %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
+         */
 	void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)});\
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
 	// MARKER [B-GET]
 {% end debug %}\
+	/**
+         * Set the ${prop.name} property of ${o.name}.
+         *
+         * @param ${prop.argumentName} ${prop.name} to set.
+{% for param in indexes %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         */
 	void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)});\
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
 	// MARKER [C-GET]
 {% end debug %}\
+	/**
+         * Set the ${prop.name} property of ${o.name}.
+         *
+         * @param ${prop.argumentName} ${prop.name} to set.
+         */
 	void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.metadataStoreArgType} ${prop.argumentName});\
 {% end %}\
 {% end %}\
@@ -144,46 +166,111 @@ import java.util.Map;
  */
 public interface MetadataStore extends BaseMetadata
 {
+        /**
+         * Create root node.  The action taken here is specific to the
+         * concrete metadata implementation.
+         */
 	void createRoot();
 
+        /**
+         * Get the root node of the metadata.  Note that the root node
+         * type will be specific to the concrete metadata
+         * implementation.
+         *
+         * @return the root node.
+         */
 	MetadataRoot getRoot();
 
+        /**
+         * Set the root node of the metadata.  Note that the root node
+         * type will be specific to the concrete metadata
+         * implementation.  An exception will be thrown if the root
+         * node is of an incompatible type.
+         *
+         * @param root the root node.
+         */
 	void setRoot(MetadataRoot root);
 
 	// -- Entity storage (manual definitions) --
 
+        /**
+         * Set the BigEndian property of Pixels.
+         *
+         * @param bigEndian @c true if big endian, or @c false if little endian.
+         * @param imageIndex the Image index.
+         * @param binDataIndex BinData index (unused).
+         */
 	void setPixelsBinDataBigEndian(Boolean bigEndian, int imageIndex, int binDataIndex);
 
+        /**
+         * Set the BinData property of Mask.
+         *
+         * @param binData the BinData to set.
+         * @param ROIIndex the ROI index.
+         * @param shapeIndex the Shape index.
+         */
 	void setMaskBinData(byte[] binData, int ROIIndex, int shapeIndex);
 
+        /**
+         * Set the values of a MapAnnotation.
+         *
+         * @param value the MapAnnotation values to set.
+         * @param mapAnnotationIndex the MapAnnotation index.
+         */
 	void setMapAnnotationValue(java.util.List<ome.xml.model.MapPair> value, int mapAnnotationIndex);
 
+        /**
+         * Set the MapAnnotation values of a GenericExcitationSource.
+         *
+         * @param map the MapAnnotation values to set.
+         * @param instrumentIndex the Instrument index.
+         */
 	void setGenericExcitationSourceMap(java.util.List<ome.xml.model.MapPair> map, int instrumentIndex, int lightSourceIndex);
 
+        /**
+         * Set the MapAnnotation values of an ImagingEnvironment.
+         *
+         * @param map the MapAnnotation values to set.
+         * @param imageIndex the Image index.
+         */
 	void setImagingEnvironmentMap(java.util.List<ome.xml.model.MapPair> map, int imageIndex);
 
 	// -- Entity storage (code generated definitions) --
 
-	/** Sets the UUID associated with this collection of metadata. */
+	/**
+         * Set the UUID associated with this collection of metadata.
+         *
+         * @param uuid the UUID to set.
+         */
 	void setUUID(String uuid);
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
+{% if debug %}\
 	// Element's text data
 	// ${repr(indexes[o.name])}
+{% end debug %}\
+	/**
+         * Set the text value of ${o.name}.
+         *
+         * @param value text value.
+{% for param in indexes[o.name].items()[0][1] %}\
+         * @param ${param['argname']} the ${param['type']} index.
+{% end for %}\
+         */
 	void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])});
 
 {% end %}\
 {% if parents[o.name] is not None and not o.isAbstract and not o.isAbstractProprietary %}\
 {% if debug %}\
 	// MARKER [EEE]
-{% end debug %}\
 	//
 	// ${o.name} property storage
 	//
 	// ${repr(parents[o.name])}
 	// Is multi path? ${is_multi_path[o.name]}
+{% end debug %}\
 
 {% choose %}\
 {% when o.isReference %}\


### PR DESCRIPTION
Generated MetadataStore, MetadataRetrieve and implementing classes now have a complete set of Javadoc comments.  These have been copied and adapted from doxygen comments in the C++ templates.

--------

Testing:

See 
https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-build/javadoc/ome/xml/meta/package-summary.html
Interfaces: MetadataStore, MetadataRetrieve, OMEXMLMetadata
Classes: AggregateMetadata, DummyMetadata, FilterMetadata, OMEXMLMetadataImpl

They should all have a complete set of javadocs.