### PR TITLE
New reader: docs addition

### DIFF
--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -86,17 +86,33 @@ public final class MetadataTools {
   // -- Utility methods - OME-XML --
 
   /**
-   * Populates the 'pixels' element of the given metadata store, using core
+   * Populates the Pixels element of the given metadata store, using core
    * metadata from the given reader.
+   *
+   * Delegate to
+   * {@link #populatePixels(MetadataStore, IFormatReader, boolean, boolean)}
+   * with {@code doPlane} set to {@code false} and {@code doImageName} set to
+   * {@code true}.
+   *
+   * @param store The metadata store which Pixels should be populated
+   * @param r     The format reader which core metadata should be used
    */
   public static void populatePixels(MetadataStore store, IFormatReader r) {
     populatePixels(store, r, false, true);
   }
 
   /**
-   * Populates the 'pixels' element of the given metadata store, using core
-   * metadata from the given reader.  If the 'doPlane' flag is set,
-   * then the 'plane' elements will be populated as well.
+   * Populates the Pixels element of the given metadata store, using core
+   * metadata from the given reader.  If the {@code doPlane} flag is set,
+   * then the Plane elements will be populated as well.
+   *
+   * Delegates to
+   * {@link #populatePixels(MetadataStore, IFormatReader, boolean, boolean)}
+   * with {@code doImageName} set to {@code true}.
+   *
+   * @param store   The metadata store which Pixels should be populated
+   * @param r       The format reader which core metadata should be used
+   * @param doPlane Specifies whether Plane elements should be populatedZZ
    */
   public static void populatePixels(MetadataStore store, IFormatReader r,
     boolean doPlane)
@@ -105,11 +121,16 @@ public final class MetadataTools {
   }
 
   /**
-   * Populates the 'pixels' element of the given metadata store, using core
-   * metadata from the given reader.  If the 'doPlane' flag is set,
-   * then the 'plane' elements will be populated as well.
-   * If the 'doImageName' flag is set, then the image name will be populated
-   * as well.  By default, 'doImageName' is true.
+   * Populates the Pixels element of the given metadata store, using core
+   * metadata from the given reader.  If the {@code doPlane} flag is set,
+   * then the Plane elements will be populated as well. If the
+   * {@code doImageName} flag is set, then the image name will be populated as
+   * well.
+   *
+   * @param store       The metadata store which Pixels should be populated
+   * @param r           The format reader which core metadata should be used
+   * @param doPlane     Specifies whether Plane elements should be populated
+   * @param doImageName Specifies whether the Image name should be populated
    */
   public static void populatePixels(MetadataStore store, IFormatReader r,
     boolean doPlane, boolean doImageName)

--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -94,8 +94,8 @@ public final class MetadataTools {
    * with {@code doPlane} set to {@code false} and {@code doImageName} set to
    * {@code true}.
    *
-   * @param store The metadata store which Pixels should be populated
-   * @param r     The format reader which core metadata should be used
+   * @param store The metadata store whose Pixels should be populated
+   * @param r     The format reader whose core metadata should be used
    */
   public static void populatePixels(MetadataStore store, IFormatReader r) {
     populatePixels(store, r, false, true);
@@ -110,9 +110,9 @@ public final class MetadataTools {
    * {@link #populatePixels(MetadataStore, IFormatReader, boolean, boolean)}
    * with {@code doImageName} set to {@code true}.
    *
-   * @param store   The metadata store which Pixels should be populated
-   * @param r       The format reader which core metadata should be used
-   * @param doPlane Specifies whether Plane elements should be populatedZZ
+   * @param store   The metadata store whose Pixels should be populated
+   * @param r       The format reader whose core metadata should be used
+   * @param doPlane Specifies whether Plane elements should be populated
    */
   public static void populatePixels(MetadataStore store, IFormatReader r,
     boolean doPlane)
@@ -127,8 +127,8 @@ public final class MetadataTools {
    * {@code doImageName} flag is set, then the image name will be populated as
    * well.
    *
-   * @param store       The metadata store which Pixels should be populated
-   * @param r           The format reader which core metadata should be used
+   * @param store       The metadata store whose Pixels should be populated
+   * @param r           The format reader whose core metadata should be used
    * @param doPlane     Specifies whether Plane elements should be populated
    * @param doImageName Specifies whether the Image name should be populated
    */

--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -74,6 +74,32 @@ Methods to override
   Also, ``super.initFile(String)`` constructs a Hashtable called "metadata"
   where you should store any relevant metadata.
 
+  The most common way to set up the OME-XML metadata for the reader is to
+  initialize the MetadataStore using the
+  :javadoc:`makeFilterMetadata() <loci/formats/FormatReader.html#makeFilterMetadata()>` method and populate the
+  Pixels elements of the metadata store from the ``core`` variable using the
+  :javadoc:`MetadataTools.populatePixels(MetadataStore, FormatReader) <loci/formats/MetadataTools.html#populatePixels(loci.formats.meta.MetadataStore, loci.formats.IFormatReader)>` method::
+
+    # Initialize the OME-XML metadata from the core variable
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this);
+
+  If the reader includes metadata at the plane level, you can initialize the
+  Plane elements under the Pixels using
+  :javadoc:`MetadataTools.populatePixels(MetadataStore, FormatReader, doPlane) <loci/formats/MetadataTools.html#populatePixels(loci.formats.meta.MetadataStore, loci.formats.IFormatReader, boolean)>`::
+
+    MetadataTools.populatePixels(store, this, true);
+
+  Once the metadatastore has been initialized with the core properties,
+  additional metadata can be added to it using the setter methods. Note that
+  for each of the model components, the ``setObjectID()`` method should be
+  called before any of the ``setObjectProperty()``, e.g.::
+
+    # Add an oil immersion objective with achromat
+    String objectiveID = MetadataTools.createLSID("Objective", 0, 0);
+    store.setObjectiveID(objectiveID, 0, 0);
+    store.setObjectiveImmersion(getImmersion("Oil"), 0, 0);
+
 - :javadoc:`close(boolean) <loci/formats/IFormatReader.html#close(boolean)>`
   Cleans up any resources used by the reader.  Global variables should be
   reset to their initial state, and any open files or delegate readers should

--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -100,7 +100,7 @@ Methods to override
   Once the metadatastore has been initialized with the core properties,
   additional metadata can be added to it using the setter methods. Note that
   for each of the model components, the ``setObjectID()`` method should be
-  called before any of the ``setObjectProperty()``, e.g.::
+  called before any of the ``setObjectProperty()`` methods, e.g.::
 
     # Add an oil immersion objective with achromat
     String objectiveID = MetadataTools.createLSID("Objective", 0, 0);

--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -25,10 +25,12 @@ Methods to override
   can be handled individually.  The return value should be one of the
   following:
 
-  * ``FormatTools.MUST_GROUP``: the files cannot be handled separately
-  * ``FormatTools.CAN_GROUP``: the files may be handled separately or as a single
-    unit
-  * ``FormatTools.CANNOT_GROUP``: the files must be handled separately
+  * :javadoc:`FormatTools.MUST_GROUP <loci/formats/FormatTools.html#MUST_GROUP>`:
+    the files cannot be handled separately
+  * :javadoc:`FormatTools.CAN_GROUP <loci/formats/FormatTools.html#CAN_GROUP>`:
+    the files may be handled separately or as a single unit
+  * :javadoc:`FormatTools.CANNOT_GROUP <loci/formats/FormatTools.html#CANNOT_GROUP>`:
+    the files must be handled separately
 
   This method only needs to be overridden for formats whose datasets can
   contain more than one file.
@@ -42,21 +44,25 @@ Methods to override
   For an example of how this works, see
   :bfreader:`loci.formats.in.PerkinElmerReader <PerkinElmerReader.java>`. It
   is recommended that the first line of this method be
-  ``FormatTools.assertId(currentId, true, 1)`` - this ensures that the file name
-  is non-null.
+  ``FormatTools.assertId(currentId, true, 1)`` - this ensures that the file
+  name is non-null.
 
 - :javadoc:`openBytes(int, byte[], int, int, int, int) <loci/formats/IFormatReader.html#openBytes(int, byte[], int, int, int, int)>`
   Returns a byte array containing the pixel data for a subimage specified
   image from the given file.  The dimensions of the subimage (upper left X
   coordinate, upper left Y coordinate, width, and height) are specified in the
-  final four int parameters.  This should throw a ``FormatException`` if the image
+  final four int parameters.  This should throw a
+  :javadoc:`FormatException <loci/formats/FormatException.html>` if the image
   number is invalid (less than 0 or >= the number of images).  The ordering of
   the array returned by openBytes should correspond to the values returned by
-  ``isLittleEndian()`` and ``isInterleaved()``.  Also, the length of the
-  byte array should be [image width * image height * bytes per pixel].  Extra
-  bytes will generally be truncated. It is recommended that the first line of
-  this method be ``FormatTools.checkPlaneParameters(this, no, buf.length, x, y,
-  w, h)`` - this ensures that all of the parameters are valid.
+  :javadoc:`isLittleEndian <loci/formats/IFormatReader.html#isLittleEndian()>`
+  and
+  :javadoc:`isInterleaved <loci/formats/IFormatReader.html#isInterleaved()>`.
+  Also, the length of the byte array should be [image width * image height *
+  bytes per pixel].  Extra bytes will generally be truncated. It is recommended
+  that the first line of this method be
+  ``FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h)`` -
+  this ensures that all of the parameters are valid.
 
 - :javadoc:`initFile(java.lang.String) <loci/formats/FormatReader.html#initFile(java.lang.String)>`
   The majority of the file parsing logic should be placed in this method.  The
@@ -65,13 +71,14 @@ Methods to override
   ``super.initFile(String)``.  You will also need to set up the stream for
   reading the file, as well as initializing any dimension information and
   metadata.
-  Most of this logic is up to you; however, you should populate the 'core'
-  variable (see
+  Most of this logic is up to you; however, you should populate the
+  :javadoc:`core <loci/formats/FormatReader.html#core>` variable (see
   :javadoc:`loci.formats.CoreMetadata <loci/formats/CoreMetadata.html>`).
 
   Note that each variable is initialized to 0 or null when
   ``super.initFile(String)`` is called.
-  Also, ``super.initFile(String)`` constructs a Hashtable called "metadata"
+  Also, ``super.initFile(String)`` constructs a Hashtable called
+  :javadoc:`metadata <loci/formats/FormatReader.html#metadata>`
   where you should store any relevant metadata.
 
   The most common way to set up the OME-XML metadata for the reader is to


### PR DESCRIPTION
Following-up on the work carried out in https://github.com/openmicroscopy/bioformats/pull/1755, this PR backports some of the discussion from the PR into the Javadocs and the Sphinx developer documentation.

- check the Javadocs for `MetadataTools.populatePixels()` describes the various signatures
- check the sections in the reader writing guide about the OME-XML metadata intiialization and the order creation for the model objects are redable