### PR TITLE
specification: Correct psi documentation description to pound-force

### DIFF
--- a/components/specification/released-schema/2015-01/ome.xsd
+++ b/components/specification/released-schema/2015-01/ome.xsd
@@ -1703,7 +1703,7 @@
 
 			<xsd:enumeration value =  "atm"><xsd:annotation><xsd:documentation>The pressure unit is standard atmosphere.</xsd:documentation></xsd:annotation></xsd:enumeration>
 
-			<xsd:enumeration value =  "psi"><xsd:annotation><xsd:documentation>The pressure unit is pounds per square inch.</xsd:documentation></xsd:annotation></xsd:enumeration>
+			<xsd:enumeration value =  "psi"><xsd:annotation><xsd:documentation>The pressure unit is pound-force per square inch.</xsd:documentation></xsd:annotation></xsd:enumeration>
 
 			<xsd:enumeration value =  "Torr"><xsd:annotation><xsd:documentation>The pressure unit is       torr.</xsd:documentation></xsd:annotation></xsd:enumeration>
 			<xsd:enumeration value = "mTorr"><xsd:annotation><xsd:documentation>The pressure unit is milli torr.</xsd:documentation></xsd:annotation></xsd:enumeration>


### PR DESCRIPTION
Nothing to test; it's just a comment correction.  We might want to regenerate the published Oxygen documentation if anyone knows how to do that.