### PR TITLE
Adding 3I website to make attribution clearer

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -8,7 +8,8 @@ Version history
 * OME-TIFF export: switch to BigTIFF if .ome.tf2, .ome.tf8, or .ome.btf
   extensions are used
 * Improved MATLAB developer documentation
-* Added SlideBook reader that uses the SDK from 3I (thanks to Richard Myers)
+* Added SlideBook reader that uses the SDK from 3I (thanks to Richard Myers
+  and `3I - Intelligent Imaging Innovations <https://www.intelligent-imaging.com>`_)
 * Preliminary work to make MATLAB toolbox work with Octave
 * Many bug fixes, including:
     - ImageJ


### PR DESCRIPTION
Just a minor addition to the BF version history to promote the commercial contribution a bit more https://trello.com/c/GLtwSegm/33-slidebook-sdk

Will be staged at https://www.openmicroscopy.org/site/support/bio-formats5.1-staging/about/whats-new.html