### PR TITLE
cmake: Add toplevel SuperBuild two-phase processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,114 +53,131 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif(POLICY CMP0054)
 
-project(bioformats)
-include(cpp/cmake/Version.cmake)
-
-if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-  message(FATAL_ERROR "In-tree builds are not supported; please run cmake from a separate build directory.")
-endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
-
+# For MSVC
 enable_language(CXX)
 
-list(APPEND CMAKE_MODULE_PATH
-     "${PROJECT_SOURCE_DIR}/cpp/cmake")
-
-include(CheckIncludeFileCXX)
-include(CheckCXXCompilerFlag)
-include(CheckCXXSourceCompiles)
-
-include(GNUInstallDirs)
-
-if (NOT DEFINED OME_BIOFORMATS_INSTALL_DATADIR)
-  set(OME_BIOFORMATS_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/ome/bioformats"
-      CACHE PATH "Bio-Formats-specific datadir")
+set(sb_default OFF)
+if(MSVC)
+  set(sb_default ON)
 endif()
+option(bioformats-superbuild "Build Bio-Formats and the projects it depends upon using a Super-Build setup" ${sb_default})
+mark_as_advanced(bioformats-superbuild)
+unset(sb_default)
 
-# Use standard path if using a prefix.
-if(CMAKE_INSTALL_PREFIX)
-  if (NOT DEFINED OME_BIOFORMATS_INSTALL_LIBEXECDIR)
-    set(OME_BIOFORMATS_INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}/ome/bioformats"
-        CACHE PATH "Bio-Formats-specific libexecdir")
-  endif()
-  if (NOT DEFINED OME_BIOFORMATS_INSTALL_ICONDIR)
-    set(OME_BIOFORMATS_INSTALL_ICONDIR "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable"
-        CACHE PATH "Icon directory")
-  endif()
+include("${CMAKE_CURRENT_LIST_DIR}/cpp/cmake/BioFormatsCommon.cmake")
+
+if(bioformats-superbuild)
+  include("${CMAKE_CURRENT_LIST_DIR}/cpp/cmake/BioFormatsSuperBuild.cmake")
+  return()
 else()
-  if (NOT DEFINED OME_BIOFORMATS_INSTALL_LIBEXECDIR)
-    set(OME_BIOFORMATS_INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}"
-        CACHE PATH "Bio-Formats-specific libexecdir")
-  endif()
-  if (NOT DEFINED OME_BIOFORMATS_INSTALL_ICONDIR)
-    set(OME_BIOFORMATS_INSTALL_ICONDIR "${CMAKE_INSTALL_DATADIR}/icons"
-        CACHE PATH "Icon directory")
-  endif()
-endif()
+  project(bioformats)
+  message(STATUS "Configuring Bio-Formats main build")
+  message(STATUS "BFSB prefix path: ${CMAKE_PREFIX_PATH}")
 
-if (NOT DEFINED OME_BIOFORMATS_INSTALL_SCHEMADIR)
-  set(OME_BIOFORMATS_INSTALL_SCHEMADIR "${CMAKE_INSTALL_DATADIR}/xml/ome"
-      CACHE PATH "Bio-Formats schema directory")
-endif()
-if (NOT DEFINED OME_BIOFORMATS_INSTALL_TRANSFORMDIR)
-  set(OME_BIOFORMATS_INSTALL_TRANSFORMDIR "${CMAKE_INSTALL_DATADIR}/xsl/ome"
-      CACHE PATH "Bio-Formats transform directory")
-endif()
+  include(cpp/cmake/Version.cmake)
 
-foreach(dir
-    DATADIR
-    LIBEXECDIR
-    ICONDIR
-    SCHEMADIR
-    TRANSFORMDIR
-    )
-  mark_as_advanced(OME_BIOFORMATS_INSTALL_${dir})
-  if(NOT IS_ABSOLUTE ${OME_BIOFORMATS_INSTALL_${dir}})
-    set(OME_BIOFORMATS_INSTALL_FULL_${dir} "${CMAKE_INSTALL_PREFIX}/${OME_BIOFORMATS_INSTALL_${dir}}")
+  if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+    message(FATAL_ERROR "In-tree builds are not supported; please run cmake from a separate build directory.")
+  endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+
+  enable_language(CXX)
+
+  list(APPEND CMAKE_MODULE_PATH
+       "${PROJECT_SOURCE_DIR}/cpp/cmake")
+
+  include(GNUInstallDirs)
+  include(CompilerChecks)
+  include(PlatformChecks)
+  include(BoostChecks)
+  include(RegexChecks)
+  include(ThreadChecks)
+  include(XercesChecks)
+  include(ImageLibraries)
+  include(QtGLChecks)
+  include(XsdFu)
+  include(GTest)
+  include(Doxygen)
+  include(HeaderTest)
+
+  if (NOT DEFINED OME_BIOFORMATS_INSTALL_DATADIR)
+    set(OME_BIOFORMATS_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/ome/bioformats"
+        CACHE PATH "Bio-Formats-specific datadir")
+  endif()
+
+  # Use standard path if using a prefix.
+  if(CMAKE_INSTALL_PREFIX)
+    if (NOT DEFINED OME_BIOFORMATS_INSTALL_LIBEXECDIR)
+      set(OME_BIOFORMATS_INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}/ome/bioformats"
+          CACHE PATH "Bio-Formats-specific libexecdir")
+    endif()
+    if (NOT DEFINED OME_BIOFORMATS_INSTALL_ICONDIR)
+      set(OME_BIOFORMATS_INSTALL_ICONDIR "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable"
+          CACHE PATH "Icon directory")
+    endif()
   else()
-    set(OME_BIOFORMATS_INSTALL_FULL_${dir} "${OME_BIOFORMATS_INSTALL_${dir}}")
+    if (NOT DEFINED OME_BIOFORMATS_INSTALL_LIBEXECDIR)
+      set(OME_BIOFORMATS_INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}"
+          CACHE PATH "Bio-Formats-specific libexecdir")
+    endif()
+    if (NOT DEFINED OME_BIOFORMATS_INSTALL_ICONDIR)
+      set(OME_BIOFORMATS_INSTALL_ICONDIR "${CMAKE_INSTALL_DATADIR}/icons"
+          CACHE PATH "Icon directory")
+    endif()
   endif()
-endforeach()
 
-include(CompilerChecks)
-include(PlatformChecks)
-include(BoostChecks)
-include(RegexChecks)
-include(ThreadChecks)
-include(XercesChecks)
-include(ImageLibraries)
-include(QtGLChecks)
-include(XsdFu)
-include(GTest)
-include(Doxygen)
-include(HeaderTest)
+  if (NOT DEFINED OME_BIOFORMATS_INSTALL_SCHEMADIR)
+    set(OME_BIOFORMATS_INSTALL_SCHEMADIR "${CMAKE_INSTALL_DATADIR}/xml/ome"
+        CACHE PATH "Bio-Formats schema directory")
+  endif()
+  if (NOT DEFINED OME_BIOFORMATS_INSTALL_TRANSFORMDIR)
+    set(OME_BIOFORMATS_INSTALL_TRANSFORMDIR "${CMAKE_INSTALL_DATADIR}/xsl/ome"
+        CACHE PATH "Bio-Formats transform directory")
+  endif()
 
-add_subdirectory(docs/doxygen)
-add_subdirectory(docs/sphinx)
-add_subdirectory(cpp)
+  foreach(dir
+      DATADIR
+      LIBEXECDIR
+      ICONDIR
+      SCHEMADIR
+      TRANSFORMDIR
+      )
+    mark_as_advanced(OME_BIOFORMATS_INSTALL_${dir})
+    if(NOT IS_ABSOLUTE ${OME_BIOFORMATS_INSTALL_${dir}})
+      set(OME_BIOFORMATS_INSTALL_FULL_${dir} "${CMAKE_INSTALL_PREFIX}/${OME_BIOFORMATS_INSTALL_${dir}}")
+    else()
+      set(OME_BIOFORMATS_INSTALL_FULL_${dir} "${OME_BIOFORMATS_INSTALL_${dir}}")
+    endif()
+  endforeach()
 
-set(LIBRARY_PREFIX OME)
-file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cpp/bin")
-configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateShellConfig.cmake.in
-               ${PROJECT_BINARY_DIR}/config @ONLY)
-configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateInternalShellWrapper.cmake.in
-               ${PROJECT_BINARY_DIR}/cpp/cmake/bf-test @ONLY)
-configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateShellWrapper.cmake.in
-               ${PROJECT_BINARY_DIR}/cpp/bin/bf-test @ONLY)
-file(COPY ${PROJECT_BINARY_DIR}/cpp/cmake/bf-test
-     DESTINATION ${PROJECT_BINARY_DIR}
-     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
-     GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-install(PROGRAMS ${PROJECT_BINARY_DIR}/cpp/bin/bf-test
-        DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
-if(WIN32)
-configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateCmdConfig.cmake.in
-               ${PROJECT_BINARY_DIR}/config.bat @ONLY)
-configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateInternalCmdWrapper.cmake.in
-               ${PROJECT_BINARY_DIR}/bf-test.bat @ONLY)
-configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateCmdWrapper.cmake.in
-               ${PROJECT_BINARY_DIR}/cpp/bin/bf-test.bat @ONLY)
-install(PROGRAMS ${PROJECT_BINARY_DIR}/cpp/bin/bf-test.bat
-        DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+  add_subdirectory(docs/doxygen)
+  add_subdirectory(docs/sphinx)
+  add_subdirectory(cpp)
+
+  set(LIBRARY_PREFIX OME)
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cpp/bin")
+  configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateShellConfig.cmake.in
+                 ${PROJECT_BINARY_DIR}/config @ONLY)
+  configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateInternalShellWrapper.cmake.in
+                 ${PROJECT_BINARY_DIR}/cpp/cmake/bf-test @ONLY)
+  configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateShellWrapper.cmake.in
+                 ${PROJECT_BINARY_DIR}/cpp/bin/bf-test @ONLY)
+  file(COPY ${PROJECT_BINARY_DIR}/cpp/cmake/bf-test
+       DESTINATION ${PROJECT_BINARY_DIR}
+       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+       GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  install(PROGRAMS ${PROJECT_BINARY_DIR}/cpp/bin/bf-test
+          DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+  if(WIN32)
+    configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateCmdConfig.cmake.in
+                   ${PROJECT_BINARY_DIR}/config.bat @ONLY)
+    configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateInternalCmdWrapper.cmake.in
+                   ${PROJECT_BINARY_DIR}/bf-test.bat @ONLY)
+    configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateCmdWrapper.cmake.in
+                   ${PROJECT_BINARY_DIR}/cpp/bin/bf-test.bat @ONLY)
+    install(PROGRAMS ${PROJECT_BINARY_DIR}/cpp/bin/bf-test.bat
+            DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+    endif()
+  return()
 endif()
 
 message("NOTE: The Bio-Formats ${OME_VERSION_SHORT} C++ library is new in version 5.1")

--- a/cpp/cmake/BioFormatsCommon.cmake
+++ b/cpp/cmake/BioFormatsCommon.cmake
@@ -1,0 +1,36 @@
+# #%L
+# Bio-Formats C++ libraries (cmake build infrastructure)
+# %%
+# Copyright © 2006 - 2014 Open Microscopy Environment:
+#   - Massachusetts Institute of Technology
+#   - National Institutes of Health
+#   - University of Dundee
+#   - Board of Regents of the University of Wisconsin-Madison
+#   - Glencoe Software, Inc.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of any organization.
+# #L%
+

--- a/cpp/cmake/BioFormatsSuperBuild.cmake
+++ b/cpp/cmake/BioFormatsSuperBuild.cmake
@@ -1,0 +1,90 @@
+# #%L
+# Bio-Formats C++ libraries (cmake build infrastructure)
+# %%
+# Copyright © 2006 - 2014 Open Microscopy Environment:
+#   - Massachusetts Institute of Technology
+#   - National Institutes of Health
+#   - University of Dundee
+#   - Board of Regents of the University of Wisconsin-Madison
+#   - Glencoe Software, Inc.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of any organization.
+# #L%
+
+project(bioformats-superbuild)
+# Given that the SuperBuild infrastructure is primarily for Windows,
+# we do require a recent cmake for this.
+cmake_minimum_required(VERSION 3.2.0)
+
+message(STATUS "Configuring Bio-Formats Super-Build")
+
+list(APPEND CMAKE_MODULE_PATH
+     "${PROJECT_SOURCE_DIR}/cpp/cmake")
+
+include(GNUInstallDirs)
+include(ExternalProject)
+include("${CMAKE_CURRENT_LIST_DIR}/ExternalProjectHelpers.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/External_zlib.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/External_png.cmake")
+
+install(DIRECTORY ${BIOFORMATS_EP_INSTALL_DIR}/
+        DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+# Re-run top-level CMakeLists.txt as an external project.
+set(proj bioformats)
+
+set(bioformats_DEPENDENCIES zlib png)
+set(bioformats_ARGS)
+
+set(EP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+ExternalProject_Add(${proj}
+  ${BIOFORMATS_EP_COMMON_ARGS}
+  DOWNLOAD_COMMAND ""
+  SOURCE_DIR ${EP_SOURCE_DIR}
+  BINARY_DIR ${EP_BINARY_DIR}
+  INSTALL_DIR ""
+  INSTALL_COMMAND "make;install;DESTDIR=${EP_INSTALL_DIR}"
+  CMAKE_ARGS
+    ${bioformats_ARGS}
+  CMAKE_CACHE_ARGS
+    -Dbioformats-superbuild:BOOL=OFF
+  DEPENDS
+    ${bioformats_DEPENDENCIES}
+  )
+
+# Force rebuilding of the main subproject every time building from super structure
+ExternalProject_Add_Step(${proj} forcebuild
+    COMMAND ${CMAKE_COMMAND} -E remove
+    ${CMAKE_CURRENT_BUILD_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build
+    DEPENDEES configure
+    DEPENDERS build
+    ALWAYS 1
+  )
+
+install(DIRECTORY ${EP_INSTALL_DIR}/
+        DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -42,6 +42,10 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif(POLICY CMP0054)
 
+include(CheckIncludeFileCXX)
+include(CheckCXXCompilerFlag)
+include(CheckCXXSourceCompiles)
+
 function(cxx_std_check flag var)
   check_cxx_compiler_flag("${flag}" ${var})
   if (${var})

--- a/cpp/cmake/ExternalProjectHelpers.cmake
+++ b/cpp/cmake/ExternalProjectHelpers.cmake
@@ -1,0 +1,75 @@
+## #%L
+# Bio-Formats C++ libraries (cmake build infrastructure)
+# %%
+# Copyright © 2006 - 2014 Open Microscopy Environment:
+#   - Massachusetts Institute of Technology
+#   - National Institutes of Health
+#   - University of Dundee
+#   - Board of Regents of the University of Wisconsin-Madison
+#   - Glencoe Software, Inc.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing official
+# policies, either expressed or implied, of any organization.
+# #L%
+
+# Compute -G arg for configuring external projects with the same CMake generator:
+if(CMAKE_EXTRA_GENERATOR)
+  set(BIOFORMATS_EP_GENERATOR "${CMAKE_EXTRA_GENERATOR} - ${CMAKE_GENERATOR}")
+else()
+  set(BIOFORMATS_EP_GENERATOR "${CMAKE_GENERATOR}")
+endif()
+
+set(BIOFORMATS_EP_SOURCE_CACHE "${CMAKE_BINARY_DIR}/sourcecache" CACHE FILEPATH "Directory for cached source downloads")
+file(MAKE_DIRECTORY ${BIOFORMATS_EP_SOURCE_CACHE})
+
+set(BIOFORMATS_EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/superbuild-install)
+
+list(APPEND CMAKE_PREFIX_PATH "${BIOFORMATS_EP_INSTALL_DIR}")
+
+string(REPLACE ";" "^^" BIOFORMATS_EP_ESCAPED_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+
+set(BIOFORMATS_EP_CMAKE_ARGS
+  "-DCMAKE_PREFIX_PATH=${BIOFORMATS_EP_ESCAPED_CMAKE_PREFIX_PATH}"
+)
+
+# Set CMake OSX variables needed to be passed to external projects
+if(APPLE)
+  list(APPEND BIOFORMATS_EP_CMAKE_ARGS
+    -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES}
+    -DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT}
+    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET})
+endif()
+
+set(BIOFORMATS_EP_CMAKE_CACHE_ARGS
+  "-DCMAKE_INSTALL_PREFIX:PATH="
+)
+
+set(BIOFORMATS_EP_COMMON_ARGS
+  LIST_SEPARATOR "^^"
+  DOWNLOAD_DIR ${BIOFORMATS_EP_SOURCE_CACHE}
+  CMAKE_GENERATOR ${BIOFORMATS_EP_GENERATOR}
+  CMAKE_ARGS ${BIOFORMATS_EP_CMAKE_ARGS}
+  CMAKE_CACHE_ARGS ${BIOFORMATS_EP_CMAKE_CACHE_ARGS}
+)

--- a/cpp/cmake/External_png.cmake
+++ b/cpp/cmake/External_png.cmake
@@ -1,0 +1,36 @@
+# png superbuild
+set(proj png)
+
+# Set dependency list
+set(png_DEPENDENCIES zlib)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  unset(png_DIR CACHE)
+  find_package(PNG REQUIRED)
+endif()
+
+if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}-source)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  # Notes:
+  # INSTALL_LIB_DIR overridden to use GNUInstallDirs setting
+  # Installs cmake settings into lib/libpng; could be deleted
+
+  ExternalProject_Add(${proj}
+    ${BIOFORMATS_EP_COMMON_ARGS}
+    URL "ftp://ftp.heanet.ie/mirrors/download.sourceforge.net/pub/sourceforge/l/li/libpng/libpng16/1.6.17/libpng-1.6.17.tar.xz"
+    URL_HASH "SHA512=f22a48b355adea197a2d79f90ccc6b3edef2b5e8f6fb17319bd38652959126bbecb9442fd95e5147a894484446e87e535667fbfcf3b1e901b8375e5bb00a3bf3"
+    SOURCE_DIR "${EP_SOURCE_DIR}"
+    BINARY_DIR "${EP_BINARY_DIR}"
+    INSTALL_DIR ""
+    INSTALL_COMMAND "make;install;DESTDIR=${BIOFORMATS_EP_INSTALL_DIR}"
+    CMAKE_ARGS
+      -Wno-dev --no-warn-unused-cli
+      "-DCMAKE_INSTALL_LIBDIR=/${CMAKE_INSTALL_LIBDIR}"
+    DEPENDS
+      ${png_DEPENDENCIES}
+    )
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${png_DEPENDENCIES})
+endif()

--- a/cpp/cmake/External_zlib.cmake
+++ b/cpp/cmake/External_zlib.cmake
@@ -1,0 +1,37 @@
+# zlib superbuild
+set(proj zlib)
+
+# Set dependency list
+set(zlib_DEPENDENCIES)
+
+if(${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  unset(zlib_DIR CACHE)
+  find_package(ZLIB REQUIRED)
+endif()
+
+if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}-source)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  # Notes:
+  # INSTALL_LIB_DIR overridden to use GNUInstallDirs setting
+
+  ExternalProject_Add(${proj}
+    ${BIOFORMATS_EP_COMMON_ARGS}
+    URL "ftp://ftp.heanet.ie/mirrors/download.sourceforge.net/pub/sourceforge/l/li/libpng/zlib/1.2.8/zlib-1.2.8.tar.xz"
+    URL_HASH "SHA512=405fbb4fc9ca8a59f34488205f403e77d4f184b08d344efbec6a8f558cac0512ee6cda1dc01b7913d61d9bed04cc710e61db1081bb8782c139fcb727f586fa54"
+    SOURCE_DIR "${EP_SOURCE_DIR}"
+    BINARY_DIR "${EP_BINARY_DIR}"
+    INSTALL_DIR ""
+    INSTALL_COMMAND "make;install;DESTDIR=${BIOFORMATS_EP_INSTALL_DIR}"
+    CMAKE_ARGS
+      -Wno-dev --no-warn-unused-cli
+      "-DINSTALL_LIB_DIR=/${CMAKE_INSTALL_LIBDIR}"
+    CMAKE_CACHE_ARGS
+    DEPENDS
+      ${zlib_DEPENDENCIES}
+    )
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${zlib_DEPENDENCIES})
+endif()
+

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -676,6 +676,14 @@ Run ``cmake -LH`` to see the configurable project options; use
 ``-LAH`` to see advanced options.  The following basic options are
 supported:
 
+bioformats-superbuild=(ON|OFF)
+  Build Bio-Formats as part of a “super-build” project.  This will
+  download and build all needed library dependencies (Boost, libtiff
+  etc.) prior to building Bio-Formats.  This option is disabled by
+  default since most platforms provide all the libraries by default.
+  However, it is enabled by default when using Microsoft Visual C++,
+  since this platform does not provide libraries unless you have built
+  your own.
 cxxstd-autodetect=(ON|OFF)
   Enable or disable (default) C++ compiler standard autodetection.  If
   enabled, the compiler will be put into C++11 mode if available,


### PR DESCRIPTION
Add initial cmake "superbuild" infrastructure.

- Will download and build zlib and libpng as a proof of concept (more will follow); this is to verify that the inter-module dependencies and build logic are functional
- Not enabled by default; existing builds will be unaffected
- When enabled, all builds are relocatable; it's not possible to build with a fixed install prefix.  This is likely what is always wanted on Windows.  This is due to the complications of building with a fixed prefix and then linking against the staged libraries and its interactions with rpath
- Currently hard-coded to use `make` with `DESTDIR` staging, so won't work on Windows yet; I'll get the superbuild setup fully functional on Unix and then tweak it to work on Windows once all the library support is in place (this avoids the additional complexity of battling with superbuild setup and Windows at the same time)

When enabled, the superbuild will add `zlib`, `png` and `bioformats` as subsidiary "external" projects, with the toplevel project being `bioformats-superbuild`.  This means the main build will recurse into these subprojects, which depend upon each other (you can still parallel-build them all).  Our code provides both the top-level `bioformats-superbuild` project (`cpp/cmake/BioFormatsSuperBuild.cmake`) and the subsidiary `bioformats` project (`CMakeLists.txt`); the `bioformats` project is the only project used if the superbuild feature is disabled.

--------

Testing:

- Build by adding `-Dbioformats-superbuild:BOOL=ON` to the cmake command-line
- You can also set `-DBIOFORMATS_EP_SOURCE_CACHE:PATH=/path/to/cache` to avoid repeatedly re-downloaded sources each time
- You can configure an install prefix with `-DCMAKE_INSTALL_PREFIX=/prefix`, and this will be used by `make install` with or without `DESTDIR` set; but it won't be used for the subsidiary builds
- After running `make install` you should see that the `include` and `lib` directories now contain the zlib and png headers and libraries in addition to the bioformats headers and libraries.

You can verify that the superbuild is working by:

- zlib and libpng will be downloaded, built and installed when running `make`
- cmake output in the subsidiary bioformats build will find zlib and libpng in the superbuild staging directory:

```
-- Found ZLIB: /tmp/b/superbuild-install/lib/x86_64-linux-gnu/libz.so (found version "1.2.8") 
-- Found PNG: /tmp/b/superbuild-install/lib/x86_64-linux-gnu/libpng.so (found version "1.6.17") 
```

- bioformats libraries and programs will be linked against the libraries in the superbuild staging directory.  On Linux:

```
% ldd bioformats-build/cpp/test/ome-bioformats/tiff | egrep "lib(png|z)"
        libpng16.so.16 => /tmp/b/superbuild-install/lib/x86_64-linux-gnu/libpng16.so.16 (0x00007f43a39ab000)
        libz.so.1 => /tmp/b/superbuild-install/lib/x86_64-linux-gnu/libz.so.1 (0x00007f439fe99000)
```

- If you build with `-Dbioformats-superbuild:BOOL=OFF` (or omitted, since it's the default), you'll get a normal build (the superbuild will be ignored)