### PR TITLE
bfconvert: mention BigTiff flag and extension

### DIFF
--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -118,7 +118,9 @@ name pattern, then the other must be included too.  The only exception is if
 
       bfconvert -bigtiff /path/to/input output.ome.tiff
 
-    Note that this option is not necessary if a BigTiff extension is used for
-    the output file, e.g.::
+    .. versionadded:: 5.1.2
 
-      bfconvert -bigtiff /path/to/input output.ome.btf
+      The :option:`-bigtiff` option is not necessary if a BigTiff extension is
+      used for the output file, e.g.::
+
+        bfconvert /path/to/input output.ome.btf

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -20,60 +20,48 @@ The output file format is determined by the extension of the output file, e.g.
 .. option:: -series SERIES
 
     All images in the input file are converted by default.  To convert only one
-    series:
-
-    ::
+    series::
 
       bfconvert -series 0 /path/to/input output-first-series.tiff
 
 .. option:: -timepoint TIMEPOINT
 
-    To convert only one timepoint:
-
-    ::
+    To convert only one timepoint::
 
       bfconvert -timepoint 0 /path/to/input output-first-timepoint.tiff
 
 .. option:: -channel CHANNEL
 
-    To convert only one channel:
-
-    ::
+    To convert only one channel::
 
       bfconvert -channel 0 /path/to/input output-first-channel.tiff
 
 .. option:: -z Z
 
-    To convert only one Z section:
-
-    ::
+    To convert only one Z section::
 
       bfconvert -z 0 /path/to/input output-first-z.tiff
 
 .. option:: -range START END
 
-    To convert images between certain indices (inclusive):
-
-    ::
+    To convert images between certain indices (inclusive)::
 
       bfconvert -range 0 2 /path/to/input output-first-3-images.tiff
 
-.. option:: -tilex TILEX
-.. option:: -tiley TILEY
+.. option:: -tilex TILEX, -tiley TILEY
 
     All images larger than 4096x4096 will be saved as a set of tiles if the
     output format supports doing so.  The default tile size is determined by
-    the input format, and can be overridden like this:
-
-    ::
+    the input format, and can be overridden like this::
 
       bfconvert -tilex 512 -tiley 512 /path/to/input output-512x512-tiles.tiff
 
-    ``-tilex`` is the width in pixel of each tile; ``-tiley`` is the height in
-    pixels of each tile.  The last row and column of tiles may be slightly
-    smaller if the image width and height are not multiples of the specified
-    tile width and height.  Note that specifying ``-tilex`` and ``-tiley``
-    will cause tiles to be written even if the image is smaller than 4096x4096.
+    :option:`-tilex` is the width in pixel of each tile; :option:`-tiley` is
+    the height in pixels of each tile.  The last row and column of tiles may
+    be slightly smaller if the image width and height are not multiples of the
+    specified tile width and height.  Note that specifying :option:`-tilex`
+    and :option:`-tiley` will cause tiles to be written even if the image is
+    smaller than 4096x4096.
 
     Also note that the specified tile size will affect performance.  If large
     amounts of data are being processed, it is a good idea to try converting a
@@ -82,9 +70,7 @@ The output file format is determined by the extension of the output file, e.g.
 
 Images can also be written to multiple files by specifying a pattern string
 in the output file.  For example, to write one series, timepoint, channel, and
-Z section per file:
-
-::
+Z section per file::
 
   bfconvert /path/to/input output_series_%s_Z%z_C%c_T%t.tiff
 
@@ -92,9 +78,7 @@ Z section per file:
 channel index, and ``%t`` is the timepoint index (all indices begin at 0).
 
 For large images in particular, it can also be useful to write each tile to
-a separate file:
-
-::
+a separate file::
 
   bfconvert -tilex 512 -tiley 512 /path/to/input output_tile_%x_%y_%m.jpg
 
@@ -108,10 +92,8 @@ name pattern, then the other must be included too.  The only exception is if
 
     By default, all images will be written uncompressed.  Supported compression
     modes vary based upon the output format, but when multiple modes are
-    available the compression can be changed using the ``-compression``
-    option. For example, to use LZW compression in a TIFF file:
-
-    ::
+    available the compression can be changed using the :option:`-compression`
+    option. For example, to use LZW compression in a TIFF file::
 
       bfconvert -compression LZW /path/to/input output-lzw.tiff
 
@@ -120,16 +102,12 @@ name pattern, then the other must be included too.  The only exception is if
     If the specified output file already exists, :program:`bfconvert` will
     prompt to overwrite the file.  When running :program:`bfconvert`
     non-interactively, it may be useful to always allow :program:`bfconvert` to
-    overwrite the output file:
-
-    ::
+    overwrite the output file::
 
       bfconvert -overwrite /path/to/input /path/to/output
 
 .. option:: -nooverwrite
 
-    To always exit without overwriting:
-
-    ::
+    To always exit without overwriting::
 
       bfconvert -nooverwrite /path/to/input /path/to/output

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -111,3 +111,14 @@ name pattern, then the other must be included too.  The only exception is if
     To always exit without overwriting::
 
       bfconvert -nooverwrite /path/to/input /path/to/output
+
+.. option:: -bigtiff
+
+    This option allows to force the writing of a BigTiff file::
+
+      bfconvert -bigtiff /path/to/input output.ome.tiff
+
+    Note that this option is not necessary if a BigTiff extension is used for
+    the output file, e.g.::
+
+      bfconvert -bigtiff /path/to/input output.ome.btf

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -48,7 +48,7 @@ The output file format is determined by the extension of the output file, e.g.
 
       bfconvert -range 0 2 /path/to/input output-first-3-images.tiff
 
-.. option:: -tilex TILEX, -tiley TILEY
+.. option:: -tilex TILEX, -tiley TILEX
 
     All images larger than 4096x4096 will be saved as a set of tiles if the
     output format supports doing so.  The default tile size is determined by
@@ -56,7 +56,7 @@ The output file format is determined by the extension of the output file, e.g.
 
       bfconvert -tilex 512 -tiley 512 /path/to/input output-512x512-tiles.tiff
 
-    :option:`-tilex` is the width in pixel of each tile; :option:`-tiley` is
+    :option:`-tilex` is the width in pixels of each tile; :option:`-tiley` is
     the height in pixels of each tile.  The last row and column of tiles may
     be slightly smaller if the image width and height are not multiples of the
     specified tile width and height.  Note that specifying :option:`-tilex`
@@ -114,7 +114,7 @@ name pattern, then the other must be included too.  The only exception is if
 
 .. option:: -bigtiff
 
-    This option allows to force the writing of a BigTiff file::
+    This option forces the writing of a BigTiff file::
 
       bfconvert -bigtiff /path/to/input output.ome.tiff
 

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -48,7 +48,7 @@ The output file format is determined by the extension of the output file, e.g.
 
       bfconvert -range 0 2 /path/to/input output-first-3-images.tiff
 
-.. option:: -tilex TILEX, -tiley TILEX
+.. option:: -tilex TILEX, -tiley TILEY
 
     All images larger than 4096x4096 will be saved as a set of tiles if the
     output format supports doing so.  The default tile size is determined by

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -6,6 +6,8 @@ files between :doc:`supported formats </supported-formats>`.
 
 :command:`bfconvert` with no options displays a summary of available options.
 
+.. program:: bfconvert
+
 To convert a file to single output file (e.g. TIFF):
 
 ::
@@ -15,55 +17,68 @@ To convert a file to single output file (e.g. TIFF):
 The output file format is determined by the extension of the output file, e.g.
 .tiff for TIFF files, .ome.tiff for OME-TIFF, .png for PNG.
 
-All images in the input file are converted by default.  To convert only one
-series:
+.. option:: -series SERIES
 
-::
+    All images in the input file are converted by default.  To convert only one
+    series:
 
-  bfconvert -series 0 /path/to/input output-first-series.tiff
+    ::
 
-To convert only one timepoint:
+      bfconvert -series 0 /path/to/input output-first-series.tiff
 
-::
+.. option:: -timepoint TIMEPOINT
 
-  bfconvert -timepoint 0 /path/to/input output-first-timepoint.tiff
+    To convert only one timepoint:
 
-To convert only one channel:
+    ::
 
-::
+      bfconvert -timepoint 0 /path/to/input output-first-timepoint.tiff
 
-  bfconvert -channel 0 /path/to/input output-first-channel.tiff
+.. option:: -channel CHANNEL
 
-To convert only one Z section:
+    To convert only one channel:
 
-::
+    ::
 
-  bfconvert -z 0 /path/to/input output-first-z.tiff
+      bfconvert -channel 0 /path/to/input output-first-channel.tiff
 
-To convert images between certain indices (inclusive):
+.. option:: -z Z
 
-::
+    To convert only one Z section:
 
-  bfconvert -range 0 2 /path/to/input output-first-3-images.tiff
+    ::
 
-All images larger than 4096x4096 will be saved as a set of tiles if the output
-format supports doing so.  The default tile size is determined by the input
-format, and can be overridden like this:
+      bfconvert -z 0 /path/to/input output-first-z.tiff
 
-::
+.. option:: -range START END
 
-  bfconvert -tilex 512 -tiley 512 /path/to/input output-512x512-tiles.tiff
+    To convert images between certain indices (inclusive):
 
-``-tilex`` is the width in pixel of each tile; ``-tiley`` is the height in
-pixels of each tile.  The last row and column of tiles may be slightly smaller
-if the image width and height are not multiples of the specified tile width
-and height.  Note that specifying ``-tilex`` and ``-tiley`` will cause tiles
-to be written even if the image is smaller than 4096x4096.
+    ::
 
-Also note that the specified tile size will affect performance.  If large
-amounts of data are being processed, it is a good idea to try converting a
-single tile with a few different tile sizes using the ``-crop`` option.
-This gives an idea of what the most performant size will be.
+      bfconvert -range 0 2 /path/to/input output-first-3-images.tiff
+
+.. option:: -tilex TILEX
+.. option:: -tiley TILEY
+
+    All images larger than 4096x4096 will be saved as a set of tiles if the
+    output format supports doing so.  The default tile size is determined by
+    the input format, and can be overridden like this:
+
+    ::
+
+      bfconvert -tilex 512 -tiley 512 /path/to/input output-512x512-tiles.tiff
+
+    ``-tilex`` is the width in pixel of each tile; ``-tiley`` is the height in
+    pixels of each tile.  The last row and column of tiles may be slightly
+    smaller if the image width and height are not multiples of the specified
+    tile width and height.  Note that specifying ``-tilex`` and ``-tiley``
+    will cause tiles to be written even if the image is smaller than 4096x4096.
+
+    Also note that the specified tile size will affect performance.  If large
+    amounts of data are being processed, it is a good idea to try converting a
+    single tile with a few different tile sizes using the :option:`-crop`
+    option. This gives an idea of what the most performant size will be.
 
 Images can also be written to multiple files by specifying a pattern string
 in the output file.  For example, to write one series, timepoint, channel, and
@@ -89,25 +104,32 @@ indices begin at 0.  Note that if ``%x`` or ``%y`` is included in the file
 name pattern, then the other must be included too.  The only exception is if
 ``%m`` was also included in the pattern.
 
-By default, all images will be written uncompressed.  Supported compression
-modes vary based upon the output format, but when multiple modes are available
-the compression can be changed using the ``-compression`` option.  For
-example, to use LZW compression in a TIFF file:
+.. option:: -compression COMPRESSION
 
-::
+    By default, all images will be written uncompressed.  Supported compression
+    modes vary based upon the output format, but when multiple modes are
+    available the compression can be changed using the ``-compression``
+    option. For example, to use LZW compression in a TIFF file:
 
-  bfconvert -compression LZW /path/to/input output-lzw.tiff
+    ::
 
-If the specified output file already exists, :command:`bfconvert` will prompt to
-overwrite the file.  When running :command:`bfconvert` non-interactively, it may be
-useful to always allow :command:`bfconvert` to overwrite the output file:
+      bfconvert -compression LZW /path/to/input output-lzw.tiff
 
-::
+.. option:: -overwrite
 
-  bfconvert -overwrite /path/to/input /path/to/output
+    If the specified output file already exists, :program:`bfconvert` will
+    prompt to overwrite the file.  When running :program:`bfconvert`
+    non-interactively, it may be useful to always allow :program:`bfconvert` to
+    overwrite the output file:
 
-or always exit without overwriting:
+    ::
 
-::
+      bfconvert -overwrite /path/to/input /path/to/output
 
-  bfconvert -nooverwrite /path/to/input /path/to/output
+.. option:: -nooverwrite
+
+    To always exit without overwriting:
+
+    ::
+
+      bfconvert -nooverwrite /path/to/input /path/to/output

--- a/docs/sphinx/users/comlinetools/formatlist.txt
+++ b/docs/sphinx/users/comlinetools/formatlist.txt
@@ -2,34 +2,35 @@ List supported file formats
 ===========================
 
 A detailed list of supported formats can be displayed using the
-:command:`formatlist` command.
+:program:`formatlist` command.
 
-Current usage information can be shown by running:
+.. program:: formatlist
 
-::
-
-    formatlist -help
-
-The default behavior is to print a plain-text list of formats:
-
-::
+The default behavior is to print a plain-text list of formats::
 
     formatlist
 
-This can also be accomplished using by specifying the ``-txt`` argument:
+.. option:: -txt
 
-::
+    This can also be accomplished using by specifying the :option:`-txt`
+    argument::
 
-    formatlist -txt
+        formatlist -txt
 
-The same information also be formatted as HTML:
+.. option:: -html
 
-::
+    This option allows to print the list of formats as HTML::
 
-    formatlist -html
+        formatlist -html
 
-or XML:
+.. option:: -xml
 
-::
+    This option allows to print the list of formats as XML::
 
-    formatlist -xml
+        formatlist -xml
+
+.. option:: -help
+
+    Current usage information can be shown by running::
+
+        formatlist -help

--- a/docs/sphinx/users/comlinetools/formatlist.txt
+++ b/docs/sphinx/users/comlinetools/formatlist.txt
@@ -12,25 +12,24 @@ The default behavior is to print a plain-text list of formats::
 
 .. option:: -txt
 
-    This can also be accomplished using by specifying the :option:`-txt`
-    argument::
+    Prints the list of formats as plaint-text::
 
         formatlist -txt
 
 .. option:: -html
 
-    This option allows to print the list of formats as HTML::
+    Prints the list of formats as HTML::
 
         formatlist -html
 
 .. option:: -xml
 
-    This option allows to print the list of formats as XML::
+    Prints the list of formats as XML::
 
         formatlist -xml
 
 .. option:: -help
 
-    Current usage information can be shown by running::
+    Displays the usage information::
 
         formatlist -help

--- a/docs/sphinx/users/comlinetools/formatlist.txt
+++ b/docs/sphinx/users/comlinetools/formatlist.txt
@@ -12,7 +12,7 @@ The default behavior is to print a plain-text list of formats::
 
 .. option:: -txt
 
-    Prints the list of formats as plaint-text::
+    Prints the list of formats as plain-text::
 
         formatlist -txt
 

--- a/docs/sphinx/users/comlinetools/mkfake.txt
+++ b/docs/sphinx/users/comlinetools/mkfake.txt
@@ -1,12 +1,14 @@
 Create a high-content screen for testing
 ========================================
 
-The :command:`mkfake` command creates a high-content screen for testing.  The
+The :program:`mkfake` command creates a high-content screen for testing.  The
 image data will be meaningless, but it allows testing of screen, plate, and
 well metadata without having to find appropriately-sized screens from real
 acquisitions.
 
-If no arguments are specified, :command:`mkfake` prints usage information.
+If no arguments are specified, :program:`mkfake` prints usage information.
+
+.. program:: mkfake
 
 To create a single screen with default plate dimensions:
 
@@ -18,35 +20,45 @@ This will create a directory that represents one screen with a single plate
 containing one well, one field, and one acquisition of the plate (see
 :schema:`PlateAcquisition <OME-2015-01/SPW_xsd.html#PlateAcquisition_ID>`).
 
-To change the number of plates in the screen:
+.. option:: -plates PLATES
 
-::
+    To change the number of plates in the screen:
 
-  mkfake -plates 3 three-plates.fake
+    ::
 
-To change the number of acquisitions for each plate:
+      mkfake -plates 3 three-plates.fake
 
-::
+.. option:: -runs RUNS
 
-  mkfake -runs 4 four-plate-acquisitions.fake
+    To change the number of acquisitions for each plate:
 
-To change the number of rows of wells in each plate:
+    ::
 
-::
+      mkfake -runs 4 four-plate-acquisitions.fake
 
-  mkfake -rows 8 eight-row-plate.fake
+.. option:: -rows ROWS
 
-To change the number of columns of wells in each plate:
+    To change the number of rows of wells in each plate:
 
-::
+    ::
 
-  mkfake -columns 12 twelve-column-plate.fake
+      mkfake -rows 8 eight-row-plate.fake
 
-To change the number of fields per well:
+.. option:: -columns COLUMNS
 
-::
+    To change the number of columns of wells in each plate:
 
-  mkfake -fields 2 two-field-plate.fake
+    ::
+
+      mkfake -columns 12 twelve-column-plate.fake
+
+.. option:: -fields FIELDS
+
+    To change the number of fields per well:
+
+    ::
+
+      mkfake -fields 2 two-field-plate.fake
 
 It is often most useful to use the arguments together to create a realistic
 screen, for example:
@@ -55,10 +67,11 @@ screen, for example:
 
   mkfake -rows 16 -columns 24 -plates 2 -fields 3 two-384-well-plates.fake
 
+.. option:: -debug DEBUG
 
-As with other command line tools, debugging output can be enabled if
-necessary:
+    As with other command line tools, debugging output can be enabled if
+    necessary:
 
-::
+    ::
 
-  mkfake -debug debug-screen.fake
+      mkfake -debug debug-screen.fake


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7830

This PR moves to using the `program/option` markup across the command-line tools pages and also documents the usage of the `-bigtiff` flag and/or the BigTiff extension in `bfconvert`.