### PR TITLE
AVI: read frame index tables

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -460,7 +460,7 @@ public class AVIReader extends FormatReader {
         buf = lastImage;
       }
 
-      if (!lengths.contains(0)) {
+      if (!lengths.contains(0L)) {
         motionJPEG = false;
       }
 

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -866,7 +866,7 @@ public class AVIReader extends FormatReader {
                         if (chunkSize == 0 && offsets.size() > 0 && bmpCompression == 0) {
                           offsets.add(offsets.get(offsets.size() - 1));
                         }
-                        else {
+                        else if (chunkSize > 0 || offsets.size() > 0) {
                           offsets.add(new Long(useSOM ? startOfMovi + offset : offset));
                         }
                         lengths.add(new Long(chunkSize));

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -774,7 +774,7 @@ public class AVIReader extends FormatReader {
 
               spos = in.getFilePointer();
               boolean end = false;
-              while (!end) {
+              while (!end && in.getFilePointer() < in.length() - 8) {
                 readTypeAndSize();
                 String oldType = type;
                 while (type.startsWith("ix") || type.endsWith("tx") ||

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -329,7 +329,12 @@ public class AVIReader extends FormatReader {
     if (bmpCompression == JPEG) {
       long fileOff = offsets.get(0).longValue();
       in.seek(fileOff);
-      int nBytes = uncompress(0, null).length / (getSizeX() * getSizeY());
+      int planeSize = uncompress(0, null).length;
+      int nBytes = planeSize / (getSizeX() * getSizeY());
+      if (nBytes * getSizeX() * getSizeY() != planeSize) {
+        ms0.sizeY /= 2;
+        nBytes = planeSize / (getSizeX() * getSizeY());
+      }
 
       if (bmpBitsPerPixel == 16) {
         nBytes /= 2;
@@ -455,6 +460,10 @@ public class AVIReader extends FormatReader {
         buf = lastImage;
       }
 
+      if (!lengths.contains(0)) {
+        motionJPEG = false;
+      }
+
       if (motionJPEG) {
         // transform YCbCr data to RGB
         // see http://en.wikipedia.org/wiki/YCbCr#JPEG_conversion
@@ -567,6 +576,10 @@ public class AVIReader extends FormatReader {
         if (type.equals("JUNK")) {
           in.skipBytes(size);
         }
+      }
+      else if (listString.equals("IDIT")) {
+        readTypeAndSize();
+        in.skipBytes(size);
       }
       else if (listString.equals("LIST")) {
         spos = in.getFilePointer();
@@ -783,6 +796,9 @@ public class AVIReader extends FormatReader {
                       in.skipBytes(size);
                     }
                   }
+                  else if (check.equals("wb")) {
+                    in.skipBytes(size);
+                  }
 
                   spos = in.getFilePointer();
                   if (spos + 8 >= in.length()) return;
@@ -794,6 +810,17 @@ public class AVIReader extends FormatReader {
                     if (spos + 8 >= in.length()) return;
                     readTypeAndSize();
                   }
+                  else if (type.length() < 4 || type.endsWith("JUN")) {
+                    in.seek(spos + 1);
+                    readTypeAndSize();
+                    in.skipBytes(size);
+                    spos = in.getFilePointer();
+                    if (spos + 8 >= in.length()) return;
+                    readTypeAndSize();
+                  }
+                  if (type.length() < 4) {
+                    return;
+                  }
                   check = type.substring(2);
                   if (check.equals("0d")) {
                     in.seek(spos + 1);
@@ -803,6 +830,37 @@ public class AVIReader extends FormatReader {
                 }
                 in.seek(spos);
                 if (!oldType.startsWith("ix") && !foundPixels) {
+                  if (check.equals("x1") && in.getFilePointer() < in.length() - 24) {
+                    // read the index table
+                    // the number of entries in the index table may not
+                    // match the number of frame streams (frames can
+                    // be omitted or duplicated)
+                    in.skipBytes(24);
+
+                    offsets.clear();
+                    lengths.clear();
+
+                    long tableEnd = in.getFilePointer() + size;
+                    if (tableEnd <= 0 || tableEnd > in.length()) {
+                      tableEnd = in.length();
+                    }
+                    while (in.getFilePointer() + 16 <= tableEnd) {
+                      String chunkID = in.readString(4);
+                      int flags = in.readInt();
+                      int offset = in.readInt() + 8;
+                      int chunkSize = in.readInt();
+
+                      if (chunkID.endsWith("db") || chunkID.endsWith("dc")) {
+                        offsets.add(new Long(offset));
+                        lengths.add(new Long(chunkSize));
+                      }
+                    }
+                  }
+                  else {
+                    end = true;
+                  }
+                }
+                else if (oldType.startsWith("ix") && !foundPixels) {
                   end = true;
                 }
               }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -549,21 +549,26 @@ public class Configuration {
       }
 
       for (int p=0; p<reader.getImageCount(); p++) {
-        Time deltaT = retrieve.getPlaneDeltaT(series, p);
-        if (deltaT != null) {
-          seriesTable.put(DELTA_T + p, deltaT.value(UNITS.S).toString());
+        try {
+          Time deltaT = retrieve.getPlaneDeltaT(series, p);
+          if (deltaT != null) {
+            seriesTable.put(DELTA_T + p, deltaT.value(UNITS.S).toString());
+          }
+          Length xPos = retrieve.getPlanePositionX(series, p);
+          if (xPos != null) {
+            seriesTable.put(X_POSITION + p, xPos.value(UNITS.REFERENCEFRAME).toString());
+          }
+          Length yPos = retrieve.getPlanePositionY(series, p);
+          if (yPos != null) {
+            seriesTable.put(Y_POSITION + p, yPos.value(UNITS.REFERENCEFRAME).toString());
+          }
+          Length zPos = retrieve.getPlanePositionZ(series, p);
+          if (zPos != null) {
+            seriesTable.put(Z_POSITION + p, zPos.value(UNITS.REFERENCEFRAME).toString());
+          }
         }
-        Length xPos = retrieve.getPlanePositionX(series, p);
-        if (xPos != null) {
-          seriesTable.put(X_POSITION + p, xPos.value(UNITS.REFERENCEFRAME).toString());
-        }
-        Length yPos = retrieve.getPlanePositionY(series, p);
-        if (yPos != null) {
-          seriesTable.put(Y_POSITION + p, yPos.value(UNITS.REFERENCEFRAME).toString());
-        }
-        Length zPos = retrieve.getPlanePositionZ(series, p);
-        if (zPos != null) {
-          seriesTable.put(Z_POSITION + p, zPos.value(UNITS.REFERENCEFRAME).toString());
+        catch (IndexOutOfBoundsException e) {
+          // only happens if no Plane elements were populated
         }
       }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/11264.

To test, use the files from QA 7450 and 11011.  When opened in ImageJ (```Use virtual stack``` may be necessary), each file should have a frame count that matches what is indicated by ```mplayer```.

The only difference between Bio-Formats and mplayer should be with QA 11011 - in this file, there is a conflict between the plane height stored in the AVI container (408) and the plane height stored in each of the MJPEG compressed streams (204).  Bio-Formats is using the MJPEG height instead of scaling the images (which I think is what mplayer does).