### PR TITLE
Metamorph: better detection of time series

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1721,7 +1721,7 @@ public class MetamorphReader extends BaseTiffReader {
             }
             skipKey = true;
           }
-          else if (valOrOffset == 0) {
+          else if (valOrOffset == 0 && getSizeZ() < mmPlanes) {
             core.get(0).sizeZ = 1;
           }
           break;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Vector;
 
 import org.joda.time.DateTime;
@@ -1516,15 +1518,22 @@ public class MetamorphReader extends BaseTiffReader {
 
   private void readRationals(String[] labels) throws IOException {
     String pos;
+    Set<Double> uniqueZ = new HashSet<Double>();
     for (int i=0; i<mmPlanes; i++) {
       pos = intFormatMax(i, mmPlanes);
       for (int q=0; q<labels.length; q++) {
         double v = readRational(in).doubleValue();
-        if (labels[q].endsWith("absoluteZ") && i == 0) {
-          tempZ = v;
+        if (labels[q].endsWith("absoluteZ")) {
+          if (i == 0) {
+            tempZ = v;
+          }
+          uniqueZ.add(v);
         }
         addSeriesMeta(labels[q] + "[" + pos + "]", v);
       }
+    }
+    if (uniqueZ.size() == mmPlanes) {
+      core.get(0).sizeZ = mmPlanes;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1721,6 +1721,9 @@ public class MetamorphReader extends BaseTiffReader {
             }
             skipKey = true;
           }
+          else if (valOrOffset == 0) {
+            core.get(0).sizeZ = 1;
+          }
           break;
         case 49:
           if (valOrOffset < in.length()) {


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12503.

To test, use the files linked from http://fiji.sc/bugzilla/show_bug.cgi?id=868.  ```file1.stk``` and ```file2.stk``` should each be a single time series with this change (i.e. SizeZ = 1).  Without this change, SizeZ would have been > 1.  Builds should remain green; other datasets should not be affected.