### PR TITLE
Also include ome-transforms.xml in Maven specification JAR

### DIFF
--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -81,6 +81,7 @@
                 <directory>${basedir}/transforms</directory>
                 <includes>
                   <include>**/*.xsl</include>
+                  <include>**/*.xml</include>
                 </includes>
               </resource>
             </resources>


### PR DESCRIPTION
While trying to consume Maven specification.jar for the OMERO exporter
integration tests, the transformation catalog could not be found as it
currently not bundled.

/cc @jburel