### PR TITLE
bfconvert: fix plane indexes for multi-series exports

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -552,6 +552,9 @@ public final class ImageConverter {
         write += e - m;
 
         nextOutputIndex.put(outputName, outputIndex + 1);
+        if (i == endPlane - 1) {
+          nextOutputIndex.remove(outputName);
+        }
 
         // log number of planes processed every second or so
         if (count == numImages - 1 || (e - timeLastLogged) / 1000 > 0) {


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12926.  This prevents the plane index from being too large for series beyond the first.

To test, choose any MIF (the ticket indicates ```test_images_good/leica-lif/Beta Canenin.lif```), and use ```bfconvert``` to convert to a single OME-TIFF.  With this change, the conversion should be successful, and ```showinf -nopixels``` on both files should show matching metadata.  Without this change, the conversion would have thrown an exception.