### PR TITLE
Be defensive when trying to group multi-file CZI datasets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -507,8 +507,12 @@ public class ZeissCZIReader extends FormatReader {
     for (String f : list) {
       if (f.startsWith(base + "(") || f.startsWith(base + " (")) {
         String part = f.substring(f.lastIndexOf("(") + 1, f.lastIndexOf(")"));
-        pixels.put(Integer.parseInt(part),
-          new Location(parent, f).getAbsolutePath());
+        try {
+          pixels.put(Integer.parseInt(part),
+            new Location(parent, f).getAbsolutePath());
+        } catch (NumberFormatException e) {
+          LOGGER.debug("{} not included in multi-file dataset", f);
+        }
       }
     }
 


### PR DESCRIPTION
This commits catches any NumberFormatException thrown when parsing multi-file CZI datasets with a file is named 'master (string).czi' and excludes it from the fileset.

Fixes https://github.com/openmicroscopy/bioformats/issues/1840

To test this PR:
- check automated tests are still passing especially for czi files
- create a folder with a `master.czi` and a `master (string).czi` file and check `showinf -nopix` fails without this PR but works with it.