### PR TITLE
Metamorph: fix Z and T settings when the .nd file is inconsistent

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -499,6 +499,12 @@ public class MetamorphReader extends BaseTiffReader {
         currentValue.append(line.substring(comma + 1).trim());
       }
 
+      if (!globalDoZ) {
+        for (int i=0; i<hasZ.size(); i++) {
+          hasZ.set(i, false);
+        }
+      }
+
       // figure out how many files we need
 
       if (z != null) zc = Integer.parseInt(z);
@@ -511,6 +517,9 @@ public class MetamorphReader extends BaseTiffReader {
       if (cc == 0) cc = 1;
       if (cc == 1 && bizarreMultichannelAcquisition) {
         cc = 2;
+      }
+      if (tc == 0) {
+        tc = 1;
       }
 
       int numFiles = cc * tc;


### PR DESCRIPTION
Back (forward?) ported from a6fb748 and 2e27ca2.

See QA 11128 and http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-June/005429.html.

To test, use the dataset in QA 11128; the .nd file is the one to open/import.  Without this change, choose the second or third series and verify that the first channel appears to be from a different stage position relative to the other two channels.  With this change, all three channels in the same series should clearly be from the same stage position.