### PR TITLE
Improve performance of displaying roi's and enable show all labels

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -330,11 +330,12 @@ public class ROIHandler {
                         }
                         if (sc != null) roi.setStrokeColor(sc);
                         manager.add(images[imageNum], roi, nextRoi++);
-                        manager.setAlwaysOnTop(true);
-                        manager.runCommand("Select All");
-                        manager.runCommand("Show All");
                     }
                 }
+            }
+            if (roiCount > 0 && manager != null) {
+                manager.setAlwaysOnTop(true);
+                manager.runCommand("show all with labels");
             }
         }
 
@@ -567,7 +568,7 @@ public class ROIHandler {
             store.setPointTheC(unwrap(roi.getCPosition()), roiNum, shape);
             store.setPointTheZ(unwrap(roi.getZPosition()), roiNum, shape);
             store.setPointTheT(unwrap(roi.getTPosition()), roiNum, shape);
-            
+
             if (roi.getStrokeWidth() > 0) {
                 store.setPointStrokeWidth( new Length((roi.getStrokeWidth()), UNITS.PIXEL), roiNum, shape+cntr);
             }
@@ -673,7 +674,7 @@ public class ROIHandler {
             store.setPolygonTheC(unwrap(roi.getCPosition()), roiNum, shape);
             store.setPolygonTheZ(unwrap(roi.getZPosition()), roiNum, shape);
             store.setPolygonTheT(unwrap(roi.getTPosition()), roiNum, shape);
-            
+
             if (roi.getStrokeWidth() > 0) {
                 store.setPolygonStrokeWidth( new Length((roi.getStrokeWidth()), UNITS.PIXEL), roiNum, shape);
             }
@@ -705,7 +706,7 @@ public class ROIHandler {
         store.setEllipseTheC(unwrap(roi.getCPosition()), roiNum, shape);
         store.setEllipseTheZ(unwrap(roi.getZPosition()), roiNum, shape);
         store.setEllipseTheT(unwrap(roi.getTPosition()), roiNum, shape);
-        
+
         if (roi.getStrokeWidth() > 0) {
             store.setEllipseStrokeWidth( new Length((roi.getStrokeWidth()), UNITS.PIXEL), roiNum, shape);
         }


### PR DESCRIPTION
Update the bioformats_package.jar in the imageJ/plugins folder. (with the merge build)

Testing Instructions : 

1) Open an ome-tiff, which has more than 1000 roi's in it, using the Bio-Formats Importer in ImageJ.
and compare performance (with and without this PR).

2)Can also open an existing image within OMERO (trout/latest, user-4, image_id: 29753), and use the omero-ij plugin to open the image. 

In both cases, the performance should be much better with this PR included.

