### PR TITLE
Flex: add support for multiple plate acquisitions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -565,7 +565,18 @@ public class FlexReader extends FormatReader {
     for (int run=0; run<runCount; run++) {
       String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, run);
       store.setPlateAcquisitionID(plateAcqID, 0, run);
-      store.setPlateAcquisitionName(runDirs.get(run).getName(), 0, run);
+
+      String acqName = runDirs.get(run).getName();
+      store.setPlateAcquisitionName(acqName, 0, run);
+
+      int timeStart = acqName.indexOf("(");
+      if (timeStart > 0) {
+        String time = acqName.substring(timeStart);
+        time = DateTools.formatDate(time, "(yyyy-MM-dd_HH-mm-ss)");
+
+        store.setPlateAcquisitionStartTime(new Timestamp(time), 0, run);
+        plateAcqStartTime = null;
+      }
 
       PositiveInteger maxFieldCount = FormatTools.getMaxFieldCount(fieldCount);
       if (maxFieldCount != null) {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -565,6 +565,7 @@ public class FlexReader extends FormatReader {
     for (int run=0; run<runCount; run++) {
       String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, run);
       store.setPlateAcquisitionID(plateAcqID, 0, run);
+      store.setPlateAcquisitionName(runDirs.get(run).getName(), 0, run);
 
       PositiveInteger maxFieldCount = FormatTools.getMaxFieldCount(fieldCount);
       if (maxFieldCount != null) {
@@ -624,8 +625,15 @@ public class FlexReader extends FormatReader {
       String instrumentID = MetadataTools.createLSID("Instrument", 0);
       store.setInstrumentID(instrumentID, 0);
 
-      if (plateName == null) plateName = currentFile.getParentFile().getName();
-      if (plateBarcodes.size() > 0) plateName = plateBarcodes.iterator().next() + " " + plateName;
+      if (plateName == null) {
+        if (runCount <= 1) {
+          plateName = " " + currentFile.getParentFile().getName();
+        }
+        else {
+          plateName = "";
+        }
+      }
+      if (plateBarcodes.size() > 0) plateName = plateBarcodes.iterator().next() + plateName;
       store.setPlateName(plateName, 0);
       store.setPlateRowNamingConvention(getNamingConvention("Letter"), 0);
       store.setPlateColumnNamingConvention(getNamingConvention("Number"), 0);


### PR DESCRIPTION
If a directory contains multiple Meas_* directories, each with .flex
files, then each Meas_ directory will be automatically detected as an
acquisition of the same plate.

See https://trello.com/c/dyEq0xsZ/187-flex-runs. I haven't yet thoroughly tested this in OMERO - that's the next step. We haven't had real exposure to the multiple acquisitions use case before, so there may be some things that need changing/fixing.

The small dataset I was testing with was ```flex/karsten/Columbus_ExtendedData/Images/AFo_071214_measurement3...```. This has 8 directories, each with 10 .flex files (one per well). Picking any one of the .flex files results in 80 series, so 80 Images, 80 WellSamples, 1 Plate, 8 PlateAcquisitions. I think all of the linkages are correct, but carefully checking the output of showinf -nopix -omexml is important.