### PR TITLE
LosslessJPEG color

### DIFF
--- a/components/formats-bsd/src/loci/formats/codec/LosslessJPEGCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LosslessJPEGCodec.java
@@ -164,8 +164,14 @@ public class LosslessJPEGCodec extends BaseCodec {
 
         ByteVector b = new ByteVector();
         for (int i=0; i<toDecode.length; i++) {
-          b.add(toDecode[i]);
-          if (toDecode[i] == (byte) 0xff && toDecode[i + 1] == 0) i++;
+          byte val = toDecode[i];
+          if (val == (byte) 0xff) {
+        	if (toDecode[i + 1] == 0)
+        		b.add(val);
+    		i++;
+          } else {
+            b.add(val);
+          }
         }
         toDecode = b.toByteArray();
 

--- a/components/formats-bsd/src/loci/formats/codec/LosslessJPEGCodec.java
+++ b/components/formats-bsd/src/loci/formats/codec/LosslessJPEGCodec.java
@@ -286,24 +286,28 @@ public class LosslessJPEGCodec extends BaseCodec {
           if (huffmanTables == null) {
             huffmanTables = new short[4][];
           }
-          int s = in.read();
-          byte tableClass = (byte) ((s & 0xf0) >> 4);
-          byte destination = (byte) (s & 0xf);
-          int[] nCodes = new int[16];
-          Vector table = new Vector();
-          for (int i=0; i<nCodes.length; i++) {
-            nCodes[i] = in.read();
-            table.add(new Short((short) nCodes[i]));
-          }
-
-          for (int i=0; i<nCodes.length; i++) {
-            for (int j=0; j<nCodes[i]; j++) {
-              table.add(new Short((short) (in.read() & 0xff)));
-            }
-          }
-          huffmanTables[destination] = new short[table.size()];
-          for (int i=0; i<huffmanTables[destination].length; i++) {
-            huffmanTables[destination][i] = ((Short) table.get(i)).shortValue();
+          int bytesRead = 0;
+          while (bytesRead < length) {
+	          int s = in.read();
+	          byte tableClass = (byte) ((s & 0xf0) >> 4);
+	          byte destination = (byte) (s & 0xf);
+	          int[] nCodes = new int[16];
+	          Vector table = new Vector();
+	          for (int i=0; i<nCodes.length; i++) {
+	            nCodes[i] = in.read();
+	            table.add(new Short((short) nCodes[i]));
+	          }
+	
+	          for (int i=0; i<nCodes.length; i++) {
+	            for (int j=0; j<nCodes[i]; j++) {
+	              table.add(new Short((short) (in.read() & 0xff)));
+	            }
+	          }
+	          huffmanTables[destination] = new short[table.size()];
+	          for (int i=0; i<huffmanTables[destination].length; i++) {
+	            huffmanTables[destination][i] = ((Short) table.get(i)).shortValue();
+	          }
+	          bytesRead += table.size() + 1;
           }
         }
         in.seek(fp + length);


### PR DESCRIPTION
I found that the color images I was trying to decompress have 3 Huffman tables (one per color channel). The existing code assumed there was just one table present in the DHT marker segment and stopped processing after that. I added a loop until the entire segment has been processed, and that fixed decompression for color images.

While reading about the handling of 0xff00 in the compressed data, I realized that the existing code didn't properly handle the case where there's a valid JPEG marker with a non-zero byte after the 0xff. I updated it to always skip the byte after a 0xff, but only store the 0xff if that byte is zero.
It's probably very rare that there's a valid JPEG marker in the compressed data, but it is legal so it's good to handle it properly.

I'm afraid I can't provide test images for this. I encountered this while processing real medical image data and we can't legally share them outside our company. I don't have any other images compressed as LosslessJPEG.
I can verify that with these code changes, these color images now decompress correctly. Also, other single-channel images that already worked continue to work.
