### PR TITLE
TIFF: reduce number of seeks in OnDemandLongArray

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/OnDemandLongArray.java
+++ b/components/formats-bsd/src/loci/formats/tiff/OnDemandLongArray.java
@@ -33,6 +33,7 @@
 package loci.formats.tiff;
 
 import java.io.IOException;
+import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 
 /**
@@ -75,11 +76,12 @@ public class OnDemandLongArray {
   }
 
   public long[] toArray() throws IOException {
-    long[] arr = new long[size];
-    for (int i=0; i<arr.length; i++) {
-      arr[i] = get(i);
-    }
-    return arr;
+    long fp = stream.getFilePointer();
+    stream.seek(start);
+    byte[] rawBytes = new byte[size * 8];
+    stream.readFully(rawBytes);
+    stream.seek(fp);
+    return (long[]) DataTools.makeDataArray(rawBytes, 8, false, stream.isLittleEndian());
   }
 
   public void close() throws IOException {


### PR DESCRIPTION
This should reduce the seek count to O(1) instead of O(n) when calling
toArray().

Fixes https://trac.openmicroscopy.org/ome/ticket/12930.  To test, use the files from QA 11133 and QA 11125.  Without this change, ```showinf``` on each file should take many minutes to display images.  With this change, the same command should have minimally an order of magnitude improvement in time.  I'd suggest repeating the test several times with each branch, and comparing the average and minimum times (not just the first time).

For reference, on my Linux VM, QA 11133 takes 1m21s and QA 11125 takes 1m6s with this change.