### PR TITLE
travis: Move non-java components to oraclejdk8 and build cppwrap with oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,19 +42,19 @@ script:
 
 matrix:
   exclude:
-    - jdk: oraclejdk8
+    - jdk: openjdk6
       env: BUILD=flake8
     - jdk: oraclejdk7
       env: BUILD=flake8
-    - jdk: oraclejdk8
+    - jdk: openjdk6
       env: BUILD=sphinx
     - jdk: oraclejdk7
       env: BUILD=sphinx
-    - jdk: oraclejdk8
+    - jdk: openjdk6
       env: BUILD=cpp
     - jdk: oraclejdk7
       env: BUILD=cpp
     - jdk: oraclejdk8
       env: BUILD=cppwrap
-    - jdk: oraclejdk7
+    - jdk: openjdk6
       env: BUILD=cppwrap


### PR DESCRIPTION
- build cppwrap under java7, since this is what our users will be most likely to be using (particularly since it requires being hand-built)
- move the non-java jobs to oraclejdk8; this is to allow future removal of the openjdk6 axis without disturbing other jobs.