### PR TITLE
cppwrap: Correct OMEXMLService initialisation

### DIFF
--- a/tools/test-build
+++ b/tools/test-build
@@ -50,6 +50,8 @@ cppwrap()
         cd build
         cmake ..
         make
+        ./showinf ../../../../specification/samples/2009-09/18x24y5z1t1c8b-text.ome.tiff
+        ./minimum_writer test.ome.tiff
     )
 }
 


### PR DESCRIPTION
- Don't instantiate OMEXMLServiceImpl until the JRE is initialised
- Test showinf and minimum_writer with travis

--------

Testing: handled by travis, but if you wanted to build cppwrap and run showinf:

```
./tools/test-build cppwrap
components/formats-bsd/target/cppwrap/build/showinf
```

it should be able to show metadata for image files without faulting.