### PR TITLE
PNG: fix interlaced images that have a width or height that is not a multiple of 8

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/APNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/APNGReader.java
@@ -498,7 +498,7 @@ public class APNGReader extends FormatReader {
                   passWidth -= (PASS_WIDTHS[i] - 2);
                 }
                 if (i == 4) {
-                  passWidth -= (PASS_WIDTHS[i] =- 3);
+                  passWidth -= (PASS_WIDTHS[i] - 3);
                 }
                 if (i == 6) {
                   passWidth -= (PASS_WIDTHS[i] - 5);


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12850.

See also
http://www.libpng.org/pub/png/spec/1.2/PNG-DataRep.html#DR.Interlaced-data-order.

To test, use the file from QA 11038.  Without this change, ```showinf``` on the file should throw an exception; with this change, ```showinf``` should produce the same image as ImageMagick (the ```display``` command) and ```File > Open``` in ImageJ.