### PR TITLE
TIFF export: save dimensions in ImageJ-style comment

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -366,7 +366,8 @@ public class TiffWriter extends FormatWriter {
     int z = retrieve.getPixelsSizeZ(series).getValue().intValue();
     int t = retrieve.getPixelsSizeT(series).getValue().intValue();
     ifd.putIFDValue(IFD.IMAGE_DESCRIPTION,
-      "ImageJ=\nchannels=" + channels + "\nslices=" + z + "\nframes=" + t);
+      "ImageJ=\nhyperstack=true\nimages=" + (channels * z * t) + "\nchannels=" +
+      channels + "\nslices=" + z + "\nframes=" + t);
 
     int index = no;
     for (int i=0; i<getSeries(); i++) {

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -317,14 +317,14 @@ public class TiffWriter extends FormatWriter {
     ifd.put(new Integer(IFD.IMAGE_LENGTH), new Long(height));
 
     Length px = retrieve.getPixelsPhysicalSizeX(series);
-    Double physicalSizeX = px == null ? null : px.value(UNITS.MICROM).doubleValue();
+    Double physicalSizeX = px == null || px.value() == null ? null : px.value(UNITS.MICROM).doubleValue();
     if (physicalSizeX == null || physicalSizeX.doubleValue() == 0) {
       physicalSizeX = 0d;
     }
     else physicalSizeX = 1d / physicalSizeX;
 
     Length py = retrieve.getPixelsPhysicalSizeY(series);
-    Double physicalSizeY = py == null ? null : py.value(UNITS.MICROM).doubleValue();
+    Double physicalSizeY = py == null || py.value() == null ? null : py.value(UNITS.MICROM).doubleValue();
     if (physicalSizeY == null || physicalSizeY.doubleValue() == 0) {
       physicalSizeY = 0d;
     }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -317,14 +317,14 @@ public class TiffWriter extends FormatWriter {
     ifd.put(new Integer(IFD.IMAGE_LENGTH), new Long(height));
 
     Length px = retrieve.getPixelsPhysicalSizeX(series);
-    Double physicalSizeX = px == null || px.value() == null ? null : px.value(UNITS.MICROM).doubleValue();
+    Double physicalSizeX = px == null || px.value(UNITS.MICROM) == null ? null : px.value(UNITS.MICROM).doubleValue();
     if (physicalSizeX == null || physicalSizeX.doubleValue() == 0) {
       physicalSizeX = 0d;
     }
     else physicalSizeX = 1d / physicalSizeX;
 
     Length py = retrieve.getPixelsPhysicalSizeY(series);
-    Double physicalSizeY = py == null || py.value() == null ? null : py.value(UNITS.MICROM).doubleValue();
+    Double physicalSizeY = py == null || py.value(UNITS.MICROM) == null ? null : py.value(UNITS.MICROM).doubleValue();
     if (physicalSizeY == null || physicalSizeY.doubleValue() == 0) {
       physicalSizeY = 0d;
     }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -353,7 +353,7 @@ public class TiffWriter extends FormatWriter {
     else {
       out.seek((Long) ifd.get(IFD.REUSE));
     }
-    
+
     ifd.putIFDValue(IFD.PLANAR_CONFIGURATION,
       interleaved || getSamplesPerPixel() == 1 ? 1 : 2);
 
@@ -361,6 +361,12 @@ public class TiffWriter extends FormatWriter {
     if (FormatTools.isSigned(type)) sampleFormat = 2;
     if (FormatTools.isFloatingPoint(type)) sampleFormat = 3;
     ifd.putIFDValue(IFD.SAMPLE_FORMAT, sampleFormat);
+
+    int channels = retrieve.getPixelsSizeC(series).getValue().intValue();
+    int z = retrieve.getPixelsSizeZ(series).getValue().intValue();
+    int t = retrieve.getPixelsSizeT(series).getValue().intValue();
+    ifd.putIFDValue(IFD.IMAGE_DESCRIPTION,
+      "ImageJ=\nchannels=" + channels + "\nslices=" + z + "\nframes=" + t);
 
     int index = no;
     for (int i=0; i<getSeries(); i++) {


### PR DESCRIPTION
See https://trello.com/c/w49BvpYX/11-save-imagej-metadata-in-tiff.

To test, use ```bfconvert``` to convert any file with SizeZ and/or SizeC > 1 to TIFF and check the output of ```showinf -nopix``` on the converted file.  I used ```test_images_good/andor/FURA-2CH-T.tif```, but anything will do.

The test without this change should result in the converted file having SizeZ == SizeC == 1, with all planes stored in T.  With this change, the Z, C, and T sizes should match between the original and converted files.