### PR TITLE
APNG export: fix frame count and footer writing

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/APNGWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/APNGWriter.java
@@ -177,8 +177,13 @@ public class APNGWriter extends FormatWriter {
       in.seek(numFramesPointer);
       in.order(littleEndian);
       numFrames = in.readInt();
+      in.seek(in.length() - 12);
+      nextSequenceNumber = in.readInt();
       in.close();
       footerPointer = out.length() - 12;
+    }
+    if (numFrames == 0) {
+      nextSequenceNumber = 0;
     }
   }
 
@@ -323,7 +328,14 @@ public class APNGWriter extends FormatWriter {
   private void writeFooter() throws IOException {
     footerPointer = out.getFilePointer();
     // write IEND chunk
-    out.writeInt(0);
+
+    // decoders ignore the data field in the IEND chunk
+    // most encoders set it to zero, but we're using it as
+    // a placeholder for the sequence number, so that setting
+    // the correct fcTL/fdAT sequence number when switching between files
+    // is easy (otherwise, the entire file would have to be read for
+    // every switch)
+    out.writeInt(nextSequenceNumber);
     out.writeBytes("IEND");
     out.writeInt(crc("IEND".getBytes(Constants.ENCODING)));
 

--- a/components/formats-bsd/src/loci/formats/out/APNGWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/APNGWriter.java
@@ -174,11 +174,18 @@ public class APNGWriter extends FormatWriter {
     else {
       numFramesPointer = PNG_SIG.length + 33;
       RandomAccessInputStream in = new RandomAccessInputStream(id);
-      in.seek(numFramesPointer);
       in.order(littleEndian);
+      in.seek(8);
+      while (in.getFilePointer() < in.length()) {
+        int length = in.readInt();
+        String type = in.readString(4);
+        if (type.equals("fcTL") || type.equals("fdAT")) {
+          nextSequenceNumber = in.readInt() + 1;
+        }
+        in.skipBytes(length + 4);
+      }
+      in.seek(numFramesPointer);
       numFrames = in.readInt();
-      in.seek(in.length() - 12);
-      nextSequenceNumber = in.readInt();
       in.close();
       footerPointer = out.length() - 12;
     }
@@ -329,13 +336,7 @@ public class APNGWriter extends FormatWriter {
     footerPointer = out.getFilePointer();
     // write IEND chunk
 
-    // decoders ignore the data field in the IEND chunk
-    // most encoders set it to zero, but we're using it as
-    // a placeholder for the sequence number, so that setting
-    // the correct fcTL/fdAT sequence number when switching between files
-    // is easy (otherwise, the entire file would have to be read for
-    // every switch)
-    out.writeInt(nextSequenceNumber);
+    out.writeInt(0);
     out.writeBytes("IEND");
     out.writeInt(crc("IEND".getBytes(Constants.ENCODING)));
 

--- a/components/formats-bsd/src/loci/formats/out/APNGWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/APNGWriter.java
@@ -181,6 +181,7 @@ public class APNGWriter extends FormatWriter {
         String type = in.readString(4);
         if (type.equals("fcTL") || type.equals("fdAT")) {
           nextSequenceNumber = in.readInt() + 1;
+          length -= 4;
         }
         in.skipBytes(length + 4);
       }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12943.

To test, use ```test_images_good/ome-tiff/multi-channel-4D-series.ome.tif```, or any other multi-dimensional file.  Use ```bfconvert``` to convert the file to a variety of output file names, e.g.:

* ```test.png```
* ```test_S%s.png```
* ```test_C%c.png```
* ```test_S%s_C%c_Z%z_T%t.png```

Without this change, ```bfconvert``` should run without error, but only ```test.png``` should be readable by ```showinf``` or ImageMagick (```display```); all other .png files should show an error message upon reading.

With this change, ```bfconvert``` should still run without error, and all .png files should be readable by both ```showinf``` and ImageMagick.  Note that ImageMagick doesn't support PNG files with multiple planes, so only the first plane will be shown.