### PR TITLE
POM: add merge build profile and classifier

### DIFF
--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -67,6 +67,7 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <classifier>${envClassifier}</classifier>
           <archive>
             <manifest>
               <mainClass>MetaSupportAutogen</mainClass>

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -106,6 +106,7 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <classifier>${envClassifier}</classifier>
           <archive>
             <manifest>
               <mainClass>loci.plugins.About</mainClass>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -174,6 +174,7 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <classifier>${envClassifier}</classifier>
           <archive>
             <manifest>
               <mainClass>loci.formats.gui.ImageViewer</mainClass>

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -149,6 +149,7 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <classifier>${envClassifier}</classifier>
           <archive>
             <manifest>
               <packageName>ome.xml</packageName>

--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -57,6 +57,7 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <classifier>${envClassifier}</classifier>
           <archive>
             <manifest>
               <mainClass>loci.plugins.About</mainClass>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -99,6 +99,7 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <classifier>${envClassifier}</classifier>
           <archive>
             <manifest>
               <packageName>loci.tests</packageName>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,7 @@
           <version>2.4</version>
           <!-- Always add classpath to JAR manifests. -->
           <configuration>
+            <classifier>${envClassifier}</classifier>
             <archive>
               <manifest>
                 <addClasspath>true</addClasspath>
@@ -734,6 +735,24 @@
   </distributionManagement>
 
   <profiles>
+    <profile>
+      <id>latest-build</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <properties>
+        <envClassifier></envClassifier>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>merge-build</id>
+      <properties>
+        <envClassifier>merge</envClassifier>
+      </properties>
+    </profile>
+
     <!-- Build test artifact when tests are present. -->
     <profile>
       <id>test-jar</id>


### PR DESCRIPTION
This replaces gh-1838.  A ```merge-build``` profile is still added, which is activated with the ```-P merge-build``` command line option.  Instead of changing the deployment repository, though, it adds the ```merge``` classifier to the generated artifacts.  The default behavior of ```mvn``` should be unchanged.

See https://maven.apache.org/pom.html#Dependencies.  Consuming merge build artifacts from Ivy would likely look like: http://stackoverflow.com/questions/16344151/ivy-retrieve-with-classifiers.  I'm not totally sure of the potential stumbling blocks here, but it looks like classifiers are already being used when packaging some OMERO components, so hopefully this isn't too far off base.

I did try to get groupId switching working as discussed, but that can't be done within a profile, and I haven't found a way to override the groupId on the command line.  If that's still the preferred approach, we may need separate merge build POMs or a pre-processing step to update the groupId (similar to how the version number is changed).  Certainly happy to discuss further or try other things; the current commit just seemed like the "Maven way" from everything I've read so far.

/cc @sbesson, @bramalingam, @joshmoore, @jburel 