### PR TITLE
FakeReader: add support for `[GlobalMetadata]` (rebased onto metadata)

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -4,7 +4,7 @@
 
 # generic reader for HCS data
 # disabled for now, as it has been causing no end of problems outside of OMERO
-#loci.formats.in.ScreenReader
+loci.formats.in.ScreenReader
 
 loci.formats.in.FilePatternReader     # pattern
 

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -467,7 +467,7 @@ public class FakeReader extends FormatReader {
         }
       }
 
-      table = list.getTable(list.getHeaders().get(0));
+      table = list.getTable("GlobalMetadata");
       if (table != null) {
         for (Map.Entry<String, String> entry : table.entrySet()) {
           addGlobalMeta(entry.getKey(), entry.getValue());

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -467,6 +467,13 @@ public class FakeReader extends FormatReader {
         }
       }
 
+      table = list.getTable(list.getHeaders().get(0));
+      if (table != null) {
+        for (Map.Entry<String, String> entry : table.entrySet()) {
+          addGlobalMeta(entry.getKey(), entry.getValue());
+        }
+      }
+
       String[] newTokArr = newTokens.toArray(new String[0]);
       String[] oldTokArr = tokens;
       tokens = new String[newTokArr.length + oldTokArr.length];

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -225,6 +225,20 @@ public class FakeReaderTest {
     }
   }
 
+  @Test
+  public void testExtraMetadata() throws Exception {
+    RandomAccessFile raf = new RandomAccessFile(fakeIni, "rw");
+    try {
+      StringBuilder sb = new StringBuilder();
+      sb.append("\n[GlobalMetadata]\nfoo=bar\n");
+      raf.writeUTF(sb.toString());
+    } finally {
+      raf.close();
+    }
+    reader.setId(fakeIni.getAbsolutePath());
+    assertEquals(reader.getGlobalMetadata().get("foo"), "bar");
+  }
+
   //
   // HELPERS
   //

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -95,6 +95,14 @@ public class ScreenReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
+  @Override
+  public void reopenFile() throws IOException {
+    super.reopenFile();
+    for (ImageReader reader : readers) {
+      reader.getReader().reopenFile();
+    }
+  }
+
   /* @see loci.formats.IFormatReader#isSingleFile(String) */
   @Override
   public boolean isSingleFile(String id) throws FormatException, IOException {

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -12,6 +12,23 @@ Whatever is before the ``&`` is the image name; remaining key value pairs
 should be pretty self-explanatory. Just replace the values with whatever
 you need for testing.
 
+Additionally, you can put such values in a separate .ini file:
+
+::
+
+    touch my-special-test-file.fake
+    echo "pixelType=uint8" >> my-special-test-file.fake.ini
+    echo "sizeX=8192" >> my-special-test-file.fake.ini
+    echo "sizeY=8192" >> my-special-test-file.fake.ini
+
+In fact, just the .fake.ini file alone suffices:
+
+::
+
+    echo "pixelType=uint8" >> my-special-test-file.fake
+    echo "sizeX=8192" >> my-special-test-file.fake
+    echo "sizeY=8192" >> my-special-test-file.fake
+
 There are a few other keys that can be added as well:
 
 .. tabularcolumns:: |p{3cm}|p{11cm}|

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -35,8 +35,8 @@ global metadata map:
 
 ::
 
-    echo "[GlobalMetadata]" >> my-special-test-file.fake
-    echo "my.key=some.value" >> my-special-test-file.fake
+    echo "[GlobalMetadata]" >> my-special-test-file.fake.ini
+    echo "my.key=some.value" >> my-special-test-file.fake.ini
 
 
 There are a few other keys that can be added as well:

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -49,6 +49,16 @@ There are a few other keys that can be added as well:
 
     - * Key
       * Value
+    - * thumbSizeX
+      * number of pixels wide, for the thumbnail
+    - * thumbSizeY
+      * number of pixels tall, for the thumbnail
+    - * physicalSizeX
+      * real width of the pixels, supports units defaulting to microns
+    - * physicalSizeY
+      * real height of the pixels, supports units defaulting to microns
+    - * physicalSizeZ
+      * real depth of the pixels, supports units defaulting to microns
     - * sizeZ
       * number of Z sections
     - * sizeC
@@ -57,6 +67,8 @@ There are a few other keys that can be added as well:
       * number of timepoints
     - * bitsPerPixel
       * number of valid bits (<= number of bits implied by pixel type)
+    - * acquisitionDate
+      * timestamp formatted as "yyyy-MM-dd_HH-mm-ss"
     - * rgb
       * number of channels that are merged together
     - * dimOrder
@@ -73,6 +85,20 @@ There are a few other keys that can be added as well:
       * number of series (Images)
     - * lutLength
       * number of entries in the color lookup table
+    - * exposureTime
+      * time of exposure, supports units defaulting to seconds
+    - * plates
+      * number of plates to generate
+    - * plateAcqs
+      * number of plate runs
+    - * plateRows
+      * number of rows per plate
+    - * plateCols
+      * number of rows per plate
+    - * fields
+      * number of fields per well
+    - * annLong, annDouble, annMap, annComment, annBool, annTime, annTag, annTerm, annXml
+      * number of annotations of the given type to generate
 
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -29,6 +29,16 @@ In fact, just the .fake.ini file alone suffices:
     echo "sizeX=8192" >> my-special-test-file.fake
     echo "sizeY=8192" >> my-special-test-file.fake
 
+If you include a "[GlobalMetadata]" section to the ini file,
+then all the included values will be accessible from the
+global metadata map:
+
+::
+
+    echo "[GlobalMetadata]" >> my-special-test-file.fake
+    echo "my.key=some.value" >> my-special-test-file.fake
+
+
 There are a few other keys that can be added as well:
 
 .. tabularcolumns:: |p{3cm}|p{11cm}|


### PR DESCRIPTION

This is the same as gh-1829 but rebased onto metadata.

----

In order to round trip test the import of fake files,
having a simple way of adding arbitrary fake global
metadata to the reader is necessary. This currently adds
support to fake.ini files for parsing the `[GlobalMetadata]`
section into calls to FormatReader.addGlobalMetadata. Later
work could add series-specific metadata as well.

                