### PR TITLE
Metamorph TIFF: better check for dimension consistency

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -291,6 +291,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
     for (Double z : zPositions) {
       if (!uniqueZ.contains(z)) uniqueZ.add(z);
     }
+
     if (getSizeZ() == 0) m.sizeZ = 1;
     m.sizeZ *= uniqueZ.size();
 
@@ -308,9 +309,11 @@ public class MetamorphTiffReader extends BaseTiffReader {
 
     int seriesCount = wellCount * fieldRowCount * fieldColumnCount;
 
-    if (seriesCount > 1 && getSizeZ() > totalPlanes / seriesCount) {
+    if (seriesCount > 1 && getSizeZ() > totalPlanes / seriesCount ||
+      totalPlanes > getSizeZ() * getSizeT() * effectiveC)
+    {
       m.sizeZ = 1;
-      m.sizeT = totalPlanes / (seriesCount * getSizeT() * effectiveC);
+      m.sizeT = totalPlanes / (seriesCount * effectiveC);
     }
 
     m.imageCount = getSizeZ() * getSizeT() * effectiveC;


### PR DESCRIPTION
This should do a better job of ensuring that Z * C * T is equal to the
number of planes.

Fixes https://trac.openmicroscopy.org/ome/ticket/12940.

To test, use the files from QA 11135.  Verify that there are 61 planes in each file using ```tiffinfo filename.tif | grep -c "TIFF Directory"```.  Without this change, ```showinf``` should show that both files have SizeZ * SizeC * SizeT != 61.  With this change, SizeT should be 61 for both files.