### PR TITLE
ScreenReader: implement reopenFile

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -95,6 +95,14 @@ public class ScreenReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
+  @Override
+  public void reopenFile() throws IOException {
+    super.reopenFile();
+    for (ImageReader reader : readers) {
+      reader.getReader().reopenFile();
+    }
+  }
+
   /* @see loci.formats.IFormatReader#isSingleFile(String) */
   @Override
   public boolean isSingleFile(String id) throws FormatException, IOException {


### PR DESCRIPTION
Memoizing a ScreenReader with OpenlabTiff files led to a
NullPointerException. Now each reader in the ScreenReader
has its reopenFile method called.

Testing with OMERO:
 * activate the `ScreenReader` in both lib/client and lib/server
 * import the Rad52 screen
 * view the plate in OMERO.web

Before this PR, no thumbnails were loaded. With this PR, thumbnails load normally. Note: if you try the above with only one import of the screen, it will be necessary to delete the memo file.