### PR TITLE
Metamorph: skip TIFF files with no IFDs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -914,10 +914,19 @@ public class MetamorphReader extends BaseTiffReader {
               stream = new RandomAccessInputStream(file, 16);
               tp = new TiffParser(stream);
               tp.checkHeader();
-              lastFile = fileIndex;
-              lastIFDs = tp.getIFDs();
+              IFDList f = tp.getIFDs();
+              if (f.size() > 0) {
+                lastFile = fileIndex;
+                lastIFDs = f;
+              }
+              else {
+                file = null;
+                stks[i][fileIndex] = null;
+              }
             }
+          }
 
+          if (file != null) {
             lastIFD = lastIFDs.get(p % lastIFDs.size());
             Object commentEntry = lastIFD.get(IFD.IMAGE_DESCRIPTION);
             if (commentEntry != null) {


### PR DESCRIPTION
See QA 11163 and http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-July/005488.html.

Without this change, ```showinf``` on the .nd file from QA 11163 should result in an exception, as noted in the thread.  With this change, ```showinf``` should initialize the .nd file without error.  The series count should match the ```NStagePositions``` value in the .nd file, and every series should open without error (this is easiest to test in ImageJ with the ```Open all series``` option).  Only the first 4 series will contain valid image data - everything else should be completely black.