### PR TITLE
PSD: fix bug in pixel data offset calculation

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PSDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PSDReader.java
@@ -293,7 +293,7 @@ public class PSDReader extends FormatReader {
       }
       int len = in.readInt();
       if ((len % 4) != 0) len += 4 - (len % 4);
-      if (len > in.length() - in.getFilePointer()) {
+      if (len > in.length() - in.getFilePointer() || (len & 0xff0000) >> 16 == 1) {
         in.seek(start);
         len = 0;
       }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12629.

To test, use the file from QA 10347.  Without this change, ```showinf``` or ImageJ should show an image that looks obviously wrong.  With this change, ```showinf``` and ImageJ should show the same thing as Image/GraphicsMagick - a single RGB image with three text labels in the upper-left corner.