### PR TITLE
METADATA-ONLY!: enable ScreenReader

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -4,7 +4,7 @@
 
 # generic reader for HCS data
 # disabled for now, as it has been causing no end of problems outside of OMERO
-#loci.formats.in.ScreenReader
+loci.formats.in.ScreenReader
 
 loci.formats.in.FilePatternReader     # pattern
 


### PR DESCRIPTION
For importing some screens, it's necessary to have the
ScreenReader enabled. Until this can be done on the fly
in the server, this temporary commit is necessary.