### PR TITLE
cmake: TemplateShellWrapper uses DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/cpp/cmake/TemplateShellWrapper.cmake.in
+++ b/cpp/cmake/TemplateShellWrapper.cmake.in
@@ -118,10 +118,10 @@ if [ -d "$INSTALL_PREFIX" ]; then
   LIBEXECDIR="$BF_INSTALL_FULL_LIBEXECDIR"
   MANDIR="$INSTALL_FULL_MANDIR"
   if [ "$(uname -s)" = "Darwin" ]; then
-    if [ -z "$DYLD_LIBRARY_PATH" ]; then
-      export DYLD_LIBRARY_PATH="$INSTALL_FULL_LIBDIR"
+    if [ -z "$DYLD_FALLBACK_LIBRARY_PATH" ]; then
+      export DYLD_FALLBACK_LIBRARY_PATH="$INSTALL_FULL_LIBDIR"
     else
-      export DYLD_LIBRARY_PATH="$INSTALL_FULL_LIBDIR:$DYLD_LIBRARY_PATH"
+      export DYLD_FALLBACK_LIBRARY_PATH="$INSTALL_FULL_LIBDIR:$DYLD_FALLBACK_LIBRARY_PATH"
     fi
   else
     if [ -z "$LD_LIBRARY_PATH" ]; then
@@ -142,10 +142,10 @@ else
   LIBEXECDIR="${rootdir}${BF_INSTALL_FULL_LIBEXECDIR}"
   MANDIR="${rootdir}${INSTALL_FULL_MANDIR}"
   if [ "$(uname -s)" = "Darwin" ]; then
-    if [ -z "$DYLD_LIBRARY_PATH" ]; then
-      export DYLD_LIBRARY_PATH="$rootdir$INSTALL_FULL_LIBDIR"
+    if [ -z "$DYLD_FALLBACK_LIBRARY_PATH" ]; then
+      export DYLD_FALLBACK_LIBRARY_PATH="$rootdir$INSTALL_FULL_LIBDIR"
     else
-      export DYLD_LIBRARY_PATH="$rootdir$INSTALL_FULL_LIBDIR:$DYLD_LIBRARY_PATH"
+      export DYLD_FALLBACK_LIBRARY_PATH="$rootdir$INSTALL_FULL_LIBDIR:$DYLD_FALLBACK_LIBRARY_PATH"
     fi
   else
     if [ -z "$LD_LIBRARY_PATH" ]; then


### PR DESCRIPTION
Josh found last week while testing the superbuild code that DYLD_FALLBACK_LIBRARY_PATH should be used in place of DYLD_LIBRARY_PATH on MacOS X.  This PR changes this for the `bf-test` script template so that it can work in a superbuild context.

--------

Testing: `bf-test` will continue to work.  You can test with the zip build from any of the Mac build nodes. e.g. https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp/BUILD_TYPE=Debug,CXXSTD_AUTODETECT=ON,node=mackerel/