### PR TITLE
ND2: fix channel count correction

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -973,7 +973,10 @@ public class NativeND2Reader extends FormatReader {
         getSizeC() > 3) && getPixelType() == FormatTools.INT8)
       {
         core.get(0).pixelType = FormatTools.UINT16;
-        if (getSizeC() > 3 && availableBytes % planeSize != 0) {
+        planeSize *= 2;
+        if (getSizeC() > 3 && availableBytes % planeSize != 0 &&
+          planeSize > availableBytes)
+        {
           core.get(0).sizeC = 3;
           core.get(0).rgb = true;
         }


### PR DESCRIPTION
See https://trello.com/c/buOp7Scd/23-nd2-channel-count.

To test, use the file in ```nd2/damir```.  Verify that Nikon's NIS Elements Viewer shows 700 positions, 4 channels, 1 Z section and 1 timepoint.  Without this change, ```showinf``` only shows 3 channels; with this change, all dimensions and images should match Elements.