### PR TITLE
c++ docs: add `boost-devel` as a centos dependency

### DIFF
--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -133,8 +133,10 @@ Debian/Ubuntu
 Partial quick starts
 ^^^^^^^^^^^^^^^^^^^^
 
-Homebrew and RedHat/CentOS do not provide packages for everything you need. The lists below will install
-*most* of the dependencies, but you will need to see the details below to install further dependencies.
+Homebrew and RedHat/CentOS do not provide packages for everything that is
+needed. The commands listed will install *most* of the dependencies, but
+further dependencies will need to be installed as described in various
+sections below.
 
 Homebrew
   ``brew install boost cmake hdf5 libpng python libtiff xerces-c git glm qt5 graphviz ant``

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -132,7 +132,7 @@ Debian/Ubuntu
 Homebrew
   ``brew install boost cmake hdf5 libpng python libtiff xerces-c git glm qt5 graphviz ant``
 RedHat/CentOS
-  ``yum install libhdf5-devel libpng-devel python python-genshi libtiff-devel xerces-c-devel git gtest-devel graphviz java-1.7.0-openjdk``
+  ``yum install boost-devel libhdf5-devel libpng-devel python python-genshi libtiff-devel xerces-c-devel git gtest-devel graphviz java-1.7.0-openjdk``
 
 Note that Homebrew and RedHat/CentOS do not provide packages for everything you need; see below for details.
 

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -129,12 +129,19 @@ BSD Ports
   ``pkg install devel/boost-all devel/cmake science/hdf5 graphics/png lang/python textproc/py-genshi graphics/tiff textproc/xerces-c3 devel/git devel/googletest math/glm devel/qt5 graphics/graphviz devel/apache-ant java/openjdk7 textproc/py-sphinx print/texlive-full``
 Debian/Ubuntu
   ``apt-get install build-essential libboost-all-dev cmake libhdf5-dev libpng12-dev python python-genshi libtiff5-dev libxerces-c-dev git libgtest-dev libglm-dev qt5-default libqt5-opengl5-dev libqt5-svg5-dev graphviz ant ant-contrib ant-optional openjdk-7-jdk openjdk-7-jre python-sphinx texlive-full``
+
+Partial quick starts
+^^^^^^^^^^^^^^^^^^^^
+
+Homebrew and RedHat/CentOS do not provide packages for everything you need. The lists below will install
+*most* of the dependencies, but you will need to see the details below to install further dependencies.
+
 Homebrew
   ``brew install boost cmake hdf5 libpng python libtiff xerces-c git glm qt5 graphviz ant``
 RedHat/CentOS
-  ``yum install boost-devel libhdf5-devel libpng-devel python python-genshi libtiff-devel xerces-c-devel git gtest-devel graphviz java-1.7.0-openjdk``
+  ``yum install libhdf5-devel libpng-devel python python-genshi libtiff-devel xerces-c-devel git gtest-devel graphviz java-1.7.0-openjdk``
+  See the :ref:`boost_req` section for installing a newer version of Boost.
 
-Note that Homebrew and RedHat/CentOS do not provide packages for everything you need; see below for details.
 
 Basic toolchain
 ^^^^^^^^^^^^^^^
@@ -166,6 +173,8 @@ If possible, install the following packages:
   Run ``yum groupinstall "Development Tools"``
 §
   Install Visual Studio or `Visual Studio Express <http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop>`__
+
+.. _boost_req:
 
 Boost
 ^^^^^


### PR DESCRIPTION
Currently, all boost dependencies are missing from the
centos Quick Start. Without any boost, or with only
`boost` or `boost boost-regex` the following error
occurs:

```
centos6_1 | -- Performing Test OME_HAVE_BOOST_REGEX
centos6_1 | -- Performing Test OME_HAVE_BOOST_REGEX - Failed
centos6_1 | CMake Error at cpp/cmake/RegexChecks.cmake:84 (message):
centos6_1 |   No working regular expression implementation found
centos6_1 | Call Stack (most recent call first):
centos6_1 |   CMakeLists.txt:91 (include)
```

cc: @rleigh-dundee 

see: http://www.openmicroscopy.org/site/support/bio-formats5.1-staging/developers/cpp/overview.html#quick-start