### PR TITLE
FluoviewReader: TimeStamp - Accommodate 24 hour time format as well

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -799,7 +799,7 @@ public class FluoviewReader extends BaseTiffReader {
       }
       if (date != null) {
         date = DateTools.formatDate(date.trim(),
-          new String[] {"MM/dd/yyyy hh:mm:ss a", "MM-dd-yyyy hh:mm:ss"}, true);
+          new String[] {"MM/dd/yyyy hh:mm:ss a", "MM-dd-yyyy hh:mm:ss","MM/dd/yyyy H:mm:ss"}, true);
         Timestamp timestamp = Timestamp.valueOf(date);
         if (timeIndex >= 0 && timestamp != null) {
           long ms = timestamp.asInstant().getMillis();


### PR DESCRIPTION
ref: https://trac.openmicroscopy.org/ome/ticket/12964

Testing instructions : 

Please import the 2 files in the following thread in ImageJ using the Bio-Formats Importer,
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-July/005492.html

with the "display-metadata" option checked.

And check if you can see the TimeStamp information in the metadata table in both cases,

ex: Timestamp for Z= *s, C=*s, T=*s

Without this PR : The Old file (FURA.tif) will display the Timestamp but the new file will not show the TimeStamp, in the metadata table.