### PR TITLE
CellomicsReader:Fix for sparsely populated fields

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -373,21 +373,17 @@ public class CellomicsReader extends FormatReader {
       if (row < realRows && col < realCols) {
         wellIndex = row * realCols + col;
 
-        if (i==0){
-            wellIndexPrev = wellIndex;
-        }
-
-        if (wellIndexPrev != wellIndex){
+        if ((wellIndexPrev != wellIndex) || i==0){
+          if(i>0){
             wellCntr++;
-        }
-
-        if (wellIndexPrev != wellIndex){
+            fieldCntr = 0;
+          }else{
+            wellIndexPrev = wellIndex;
+          }
 
           store.setWellID(MetadataTools.createLSID("Well", 0, wellIndex), 0, wellCntr);
           store.setWellRow(new NonNegativeInteger(row), 0, wellCntr);
           store.setWellColumn(new NonNegativeInteger(col), 0, wellCntr);
-          fieldCntr = 0;
-
         }
 
         if (files.length == 1) {
@@ -395,19 +391,17 @@ public class CellomicsReader extends FormatReader {
         }
 
         if (fieldIndex == 0){
-            fieldCntr=0;
+          fieldCntr=0;
         }
-        System.out.println("wellIndex:" + wellIndex + "WellCntr:" + wellCntr + " fieldCntr:" + fieldCntr);
+
         String wellSampleID =
           MetadataTools.createLSID("WellSample", 0, wellIndex, fieldIndex);
         store.setWellSampleID(wellSampleID, 0, wellCntr, fieldCntr);
         store.setWellSampleIndex(
-          new NonNegativeInteger(fieldIndex), 0, wellCntr, fieldCntr);
-
+          new NonNegativeInteger(i), 0, wellCntr, fieldCntr);
         store.setWellSampleImageRef(imageID, 0, wellCntr, fieldCntr);
 
         fieldCntr++;
-
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -219,13 +219,16 @@ public class CellomicsReader extends FormatReader {
     Arrays.sort(files, new Comparator<String>() {
         @Override
         public int compare(String f1, String f2) {
+
             int wellRow1 = getWellRow(f1);
             int wellCol1 = getWellColumn(f1);
             int field1 = getField(f1);
+            int channel1 = getChannel(f1);
 
             int wellRow2 = getWellRow(f2);
             int wellCol2 = getWellColumn(f2);
             int field2 = getField(f2);
+            int channel2 = getChannel(f2);
 
             if (wellRow1 < wellRow2){
                 return -1;
@@ -238,7 +241,12 @@ public class CellomicsReader extends FormatReader {
             }else if (wellCol1 > wellCol2){
                 return 1;
             }
-            return field1-field2;
+            if (field1<field2){
+                return -1;
+            }else if (field1 > field2){
+                return 1;
+            }
+            return channel1-channel2;
 
         }
     });

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -219,13 +219,13 @@ public class CellomicsReader extends FormatReader {
     Arrays.sort(files, new Comparator<String>() {
         @Override
         public int compare(String f1, String f2) {
-            Integer wellRow1 = getWellRow(f1);
-            Integer wellCol1 = getWellColumn(f1);
-            Integer field1 = getField(f1);
+            int wellRow1 = getWellRow(f1);
+            int wellCol1 = getWellColumn(f1);
+            int field1 = getField(f1);
 
-            Integer wellRow2 = getWellRow(f2);
-            Integer wellCol2 = getWellColumn(f2);
-            Integer field2 = getField(f2);
+            int wellRow2 = getWellRow(f2);
+            int wellCol2 = getWellColumn(f2);
+            int field2 = getField(f2);
 
             if (wellRow1 < wellRow2){
                 return -1;
@@ -238,10 +238,11 @@ public class CellomicsReader extends FormatReader {
             }else if (wellCol1 > wellCol2){
                 return 1;
             }
-            return field1.compareTo(field2);
+            return field1-field2;
 
         }
     });
+
 
     core.clear();
 
@@ -380,6 +381,10 @@ public class CellomicsReader extends FormatReader {
           fieldIndex = 0;
         }
 
+        if (fieldIndex == 0){
+            cntr=0;
+        }
+
         String wellSampleID =
           MetadataTools.createLSID("WellSample", 0, wellIndex, fieldIndex);
         store.setWellSampleID(wellSampleID, 0, wellIndex, cntr);
@@ -388,6 +393,7 @@ public class CellomicsReader extends FormatReader {
 
         store.setWellSampleImageRef(imageID, 0, wellIndex, cntr);
         cntr++;
+
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -28,6 +28,8 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,7 +43,6 @@ import loci.formats.MetadataTools;
 import loci.formats.UnsupportedCompressionException;
 import loci.formats.codec.ZlibCodec;
 import loci.formats.meta.MetadataStore;
-
 import ome.xml.model.enums.NamingConvention;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveFloat;
@@ -186,7 +187,6 @@ public class CellomicsReader extends FormatReader {
     else pixelFiles.add(id);
 
     files = pixelFiles.toArray(new String[pixelFiles.size()]);
-    Arrays.sort(files);
 
     int wellRows = 0;
     int wellColumns = 0;
@@ -215,6 +215,36 @@ public class CellomicsReader extends FormatReader {
     if (fields * wellRows * wellColumns > files.length) {
       files = new String[] {id};
     }
+    final int wellColumnsFinal = wellColumns;
+    Arrays.sort(files, new Comparator<String>() {
+        @Override
+        public int compare(String f1, String f2) {
+            int wellRow1 = getWellRow(f1);
+            int wellCol1 = getWellColumn(f1);
+            int field1_1 = getField(f1);
+            String field1 = String.valueOf(field1_1);
+            if (field1_1<10) {
+                field1 = "00" + field1;
+            }else if (field1_1<100) {
+                field1 = "0" + field1;
+            }
+
+            int wellRow2 = getWellRow(f2);
+            int wellCol2 = getWellColumn(f2);
+            int field2_2 = getField(f2);
+
+            String field2 = String.valueOf(field2_2);
+            if (field2_2<10) {
+                field2 = "00" + field2;
+            }else if (field2_2<100) {
+                field2 = "0" + field2;
+            }
+
+            int fileId1 = Integer.valueOf(String.valueOf((wellRow1 * wellColumnsFinal) + wellCol1) + field1);
+            int fileId2 = Integer.valueOf(String.valueOf((wellRow2 * wellColumnsFinal) + wellCol2) + field2);
+            return fileId1 - fileId2;
+        }
+    });
 
     core.clear();
 
@@ -325,6 +355,7 @@ public class CellomicsReader extends FormatReader {
       }
     }
 
+    int cntr = 0;
     for (int i=0; i<getSeriesCount(); i++) {
       String file = files[i * getSizeC()];
 
@@ -354,11 +385,12 @@ public class CellomicsReader extends FormatReader {
 
         String wellSampleID =
           MetadataTools.createLSID("WellSample", 0, wellIndex, fieldIndex);
-        store.setWellSampleID(wellSampleID, 0, wellIndex, fieldIndex);
+        store.setWellSampleID(wellSampleID, 0, wellIndex, cntr);
         store.setWellSampleIndex(
-          new NonNegativeInteger(i), 0, wellIndex, fieldIndex);
+          new NonNegativeInteger(fieldIndex), 0, wellIndex, cntr);
 
-        store.setWellSampleImageRef(imageID, 0, wellIndex, fieldIndex);
+        store.setWellSampleImageRef(imageID, 0, wellIndex, cntr);
+        cntr++;
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -241,11 +241,13 @@ public class CellomicsReader extends FormatReader {
             }else if (wellCol1 > wellCol2){
                 return 1;
             }
-            if (field1<field2){
+
+            if (field1 < field2){
                 return -1;
             }else if (field1 > field2){
                 return 1;
             }
+
             return channel1-channel2;
 
         }

--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -215,34 +215,31 @@ public class CellomicsReader extends FormatReader {
     if (fields * wellRows * wellColumns > files.length) {
       files = new String[] {id};
     }
-    final int wellColumnsFinal = wellColumns;
+
     Arrays.sort(files, new Comparator<String>() {
         @Override
         public int compare(String f1, String f2) {
-            int wellRow1 = getWellRow(f1);
-            int wellCol1 = getWellColumn(f1);
-            int field1_1 = getField(f1);
-            String field1 = String.valueOf(field1_1);
-            if (field1_1<10) {
-                field1 = "00" + field1;
-            }else if (field1_1<100) {
-                field1 = "0" + field1;
+            Integer wellRow1 = getWellRow(f1);
+            Integer wellCol1 = getWellColumn(f1);
+            Integer field1 = getField(f1);
+
+            Integer wellRow2 = getWellRow(f2);
+            Integer wellCol2 = getWellColumn(f2);
+            Integer field2 = getField(f2);
+
+            if (wellRow1 < wellRow2){
+                return -1;
+            }else if (wellRow1 > wellRow2){
+                return 1;
             }
 
-            int wellRow2 = getWellRow(f2);
-            int wellCol2 = getWellColumn(f2);
-            int field2_2 = getField(f2);
-
-            String field2 = String.valueOf(field2_2);
-            if (field2_2<10) {
-                field2 = "00" + field2;
-            }else if (field2_2<100) {
-                field2 = "0" + field2;
+            if (wellCol1 < wellCol2){
+                return -1;
+            }else if (wellCol1 > wellCol2){
+                return 1;
             }
+            return field1.compareTo(field2);
 
-            int fileId1 = Integer.valueOf(String.valueOf((wellRow1 * wellColumnsFinal) + wellCol1) + field1);
-            int fileId2 = Integer.valueOf(String.valueOf((wellRow2 * wellColumnsFinal) + wellCol2) + field2);
-            return fileId1 - fileId2;
         }
     });
 


### PR DESCRIPTION
ref: https://trac.openmicroscopy.org/ome/ticket/12967

Testing instructions : 
See fileset uploaded in ​https://www.openmicroscopy.org/qa2/qa2/qa/feedback/11308/
Run:
showinf -nopix -omexml MFGTMP_150418130002_A01f111d0.C01 

do the same for files under: /Volumes/ome/data_repo/from_skyking/cellomics/qa-7352/test/
Run:
showinf -nopix -omexml /Volumes/ome/data_repo/from_skyking/cellomics/qa-7352/test/MFGTMP-PC_130509120002_B02f00d0.C01 

This should not throw any exceptions.
Without this PR: throws an IndexOutOfBoundsException.

Extra Check:
And Try the files on ImageJ as well! Opening just one series during the import.
Check if both the filesets open without any exceptions.