### PR TITLE
fix #12954: usage help argument

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -37,7 +37,6 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -61,10 +60,8 @@ import loci.formats.ImageWriter;
 import loci.formats.MetadataTools;
 import loci.formats.MinMaxCalculator;
 import loci.formats.MissingLibraryException;
-import loci.formats.ReaderWrapper;
 import loci.formats.UpgradeChecker;
 import loci.formats.gui.Index16ColorModel;
-import loci.formats.in.OMETiffReader;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -79,6 +79,8 @@ import loci.formats.services.OMEXMLServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * ImageInfo is a utility class for reading a file
  * and reporting information about it.
@@ -91,6 +93,9 @@ public class ImageInfo {
   private static final String NEWLINE = System.getProperty("line.separator");
 
   private static final String NO_UPGRADE_CHECK = "-no-upgrade";
+
+  private static final ImmutableSet<String> HELP_ARGUMENTS =
+      ImmutableSet.of("-h", "-help", "--help");
 
   // -- Fields --
 
@@ -989,6 +994,15 @@ public class ImageInfo {
     throws FormatException, ServiceException, IOException
   {
     DebugTools.enableLogging("INFO");
+
+    if (args.length == 1 && HELP_ARGUMENTS.contains(args[0])) {
+      /* a help argument is accepted only as the sole argument */
+      if (reader == null) {
+        reader = new ImageReader();
+      }
+      printUsage();
+      return false;
+    }
     boolean validArgs = parseArgs(args);
     if (!validArgs) return false;
     if (printVersion) {

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -995,13 +995,14 @@ public class ImageInfo {
   {
     DebugTools.enableLogging("INFO");
 
-    if (args.length == 1 && HELP_ARGUMENTS.contains(args[0])) {
-      /* a help argument is accepted only as the sole argument */
-      if (reader == null) {
-        reader = new ImageReader();
+    for (final String arg : args) {
+      if (HELP_ARGUMENTS.contains(arg)) {
+        if (reader == null) {
+          reader = new ImageReader();
+        }
+        printUsage();
+        return false;
       }
-      printUsage();
-      return false;
     }
     boolean validArgs = parseArgs(args);
     if (!validArgs) return false;


### PR DESCRIPTION
Has `showinf` print usage information if the user tries to guess an option that will print help. Fixes http://trac.openmicroscopy.org/ome/ticket/12954: try the commands listed in its description. Normal `showinf` workflows should continue to work.