### PR TITLE
Fix config directory path substitution on Windows

### DIFF
--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -40,6 +40,7 @@ import loci.common.Constants;
 import loci.common.IniList;
 import loci.common.IniParser;
 import loci.common.IniTable;
+import loci.common.Location;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,7 +137,13 @@ public class ConfigurationTree {
     }
     String parent = file.getParent();
     if (configDir != null) {
-        parent = parent.replaceAll(configDir, rootDir);
+      parent = parent.substring((int) Math.min(configDir.length() + 1, parent.length()));
+      if (parent.length() == 0) {
+        parent = rootDir;
+      }
+      else {
+        parent = new Location(rootDir, parent).getAbsolutePath();
+      }
     }
 
     configFile = file.getAbsolutePath();

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -215,7 +215,13 @@ public class TestTools {
 
     if (useConfigDir) {
       // Look for a configuration file under the configuration directory
-      String configRoot = root.replaceAll(rootDir, configDir);
+      String configRoot = root.substring((int) Math.min(rootDir.length() + 1, root.length()));
+      if (configRoot.length() == 0) {
+        configRoot = configDir;
+      }
+      else {
+        configRoot = new Location(configDir, configRoot).getAbsolutePath();
+      }
       Location configFile = new Location(configRoot, baseConfigName);
       if (configFile.exists()) {
         LOGGER.debug("found config file: {}", configFile.getAbsolutePath());


### PR DESCRIPTION
```replaceAll``` on Windows path names can quickly become kind of weird due to backslashes.  This replaces ```replaceAll``` with a less platform-dependent method of replacing the directory names.

Locally, I ran ```ant "-Dtestng.configDirectory=C:\Users\melissa\data_repo_config\test_images_good" "-Dtestng.directory=E:\test_images_good" test-automated``` (pointing to the current master branch of data_repo_config and a current copy of test_images_good respectively).  Without this change, every file in test_images_good is logged as "not configured".  With this change, only those files whose parent directory is symlinked (so no corresponding file is in data_repo_config) are logged as "not configured".

/cc @sbesson
See also https://trello.com/c/tbUfkJiE/6-external-configuration-directory-follow-up