### PR TITLE
cmake: Check for broken GCC regex implementation

### DIFF
--- a/cpp/cmake/RegexChecks.cmake
+++ b/cpp/cmake/RegexChecks.cmake
@@ -65,6 +65,16 @@ int main() {
   if (${namespace}_match(fail, bar)) return 11;
   if (${namespace}_match(fail, chk)) return 12;
 
+  // Checks for broken support in GCC 4.9 and 5.1
+  ${namespace} range1(\"^[a-z0-9][a-z0-9-]*\$\", ${namespace}::extended);
+  ${namespace} range2(\"^[a-z0-9][-a-z0-9]*\$\", ${namespace}::extended);
+  if (!${namespace}_match(test, range1)) return 13;
+  if (!${namespace}_match(test, range2)) return 14;
+  if (!${namespace}_match(\"a-\", range1)) return 15;
+  if (!${namespace}_match(\"a-\", range2)) return 16;
+  if (${namespace}_match(\"-a\", range1)) return 17;
+  if (${namespace}_match(\"-a\", range2)) return 18;
+
   return 0;
 }"
 ${outvar})


### PR DESCRIPTION
This comes from https://github.com/codelibre-net/schroot/pull/2/files and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=778112 leading to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67015

There's a subly broken regex implementation in GCC, which we weren't detecting.  This PR detects this and will fall back to using boost::regex in this case.

--------

Testing: Travis and the CI builds won't detect this since we aren't using any of the affected compiler versions.  Ideally we would have builds on more recent GCC versions, but we don't at present.  If you build with GCC 4.9.x, 5.0 or 5.1, you will find that where before the `OME_HAVE_REGEX` cmake test would succeed, it will now fail:

- run `cmake /path/to/bioformats` and note OME_HAVE_REGEX and OME_HAVE_BOOST_REGEX results
- merge this branch and repeat.  In the latter test you should see OME_HAVE_REGEX fail and OME_HAVE_BOOST_REGEX succeed, meaning it will fall back to using Boost's regex implementation.