### PR TITLE
cpp: ome-xml: Correct return in Timestamp ostream output

### DIFF
--- a/cpp/lib/ome/xml/model/primitives/Timestamp.h
+++ b/cpp/lib/ome/xml/model/primitives/Timestamp.h
@@ -213,8 +213,8 @@ namespace ome
                 }
 
               is.imbue(savedlocale);
-              return is;
             }
+          return is;
         }
 
       }


### PR DESCRIPTION
Move return to the outermost block, to fix a compiler warning.

--------

Testing: builds should remain green, no manual testing required.