### PR TITLE
Fix .dll packaging in formats-gpl

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -257,7 +257,9 @@ your FindBugs installation's lib directory. E.g.:
         include (none) to prevent problems if component.resources-bin is empty
       -->
       <fileset dir="${src.dir}" includes="(none) ${component.resources-bin}"/>
-      <fileset dir="${src.dir}/.." includes="(none) ${component.resources-bin}"/>
+    </copy>
+    <copy todir="${dest.dir}/META-INF" preservelastmodified="true">
+      <fileset dir="${src.dir}/.." includes="(non) ${component.resources-bin}"/>
     </copy>
     <!-- copy source files and text resources with filtering -->
     <copy todir="${dest.dir}" preservelastmodified="true">

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -257,6 +257,7 @@ your FindBugs installation's lib directory. E.g.:
         include (none) to prevent problems if component.resources-bin is empty
       -->
       <fileset dir="${src.dir}" includes="(none) ${component.resources-bin}"/>
+      <fileset dir="${src.dir}/.." includes="(none) ${component.resources-bin}"/>
     </copy>
     <!-- copy source files and text resources with filtering -->
     <copy todir="${dest.dir}" preservelastmodified="true">

--- a/components/formats-gpl/build.properties
+++ b/components/formats-gpl/build.properties
@@ -30,7 +30,8 @@ component.deprecation    = true
 
 component.resources-bin  = loci/formats/bio-formats-logo.png \
                            loci/formats/meta/*.xsl \
-                           loci/formats/utests/2008-09.ome
+                           loci/formats/utests/2008-09.ome \
+                           lib/**/*.dll
 component.resources-text = loci/formats/*.txt
 
 component.main-class     = loci.formats.gui.ImageViewer


### PR DESCRIPTION
See https://trello.com/c/ukrm7pbD/25-make-sure-dlls-end-up-in-formats-gpl-jar.

To test, check the output of ```jar tf artifacts/formats-gpl.jar``` and ```jar tf artifacts/bioformats_package.jar``` without this change.  Verify that no .dll files are present in formats-gpl.jar, and the only .dll files present in bioformats_package.jar correspond to Turbojpeg.

The same commands with this change should show two .dll files in the META-INF directory of formats-gpl.jar; the same two files should be present in bioformats_package.jar.