### PR TITLE
xsd-fu: MetadataRetrieve: Drop 'unused' from used parameters

### DIFF
--- a/components/xsd-fu/templates-cpp/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-cpp/MetadataRetrieve.template
@@ -17,7 +17,7 @@
 {% for param in indexes %}\
          * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
+         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index.
          * @returns the ${prop.name} property.
          */
         virtual ${prop.metadataStoreRetType}

--- a/components/xsd-fu/templates-java/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-java/MetadataRetrieve.template
@@ -19,7 +19,7 @@
 {% for param in indexes %}\
          * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
+         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index.
          * @return the ${prop.name} property.
          */
 	${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_string(indexes)}, ${index_string(prop.name)});\


### PR DESCRIPTION
This is purely a docstring change, though you can verify the generated code to check that the parameters are actually used (both for Java and C++).

A perhaps bigger question is why for example `setImageAnnotationRef` and `getImageAnnotationRef` do not have symmetric signatures, or rather do but in the former annotationRefIndex is unused and in the latter it is used, so the behaviour is not the same.  This applies to all `(get|set).*AnnotationRef` methods.  What makes these different than every other method in the model using indexes?  Even if this is valid, it would be helpful to know why and document it.