### PR TITLE
Fix new exceptions when parsing SimplePCI TIFF

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
@@ -181,8 +181,12 @@ public class SimplePCITiffReader extends BaseTiffReader {
       m.bitsPerPixel = Integer.parseInt(displayDepth);
     } else {
       String bitDepth = cameraTable.get("Bit Depth");
-      bitDepth = bitDepth.substring(0, bitDepth.length() - "-bit".length());
-      m.bitsPerPixel = Integer.parseInt(bitDepth);
+      if (bitDepth != null && bitDepth.length() > "-bit".length()) {
+        bitDepth = bitDepth.substring(0, bitDepth.length() - "-bit".length());
+        m.bitsPerPixel = Integer.parseInt(bitDepth);
+      } else {
+        throw new FormatException("Could not find bits per pixels");
+      }
     }
 
     IniTable captureTable = ini.getTable(" CAPTURE ");

--- a/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
@@ -176,15 +176,24 @@ public class SimplePCITiffReader extends BaseTiffReader {
     binning = cameraTable.get("Binning") + "x" + cameraTable.get("Binning");
     cameraType = cameraTable.get("Camera Type");
     cameraName = cameraTable.get("Camera Name");
-    m.bitsPerPixel = Integer.parseInt(cameraTable.get("Display Depth"));
+    String displayDepth = cameraTable.get("Display Depth");
+    if (displayDepth != null) {
+      m.bitsPerPixel = Integer.parseInt(displayDepth);
+    } else {
+      String bitDepth = cameraTable.get("Bit Depth");
+      bitDepth = bitDepth.substring(0, bitDepth.length() - "-bit".length());
+      m.bitsPerPixel = Integer.parseInt(bitDepth);
+    }
 
     IniTable captureTable = ini.getTable(" CAPTURE ");
-    int index = 1;
-    for (int i=0; i<getSizeC(); i++) {
-      if (captureTable.get("c_Filter" + index) != null) {
-        exposureTimes.add(new Double(captureTable.get("c_Expos" + index)));
+    if (captureTable != null) {
+      int index = 1;
+      for (int i=0; i<getSizeC(); i++) {
+        if (captureTable.get("c_Filter" + index) != null) {
+          exposureTimes.add(new Double(captureTable.get("c_Expos" + index)));
+        }
+        index++;
       }
-      index++;
     }
 
     IniTable calibrationTable = ini.getTable(" CALIBRATION ");


### PR DESCRIPTION
See  http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-July/005511.html and QA 11327

Recent version of HCImage seems to have modified the header of the TIFF file. This commit should fix NumberFormatException when parsing the bit depth and fix a following NullPointerException due to the absence of the Capture table.