### PR TITLE
cpp: common: Correct Boost.Endian C++11 noexcept macro

### DIFF
--- a/cpp/lib/ome/common/endian.h
+++ b/cpp/lib/ome/common/endian.h
@@ -53,8 +53,12 @@
 #include <ome/common/config.h>
 
 // Work around missing BOOST_NOEXCEPT in older Boost versions (e.g. 1.46)
-#if defined(noexcept) and !defined(BOOST_NOEXCEPT)
-# define BOOST_NOEXCEPT
+#ifndef BOOST_NOEXCEPT
+# ifdef OME_HAVE_NOEXCEPT
+#  define BOOST_NOEXCEPT noexcept
+# else
+#  define BOOST_NOEXCEPT
+# endif
 #endif
 
 #include <ome/common/endian/types.hpp>


### PR DESCRIPTION
Fixes a compilation failure on Windows.   This failure isn't triggered on any of our other platforms.  Essentially, we should have been using OME_HAVE_NOEXCEPT (see `cpp/cmake/CompilerChecks.cmake` and `cpp/lib/ome/common/config.h.in`).

Testing: CI jobs should remain green.  There's not much in the way of practical testing at this point.