### PR TITLE
cmake: Add error checking for xsd-fu invocation

### DIFF
--- a/cpp/cmake/XsdFu.cmake
+++ b/cpp/cmake/XsdFu.cmake
@@ -85,7 +85,7 @@ function(xsd_fu_single filetype command outvar)
                   OUTPUT_VARIABLE genfiles
                   RESULT_VARIABLE genfiles_result)
   if (genfiles_result)
-    message(FATAL_ERROR "xsd-fu: Failed to get output file list for target ${command} (${filetype}s)")
+    message(FATAL_ERROR "xsd-fu: Failed to get output file list for target ${command} (${filetype}s): ${genfiles_result}")
   endif()
 
   string(REPLACE "\n" ";" genfiles "${genfiles}")
@@ -98,7 +98,7 @@ function(xsd_fu_single filetype command outvar)
                   OUTPUT_VARIABLE gendeps
                   RESULT_VARIABLE gendeps_result)
   if (gendeps_result)
-    message(FATAL_ERROR "xsd-fu: Failed to get dependency file list for target ${command} (${filetype}s)")
+    message(FATAL_ERROR "xsd-fu: Failed to get dependency file list for target ${command} (${filetype}s): ${gendeps_result}")
   endif()
 
   string(REPLACE "\n" ";" gendeps "${gendeps}")

--- a/cpp/cmake/XsdFu.cmake
+++ b/cpp/cmake/XsdFu.cmake
@@ -80,15 +80,27 @@ set(XSD_FU_ARGS ${XSDFU_DEBUG} --language=C++ --output-directory=${GEN_DIR} ${MO
 # command: the xsd-fu command to invoke
 # outvar: variable to store generated file list in
 function(xsd_fu_single filetype command outvar)
-  message(STATUS "Determining xsd-fu dependencies and outputs for target ${command} (${filetype}s)")
+  message(STATUS "Determining xsd-fu outputs for target ${command} (${filetype}s)")
   execute_process(COMMAND ${XSD_FU} ${command} --dry-run --file-type=${filetype} --print-generated ${XSD_FU_ARGS}
-    OUTPUT_VARIABLE genfiles)
+                  OUTPUT_VARIABLE genfiles
+                  RESULT_VARIABLE genfiles_result)
+  if (genfiles_result)
+    message(FATAL_ERROR "xsd-fu: Failed to get output file list for target ${command} (${filetype}s)")
+  endif()
+
   string(REPLACE "\n" ";" genfiles "${genfiles}")
   if(WIN32)
     string(REPLACE "\\" "/" genfiles "${genfiles}")
   endif(WIN32)
+
+  message(STATUS "Determining xsd-fu dependencies for target ${command} (${filetype}s)")
   execute_process(COMMAND ${XSD_FU} ${command} --dry-run --file-type=${filetype} --print-depends ${XSD_FU_ARGS}
-    OUTPUT_VARIABLE gendeps)
+                  OUTPUT_VARIABLE gendeps
+                  RESULT_VARIABLE gendeps_result)
+  if (gendeps_result)
+    message(FATAL_ERROR "xsd-fu: Failed to get dependency file list for target ${command} (${filetype}s)")
+  endif()
+
   string(REPLACE "\n" ";" gendeps "${gendeps}")
   if(WIN32)
     string(REPLACE "\\" "/" gendeps "${gendeps}")
@@ -97,7 +109,6 @@ function(xsd_fu_single filetype command outvar)
   add_custom_command(OUTPUT ${genfiles}
                      COMMAND ${XSD_FU} ${command} --quiet --file-type=${filetype} ${XSD_FU_ARGS}
                      DEPENDS ${gendeps} ${XSD_FU_SCRIPT})
-  #execute_process(COMMAND ${CMAKE_COMMAND} -E echo Generated ${genfiles})
 
   set(${outvar} ${genfiles} PARENT_SCOPE)
 endfunction(xsd_fu_single)


### PR DESCRIPTION
If xsd-fu execution fails when obtaining output or dependency file lists, abort with error.  Previously, errors were silently ignored.

-------

Testing: On a normal system, errors will not be encountered.  If you write some junk into the top of components/xsd-fu/xsd-fu and then run cmake, you'll see an immediate abort with an error message.