### PR TITLE
adjust XML serialization of unit property values

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/OMEXMLServiceTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/OMEXMLServiceTest.java
@@ -44,6 +44,8 @@ import loci.formats.meta.OriginalMetadataAnnotation;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
 
+import ome.units.UNITS;
+import ome.units.quantity.Length;
 import ome.xml.model.OME;
 import ome.xml.model.StructuredAnnotations;
 import ome.xml.model.XMLAnnotation;
@@ -80,5 +82,61 @@ public class OMEXMLServiceTest {
     assertEquals(txt, xmlAnn.getValue());
     OriginalMetadataAnnotation omAnn = (OriginalMetadataAnnotation) xmlAnn;
     assertEquals("testValue", omAnn.getValueForKey());
+  }
+
+  /**
+   * Test that the XML serialization of floating point unit properties
+   * includes a decimal point. In the schema a shape's stroke width is
+   * {@code type="xsd:float"} which in OMERO is mapped to a {@code double}.
+   * @throws ServiceException unexpected
+   */
+  @Test
+  public void testFloatingPointUnitProperty() throws ServiceException {
+    final Length propertyValue = new Length(3.0d, UNITS.PIXEL);
+
+    final StringBuffer expectedText = new StringBuffer();
+    expectedText.append(" StrokeWidth=");
+    expectedText.append('"');
+    expectedText.append(propertyValue.value().doubleValue());
+    expectedText.append('"');
+
+    final OMEXMLMetadata metadata = service.createOMEXMLMetadata();
+    metadata.setROIID("test ROI", 0);
+    metadata.setPointID("test point", 0, 0);
+    metadata.setPointX(0.0, 0, 0);
+    metadata.setPointY(0.0, 0, 0);
+    metadata.setPointStrokeWidth(propertyValue, 0, 0);
+    final String xml = service.getOMEXML(metadata);
+
+    assertTrue(xml.contains(expectedText));
+  }
+
+
+  /**
+   * Test that the XML serialization of integer unit properties does not
+   * include a decimal point. In the schema a shape's font size is
+   * {@code type="OME:NonNegativeInt"} which in OMERO is mapped to a
+   * {@code double}.
+   * @throws ServiceException unexpected
+   */
+  @Test
+  public void testIntegerUnitProperty() throws ServiceException {
+    final Length propertyValue = new Length(12.0d, UNITS.PT);
+
+    final StringBuffer expectedText = new StringBuffer();
+    expectedText.append(" FontSize=");
+    expectedText.append('"');
+    expectedText.append(propertyValue.value().longValue());
+    expectedText.append('"');
+
+    final OMEXMLMetadata metadata = service.createOMEXMLMetadata();
+    metadata.setROIID("test ROI", 0);
+    metadata.setPointID("test point", 0, 0);
+    metadata.setPointX(0.0, 0, 0);
+    metadata.setPointY(0.0, 0, 0);
+    metadata.setPointFontSize(propertyValue, 0, 0);
+    final String xml = service.getOMEXML(metadata);
+
+    assertTrue(xml.contains(expectedText));
   }
 }

--- a/components/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -664,7 +664,12 @@ ${customAsXMLElementPropertyContent[prop.name]}
 			// Attribute property ${prop.name} with units companion prop.unitsCompanion.name
 			if (${prop.instanceVariableName}.value() != null)
 			{
+{% if prop.type.endswith('Int') %}
+				${klass.name}_element.setAttribute("${prop.name}", Long.toString(${prop.instanceVariableName}.value().longValue()));
+{% end if prop.type %}
+{% if not prop.type.endswith('Int') %}
 				${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName}.value().toString());
+{% end if not prop.type %}
 			}
 			if (${prop.instanceVariableName}.unit() != null)
 			{


### PR DESCRIPTION
The values of dimensioned quantities were being serialized as floating-point numbers regardless of their definition in the OME-XML model schema. This PR adjusts the serialization so that dimensioned integers are not serialized with a decimal point in their value. Check that the new unit tests make sense and that they pass.