### PR TITLE
xsd-fu: Correct static initialisation order for enum key-value mappings

### DIFF
--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -68,8 +68,52 @@
 
 using boost::trim;
 using boost::format;
-{% end %}\
 
+namespace
+{
+
+  typedef std::pair<std::string,${klass.langTypeNS}::enum_value> smap;
+  typedef std::pair<${klass.langTypeNS}::enum_value,std::string> vmap;
+
+  smap init_string_values[] =
+    {
+{% for value in klass.possibleValues %}\
+{% if value == klass.possibleValues[-1] %}\
+      smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+{% end %}\
+{% if value != klass.possibleValues[-1] %}\
+      smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+{% end %}\
+{% end %}\
+    };
+
+  smap init_lcase_string_values[] =
+    {
+{% for value in klass.possibleValues %}\
+{% if value == klass.possibleValues[-1] %}\
+      smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()})
+{% end %}\
+{% if value != klass.possibleValues[-1] %}\
+      smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+{% end %}\
+{% end %}\
+    };
+
+  vmap init_value_values[] =
+    {
+{% for value in klass.possibleValues %}\
+{% if value == klass.possibleValues[-1] %}\
+      vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}")
+{% end %}\
+{% if value != klass.possibleValues[-1] %}\
+      vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}"),
+{% end %}\
+{% end %}\
+    };
+
+}
+
+{% end %}\
 namespace ome
 {
   namespace xml
@@ -176,16 +220,7 @@ namespace ome
            */
           static const string_map_type&
           strings();
-{% end header%}\
-{% if fu.SOURCE_TYPE == "source" %}\
-        const ${klass.langType}::string_map_type&
-        ${klass.langType}::strings()
-        {
-          return string_map;
-        }
-{% end source%}\
 
-{% if fu.SOURCE_TYPE == "header" %}\
           /**
            * Get a map of valid enum values and string names.
            *
@@ -193,92 +228,27 @@ namespace ome
            */
           static const value_map_type&
           values();
-{% end header%}\
-{% if fu.SOURCE_TYPE == "source" %}\
-        const ${klass.langType}::value_map_type&
-        ${klass.langType}::values()
-        {
-          return value_map;
-        }
-{% end source%}\
 
-{% if fu.SOURCE_TYPE == "header" %}\
         private:
+          /**
+           * Get a map of valid lowercased string names and enum values.
+           *
+           * @returns a map of lowercased string names to enum values.
+           */
+          static const string_map_type&
+          lowercase_strings();
+
           /// Enumeration value.
           enum_value         value;
           /// Enumeration name.
           const std::string *name;
-
-          /// Mapping of enumeration name to value.
-          static const string_map_type string_map;
-          /// Mapping of lowercase enumeration name to value.
-          static const string_map_type lowercase_string_map;
-          /// Mapping of enumeration value to name.
-          static const value_map_type value_map;
-{% end %}\
+        };
+{% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
-        namespace
-        {
-
-          typedef std::pair<std::string,${klass.langType}::enum_value> smap;
-          typedef std::pair<${klass.langType}::enum_value,std::string> vmap;
-
-          smap init_string_values[] =
-            {
-{% for value in klass.possibleValues %}\
-{% if value == klass.possibleValues[-1] %}\
-              smap("${value}", ${klass.langType}::${enum_value_name(value, False).upper()}),
-{% end %}\
-{% if value != klass.possibleValues[-1] %}\
-              smap("${value}", ${klass.langType}::${enum_value_name(value, False).upper()}),
-{% end %}\
-{% end %}\
-            };
-
-          smap init_lcase_string_values[] =
-            {
-{% for value in klass.possibleValues %}\
-{% if value == klass.possibleValues[-1] %}\
-              smap("${value.lower()}", ${klass.langType}::${enum_value_name(value, False).upper()})
-{% end %}\
-{% if value != klass.possibleValues[-1] %}\
-              smap("${value.lower()}", ${klass.langType}::${enum_value_name(value, False).upper()}),
-{% end %}\
-{% end %}\
-            };
-
-          vmap init_value_values[] =
-            {
-{% for value in klass.possibleValues %}\
-{% if value == klass.possibleValues[-1] %}\
-              vmap(${klass.langType}::${enum_value_name(value, False).upper()}, "${value}")
-{% end %}\
-{% if value != klass.possibleValues[-1] %}\
-              vmap(${klass.langType}::${enum_value_name(value, False).upper()}, "${value}"),
-{% end %}\
-{% end %}\
-            };
-
-        }
-
-        const ${klass.langType}::string_map_type
-        ${klass.langType}::string_map
-        (init_string_values,
-         init_string_values + (sizeof(init_string_values) / sizeof(init_string_values[0])));
-
-        const ${klass.langType}::string_map_type
-        ${klass.langType}::lowercase_string_map
-        (init_lcase_string_values,
-         init_lcase_string_values + (sizeof(init_lcase_string_values) / sizeof(init_lcase_string_values[0])));
-
-        const ${klass.langType}::value_map_type
-        ${klass.langType}::value_map
-        (init_value_values,
-         init_value_values + (sizeof(init_value_values) / sizeof(init_value_values[0])));
-
         ${klass.langType}::${klass.langType} (enum_value value):
           value(value)
         {
+          const value_map_type& value_map(values());
           value_map_type::const_iterator i = value_map.find(value);
           if (i == value_map.end())
             {
@@ -291,6 +261,8 @@ namespace ome
 
         ${klass.langType}::${klass.langType} (const std::string& name, bool strict)
         {
+          const string_map_type& string_map(strings());
+          const string_map_type& lowercase_string_map(lowercase_strings());
           string_map_type::const_iterator i = string_map.find(name);
           if (strict == false && i == string_map.end())
             {
@@ -327,6 +299,7 @@ namespace ome
             }
           this->value = i->second;
 
+          const value_map_type& value_map(values());
           value_map_type::const_iterator i2 = value_map.find(value);
           if (i2 == value_map.end())
             {
@@ -342,9 +315,32 @@ namespace ome
           name(original.name)
         {
         }
-{% end source %}\
+
+        const ${klass.langType}::string_map_type&
+        ${klass.langType}::strings()
+        {
+          static const string_map_type string_map(init_string_values,
+                                                  init_string_values + (sizeof(init_string_values) / sizeof(init_string_values[0])));
+          return string_map;
+        }
+
+        const ${klass.langType}::value_map_type&
+        ${klass.langType}::values()
+        {
+          static const value_map_type value_map(init_value_values,
+                                                init_value_values + (sizeof(init_value_values) / sizeof(init_value_values[0])));
+          return value_map;
+        }
+
+        const ${klass.langType}::string_map_type&
+        ${klass.langType}::lowercase_strings()
+        {
+          static const string_map_type lcase_string_map(init_lcase_string_values,
+                                                        init_lcase_string_values + (sizeof(init_lcase_string_values) / sizeof(init_lcase_string_values[0])));
+          return lcase_string_map;
+        }
+{% end source%}\
 {% if fu.SOURCE_TYPE == "header" %}\
-        };
 
         /**
          * Compare two ${klass.langType} objects for equality.
@@ -529,7 +525,7 @@ namespace ome
 
           return is;
         }
-{% end %}\
+{% end header%}\
 
       }
     }


### PR DESCRIPTION
The string_map and value_map static maps were not protected with a static method, required to prevent use in other translation units ahead of construction in the program's static initalisation phase. Wrap these and also the lowercased string map (for case-insensitive lookups) in static methods, and use these methods where the plain maps were originally used.  We did have two static methods, but they just returned a reference to the static maps; they now implicitly initialise and fill the maps on their first invocation.

This is needed for Windows, though it's actually buggy on all platforms.  The reason it worked on Unix is that when using shared libraries, the static initialisation of each shared library is done in dependency order, but when using static libs this implicit ordering no longer occurs and the program will crash when it attempts to use a map prior to it being constructed.

--------

Testing: Check jobs are green.  The actual model enum API is unchanged, this being an implementation detail of the enum mappings, so unit tests are sufficient.