### PR TITLE
Leica LIF: set descriptions based upon the user comment

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1108,7 +1108,7 @@ public class LIFReader extends FormatReader {
 
       final Deque<String> nameStack = new ArrayDeque<String>();
       populateOriginalMetadata(image, nameStack);
-      addUserCommentMeta(image);
+      addUserCommentMeta(image, i);
     }
     setSeries(0);
 
@@ -1857,7 +1857,7 @@ public class LIFReader extends FormatReader {
     }
   }
 
-  private void addUserCommentMeta(Element imageNode)
+  private void addUserCommentMeta(Element imageNode, int image)
     throws FormatException
   {
     NodeList attachmentNodes = getNodes(imageNode, "User-Comment");
@@ -1865,6 +1865,9 @@ public class LIFReader extends FormatReader {
     for (int i=0; i<attachmentNodes.getLength(); i++) {
       Node attachment = attachmentNodes.item(i);
       addSeriesMeta("User-Comment[" + i + "]", attachment.getTextContent());
+      if (i == 0 && descriptions[image] == null) {
+        descriptions[image] = attachment.getTextContent();
+      }
     }
   }
 

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -124,7 +124,6 @@ public class Configuration {
       new FileInputStream(this.configFile), Constants.ENCODING));
     IniParser parser = new IniParser();
     parser.setCommentDelimiter(null);
-    parser.setBackslashContinuesLine(false);
     ini = parser.parseINI(reader);
     pruneINI();
   }

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -151,7 +151,6 @@ public class ConfigurationTree {
 
     IniParser parser = new IniParser();
     parser.setCommentDelimiter(null);
-    parser.setBackslashContinuesLine(false);
     FileInputStream stream = new FileInputStream(configFile);
     IniList iniList = parser.parseINI(new BufferedReader(
       new InputStreamReader(stream, Constants.ENCODING)));


### PR DESCRIPTION
See https://trello.com/c/IqYrynEi/98-store-lif-descriptions.

To test, use the file linked from Dropbox on the above card.  Open in Leica LAS AF Lite and verify that image ```10``` and image ```12``` have something in the ```Description``` box (when you right-click the image name and select ```Properties of ...```).  Verify that the output of ```showinf -nopix -omexml``` with this change shows matching text in the ```Description``` attribute of ```Image:9``` (```Name``` == ```10```) and ```Image:11``` (```Name``` == ```12```).  WIthout this change, ```Description``` would have been missing for all Images.