### PR TITLE
Fix automated tests to handle symlinks with external configuration

### DIFF
--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -125,13 +125,22 @@ public class ConfigurationTree {
    *  Relocate a path from an base directory into a target directory
    */
   public String relocate(String path, String oldRoot, String newRoot) {
+
+    Location oldLocation = new Location(oldRoot);
+    Location newLocation = new Location(newRoot);
+    while (oldLocation.getName().equals(newLocation.getName()))
+    {
+        oldLocation = oldLocation.getParentFile();
+        newLocation = newLocation.getParentFile();
+    }
+
     String subPath = path.substring((int) Math.min(
-      oldRoot.length() + 1, path.length()));
+      oldLocation.getAbsolutePath().length() + 1, path.length()));
     if (subPath.length() == 0) {
-      return newRoot;
+      return newLocation.getAbsolutePath();
     }
     else {
-      return new Location(newRoot, subPath).getAbsolutePath();
+      return new Location(newLocation, subPath).getAbsolutePath();
     }
   }
 

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -98,9 +98,19 @@ public class ConfigurationTree {
     if (rootDir == null) {
       throw new IllegalArgumentException("rootDir cannot be null.");
     }
-    this.rootDir = new File(rootDir).getAbsolutePath();
+
     if (configDir != null) {
-        this.configDir = new File(configDir).getAbsolutePath();
+      Location rootLocation = new Location(rootDir);
+      Location configLocation = new Location(configDir);
+      while (rootLocation.getName().equals(configLocation.getName())) {
+        rootLocation = rootLocation.getParentFile();
+        configLocation = configLocation.getParentFile();
+      }
+
+      this.rootDir = rootLocation.getAbsolutePath();
+      this.configDir = configLocation.getAbsolutePath();
+    } else {
+      this.rootDir = new File(rootDir).getAbsolutePath();
     }
     root = new DefaultMutableTreeNode();
   }
@@ -126,21 +136,13 @@ public class ConfigurationTree {
    */
   public String relocate(String path, String oldRoot, String newRoot) {
 
-    Location oldLocation = new Location(oldRoot);
-    Location newLocation = new Location(newRoot);
-    while (oldLocation.getName().equals(newLocation.getName()))
-    {
-        oldLocation = oldLocation.getParentFile();
-        newLocation = newLocation.getParentFile();
-    }
-
     String subPath = path.substring((int) Math.min(
-      oldLocation.getAbsolutePath().length() + 1, path.length()));
+      oldRoot.length() + 1, path.length()));
     if (subPath.length() == 0) {
-      return newLocation.getAbsolutePath();
+      return newRoot;
     }
     else {
-      return new Location(newLocation, subPath).getAbsolutePath();
+      return new Location(newRoot, subPath).getAbsolutePath();
     }
   }
 

--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -91,7 +91,6 @@ public class ConfigurationTree {
    *  file system with a custom configuration directory.
    *
    *  @param rootDir a string specifying the root directory
-   *
    *  @param configDir a string specifying the base configuration directory
    *
    */
@@ -122,6 +121,34 @@ public class ConfigurationTree {
     return this.configDir;
   }
 
+  /**
+   *  Relocate a path from an base directory into a target directory
+   */
+  public String relocate(String path, String oldRoot, String newRoot) {
+    String subPath = path.substring((int) Math.min(
+      oldRoot.length() + 1, path.length()));
+    if (subPath.length() == 0) {
+      return newRoot;
+    }
+    else {
+      return new Location(newRoot, subPath).getAbsolutePath();
+    }
+  }
+
+  /**
+   *  Relocate a path under the root directory to the configuration directory
+   */
+  public String relocateToConfig(String path) {
+    return relocate(path, this.rootDir, this.configDir);
+  }
+
+  /**
+   *  Relocate a path under the configuration directory to the root directory
+   */
+  public String relocateToRoot(String path) {
+    return relocate(path, this.configDir, this.rootDir);
+  }
+
   /** Retrieves the Configuration object corresponding to the given file. */
   public Configuration get(String id) throws IOException {
     DefaultMutableTreeNode pos = findNode(id, false, null);
@@ -137,13 +164,7 @@ public class ConfigurationTree {
     }
     String parent = file.getParent();
     if (configDir != null) {
-      parent = parent.substring((int) Math.min(configDir.length() + 1, parent.length()));
-      if (parent.length() == 0) {
-        parent = rootDir;
-      }
-      else {
-        parent = new Location(rootDir, parent).getAbsolutePath();
-      }
+      parent = relocateToRoot(parent);
     }
 
     configFile = file.getAbsolutePath();

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -257,7 +257,11 @@ public class TestTools {
           subsList.add(0, file.getAbsolutePath());
         }
       } else {
-        subsList.add(file.getAbsolutePath());
+        try {
+          subsList.add(file.getCanonicalPath());
+        } catch (IOException e) {
+          subsList.add(file.getAbsolutePath());
+        }
       }
     }
 

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -226,7 +226,7 @@ public class TestTools {
       if ((!isToplevel && isConfigFile(file, configFileSuffix)) ||
           (isToplevel && subs[i].equals(toplevelConfig)))
       {
-        if (config.getConfigDirectory() != null) {
+        if (config.getConfigDirectory() == null) {
           LOGGER.debug("adding config file: {}", file.getAbsolutePath());
           subsList.add(0, file.getAbsolutePath());
         }

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -218,7 +218,7 @@ public class TestTools {
     // Look for a configuration file under the configuration directory
     try {
       String canonicalRoot = new Location(root).getCanonicalPath();
-      if (root != canonicalRoot) {
+      if (!root.equals(canonicalRoot)) {
         String configCanonicalRoot = config.relocateToConfig(canonicalRoot);
         Location configFile = new Location(configCanonicalRoot, baseConfigName);
         if (configFile.exists()) {

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -191,6 +191,34 @@ public class TestTools {
     getFiles(root, files, config, toplevelConfig, subdirs, "");
   }
 
+  /**
+   * Retrieve an external configuration file given a root directory and test
+   * configuration
+   */
+  public static String getExternalConfigFile(String root,
+    final ConfigurationTree config)
+  {
+    // Look for a configuration file under the configuration directory
+    String configRoot = config.relocateToConfig(root);
+    Location configFile = new Location(configRoot, baseConfigName);
+    if (configFile.exists()) {
+      return configFile.getAbsolutePath();
+    } else
+    {
+      try {
+        String canonicalRoot = new Location(root).getCanonicalPath();
+        if (root != canonicalRoot) {
+          String configCanonicalRoot = config.relocateToConfig(canonicalRoot);
+          configFile = new Location(configCanonicalRoot, baseConfigName);
+          if (configFile.exists()) {
+            return configFile.getAbsolutePath();
+          }
+        }
+      } catch (IOException e) {};
+    }
+    return null;
+  }
+
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig, String[] subdirs,
@@ -210,12 +238,10 @@ public class TestTools {
     List<String> subsList = new ArrayList<String>();
 
     if (config.getConfigDirectory() != null) {
-      // Look for a configuration file under the configuration directory
-      String configRoot = config.relocateToConfig(root);
-      Location configFile = new Location(configRoot, baseConfigName);
-      if (configFile.exists()) {
-        LOGGER.debug("found config file: {}", configFile.getAbsolutePath());
-        subsList.add(configFile.getAbsolutePath());
+      String configFile = getExternalConfigFile(root, config);
+      if (configFile != null) {
+        LOGGER.debug("found config file: {}", configFile);
+        subsList.add(configFile);
       }
     }
 

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -207,21 +207,11 @@ public class TestTools {
      toplevelConfig != null && new File(toplevelConfig).exists();
     Arrays.sort(subs);
 
-    String rootDir = config.getRootDirectory();
-    String configDir = config.getConfigDirectory();
-    boolean useConfigDir = (configDir != null);
-
     List<String> subsList = new ArrayList<String>();
 
-    if (useConfigDir) {
+    if (config.getConfigDirectory() != null) {
       // Look for a configuration file under the configuration directory
-      String configRoot = root.substring((int) Math.min(rootDir.length() + 1, root.length()));
-      if (configRoot.length() == 0) {
-        configRoot = configDir;
-      }
-      else {
-        configRoot = new Location(configDir, configRoot).getAbsolutePath();
-      }
+      String configRoot = config.relocateToConfig(root);
       Location configFile = new Location(configRoot, baseConfigName);
       if (configFile.exists()) {
         LOGGER.debug("found config file: {}", configFile.getAbsolutePath());
@@ -236,7 +226,7 @@ public class TestTools {
       if ((!isToplevel && isConfigFile(file, configFileSuffix)) ||
           (isToplevel && subs[i].equals(toplevelConfig)))
       {
-        if (!useConfigDir) {
+        if (config.getConfigDirectory() != null) {
           LOGGER.debug("adding config file: {}", file.getAbsolutePath());
           subsList.add(0, file.getAbsolutePath());
         }


### PR DESCRIPTION
Follow up of https://github.com/openmicroscopy/bioformats/pull/1894 and https://github.com/openmicroscopy/bioformats/pull/1819.

While the external configuration logic works accurately on Linux and Windows for the main folder, this PR attempts to solve the case of data folders containing symlinks e.g. `test_images_good`. With the data repository structure being organized as follows:

```
/ome/data_repo/test_images_good      # folder containing symlinks to the data /ome/data_repo/from_skyking/
/ome/data_repo/config/breaking           # folder containing configuration files
```
the goal of this PR is to resolve the symlinks and the configuration files with the following command:

```
ant test-automated -Dtestng.directory=/ome/data_repo/test_images_good -Dtestng.configDirectory=/ome/data_repo/config/breaking/test_images_good
```

The main caveat of this PR is the extensive usage of `File.getCanonicalPath()` which may have some impact on performance while scanning files. This performance should be assessed both on Linux and Windows

To be tested via the breaking jobs.

/cc @melissalinkert 