### PR TITLE
Formats-bsd: native time units

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -806,7 +806,7 @@ public class ICSReader extends FormatReader {
 
     CoreMetadata m = core.get(0);
 
-    Double[] pixelSizes = null;
+    Double[] scales = null;
     Double[] timestamps = null;
     String[] units = null;
     String[] axes = null;
@@ -931,7 +931,7 @@ public class ICSReader extends FormatReader {
 
           if (key.equalsIgnoreCase("parameter scale")) {
             // parse physical pixel sizes and time increment
-            pixelSizes = splitDoubles(value);
+            scales = splitDoubles(value);
           }
           else if (key.equalsIgnoreCase("parameter t")) {
             // parse explicit timestamps
@@ -1501,8 +1501,8 @@ public class ICSReader extends FormatReader {
 
       // populate Dimensions data
 
-      if (pixelSizes != null) {
-        if (units != null && units.length == pixelSizes.length - 1) {
+      if (scales != null) {
+        if (units != null && units.length == scales.length - 1) {
           // correct for missing units
           // sometimes, the units for the C axis are missing entirely
           ArrayList<String> realUnits = new ArrayList<String>();
@@ -1518,10 +1518,10 @@ public class ICSReader extends FormatReader {
           units = realUnits.toArray(new String[realUnits.size()]);
         }
 
-        for (int i=0; i<pixelSizes.length; i++) {
-          Double pixelSize = pixelSizes[i];
+        for (int i=0; i<scales.length; i++) {
+          Double scale = scales[i];
 
-          if (pixelSize == null) {
+          if (scale == null) {
             continue;
           }
 
@@ -1529,7 +1529,7 @@ public class ICSReader extends FormatReader {
           String unit = units != null && units.length > i ? units[i] : "";
           if (axis.equals("x")) {
             if (checkUnit(unit, "um", "microns", "micrometers")) {
-              Length x = FormatTools.getPhysicalSizeX(pixelSize);
+              Length x = FormatTools.getPhysicalSizeX(scale);
               if (x != null) {
                 store.setPixelsPhysicalSizeX(x, 0);
               }
@@ -1537,7 +1537,7 @@ public class ICSReader extends FormatReader {
           }
           else if (axis.equals("y")) {
             if (checkUnit(unit, "um", "microns", "micrometers")) {
-              Length y = FormatTools.getPhysicalSizeY(pixelSize);
+              Length y = FormatTools.getPhysicalSizeY(scale);
               if (y != null) {
                 store.setPixelsPhysicalSizeY(y, 0);
               }
@@ -1545,18 +1545,18 @@ public class ICSReader extends FormatReader {
           }
           else if (axis.equals("z")) {
             if (checkUnit(unit, "um", "microns", "micrometers")) {
-              Length z = FormatTools.getPhysicalSizeZ(pixelSize);
+              Length z = FormatTools.getPhysicalSizeZ(scale);
               if (z != null) {
                 store.setPixelsPhysicalSizeZ(z, 0);
               }
             }
           }
-          else if (axis.equals("t") && pixelSize != null) {
+          else if (axis.equals("t") && scale != null) {
             if (checkUnit(unit, "ms")) {
-              store.setPixelsTimeIncrement(new Time(1000 * pixelSize, UNITS.S), 0);
+              store.setPixelsTimeIncrement(new Time(scale, UNITS.MS), 0);
             }
             else if (checkUnit(unit, "seconds") || checkUnit(unit, "s") ) {
-              store.setPixelsTimeIncrement(new Time(pixelSize, UNITS.S), 0);
+              store.setPixelsTimeIncrement(new Time(scale, UNITS.S), 0);
             }
           }
         }

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -336,7 +336,7 @@ public class MicromanagerReader extends FormatReader {
             nextStamp < p.timestamps.length &&
             p.timestamps[nextStamp] != null)
           {
-            store.setPlaneDeltaT(new Time(p.timestamps[nextStamp++], UNITS.S), i, q);
+            store.setPlaneDeltaT(new Time(p.timestamps[nextStamp++], UNITS.MS), i, q);
           }
         }
 
@@ -626,11 +626,11 @@ public class MicromanagerReader extends FormatReader {
 
           if (key.equals("Exposure-ms")) {
             double t = Double.parseDouble(value);
-            p.exposureTime = new Time(new Double(t / 1000), UNITS.S);
+            p.exposureTime = new Time(new Double(t), UNITS.MS);
           }
           else if (key.equals("ElapsedTime-ms")) {
             double t = Double.parseDouble(value);
-            stamps.add(new Double(t / 1000));
+            stamps.add(new Double(t));
           }
           else if (key.equals("Core-Camera")) p.cameraRef = value;
           else if (key.equals(p.cameraRef + "-Binning")) {

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -626,11 +626,11 @@ public class MicromanagerReader extends FormatReader {
 
           if (key.equals("Exposure-ms")) {
             double t = Double.parseDouble(value);
-            p.exposureTime = new Time(new Double(t), UNITS.MS);
+            p.exposureTime = new Time(Double.valueOf(t), UNITS.MS);
           }
           else if (key.equals("ElapsedTime-ms")) {
             double t = Double.parseDouble(value);
-            stamps.add(new Double(t));
+            stamps.add(Double.valueOf(t));
           }
           else if (key.equals("Core-Camera")) p.cameraRef = value;
           else if (key.equals(p.cameraRef + "-Binning")) {


### PR DESCRIPTION
See https://trello.com/c/nO35TKXK/4-units-and-readers

This PR modifies the storage of time metadata in the BSD formats to use the native time unit when appropriate. The `pixelSizes` variable in the `ICSReader` is also renamed as `scales` to prevent confusion as it applies both to the pixels physical size and the pixels time increment.