### PR TITLE
minor code adjustments to several GPL readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/IPWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPWReader.java
@@ -27,8 +27,8 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Hashtable;
-import java.util.StringTokenizer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import ome.xml.model.primitives.Timestamp;
@@ -67,7 +67,7 @@ public class IPWReader extends FormatReader {
   // -- Fields --
 
   /** List of embedded image file names (one per image plane). */
-  private Hashtable<Integer, String> imageFiles;
+  private Map<Integer, String> imageFiles;
 
   /** Helper reader - parses embedded files from the OLE document. */
   private transient POIService poi;
@@ -199,7 +199,7 @@ public class IPWReader extends FormatReader {
     in = new RandomAccessInputStream(id);
     initPOIService();
 
-    imageFiles = new Hashtable<Integer, String>();
+    imageFiles = new HashMap<Integer, String>();
 
     Vector<String> fileList = poi.getDocumentList();
 

--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -26,7 +26,8 @@
 package loci.formats.in;
 
 import java.io.IOException;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import loci.common.DataTools;
 import loci.common.Location;
@@ -66,9 +67,9 @@ public class ImarisHDFReader extends FormatReader {
   private NetCDFService netcdf;
 
   // channel parameters
-  private Vector<String> emWave, exWave, channelMin, channelMax;
-  private Vector<String> gain, pinhole, channelName, microscopyMode;
-  private Vector<double[]> colors;
+  private List<String> emWave, exWave, channelMin, channelMax;
+  private List<String> gain, pinhole, channelName, microscopyMode;
+  private List<double[]> colors;
   private int lastChannel = 0;
 
   // -- Constructor --
@@ -251,15 +252,15 @@ public class ImarisHDFReader extends FormatReader {
 
     pixelSizeX = pixelSizeY = pixelSizeZ = 1;
 
-    emWave = new Vector<String>();
-    exWave = new Vector<String>();
-    channelMin = new Vector<String>();
-    channelMax = new Vector<String>();
-    gain = new Vector<String>();
-    pinhole = new Vector<String>();
-    channelName = new Vector<String>();
-    microscopyMode = new Vector<String>();
-    colors = new Vector<double[]>();
+    emWave = new ArrayList<String>();
+    exWave = new ArrayList<String>();
+    channelMin = new ArrayList<String>();
+    channelMax = new ArrayList<String>();
+    gain = new ArrayList<String>();
+    pinhole = new ArrayList<String>();
+    channelName = new ArrayList<String>();
+    microscopyMode = new ArrayList<String>();
+    colors = new ArrayList<double[]>();
 
     seriesCount = 0;
 
@@ -477,7 +478,7 @@ public class ImarisHDFReader extends FormatReader {
   }
 
   private void parseAttributes() {
-    Vector<String> attributes = netcdf.getAttributeList();
+    final List<String> attributes = netcdf.getAttributeList();
     CoreMetadata ms0 = core.get(0);
 
     for (String attr : attributes) {

--- a/components/formats-gpl/src/loci/formats/in/ImarisReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisReader.java
@@ -35,8 +35,6 @@ import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 
-import ome.xml.model.primitives.PositiveFloat;
-
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
 import ome.units.UNITS;
@@ -218,9 +216,9 @@ public class ImarisReader extends FormatReader {
 
       // populate Dimensions data
 
-      Length sizeX = FormatTools.getPhysicalSizeX(new Double(dx));
-      Length sizeY = FormatTools.getPhysicalSizeY(new Double(dy));
-      Length sizeZ = FormatTools.getPhysicalSizeZ(new Double(dz));
+      Length sizeX = FormatTools.getPhysicalSizeX((double) dx);
+      Length sizeY = FormatTools.getPhysicalSizeY((double) dy);
+      Length sizeZ = FormatTools.getPhysicalSizeZ((double) dz);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);
@@ -245,9 +243,9 @@ public class ImarisReader extends FormatReader {
 
       for (int i=0; i<getSizeC(); i++) {
         if (gains[i] > 0) {
-          store.setDetectorSettingsGain(new Double(gains[i]), 0, i);
+          store.setDetectorSettingsGain((double) gains[i], 0, i);
         }
-        store.setDetectorSettingsOffset(new Double(offsets[i]), i, 0);
+        store.setDetectorSettingsOffset((double) offsets[i], i, 0);
 
         // link DetectorSettings to an actual Detector
         String detectorID = MetadataTools.createLSID("Detector", 0, i);

--- a/components/formats-gpl/src/loci/formats/in/L2DReader.java
+++ b/components/formats-gpl/src/loci/formats/in/L2DReader.java
@@ -27,8 +27,8 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import loci.common.DataTools;
 import loci.common.DateTools;
@@ -215,9 +215,9 @@ public class L2DReader extends FormatReader {
       core = new ArrayList<CoreMetadata>(r.getCoreMetadataList());
       metadataStore = r.getMetadataStore();
 
-      final Hashtable<String, Object> globalMetadata = r.getGlobalMetadata();
-      for (Object key : globalMetadata.keySet()) {
-        addGlobalMeta(key.toString(), globalMetadata.get(key));
+      final Map<String, Object> globalMetadata = r.getGlobalMetadata();
+      for (final Map.Entry<String, Object> entry : globalMetadata.entrySet()) {
+        addGlobalMeta(entry.getKey(), entry.getValue());
       }
       r.close();
       reader = new MinimalTiffReader();

--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -33,7 +33,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.Arrays;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import ome.xml.model.primitives.Timestamp;
@@ -130,9 +131,9 @@ public class LiFlimReader extends FormatReader {
   private String backgroundP;
   private String backgroundF;
 
-  private int numRegions = 0;
-  private Hashtable<Integer, ROI> rois;
-  private Hashtable<Integer, String> stampValues;
+  private int numRegions = 0;  /* note: set but not used */
+  private Map<Integer, ROI> rois;
+  private Map<Integer, String> stampValues;
   private Double exposureTime;
 
   /** True if gzip compression was used to deflate the pixels. */
@@ -263,8 +264,8 @@ public class LiFlimReader extends FormatReader {
   }
 
   private void initOriginalMetadata() {
-    rois = new Hashtable<Integer, ROI>();
-    stampValues = new Hashtable<Integer, String>();
+    rois = new HashMap<Integer, ROI>();
+    stampValues = new HashMap<Integer, String>();
 
     IniTable layoutTable = ini.getTable(LAYOUT_TABLE);
     datatype = layoutTable.get(DATATYPE_KEY);
@@ -550,7 +551,7 @@ public class LiFlimReader extends FormatReader {
 
   private class ROI {
     public String name;
-    public Hashtable<Integer, String> points = new Hashtable<Integer, String>();
+    public final Map<Integer, String> points = new HashMap<Integer, String>();
 
     public String pointsToString() {
       StringBuilder s = new StringBuilder();

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -417,7 +417,7 @@ public class SVSReader extends BaseTiffReader {
       for (int c = 0; c < resolutions; c++) {
         savedCore.add(core.get(i + c));
         savedIFDs[c] = getIFDIndex(i+c);
-        levels.put(new Integer(savedCore.get(c).sizeX), new Integer(c));
+        levels.put(savedCore.get(c).sizeX, c);
       }
 
       Integer[] keys = levels.keySet().toArray(new Integer[resolutions]);

--- a/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
@@ -30,9 +30,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import ome.xml.model.primitives.Timestamp;
@@ -79,14 +82,14 @@ public class TillVisionReader extends FormatReader {
 
   private String[] pixelsFiles;
   private transient RandomAccessInputStream pixelsStream;
-  private Hashtable<Integer, Double> exposureTimes;
+  private Map<Integer, Double> exposureTimes;
   private boolean embeddedImages;
   private long[] embeddedOffset;
   private String[] infFiles;
 
-  private Vector<String> imageNames = new Vector<String>();
-  private Vector<String> types = new Vector<String>();
-  private Vector<String> dates = new Vector<String>();
+  private final List<String> imageNames = new ArrayList<String>();
+  private final List<String> types = new ArrayList<String>();
+  private final List<String> dates = new ArrayList<String>();
 
   // -- Constructor --
 
@@ -170,7 +173,7 @@ public class TillVisionReader extends FormatReader {
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
 
-    Vector<String> files = new Vector<String>();
+    final List<String> files = new ArrayList<String>();
     files.add(currentId);
     if (!noPixels) {
       if (pixelsFiles[getCoreIndex()] != null) {
@@ -224,7 +227,7 @@ public class TillVisionReader extends FormatReader {
 
     super.initFile(id);
 
-    exposureTimes = new Hashtable<Integer, Double>();
+    exposureTimes = new HashMap<Integer, Double>();
 
     POIService poi = null;
     try {
@@ -240,7 +243,7 @@ public class TillVisionReader extends FormatReader {
 
     int nImages = 0;
 
-    Hashtable tmpSeriesMetadata = new Hashtable();
+    final Hashtable<String, Object> tmpSeriesMetadata = new Hashtable<String, Object>();
 
     for (String name : documents) {
       LOGGER.debug("Reading {}", name);
@@ -383,7 +386,7 @@ public class TillVisionReader extends FormatReader {
               }
               else if (key.equals("Exposure time [ms]")) {
                 double exp = Double.parseDouble(value) / 1000;
-                exposureTimes.put(new Integer(nImages), new Double(exp));
+                exposureTimes.put(nImages, exp);
               }
               else if (key.equals("Image type")) {
                 types.add(value);
@@ -529,7 +532,7 @@ public class TillVisionReader extends FormatReader {
       ms.littleEndian = true;
       ms.dimensionOrder = "XYCZT";
 
-      ms.seriesMetadata = new Hashtable();
+      ms.seriesMetadata = new Hashtable<String, Object>();
       for (Object key : metadataKeys) {
         String keyName = key.toString();
         if (keyName.startsWith("Series " + i + " ")) {
@@ -539,7 +542,6 @@ public class TillVisionReader extends FormatReader {
       }
     }
     setSeries(0);
-    tmpSeriesMetadata = null;
     populateMetadataStore();
 
     poi.close();
@@ -637,7 +639,7 @@ public class TillVisionReader extends FormatReader {
   }
 
   private Long[] findImages(RandomAccessInputStream s) throws IOException {
-    Vector<Long> offsets = new Vector<Long>();
+    final List<Long> offsets = new ArrayList<Long>();
 
     byte[] buf = new byte[8192];
     int overlap = 128;


### PR DESCRIPTION
This PR rewrites some GPL reader code in a minor way to increase readability and/or efficiency:
* ImarisHDFReader
* ImarisReader
* IPWReader
* L2DReader
* LiFlimReader
* SVSReader
* TillVisionReader

CI does the testing.