### PR TITLE
cpp: bioformats: Correct unused variable warnings in catch statements

### DIFF
--- a/cpp/lib/ome/bioformats/MetadataMap.h
+++ b/cpp/lib/ome/bioformats/MetadataMap.h
@@ -240,7 +240,7 @@ namespace ome
             list_type& list(get<list_type>(key));
             list.push_back(value);
           }
-        catch (const boost::bad_get& /* e */)
+        catch (const boost::bad_get&)
           {
             list_type new_list;
             new_list.push_back(value);
@@ -290,7 +290,7 @@ namespace ome
             value = get<T>(key);
             return true;
           }
-        catch (const boost::bad_get& /* e */)
+        catch (const boost::bad_get&)
           {
             return false;
           }

--- a/cpp/lib/ome/bioformats/MetadataMap.h
+++ b/cpp/lib/ome/bioformats/MetadataMap.h
@@ -240,7 +240,7 @@ namespace ome
             list_type& list(get<list_type>(key));
             list.push_back(value);
           }
-        catch (boost::bad_get& e)
+        catch (const boost::bad_get& /* e */)
           {
             list_type new_list;
             new_list.push_back(value);
@@ -290,7 +290,7 @@ namespace ome
             value = get<T>(key);
             return true;
           }
-        catch (boost::bad_get& e)
+        catch (const boost::bad_get& /* e */)
           {
             return false;
           }

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -405,7 +405,7 @@ namespace ome
                   samples = meta.getChannelSamplesPerPixel(series, c);
                   realSizeC += samples;
                 }
-              catch (const MetadataException& e)
+              catch (const MetadataException& /* e */)
                 {
                   badChannels.push_back(c);
                 }
@@ -508,7 +508,7 @@ namespace ome
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
               addMetadataOnly(omexml, s);
             }
-          catch (const std::bad_cast& e)
+          catch (const std::bad_cast& /* e */)
             {
             }
 
@@ -551,7 +551,7 @@ namespace ome
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
               addMetadataOnly(omexml, s);
             }
-          catch (const std::bad_cast& e)
+          catch (const std::bad_cast& /* e */)
             {
             }
 
@@ -795,7 +795,7 @@ namespace ome
           if (!store.getRoot())
             throw FormatException("Metadata object has null root; call createRoot() first");
         }
-      catch (const std::bad_cast& e)
+      catch (const std::bad_cast& /* e */)
         {
         }
 
@@ -1082,7 +1082,7 @@ namespace ome
           std::cerr << "SAXParseException parsing schema version: " << message << '\n';
           return "";
         }
-      catch (const xercesc::SAXException& e)
+      catch (const xercesc::SAXException& /* e */)
         {
           // Early termination (expected).
         }

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -405,7 +405,7 @@ namespace ome
                   samples = meta.getChannelSamplesPerPixel(series, c);
                   realSizeC += samples;
                 }
-              catch (const MetadataException& /* e */)
+              catch (const MetadataException&)
                 {
                   badChannels.push_back(c);
                 }
@@ -508,7 +508,7 @@ namespace ome
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
               addMetadataOnly(omexml, s);
             }
-          catch (const std::bad_cast& /* e */)
+          catch (const std::bad_cast&)
             {
             }
 
@@ -551,7 +551,7 @@ namespace ome
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
               addMetadataOnly(omexml, s);
             }
-          catch (const std::bad_cast& /* e */)
+          catch (const std::bad_cast&)
             {
             }
 
@@ -795,7 +795,7 @@ namespace ome
           if (!store.getRoot())
             throw FormatException("Metadata object has null root; call createRoot() first");
         }
-      catch (const std::bad_cast& /* e */)
+      catch (const std::bad_cast&)
         {
         }
 
@@ -955,7 +955,7 @@ namespace ome
                           continue;
                         }
                     }
-                  catch (const std::exception& /* e */)
+                  catch (const std::exception&)
                     {
                       /// @todo log error
                     }
@@ -1082,7 +1082,7 @@ namespace ome
           std::cerr << "SAXParseException parsing schema version: " << message << '\n';
           return "";
         }
-      catch (const xercesc::SAXException& /* e */)
+      catch (const xercesc::SAXException&)
         {
           // Early termination (expected).
         }

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -435,7 +435,7 @@ namespace ome
           {
             array();
           }
-        catch (const std::runtime_error& /* e */)
+        catch (const std::runtime_error&)
           {
             is_valid = false;
           }

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -435,7 +435,7 @@ namespace ome
           {
             array();
           }
-        catch (const std::runtime_error& e)
+        catch (const std::runtime_error& /* e */)
           {
             is_valid = false;
           }

--- a/cpp/lib/ome/bioformats/XMLTools.cpp
+++ b/cpp/lib/ome/bioformats/XMLTools.cpp
@@ -137,7 +137,7 @@ namespace ome
           ome::common::xml::Platform xmlplat;
           ome::common::xml::dom::createDocument(s);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
           valid = false;
         }

--- a/cpp/lib/ome/bioformats/XMLTools.cpp
+++ b/cpp/lib/ome/bioformats/XMLTools.cpp
@@ -137,7 +137,7 @@ namespace ome
           ome::common::xml::Platform xmlplat;
           ome::common::xml::dom::createDocument(s);
         }
-      catch (const std::runtime_error& e)
+      catch (const std::runtime_error& /* e */)
         {
           valid = false;
         }

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -190,12 +190,12 @@ namespace ome
                         break;
                       }
                   }
-                catch (const boost::filesystem::filesystem_error& e)
+                catch (const boost::filesystem::filesystem_error& /* e */)
                   {
                   }
               }
           }
-        catch (const boost::filesystem::filesystem_error& e)
+        catch (const boost::filesystem::filesystem_error& /* e */)
           {
           }
 
@@ -1398,7 +1398,7 @@ namespace ome
                               if (!imageName.empty() && ome::common::trim(imageName).size() != 0)
                                 name = imageName;
                             }
-                          catch (std::exception& e)
+                          catch (const std::exception& /* e */)
                             {
                             }
                           setSeries(series);

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -190,12 +190,12 @@ namespace ome
                         break;
                       }
                   }
-                catch (const boost::filesystem::filesystem_error& /* e */)
+                catch (const boost::filesystem::filesystem_error&)
                   {
                   }
               }
           }
-        catch (const boost::filesystem::filesystem_error& /* e */)
+        catch (const boost::filesystem::filesystem_error&)
           {
           }
 
@@ -1364,7 +1364,7 @@ namespace ome
           {
             canonicalpath = ome::common::canonical(id);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -1398,7 +1398,7 @@ namespace ome
                               if (!imageName.empty() && ome::common::trim(imageName).size() != 0)
                                 name = imageName;
                             }
-                          catch (const std::exception& /* e */)
+                          catch (const std::exception&)
                             {
                             }
                           setSeries(series);

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -112,7 +112,7 @@ namespace ome
           {
             canonicalpath = ome::common::canonical(id);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -455,7 +455,7 @@ namespace ome
           {
             samples = metadataRetrieve->getChannelSamplesPerPixel(series, channel);
           }
-        catch (const MetadataException& /* e */)
+        catch (const MetadataException&)
           {
             // No SamplesPerPixel; default to 1.
           }

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -455,7 +455,7 @@ namespace ome
           {
             samples = metadataRetrieve->getChannelSamplesPerPixel(series, channel);
           }
-        catch (const MetadataException& e)
+        catch (const MetadataException& /* e */)
           {
             // No SamplesPerPixel; default to 1.
           }

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -585,7 +585,7 @@ namespace ome
                   {
                     filename = path(meta->getUUIDFileName(series, td));
                   }
-                catch (const std::exception& e)
+                catch (const std::exception& /* e */)
                   {
                     BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
                       << "Ignoring null UUID object when retrieving filename";
@@ -594,7 +594,7 @@ namespace ome
                   {
                     uuid = meta->getUUIDValue(series, td);
                   }
-                catch (const std::exception& e)
+                catch (const std::exception& /* e */)
                   {
                     BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
                       << "Ignoring null UUID object when retrieving value";
@@ -1086,7 +1086,7 @@ namespace ome
               {
                 firstC = meta.getTiffDataFirstC(series, td);
               }
-            catch (const std::exception& e)
+            catch (const std::exception& /* e */)
               {
               }
             if (!cIndexStart)
@@ -1099,7 +1099,7 @@ namespace ome
               {
                 firstZ = meta.getTiffDataFirstC(series, td);
               }
-            catch (const std::exception& e)
+            catch (const std::exception& /* e */)
               {
               }
             if (!zIndexStart)
@@ -1112,7 +1112,7 @@ namespace ome
               {
                 firstT = meta.getTiffDataFirstT(series, td);
               }
-            catch (const std::exception& e)
+            catch (const std::exception& /* e */)
               {
               }
             if (!tIndexStart)
@@ -1138,7 +1138,7 @@ namespace ome
           {
             tdIFD = meta.getTiffDataIFD(series, tiffData);
           }
-        catch (const std::exception& e)
+        catch (const std::exception& /* e */)
           {
           }
 
@@ -1146,7 +1146,7 @@ namespace ome
           {
             numPlanes = meta.getTiffDataPlaneCount(series, tiffData);
           }
-        catch (const std::exception& e)
+        catch (const std::exception& /* e */)
           {
             if (tdIFD)
               numPlanes = 1;
@@ -1165,7 +1165,7 @@ namespace ome
           {
             firstC = meta.getTiffDataFirstC(series, tiffData);
           }
-        catch (const std::exception& e)
+        catch (const std::exception& /* e */)
           {
           }
 
@@ -1173,7 +1173,7 @@ namespace ome
           {
             firstT = meta.getTiffDataFirstT(series, tiffData);
           }
-        catch (const std::exception& e)
+        catch (const std::exception& /* e */)
           {
           }
 
@@ -1181,7 +1181,7 @@ namespace ome
           {
             firstZ = meta.getTiffDataFirstZ(series, tiffData);
           }
-        catch (const std::exception& e)
+        catch (const std::exception& /* e */)
           {
           }
 
@@ -1201,7 +1201,7 @@ namespace ome
               if (meta.getTiffDataCount(series) > 0)
                 uuidFileName = meta.getUUIDFileName(series, 0);
             }
-          catch (const std::exception& e)
+          catch (const std::exception& /* e */)
             {
             }
           if (meta.getChannelCount(series) > 0)
@@ -1216,7 +1216,7 @@ namespace ome
                       coreMeta)
                     coreMeta->dimensionOrder = ome::xml::model::enums::DimensionOrder("XYZCT");
                 }
-              catch (const std::exception& e)
+              catch (const std::exception& /* e */)
                 {
                 }
             }

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -127,7 +127,7 @@ namespace ome
               else
                 throw tiff::Exception("No TIFF IFDs found");
             }
-          catch (const tiff::Exception& /* e */)
+          catch (const tiff::Exception&)
             {
               throw FormatException("No TIFF ImageDescription found");
             }
@@ -294,7 +294,7 @@ namespace ome
               }
             return meta->getImageCount() > 0;
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
             return false;
           }
@@ -368,7 +368,7 @@ namespace ome
             if (!isSingleFile(id))
               group = MUST_GROUP;
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -430,7 +430,7 @@ namespace ome
             if (!metadataFile.empty() && boost::filesystem::exists(metadataFile))
               meta = createOMEXMLMetadata(metadataFile);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
             /// @todo Log.
             metadataFile.clear();
@@ -441,7 +441,7 @@ namespace ome
           {
             this->hasSPW = meta->getPlateCount() > 0U;
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -464,7 +464,7 @@ namespace ome
           {
             currentUUID = meta->getUUID();
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
             // null UUID.
           }
@@ -506,7 +506,7 @@ namespace ome
                       {
                         samplesPerPixel = static_cast<dimension_size_type>(meta->getChannelSamplesPerPixel(series, 0));
                       }
-                    catch (const std::exception& /* e */)
+                    catch (const std::exception&)
                       {
                       }
                     coreMeta->sizeC.push_back(samplesPerPixel);
@@ -585,7 +585,7 @@ namespace ome
                   {
                     filename = path(meta->getUUIDFileName(series, td));
                   }
-                catch (const std::exception& /* e */)
+                catch (const std::exception&)
                   {
                     BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
                       << "Ignoring null UUID object when retrieving filename";
@@ -594,7 +594,7 @@ namespace ome
                   {
                     uuid = meta->getUUIDValue(series, td);
                   }
-                catch (const std::exception& /* e */)
+                catch (const std::exception&)
                   {
                     BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
                       << "Ignoring null UUID object when retrieving value";
@@ -980,7 +980,7 @@ namespace ome
                   {
                     uuid = meta.getUUIDValue(series, td);
                   }
-                catch (const std::exception& /* e */)
+                catch (const std::exception&)
                   {
                   }
                 if (uuid.empty())
@@ -996,7 +996,7 @@ namespace ome
                       {
                         uuidFilename = meta.getUUIDFileName(series, td);
                       }
-                    catch (const std::exception& /* e */)
+                    catch (const std::exception&)
                       {
                       }
                     if (fs::exists(uuidFilename))
@@ -1051,7 +1051,7 @@ namespace ome
               {
                 meta.getImageAcquisitionDate(i);
               }
-            catch (const std::exception& /* e */)
+            catch (const std::exception&)
               {
                 // null timestamp.
               }
@@ -1086,7 +1086,7 @@ namespace ome
               {
                 firstC = meta.getTiffDataFirstC(series, td);
               }
-            catch (const std::exception& /* e */)
+            catch (const std::exception&)
               {
               }
             if (!cIndexStart)
@@ -1099,7 +1099,7 @@ namespace ome
               {
                 firstZ = meta.getTiffDataFirstC(series, td);
               }
-            catch (const std::exception& /* e */)
+            catch (const std::exception&)
               {
               }
             if (!zIndexStart)
@@ -1112,7 +1112,7 @@ namespace ome
               {
                 firstT = meta.getTiffDataFirstT(series, td);
               }
-            catch (const std::exception& /* e */)
+            catch (const std::exception&)
               {
               }
             if (!tIndexStart)
@@ -1138,7 +1138,7 @@ namespace ome
           {
             tdIFD = meta.getTiffDataIFD(series, tiffData);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -1146,7 +1146,7 @@ namespace ome
           {
             numPlanes = meta.getTiffDataPlaneCount(series, tiffData);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
             if (tdIFD)
               numPlanes = 1;
@@ -1165,7 +1165,7 @@ namespace ome
           {
             firstC = meta.getTiffDataFirstC(series, tiffData);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -1173,7 +1173,7 @@ namespace ome
           {
             firstT = meta.getTiffDataFirstT(series, tiffData);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -1181,7 +1181,7 @@ namespace ome
           {
             firstZ = meta.getTiffDataFirstZ(series, tiffData);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 
@@ -1201,7 +1201,7 @@ namespace ome
               if (meta.getTiffDataCount(series) > 0)
                 uuidFileName = meta.getUUIDFileName(series, 0);
             }
-          catch (const std::exception& /* e */)
+          catch (const std::exception&)
             {
             }
           if (meta.getChannelCount(series) > 0)
@@ -1216,7 +1216,7 @@ namespace ome
                       coreMeta)
                     coreMeta->dimensionOrder = ome::xml::model::enums::DimensionOrder("XYZCT");
                 }
-              catch (const std::exception& /* e */)
+              catch (const std::exception&)
                 {
                 }
             }

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -453,7 +453,7 @@ namespace ome
           {
             canonicalpath = ome::common::canonical(id);
           }
-        catch (const std::exception& /* e */)
+        catch (const std::exception&)
           {
           }
 

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -801,7 +801,7 @@ namespace ome
                 getField(TILELENGTH).get(h);
                 impl->tiletype = TILE;
               }
-            catch (const Exception& e)
+            catch (const Exception& /* e */)
               {
                 getField(ROWSPERSTRIP).get(h);
                 impl->tiletype = STRIP;
@@ -975,7 +975,7 @@ namespace ome
               {
                 getField(SAMPLEFORMAT).get(sampleformat);
               }
-            catch(const Exception& e)
+            catch(const Exception& /* e */)
               {
                 // Default to unsigned integer.
                 sampleformat = UNSIGNED_INT;

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -801,7 +801,7 @@ namespace ome
                 getField(TILELENGTH).get(h);
                 impl->tiletype = TILE;
               }
-            catch (const Exception& /* e */)
+            catch (const Exception&)
               {
                 getField(ROWSPERSTRIP).get(h);
                 impl->tiletype = STRIP;
@@ -975,7 +975,7 @@ namespace ome
               {
                 getField(SAMPLEFORMAT).get(sampleformat);
               }
-            catch(const Exception& /* e */)
+            catch(const Exception&)
               {
                 // Default to unsigned integer.
                 sampleformat = UNSIGNED_INT;

--- a/cpp/lib/ome/bioformats/tiff/ImageJMetadata.h
+++ b/cpp/lib/ome/bioformats/tiff/ImageJMetadata.h
@@ -147,7 +147,7 @@ namespace ome
                   is.exceptions(std::ios::failbit);
                   is >> value;
                 }
-              catch (const std::ios_base::failure& /* e */)
+              catch (const std::ios_base::failure&)
                 {
                   parse_value_error(key, i->second);
                 }

--- a/cpp/lib/ome/bioformats/tiff/ImageJMetadata.h
+++ b/cpp/lib/ome/bioformats/tiff/ImageJMetadata.h
@@ -147,7 +147,7 @@ namespace ome
                   is.exceptions(std::ios::failbit);
                   is >> value;
                 }
-              catch (const std::ios_base::failure& e)
+              catch (const std::ios_base::failure& /* e */)
                 {
                   parse_value_error(key, i->second);
                 }

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -145,7 +145,7 @@ namespace ome
             {
               close();
             }
-          catch (const Exception& /* e */)
+          catch (const Exception&)
             {
               /// @todo Log the error elsewhere.
             }

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -145,7 +145,7 @@ namespace ome
             {
               close();
             }
-          catch (Exception& e)
+          catch (const Exception& /* e */)
             {
               /// @todo Log the error elsewhere.
             }

--- a/cpp/lib/ome/xml/meta/Convert.cpp
+++ b/cpp/lib/ome/xml/meta/Convert.cpp
@@ -126,7 +126,7 @@ namespace
         {
           value = (src.*get)();
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
         }
       return value;
@@ -149,7 +149,7 @@ namespace
         {
           value = (src.*get)(param);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
         }
       return value;
@@ -175,7 +175,7 @@ namespace
         {
           value = (src.*get)(param1, param2);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
         }
       return value;
@@ -204,7 +204,7 @@ namespace
         {
           value = (src.*get)(param1, param2, param3);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
         }
       return value;
@@ -228,7 +228,7 @@ namespace
         {
           (dest.*set)((src.*get)());
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
           ok = false;
         }
@@ -256,7 +256,7 @@ namespace
           (dest.*set)((src.*get)(param),
                       param);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
           ok = false;
         }
@@ -289,7 +289,7 @@ namespace
           (dest.*set)((src.*get)(param1, param2),
                       param1, param2);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
           ok = false;
         }
@@ -326,7 +326,7 @@ namespace
           (dest.*set)((src.*get)(param1, param2, param3),
                       param1, param2, param3);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
           ok = false;
         }
@@ -367,7 +367,7 @@ namespace
           (dest.*set)((src.*get)(param1, param2, param3, param4),
                       param1, param2, param3, param4);
         }
-      catch (const std::runtime_error& /* e */)
+      catch (const std::runtime_error&)
         {
           ok = false;
         }

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -114,7 +114,7 @@ namespace ome
                       ret.push_back(child);
                     }
                 }
-              catch (std::logic_error& /* e */)
+              catch (std::logic_error&)
                 {
                   // Not an Element.
                 }


### PR DESCRIPTION
Fixes warnings about unused variables with MSVC.  GCC and clang don't seem to treat unused exceptions as being problematic.  Comment out as for unused function arguments.

Also mark a couple of exceptions as `const` or else they won't be caught (since all exceptions are const).

--------

Testing: Just check the jobs are green.