### PR TITLE
xsd-fu: Correct static initialisation order issues in the C++ templates

### DIFF
--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -75,42 +75,6 @@ namespace
   typedef std::pair<std::string,${klass.langTypeNS}::enum_value> smap;
   typedef std::pair<${klass.langTypeNS}::enum_value,std::string> vmap;
 
-  smap init_string_values[] =
-    {
-{% for value in klass.possibleValues %}\
-{% if value == klass.possibleValues[-1] %}\
-      smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
-{% end %}\
-{% if value != klass.possibleValues[-1] %}\
-      smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
-{% end %}\
-{% end %}\
-    };
-
-  smap init_lcase_string_values[] =
-    {
-{% for value in klass.possibleValues %}\
-{% if value == klass.possibleValues[-1] %}\
-      smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()})
-{% end %}\
-{% if value != klass.possibleValues[-1] %}\
-      smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
-{% end %}\
-{% end %}\
-    };
-
-  vmap init_value_values[] =
-    {
-{% for value in klass.possibleValues %}\
-{% if value == klass.possibleValues[-1] %}\
-      vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}")
-{% end %}\
-{% if value != klass.possibleValues[-1] %}\
-      vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}"),
-{% end %}\
-{% end %}\
-    };
-
 }
 
 {% end %}\
@@ -319,24 +283,63 @@ namespace ome
         const ${klass.langType}::string_map_type&
         ${klass.langType}::strings()
         {
+	  const smap init_string_values[] =
+	    {
+{% for value in klass.possibleValues %}\
+{% if value == klass.possibleValues[-1] %}\
+              smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+{% end %}\
+{% if value != klass.possibleValues[-1] %}\
+              smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+{% end %}\
+{% end %}\
+	    };
+
           static const string_map_type string_map(init_string_values,
                                                   init_string_values + (sizeof(init_string_values) / sizeof(init_string_values[0])));
+
           return string_map;
         }
 
         const ${klass.langType}::value_map_type&
         ${klass.langType}::values()
         {
+	  vmap init_value_values[] =
+	    {
+{% for value in klass.possibleValues %}\
+{% if value == klass.possibleValues[-1] %}\
+              vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}")
+{% end %}\
+{% if value != klass.possibleValues[-1] %}\
+              vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}"),
+{% end %}\
+{% end %}\
+	    };
+
           static const value_map_type value_map(init_value_values,
                                                 init_value_values + (sizeof(init_value_values) / sizeof(init_value_values[0])));
+
           return value_map;
         }
 
         const ${klass.langType}::string_map_type&
         ${klass.langType}::lowercase_strings()
         {
+	  smap init_lcase_string_values[] =
+	    {
+{% for value in klass.possibleValues %}\
+{% if value == klass.possibleValues[-1] %}\
+              smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()})
+{% end %}\
+{% if value != klass.possibleValues[-1] %}\
+              smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+{% end %}\
+{% end %}\
+	    };
+
           static const string_map_type lcase_string_map(init_lcase_string_values,
                                                         init_lcase_string_values + (sizeof(init_lcase_string_values) / sizeof(init_lcase_string_values[0])));
+
           return lcase_string_map;
         }
 {% end source%}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -528,7 +528,7 @@ namespace ome
                 {
                   enumeration = ${klass.langType}(value, false);
                 }
-              catch (const EnumerationException& e)
+              catch (const EnumerationException&)
                 {
                   is.setstate(std::ios::failbit);
                 }

--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -228,6 +228,7 @@ namespace ome
           const string_map_type& string_map(strings());
           const string_map_type& lowercase_string_map(lowercase_strings());
           string_map_type::const_iterator i = string_map.find(name);
+          string_map_type::const_iterator li = lowercase_string_map.end();
           if (strict == false && i == string_map.end())
             {
               // Trim leading and trailing whitespace and lowercase.
@@ -236,9 +237,9 @@ namespace ome
               std::string lname(name);
               trim(lname);
               std::transform(lname.begin(), lname.end(), lname.begin(), std::ptr_fun(::tolower));
-              i = lowercase_string_map.find(lname);
+              li = lowercase_string_map.find(lname);
 {% if 'Other' in klass.possibleValues %}\
-              if (i == lowercase_string_map.end())
+              if (li == lowercase_string_map.end())
                 {
                   ome::common::Logger logger = ome::common::createLogger("${klass.langType}");
                   format fmt("Unsupported %1% value of ‘%2%’ will be stored as “Other”");
@@ -250,18 +251,25 @@ namespace ome
                 {
                   ome::common::Logger logger = ome::common::createLogger("${klass.langType}");
                   format fmt("Unsupported %1% value of ‘%2%’ will be stored as “%3%”");
-                  fmt % "${klass.langType}" % name % ${klass.langType}(i->second);
+                  fmt % "${klass.langType}" % name % ${klass.langType}(li->second);
                   BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt;
                 }
 {% end %}\
             }
-          if (i == string_map.end() || i == lowercase_string_map.end())
+          if (i != string_map.end())
+	    {
+	      this->value = i->second;
+	    }
+	  else if (li != lowercase_string_map.end())
+	    {
+	      this->value = li->second;
+	    }
+	  else
             {
               format fmt("‘%1%’ not a supported value of %2%");
               fmt % name % "${klass.langType}";
               throw EnumerationException(fmt.str());
             }
-          this->value = i->second;
 
           const value_map_type& value_map(values());
           value_map_type::const_iterator i2 = value_map.find(value);

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -108,12 +108,6 @@ namespace ome
       {
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      namespace
-      {
-
-        const std::string NAMESPACE("${klass.namespace}");
-
-      }
 
       /// Private implementation details of ${klass.name} model object.
       class ${klass.name}::Impl
@@ -1184,7 +1178,7 @@ ${customUpdatePropertyContent[prop.name]}
       ${klass.name}::asXMLElement (common::xml::dom::Document& document) const
       {
 {% if klass.name != "OME" %}\
-        common::xml::dom::Element element(document.createElementNS(NAMESPACE, "${klass.name}"));
+        common::xml::dom::Element element(document.createElementNS(getXMLNamespace(), "${klass.name}"));
 {% end if %}\
 {% if klass.name == "OME" %}\
         common::xml::dom::Element element(document.getDocumentElement());
@@ -1212,21 +1206,21 @@ ${customUpdatePropertyContent[prop.name]}
 {% if klass.name == "OME" %}\
         static const std::string XSI_NAMESPACE("http://www.w3.org/2001/XMLSchema-instance");
         element.setAttribute("xmlns:xsi", XSI_NAMESPACE);
-        element.setAttribute("xsi:schemaLocation", NAMESPACE + " " + NAMESPACE + "/ome.xsd");
+        element.setAttribute("xsi:schemaLocation", getXMLNamespace() + " " + getXMLNamespace() + "/ome.xsd");
 {% end %}\
 {% if klass.isAbstractProprietary %}\
         // Class is abstract so we may need to create its "container" element
         if (std::string(element.getTagName()) != "${klass.name}")
           {
             common::xml::dom::Element abstractElement =
-              document.createElementNS(NAMESPACE, "${klass.name}");
+              document.createElementNS(getXMLNamespace(), "${klass.name}");
             abstractElement.appendChild(element);
             element = abstractElement;
           }
 {% end %}\
         if (!element)
           {
-            common::xml::dom::Element newElement = document.createElementNS(NAMESPACE, "${klass.name}");
+            common::xml::dom::Element newElement = document.createElementNS(getXMLNamespace(), "${klass.name}");
             element = newElement;
           }
 
@@ -1352,7 +1346,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // sub-elements)
           {
 {% if prop.minOccurs == 1 %}\
-            common::xml::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
+            common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
             std::ostringstream os;
             os.imbue(std::locale::classic());
 {% if prop.langTypeNS != 'bool' %}\
@@ -1367,7 +1361,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% if prop.minOccurs == 0 %}\
             if (this->impl->${prop.instanceVariableName})
               {
-                common::xml::dom::Element child(document.createElementNS(NAMESPACE, "${prop.name}"));
+                common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
                 std::ostringstream os;
                 os.imbue(std::locale::classic());
 {% if prop.langTypeNS != 'bool' %}\
@@ -1407,7 +1401,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
                  ++i)
               {
                 common::xml::dom::Element this->impl->${prop.instanceVariableName}_element =
-                                                                   document.createElementNS(NAMESPACE, "${prop.name}");
+                                                                   document.createElementNS(getXMLNamespace(), "${prop.name}");
                 std::ostringstream os;
                 os.imbue(std::locale::classic());
 {% if prop.langTypeNS != 'bool' %}\
@@ -1452,7 +1446,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
       const std::string&
       ${klass.name}::getXMLNamespace() const
       {
-        return NAMESPACE;
+        static const std::string ns("${klass.namespace}");
+        return ns;
       }
 {% end source %}\
 {% if fu.SOURCE_TYPE == "header" %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
@@ -8,7 +8,7 @@
         common::xml::dom::ParseParameters params;
         params.validationScheme = xercesc::XercesDOMParser::Val_Never;
         common::xml::dom::Document Value_document(ome::common::xml::dom::createDocument(wrappedValue, params));
-        common::xml::dom::Element value_element = document.createElementNS(NAMESPACE, "Value");
+        common::xml::dom::Element value_element = document.createElementNS(getXMLNamespace(), "Value");
         common::xml::dom::NodeList Value_subNodes = Value_document.getDocumentElement().getChildNodes();
 
         for (common::xml::dom::NodeList::iterator elem = Value_subNodes.begin();

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
@@ -73,7 +73,7 @@
                     text += textvalue;
 
                   }
-                catch (const std::exception& e)
+                catch (const std::exception&)
                   {
                     // Not an Element.
                   }


### PR DESCRIPTION
While GCC and Clang provide certain guarantees with regard to the initialisation order (or at least, do so in practice), this is not the case with MSVC.  This PR removes all static variables in the unnamed namespace in the enum template, as well as the XML namespace in the model object template.  It also fixes a potential problem with iterators which MSVC seemed to object to but which the other compilers were happy with.

--------

Testing: Check jobs are green (https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp).  Double-check the code generation changes look sane.