### PR TITLE
cpp: common: Correct string iterator use in mstream and formatreader tests

### DIFF
--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -323,14 +323,14 @@ TEST_P(FormatReaderTest, IsThisType)
   EXPECT_TRUE(r.isThisType("valid.test.gz", true));
   EXPECT_TRUE(r.isThisType("valid.test.gz", false));
 
-  EXPECT_FALSE(r.isThisType(reinterpret_cast<uint8_t *>(&*icontent.begin()),
-                            reinterpret_cast<uint8_t *>(&*icontent.end())));
+  EXPECT_FALSE(r.isThisType(reinterpret_cast<uint8_t *>(&icontent[0]),
+                            reinterpret_cast<uint8_t *>(&icontent[0] + icontent.size())));
   EXPECT_FALSE(r.isThisType(reinterpret_cast<uint8_t *>(&*icontent.begin()),
                             icontent.size()));
   EXPECT_FALSE(r.isThisType(isicontent));
 
-  EXPECT_TRUE(r.isThisType(reinterpret_cast<uint8_t *>(&*vcontent.begin()),
-                           reinterpret_cast<uint8_t *>(&*vcontent.end())));
+  EXPECT_TRUE(r.isThisType(reinterpret_cast<uint8_t *>(&vcontent[0]),
+                           reinterpret_cast<uint8_t *>(&vcontent[0] + vcontent.size())));
   EXPECT_TRUE(r.isThisType(reinterpret_cast<uint8_t *>(&*vcontent.begin()),
                            vcontent.size()));
   EXPECT_TRUE(r.isThisType(isvcontent));

--- a/cpp/test/ome-common/mstream.cpp
+++ b/cpp/test/ome-common/mstream.cpp
@@ -45,7 +45,7 @@ using ome::common::imstream;
 TEST(Imstream, CreateFromIterator)
 {
   std::string src("43 992.82 objective");
-  imstream is(&*src.begin(), &*src.end());
+  imstream is(&src[0], src.size());
 
   int i;
   double d;


### PR DESCRIPTION
This change fixes the nonstandard use of iterators in these unit tests.  This doesn't work on Windows--dereferencing an end iterator is not really allowed but works fine with GCC and Clang.  Use a pointer to the start and size instead, or pointer to the start and pointer to one-past-the-end as pointer arithmetic without using iterators.

--------

Testing: Covered by the mstream unit test; check jobs are green.