### PR TITLE
cpp: common: Correct units test for MSVC stream output

### DIFF
--- a/cpp/lib/ome/compat/regex.h
+++ b/cpp/lib/ome/compat/regex.h
@@ -59,6 +59,7 @@ namespace ome
     using std::regex;
     using std::regex_error;
     using std::regex_match;
+    using std::regex_replace;
     using std::regex_search;
     using std::cmatch;
     using std::smatch;
@@ -73,6 +74,7 @@ namespace ome
     using std::tr1::regex;
     using std::tr1::regex_error;
     using std::tr1::regex_match;
+    using std::tr1::regex_replace;
     using std::tr1::regex_search;
     using std::tr1::cmatch;
     using std::tr1::smatch;
@@ -87,6 +89,7 @@ namespace ome
     using boost::regex;
     using boost::regex_error;
     using boost::regex_match;
+    using boost::regex_replace;
     using boost::regex_search;
     using boost::cmatch;
     using boost::smatch;

--- a/cpp/test/ome-common/units.h
+++ b/cpp/test/ome-common/units.h
@@ -53,6 +53,8 @@
 #include <boost/units/io.hpp>
 #include <boost/units/systems/si/io.hpp>
 
+#include <ome/compat/regex.h>
+
 #include <ome/common/units/types.h>
 #include <ome/common/filesystem.h>
 
@@ -157,7 +159,17 @@ TYPED_TEST_P(UnitConv, StreamOutput)
       // errors lead to unpredicable output)
       os << std::setprecision(4) << obs;
 
-      EXPECT_EQ(i->expected_output, os.str());
+      std::string obsstr(os.str());
+
+      // MSVC stream output uses a slightly different format than GCC
+      // and Clang; it outputs three digits for the exponent instead
+      // of two.  Drop the leading zero to make it compatible with the
+      // expected test output.
+      ome::compat::regex repl("e([+-]?)0([0-9][0-9])", ome::compat::regex::extended);
+
+      std::string obsstr_fixed(ome::compat::regex_replace(obsstr, repl, "e$1$2"));
+
+      EXPECT_EQ(i->expected_output, obsstr_fixed);
     }
 }
 


### PR DESCRIPTION
The output of floating point exponents is slightly different for MSVC--it uses three digits rather than two when there are only two significant digits.  This is not specified by the C++ standard and so implementations can differ slightly.  Adjust the output to match what is expected by removing the leading zero with a regular expression.

See http://stackoverflow.com/questions/9226400/portable-printing-of-exponent-of-a-double-to-c-iostreams for some background.

--------

Testing: Check jobs are green (https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp/).  Should be a no-op for the existing Unix CI jobs.  Not tested by the windows jobs yet but will be once the other pending PRs are merged and we can turn on a full Windows build of the whole bioformats library set.