### PR TITLE
Trac URLs cleanup

### DIFF
--- a/components/formats-api/src/loci/formats/meta/ModuloAnnotation.java
+++ b/components/formats-api/src/loci/formats/meta/ModuloAnnotation.java
@@ -80,7 +80,7 @@ public class ModuloAnnotation extends XMLAnnotation {
       type = type.toLowerCase();
     }
     // Handle CZI files for the moment.
-    // TODO: see http://trac.openmicroscopy.org.uk/ome/ticket/11720
+    // TODO: see https://trac.openmicroscopy.org/ome/ticket/11720
     if (type.equals("rotation")) {
       type = "angle";
     }

--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -46,7 +46,7 @@ function [result] = bfopen(id, varargin)
 %     bioformats_package.jar.
 %
 % For many examples of how to use the bfopen function, please see:
-%     http://trac.openmicroscopy.org.uk/ome/wiki/BioFormats-Matlab
+%     http://www.openmicroscopy.org/site/support/bio-formats5.1/developers/matlab-dev.html
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %

--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -47,12 +47,6 @@ import ome.xml.model.primitives.NonNegativeInteger;
 
 /**
  * Reader for CellH5 (HDF) files.
- *
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a
- * href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/in/CellH5Reader.java">Trac</a>,
- * <a
- * href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/src/loci/formats/in/CellH5Reader.java;hb=HEAD">Gitweb</a></dd></dl>
  */
 public class CellH5Reader extends FormatReader {
 

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -255,7 +255,7 @@ public class MRCReader extends FormatReader {
     double pixelTypeMax = pixelTypeMin + range;
 
     // Fix for EMAN2 generated MRC files containining unsigned 16-bit data
-    // See https://trac.openmicroscopy.org.uk/ome/ticket/4619
+    // See https://trac.openmicroscopy.org/ome/ticket/4619
     if (pixelTypeMax < maxValue || pixelTypeMin > minValue && signed) {
       switch (getPixelType()) {
         case FormatTools.INT16:

--- a/components/formats-gpl/src/loci/formats/in/VeecoReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VeecoReader.java
@@ -47,10 +47,6 @@ import ome.xml.model.primitives.PositiveFloat;
 
 /**
  * VeecoReader is the file format reader for Veeco HDF files.
- *
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/in/VeecoReader.java">Trac</a>,
- * <a href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/src/loci/formats/in/VeecoReader.java;hb=HEAD">Gitweb</a></dd></dl>
  */
 public class VeecoReader extends FormatReader {
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
@@ -40,10 +40,6 @@ import loci.formats.meta.MetadataStore;
 /**
  * Zeiss LMS reader for data from Zeiss CSM 700 systems.  Not to be confused
  * with the Zeiss LSM reader, which reads the much more common .lsm format
- *
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/in/ZeissLMSReader.java">Trac</a>,
- * <a href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/src/loci/formats/in/ZeissLMSReader.java;hb=HEAD">Gitweb</a></dd></dl>
  */
 public class ZeissLMSReader extends FormatReader {
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -24,7 +24,7 @@
  */
 
 /*
- * https://trac.openmicroscopy.org.uk/ome/ticket/4151
+ * https://trac.openmicroscopy.org/ome/ticket/4151
  *
  * AxioVision TIFF format documentation:
  *

--- a/components/formats-gpl/src/loci/formats/services/JHDFService.java
+++ b/components/formats-gpl/src/loci/formats/services/JHDFService.java
@@ -38,12 +38,6 @@ import loci.common.services.ServiceException;
 
 /**
  * Utility class for working with NetCDF/HDF files.
- *
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a
- * href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/services/NetCDFService.java">Trac</a>,
- * <a
- * href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/src/loci/formats/services/NetCDFService.java;hb=HEAD">Gitweb</a></dd></dl>
  */
 public interface JHDFService extends Service {
 

--- a/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
@@ -50,12 +50,6 @@ import ch.systemsx.cisd.hdf5.IHDF5Writer;
 
 /**
  * Utility class for working with HDF files.
- *
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a
- * href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/src/loci/formats/services/JHDFServiceImpl.java">Trac</a>,
- * <a
- * href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/src/loci/formats/services/JHDFServiceImpl.java;hb=HEAD">Gitweb</a></dd></dl>
  */
 public class JHDFServiceImpl extends AbstractService
         implements JHDFService {

--- a/components/formats-gpl/src/loci/formats/tools/MakeDatasetStructureTable.java
+++ b/components/formats-gpl/src/loci/formats/tools/MakeDatasetStructureTable.java
@@ -38,7 +38,7 @@ import loci.formats.ImageReader;
  * Utility class for generating a table containing the dataset structure for
  * every supported format.
  * This class is used to generate this wiki page:
- * http://trac.openmicroscopy.org.uk/ome/wiki/BioFormats-DatasetStructureTable
+ * http://www.openmicroscopy.org/site/support/bio-formats5.1/formats/dataset-table.html
  *
  * @author Melissa Linkert melissa at glencoesoftware.com
  */

--- a/components/formats-gpl/test/loci/formats/utests/JHDFServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/JHDFServiceTest.java
@@ -39,12 +39,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a
- * href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/test/loci/formats/utests/JHDFServiceTest.java">Trac</a>,
- * <a
- * href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/test/loci/formats/utests/JHDFServiceTest.java;hb=HEAD">Gitweb</a></dd></dl>
- *
  * @author Christop Sommer christoph.sommer (at) imba.oeaw.ac.at
  */
 public class JHDFServiceTest {

--- a/components/formats-gpl/test/loci/formats/utests/MissingJHDFServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/MissingJHDFServiceTest.java
@@ -33,12 +33,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * <dl><dt><b>Source code:</b></dt>
- * <dd><a
- * href="http://trac.openmicroscopy.org.uk/ome/browser/bioformats.git/components/bio-formats/test/loci/formats/utests/MissingJHDFServiceTest.java">Trac</a>,
- * <a
- * href="http://git.openmicroscopy.org/?p=bioformats.git;a=blob;f=components/bio-formats/test/loci/formats/utests/MissingJHDFServiceTest.java;hb=HEAD">Gitweb</a></dd></dl>
- *
  * @author Chris Allan <callan at blackcat dot ca>
  */
 public class MissingJHDFServiceTest {

--- a/components/xsd-fu/setup.py
+++ b/components/xsd-fu/setup.py
@@ -39,8 +39,8 @@ setup(
 Python tools for generating code from the OME specification""",
     author="The Open Microscopy Consortium",
     author_email="ome-users@lists.openmicroscopy.org.uk",
-    url="http://trac.openmicroscopy.org.uk/ome/wiki/XsdFu",
-    download_url="http://trac.openmicroscopy.org.uk/ome/wiki/XsdFu",
+    url="http://downloads.openmicroscopy.org/bio-formats/",
+    download_url="http://downloads.openmicroscopy.org/bio-formats/",
     # package_dir = {"": "target"},
     # packages=packages,
     test_suite='test.suite'

--- a/docs/sphinx/about/index.txt
+++ b/docs/sphinx/about/index.txt
@@ -36,7 +36,7 @@ to the documentation.
 Other places where questions are commonly asked and/or bugs are reported
 include:
 
--  `OME Trac <http://trac.openmicroscopy.org.uk/ome>`_
+-  `OME Trac <https://trac.openmicroscopy.org/ome>`_
 -  `ome-devel mailing
    list <http://lists.openmicroscopy.org.uk/pipermail/ome-devel>`_
    (searchable using google with 'site:lists.openmicroscopy.org.uk')

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -433,7 +433,7 @@ Version history
 * Updated to 2011-06 OME-XML schema
 * Minor speed improvements in many formats
 * Switched version control system from SVN to Git
-* Moved all Trac tickets into the OME Trac: http://trac.openmicroscopy.org.uk
+* Moved all Trac tickets into the OME Trac: https://trac.openmicroscopy.org
 * Improvements to testing frameworks
 * Added Maven build system as an alternative to the existing Ant build system
 * Added pre-compiled C++ bindings to the download page

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -137,7 +137,7 @@ jenkins_view_root = jenkins_root + '/view'
 
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
-trac_root = 'http://trac.openmicroscopy.org.uk/ome'
+trac_root = 'https://trac.openmicroscopy.org/ome'
 oo_root = 'http://www.openmicroscopy.org'
 oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'

--- a/docs/sphinx/developers/export.txt
+++ b/docs/sphinx/developers/export.txt
@@ -188,4 +188,4 @@ Known issues
 ------------
 
 `List of Trac tickets
-<http://trac.openmicroscopy.org.uk/ome/query?status=accepted&status=new&status=reopened&keywords=~export&component=Bio-Formats&col=id&col=summary&col=status&col=type&col=priority&col=milestone&col=component&order=priority>`_
+<https://trac.openmicroscopy.org/ome/query?status=accepted&status=new&status=reopened&keywords=~export&component=Bio-Formats&col=id&col=summary&col=status&col=type&col=priority&col=milestone&col=component&order=priority>`_

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -71,7 +71,7 @@ Contributing to Bio-Formats
     xsd-fu
     useful-scripts
 
-See `open Trac tickets for Bio-Formats <https://trac.openmicroscopy.org.uk/ome/report/44>`_ 
+See `open Trac tickets for Bio-Formats <https://trac.openmicroscopy.org/ome/report/44>`_
 for information on work currently planned or in progress.
 
 For more general guidance about how to contribute to OME projects, see the 

--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
 
   <issueManagement>
     <system>Trac</system>
-    <url>https://trac.openmicroscopy.org</url>
+    <url>https://trac.openmicroscopy.org/ome</url>
   </issueManagement>
 
   <ciManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -637,12 +637,12 @@
 
   <issueManagement>
     <system>Trac</system>
-    <url>http://trac.openmicroscopy.org.uk/ome/wiki/BioFormats</url>
+    <url>https://trac.openmicroscopy.org/ome/wiki/BioFormats</url>
   </issueManagement>
 
   <ciManagement>
     <system>Jenkins</system>
-    <url>http://ci.openmicroscopy.org/</url>
+    <url>https://ci.openmicroscopy.org/</url>
   </ciManagement>
 
   <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
 
   <issueManagement>
     <system>Trac</system>
-    <url>https://trac.openmicroscopy.org/ome/wiki/BioFormats</url>
+    <url>https://trac.openmicroscopy.org</url>
   </issueManagement>
 
   <ciManagement>


### PR DESCRIPTION
This is the Bio-Formats equivalent of https://github.com/openmicroscopy/ome-documentation/pull/1245.

- all Trac URLs are reviewed to use `https://trac.openmicroscopy.org`
- the remaining `Source code` blocks which were not cleaned up as part of https://github.com/openmicroscopy/bioformats/pull/1455 are removed
- some outdated Trac links are redirected to the appropriate resources (documentation, downloads)