### PR TITLE
C++: Final fixes to build on Windows

### DIFF
--- a/cpp/lib/ome/bioformats/MetadataMap.h
+++ b/cpp/lib/ome/bioformats/MetadataMap.h
@@ -136,11 +136,8 @@ namespace ome
       /// Aggregate view of all storable types.
       typedef boost::mpl::joint_view<basic_types_view, list_types_view> all_types_view;
 
-      /// Empty vector placeholder.
-      typedef boost::mpl::vector<> empty_types;
-
       /// List of discriminated types used by boost::variant.
-      typedef boost::mpl::insert_range<empty_types, boost::mpl::end<empty_types>::type, all_types_view>::type discriminated_types;
+      typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<> >::type, all_types_view>::type discriminated_types;
 
     public:
       /// Key type.

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -38,7 +38,6 @@
 #include <string>
 
 #include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <ome/bioformats/FormatException.h>
 #include <ome/bioformats/FormatTools.h>
@@ -77,6 +76,9 @@
 #include <xercesc/sax2/DefaultHandler.hpp>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
+
+// Include last due to side effect of MPL vector limit setting which can change the default
+#include <boost/lexical_cast.hpp>
 
 using boost::format;
 

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -38,6 +38,7 @@
 #include <string>
 
 #include <ome/bioformats/FormatReader.h>
+#include <ome/bioformats/MetadataMap.h>
 #include <ome/bioformats/Types.h>
 
 #include <ome/common/filesystem.h>

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -42,8 +42,6 @@
 #include <vector>
 #include <map>
 
-#include <boost/lexical_cast.hpp>
-
 #include <ome/bioformats/FormatReader.h>
 #include <ome/bioformats/FormatHandler.h>
 

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -130,7 +130,7 @@ namespace ome
           Sentry sentry;
 
 #ifdef _MSC_VER
-          tiff = TIFFOpen(filename.wstring().c_str(), mode.c_str());
+          tiff = TIFFOpenW(filename.wstring().c_str(), mode.c_str());
 #else
           tiff = TIFFOpen(filename.string().c_str(), mode.c_str());
 #endif

--- a/cpp/lib/ome/common/config.h.in
+++ b/cpp/lib/ome/common/config.h.in
@@ -65,11 +65,32 @@
 #cmakedefine OME_HAVE_SNPRINTF 1
 #cmakedefine OME_VARIANT_LIMIT 1
 
+#ifndef OME_VARIANT_LIMIT
+#  ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+/// Disable MPL header preprocessing (to allow the following macros to be modified).
+#    define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+#  endif
+#  if !defined(BOOST_MPL_LIMIT_VECTOR_SIZE) || BOOST_MPL_LIMIT_VECTOR_SIZE < 40
+/// MPL vector size limit increase.
+#    ifdef BOOST_MPL_LIMIT_VECTOR_SIZE
+#      undef BOOST_MPL_LIMIT_VECTOR_SIZE
+#    endif
+#  define BOOST_MPL_LIMIT_VECTOR_SIZE 40
+#  endif
+#  if !defined(BOOST_MPL_LIMIT_LIST_SIZE) || BOOST_MPL_LIMIT_LIST_SIZE < 40
+/// MPL list size limit increase.
+#    ifdef BOOST_MPL_LIMIT_LIST_SIZE
+#      undef BOOST_MPL_LIMIT_LIST_SIZE
+#    endif
+#  define BOOST_MPL_LIMIT_LIST_SIZE 40
+#  endif
+#endif
+
 #ifndef OME_HAVE_NOEXCEPT
-# ifdef _MSC_VER
-#  define _ALLOW_KEYWORD_MACROS 1
-# endif
-# define noexcept
+#  ifdef _MSC_VER
+#    define _ALLOW_KEYWORD_MACROS 1
+#  endif
+#  define noexcept
 #endif
 
 #endif // OME_COMMON_CONFIG_H

--- a/cpp/lib/ome/common/variant.h
+++ b/cpp/lib/ome/common/variant.h
@@ -68,6 +68,7 @@
 #include <boost/mpl/joint_view.hpp>
 #include <boost/mpl/transform_view.hpp>
 #include <boost/mpl/vector.hpp>
+#include <boost/mpl/vector/vector0.hpp>
 
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 105800

--- a/cpp/lib/ome/common/variant.h
+++ b/cpp/lib/ome/common/variant.h
@@ -49,21 +49,6 @@
 
 # include <ome/common/config.h>
 
-#ifndef OME_VARIANT_LIMIT
-# ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-/// Disable MPL header preprocessing (to allow the following macros to be modified).
-#  define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-# endif
-# ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
-/// MPL vector size limit increase.
-#  define BOOST_MPL_LIMIT_VECTOR_SIZE 40
-# endif
-# ifndef BOOST_MPL_LIMIT_LIST_SIZE
-/// MPL list size limit increase.
-#  define BOOST_MPL_LIMIT_LIST_SIZE 40
-# endif
-#endif
-
 #include <boost/mpl/insert_range.hpp>
 #include <boost/mpl/joint_view.hpp>
 #include <boost/mpl/transform_view.hpp>

--- a/cpp/test/ome-bioformats/CMakeLists.txt
+++ b/cpp/test/ome-bioformats/CMakeLists.txt
@@ -36,7 +36,8 @@
 
 include_directories(${OME_TOPLEVEL_INCLUDES}
                     ${Boost_INCLUDE_DIRS}
-                    ${PNG_INCLUDE_DIRS})
+                    ${PNG_INCLUDE_DIRS}
+                    ${XercesC_INCLUDE_DIRS})
 
 add_subdirectory(data)
 

--- a/cpp/test/ome-bioformats/metadatamap.cpp
+++ b/cpp/test/ome-bioformats/metadatamap.cpp
@@ -42,9 +42,10 @@
 #include <stdexcept>
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
-
 #include <ome/test/test.h>
+
+// Include last due to side effect of MPL vector limit setting which can change the default
+#include <boost/lexical_cast.hpp>
 
 using ome::bioformats::MetadataMap;
 using boost::lexical_cast;

--- a/cpp/test/ome-common/variant.cpp
+++ b/cpp/test/ome-common/variant.cpp
@@ -129,8 +129,7 @@ TEST(Variant, MPLVectorInteger)
 typedef boost::mpl::joint_view<non_numeric_types,
                                integer_types>::type joint_types_view;
 
-typedef boost::mpl::vector<> empty_types;
-typedef boost::mpl::insert_range<empty_types, boost::mpl::end<empty_types>::type, joint_types_view>::type joint_types;
+typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<> >::type, joint_types_view>::type joint_types;
 typedef boost::make_variant_over<joint_types>::type joint_variant;
 
 TEST(Variant, MPLVectorJointView)
@@ -149,7 +148,7 @@ struct make_vector
 };
 
 typedef boost::mpl::transform_view<joint_types_view, make_vector<boost::mpl::_1> >::type list_types_view;
-typedef boost::mpl::insert_range<empty_types, boost::mpl::end<empty_types>::type, list_types_view>::type list_types;
+typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<> >::type, list_types_view>::type list_types;
 typedef boost::make_variant_over<list_types>::type list_variant;
 
 TEST(Variant, MPLVectorTransformList)

--- a/cpp/test/ome-xml/CMakeLists.txt
+++ b/cpp/test/ome-xml/CMakeLists.txt
@@ -35,7 +35,8 @@
 # #L%
 
 include_directories(${OME_TOPLEVEL_INCLUDES}
-                    ${Boost_INCLUDE_DIRS})
+                    ${Boost_INCLUDE_DIRS}
+                    ${XercesC_INCLUDE_DIRS})
 
 if(BUILD_TESTS)
   add_executable(color color.cpp)


### PR DESCRIPTION
- Use correct wide TIFF open call
- Boost.Variant/lexical_cast include ordering fixes

--------

Testing: Will be tested by https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp-superbuild-win/ once included in the merge build and the job is updated.  Also check https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp/ to ensure that it hasn't broken the Unix builds.