### PR TITLE
TEST: Force generation of diffs for metadata

### DIFF
--- a/components/xsd-fu/templates-cpp/MetadataStore.template
+++ b/components/xsd-fu/templates-cpp/MetadataStore.template
@@ -105,6 +105,8 @@
  *─────────────────────────────────────────────────────────────────────────────
  */
 
+// Test diff generation (C++).
+
 {% if fu.SOURCE_TYPE == "header" %}\
 #ifndef ${fu.GUARD}
 #define ${fu.GUARD}

--- a/components/xsd-fu/templates-java/MetadataStore.template
+++ b/components/xsd-fu/templates-java/MetadataStore.template
@@ -110,6 +110,8 @@
  *-----------------------------------------------------------------------------
  */
 
+// Test diff generation (Java).
+
 package ${lang.metadata_package};
 
 import ${lang.omexml_model_package}.*;


### PR DESCRIPTION
Not for merging.

Check that https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-generated-sources/ has metadata diffs for java and cpp, and that both match the template change for MetadataStore (one comment addition per file).