### PR TITLE
Add new public Imaris HDF documentation to the format page

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -392,7 +392,7 @@ bsd = no
 export = no
 versions = 2.7, 3.0, 5.5
 weHave = * an `Imaris (RAW) specification document <http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) \n
-* an Imaris 5.5 (HDF) specification document \n
+* an `Imaris 5.5 (HDF) specification document <http://open.bitplane.com/Default.aspx?tabid=268>`_ \n
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) \n
 * several older Imaris (RAW) datasets \n
 * one Imaris 3 (TIFF) dataset \n
@@ -401,7 +401,7 @@ weWant = * an Imaris 3 (TIFF) specification document \n
 * more Imaris 3 (TIFF) datasets
 pixelsRating = Very good
 metadataRating = Very good
-opennessRating = Good
+opennessRating = Very good
 presenceRating = Fair
 utilityRating = Fair
 reader = ImarisHDFReader.java, ImarisTiffReader.java, ImarisReader.java

--- a/docs/sphinx/formats/bitplane-imaris.txt
+++ b/docs/sphinx/formats/bitplane-imaris.txt
@@ -25,7 +25,7 @@ Supported Metadata Fields: :doc:`Bitplane Imaris <bitplane-imaris-metadata>`
 We currently have:
 
 * an `Imaris (RAW) specification document <http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) 
-* an Imaris 5.5 (HDF) specification document 
+* an `Imaris 5.5 (HDF) specification document <http://open.bitplane.com/Default.aspx?tabid=268>`_ 
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) 
 * several older Imaris (RAW) datasets 
 * one Imaris 3 (TIFF) dataset 
@@ -43,7 +43,7 @@ Pixels: |Very good|
 
 Metadata: |Very good|
 
-Openness: |Good|
+Openness: |Very good|
 
 Presence: |Fair|
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -209,7 +209,7 @@ Supported Formats
      - .ims
      - |Very good|
      - |Very good|
-     - |Good|
+     - |Very good|
      - |Fair|
      - |Fair|
      - |no|


### PR DESCRIPTION
http://open.bitplane.com/Default.aspx?tabid=268 was announced today, see http://www.bitplane.com/news/bitplane-makes-the-ims-file-format-open-source-130815.

As the documentation is now publicly available, the openness rating is also increased accordingly.