### PR TITLE
Remove defunct anchor link from DICOM page

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -554,7 +554,7 @@ bsd = yes
 export = no
 software = `OsiriX Medical Imaging Software <http://www.osirix-viewer.com/>`_ \n
 `ezDICOM <http://www.sph.sc.edu/comd/rorden/ezdicom.html>`_ \n
-`Wikipedia's list of freeware health software <http://en.wikipedia.org/wiki/List_of_freeware_health_software#Imaging.2FVisualization>`_
+`Wikipedia's list of freeware health software <http://en.wikipedia.org/wiki/List_of_freeware_health_software>`_
 samples = `MRI Chest from FreeVol-3D web site <http://members.tripod.com/%7Eclunis_immensus/free3d/hk-40.zip>`_ \n
 `Medical Image Samples from Sebastien Barre's Medical Imaging page <http://www.barre.nom.fr/medical/samples/>`_ \n
 `DICOM sample image sets from OsiriX web site <http://osirix-viewer.com/datasets/>`_

--- a/docs/sphinx/formats/dicom.txt
+++ b/docs/sphinx/formats/dicom.txt
@@ -24,7 +24,7 @@ Freely Available Software:
 
 - `OsiriX Medical Imaging Software <http://www.osirix-viewer.com/>`_ 
 - `ezDICOM <http://www.sph.sc.edu/comd/rorden/ezdicom.html>`_ 
-- `Wikipedia's list of freeware health software <http://en.wikipedia.org/wiki/List_of_freeware_health_software#Imaging.2FVisualization>`_
+- `Wikipedia's list of freeware health software <http://en.wikipedia.org/wiki/List_of_freeware_health_software>`_
 
 Sample Datasets:
 


### PR DESCRIPTION
The wiki page on free health software has had the subheadings removed even though the content is still there so this missing anchor link is making the build unstable.