### PR TITLE
cmake: Correct tiff superbuild symbol versioning properties

### DIFF
--- a/cpp/cmake/External_tiff_files/libtiff/CMakeLists.txt
+++ b/cpp/cmake/External_tiff_files/libtiff/CMakeLists.txt
@@ -149,16 +149,16 @@ install(FILES ${tiff_HEADERS} ${nodist_tiff_HEADERS}
 if(cxx)
   add_library(tiffxx SHARED ${tiffxx_SOURCES} ${tiffxx_HEADERS})
   target_link_libraries(tiffxx tiff)
-  set_target_properties(tiff PROPERTIES SOVERSION ${SO_COMPATVERSION})
+  set_target_properties(tiffxx PROPERTIES SOVERSION ${SO_COMPATVERSION})
   if(NOT CYGWIN)
     # This property causes shared libraries on Linux to have the full version
     # encoded into their final filename.  We disable this on Cygwin because
     # it causes cygz-${TIFF_FULL_VERSION}.dll to be created when cygz.dll
     # seems to be the default.
-    set_target_properties(tiff PROPERTIES VERSION ${SO_VERSION})
+    set_target_properties(tiffxx PROPERTIES VERSION ${SO_VERSION})
   endif()
   if(HAVE_LD_VERSION_SCRIPT)
-    set_target_properties(tiff PROPERTIES LINK_FLAGS
+    set_target_properties(tiffxx PROPERTIES LINK_FLAGS
                           "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libtiffxx.map")
   endif()
 


### PR DESCRIPTION
The target properties for the libtiffxx library were being erroneously applied to libtiff, which broke the symbol versioning of exported symbols.  This didn't affect the build, but did make the binaries incompatible with the libtiff built by Linux distributions.  This corrects the target names.

--------

Testing: get a Linux superbuild artefact from https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp-superbuild/BUILD_TYPE=Release,CXXSTD_AUTODETECT=OFF,node=cod/

Run `objdump -p` on `libtiff.so.5` and you should see toward the end of the output:

```
Version definitions:
1 0x01 0x0bba1ce5 libtiff.so.5
2 0x00 0x0dfcf290 LIBTIFF_4.0
```

If you repeat with a build from before today, the latter version will be LIBTIFFXX_4.0.  This demonstrates that the versioning is now correct.  Also, do the same with the system libtiff to compare with the distribution built libtiff.  I suggest doing this on Ubuntu 14.04 or similar with libtiff >= 4.0.

FYI: https://ci.openmicroscopy.org/job/TIFF-HEAD/ set up to test against the upstream CVS repo to make sure it doesn't break.  This will test the same patch submitted upstream once they apply it.