### PR TITLE
MicromanagerReader: do not return intermediate primitive double

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -625,12 +625,10 @@ public class MicromanagerReader extends FormatReader {
           addSeriesMeta(key, value);
 
           if (key.equals("Exposure-ms")) {
-            double t = Double.parseDouble(value);
-            p.exposureTime = new Time(Double.valueOf(t), UNITS.MS);
+            p.exposureTime = new Time(Double.valueOf(value), UNITS.MS);
           }
           else if (key.equals("ElapsedTime-ms")) {
-            double t = Double.parseDouble(value);
-            stamps.add(Double.valueOf(t));
+            stamps.add(Double.valueOf(value));
           }
           else if (key.equals("Core-Camera")) p.cameraRef = value;
           else if (key.equals(p.cameraRef + "-Binning")) {


### PR DESCRIPTION
Instead use Double.valueOf() directory to create a Double instance for both timestamps and exposure times.

Follow-up of https://github.com/openmicroscopy/bioformats/pull/1913#issuecomment-130858035

Tests should remain green with this change.