### PR TITLE
cmake: Allow verbose sub-builds with Ninja generator

### DIFF
--- a/cpp/cmake/ExternalProjectEnvironment.cmake
+++ b/cpp/cmake/ExternalProjectEnvironment.cmake
@@ -40,3 +40,7 @@ else()
 endif()
 
 string(REPLACE "^^" ";" CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS}")
+
+if (CMAKE_VERBOSE_MAKEFILE AND CMAKE_GENERATOR MATCHES "Ninja")
+  set(MAKE_VERBOSE -v)
+endif()

--- a/cpp/cmake/ExternalProject_cmake_build.cmake
+++ b/cpp/cmake/ExternalProject_cmake_build.cmake
@@ -2,18 +2,11 @@
 include("${EP_SCRIPT_CONFIG}")
 include("${CMAKE_CURRENT_LIST_DIR}/ExternalProjectEnvironment.cmake")
 
-if(CMAKE_GENERATOR MATCHES "Unix Makefiles")
-
-  execute_process(COMMAND ${CMAKE_MAKE_PROGRAM}
-                  WORKING_DIRECTORY "${EP_BUILD_DIR}"
-                  RESULT_VARIABLE install_result)
-
-else()
-
-  execute_process(COMMAND "${CMAKE_COMMAND}" --build .
-                                             --config "${CONFIG}"
-                  WORKING_DIRECTORY "${EP_BUILD_DIR}"
-                  RESULT_VARIABLE install_result)
+execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+                                           --config "${CONFIG}"
+                                           -- ${MAKE_VERBOSE}
+                WORKING_DIRECTORY "${EP_BUILD_DIR}"
+                RESULT_VARIABLE install_result)
 
 endif()
 

--- a/cpp/cmake/ExternalProject_cmake_install.cmake
+++ b/cpp/cmake/ExternalProject_cmake_install.cmake
@@ -13,6 +13,7 @@ else()
   execute_process(COMMAND "${CMAKE_COMMAND}" --build .
                                              --target install
                                              --config "${CONFIG}"
+                                             -- ${MAKE_VERBOSE}
                   WORKING_DIRECTORY "${EP_BUILD_DIR}"
                   RESULT_VARIABLE install_result)
 


### PR DESCRIPTION
Add verbose sub-project building with the Ninja generator when doing a superbuild.

Also consolidates the build logic in `ExternalProject_cmake_build.cmake` to be the same for all generators.

--------

Testing: Configure with

```
cmake -G Ninja -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -Dbioformats-superbuild:BOOL=ON ... /path/to/bioformats
```

with whatever additional options you like.  When you run `ninja` to do the build, you will get verbose output for the sub-project builds.  You can use `ninja -v` to make the top-level build verbose as well.  Without this patch, there will be very little detail for progress and diagnostics from the sub-project builds.