### PR TITLE
Added CZT positions computation for non-hyperstacks

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -323,17 +323,26 @@ public class ROIHandler {
                             }
                             
                             // ImageJ expects 1-based indexing, opposed to 
-                            // 0-based indexing in OME  
-                            if (images[imageNum].getNChannels()== 1 &&
-                                    images[imageNum].getNSlices()== 1) {
-                                roi.setPosition(t+1);
+                            // 0-based indexing in OME                             
+                            // Roi positions differ between hyperstacks and normal stacks
+                            ImagePlus imp = images[imageNum];
+                            if (imp.isHyperStack()) {
+                            	// Set position in CZT fashion for hyperstack
+                            	roi.setPosition(c+1, z+1, t+1);
+                            } else {
+                    			// Number of channels in imp
+                    			int imageC = imp.getNChannels();
+                    			// Number of frames in imp
+                    			int imageT = imp.getNFrames();
+                            	
+                            	// Determine which dimension is used as position 
+                            	if (imageT > 1) {
+                            		roi.setPosition(t+1);
+                            	} else if (imageC > 1) {
+                            		roi.setPosition(c+1);
+                            	}
                             }
-                            else {
-                                roi.setPosition(c+1, z+1, t+1);
-                            }
-                            
                         }
-                        roi.setImage(images[imageNum]);
 
                         if (sw == null){
                             roi.setStrokeWidth((float) 1);


### PR DESCRIPTION
This fix is related to https://github.com/openmicroscopy/openmicroscopy/pull/4045

It improves the heuristic for finding out, whether to call `roi.setPosition(int)` or `roi.setPosition(int, int, int)` based on the dimensionality of the image that the ROI is associated with.