### PR TITLE
Handle NPDI files with macro slide image and mask image

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -55,6 +55,7 @@ public class NDPIReader extends BaseTiffReader {
   // -- Constants --
 
   private static final int MAX_SIZE = 2048;
+  private static final int SOURCE_LENS = 65421;
   private static final int MARKER_TAG = 65426;
   private static final int THUMB_TAG_2 = 65439;
   private static final int METADATA_TAG = 65449;
@@ -346,12 +347,13 @@ public class NDPIReader extends BaseTiffReader {
     for (int i=1; i<ifds.size(); i++) {
       IFD ifd = ifds.get(i);
 
+      float source_lens = (Float) ifd.getIFDValue(SOURCE_LENS);
       if (ifd.getImageWidth() == ifds.get(0).getImageWidth() &&
         ifd.getImageLength() == ifds.get(0).getImageLength())
       {
         sizeZ++;
       }
-      else if (sizeZ == 1 && i < ifds.size() - 1) {
+      else if (sizeZ == 1 && source_lens != -1 && source_lens != -2) {
         pyramidHeight++;
       }
     }


### PR DESCRIPTION
In addition to the pyramid images and the macro slide image, some NDPI files contain a trailing image associate to a mask or activation map. Previously, this was handled by assuming the last series only was not part of the pyramid for data with sizeZ=1. This commit uses the tag 65421 instead to determine the macro slide image (-1) and the mask (-2) if applicable.

To test this PR:
- check the automated tests remain green
- import `npdi` samples into OMERO with this PR included into Bio-Formats. Check either 2 or 3 images are created depending on the file and that the pyramid image and the macro slide image are always imported as separate images.