### PR TITLE
Automated tests documentation

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2532,7 +2532,7 @@ public class FormatReaderTest {
       }
       boolean single = used.length == 1;
       if (single && base) LOGGER.debug("OK");
-      else LOGGER.info("{} {}", used.length, single ? "file" : "files");
+      else LOGGER.debug("{} {}", used.length, single ? "file" : "files");
       if (!base) {
         LOGGER.error("Used files list does not include base file");
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2364,7 +2364,7 @@ public class FormatReaderTest {
         // log the memo file's size
         try {
           RandomAccessInputStream s = new RandomAccessInputStream(memoFile.getAbsolutePath());
-          LOGGER.info("memo file size for {} = {} bytes",
+          LOGGER.debug("memo file size for {} = {} bytes",
                       new Location(reader.getCurrentFile()).getAbsolutePath(),
                       s.length());
           s.close();

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -18,7 +18,7 @@ where ``$DATA`` is the path to the full data repository.
 
 
 Multiple options can be passed to the :program:`ant` ``test-automated`` target 
-either by setting the ``testng.${option}`` via the command line. Useful options
+by setting the ``testng.${option}`` option via the command line. Useful options
 are described below.
 
 testng.directory

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -4,81 +4,107 @@ Testing code changes
 Automated tests
 ---------------
 
-At the bottom of many commit messages in
-https://github.com/openmicroscopy/bioformats, you will find a few lines
-similar to this:
+The :source:`Bio-Formats testing framework <components/test-suite>` component
+contains most of the infrastructure to run automated tests against the data
+repository.
 
-::
-
-    To test, please run:
-
-    ant -Dtestng.directory=$DATA/metamorph test-automated
-
-This shows the command(s) necessary to run automated tests against the
-files likely to be affected by that commit. If you want to run these
-tests, you will need to do the following:
-
-Clone bioformats.git and checkout the appropriate branch (by following
-the directions on the :devs_doc:`Git usage <using-git.html>`
-page). Run this command to build all of the JAR files:
-
-::
-
-    $ ant clean jars
-
-Switch to the test-suite component:
-
-::
+After checking out source code and building all the JAR files (see
+:doc:`building-bioformats`), switch to the test-suite component and run the tests using the :program:`ant test-automated` target::
 
     $ cd components/test-suite
-
-Run the tests, where $DATA is the path to the full data repository:
-
-::
-
     $ ant -Dtestng.directory=$DATA/metamorph test-automated
 
-On Windows, the arguments to the test command must be quoted:
+where $DATA is the path to the full data repository.
 
-::
+.. program:: ant test-automated
+
+Multiple options can be passed to the :program:`ant test-automated` target 
+either via environment variable of by passing
+:option:`-Dtestng.parameter=value` via the command-line.
+
+.. envvar:: testng.directory
+ 
+  Mandatory option. Specifies the root of the data directory to be tested::
+
+     $ ant -Dtestng.directory=$DATA/metamorph test-automated
+
+  On Windows, the arguments to the test command must be quoted::
 
     > ant "-Dtestng.directory=$DATA\metamorph" test-automated
 
-By default, 512 MB of memory are allocated to the |JVM|. You can increase
-this by adding the '-Dtestng.memory=XXXm' option. You should now see
-output similar to this:
+.. envvar:: testng.configDirectory
 
-::
+  Specifies the root of the directory containing the configuration files. This
+  directory must have the same hierarchy as the one specified by
+  :envvar:`testng.directory` and contain :file:`.bioformats` configuration
+  files::
+
+    $ ant -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config test-automated
+
+  If no configuration directory is passed, the assumption is that it is the 
+  same as the data directory.
+
+.. envvar:: testng.configSuffix
+
+  Specifies an optional suffix for the configuration files::
+
+    $ ant -Dtestng.directory=/path/to/data -Dtestng.configSuffix=win test-automated
+
+.. envvar:: testng.memory
+
+  Specifies the amount of memory to be allocated to the |JVM|::
+
+    $ ant -Dtestng.directory=$DATA -Dtestng.memory=4g test-automated
+
+  Default: 512m.
+
+.. envvar:: testng.threadCount
+
+  Specifies the number of threads to use for testing::
+
+    $ ant -Dtestng.directory=$DATA -Dtestng.threadCount=4 test-automated
+
+  Default: 1.
+
+You should now see output similar to this::
 
     Buildfile: build.xml
 
     init-title:
          [echo] ----------=========== bio-formats-testing-framework ===========----------
-
-    init-timestamp:
-
-    release-version:
-
-    init-manifest-cp:
-
-    init:
-
-    copy-source:
-
-    compile:
-
+    ...
     test-automated:
-       [testng] [Parser] Running:
-       [testng]   Bio-Formats software test suite
-       [testng]
+       [testng] 17:05:28,713 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [${logback.configurationFile}]
+       [testng] 17:05:28,713 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
+       [testng] 17:05:28,713 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
+       [testng] 17:05:28,713 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/opt/ome/bioformats/components/test-suite/logback.xml]
+       [testng] 17:05:28,835 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
+       [testng] 17:05:28,837 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [stdout]
+       [testng] 17:05:28,876 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.classic.sift.SiftingAppender]
+       [testng] 17:05:28,878 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [SIFT]
+       [testng] 17:05:28,891 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [loci.tests.testng] to DEBUG
+       [testng] 17:05:28,891 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to INFO
+       [testng] 17:05:28,891 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [SIFT] to Logger[ROOT]
+       [testng] 17:05:28,892 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [stdout] to Logger[loci.tests.testng]
+       [testng] 17:05:28,892 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
+       [testng] 17:05:28,894 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@706a04ae - Registering current configuration as safe fallback point
+       [testng] [2015-08-18 17:05:28,904] [main] testng.directory = /ome/data_repo/test_per_commit/
+       [testng] 17:05:28,908 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [loci.tests.testng.TimestampedLogFileAppender]
+       [testng] 17:05:28,909 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [logfile-main]
+       [testng] 17:05:28,955 |-INFO in loci.tests.testng.TimestampedLogFileAppender[logfile-main] - File property is set to [target/bio-formats-test-main-2015-08-18_17-05-28.log]
+       [testng] [2015-08-18 17:05:28,963] [main] testng.multiplier = 1.0
+       [testng] [2015-08-18 17:05:28,964] [main] testng.in-memory = false
+       [testng] [2015-08-18 17:05:28,964] [main] user.language = en
+       [testng] [2015-08-18 17:05:28,964] [main] user.country = US
+       [testng] [2015-08-18 17:05:28,964] [main] Maximum heap size = 455 MB
        [testng] Scanning for files...
+       [testng] [2015-08-18 17:05:32,258] [main] ----------------------------------------
+       [testng] [2015-08-18 17:05:32,258] [main] Total files: 480
+       [testng] [2015-08-18 17:05:32,258] [main] Scan time: 3.293 s (6 ms/file)
+       [testng] [2015-08-18 17:05:32,258] [main] ----------------------------------------
        [testng] Building list of tests...
-       [testng] Ready to test 490 files
-       [testng] ........................................
 
-and then eventually:
-
-::
+and then eventually::
 
        [testng] ===============================================
        [testng] Bio-Formats software test suite
@@ -89,18 +115,25 @@ and then eventually:
     BUILD SUCCESSFUL
     Total time: 16 minutes 42 seconds
 
-Each of the dots represents a single passed test; a '-' is a skipped
-test, and an 'F' is a failed test. This is mostly just for your
-amusement if you happen to be staring at the console while the tests
-run, as a more detailed report is logged to
-:file:`bio-formats-software-test-$DATE.log`
-(where "$DATE" is the date on which the tests
-started in "yyyy-MM-dd_hh-mm-ss" format).
+In most cases, test failures  should be logged in the main console output as::
 
-If Ant reports that the build was successful, then there is nothing that
-you need to do. Otherwise, it is helpful if you can provide the command,
-branch name, number of failures at the bottom of the Ant output, and the
-:file:`bio-formats-software-test-\*.log` file.
+       [testng] [2015-08-18 17:13:13,625] [pool-1-thread-1] 	SizeZ: FAILED (Series 0 (expected 2, actual 1))
+
+To identify the file, look for the initialization line preceding the test
+failures under the same thread::
+
+   [testng] [2015-08-18 17:13:12,376] [pool-1-thread-1] Initializing /ome/data_repo/test_per_commit/ome-tiff/img_bk_20110701.ome.tif: 
+
+The console output is also recorded under :file:`components/test-suite/target` 
+as :file:`bio-formats-software-test-main-$DATE.log` where "$DATE" is the date 
+on which the tests started in "yyyy-MM-dd_hh-mm-ss" format. The detailed report
+of each thread is recorder under
+:file:`bio-formats-software-pool-$POOL-thread-$THREAD-main-$DATE.log`
+
+Configuration files can be generated for files or directories using the 
+:program:`ant gen-config` target. This generation target supports the same options as :program:`ant test-automated`::
+
+  $ ant gen-config -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config -Dtestng.memory=4g -Dtestng.threadCount=6
 
 MATLAB tests
 ------------

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -11,21 +11,21 @@ repository.
 After checking out source code and building all the JAR files (see
 :doc:`building-bioformats`), switch to the :file:`test-suite` component and run the tests using the :program:`ant` ``test-automated`` target::
 
-    $ cd components/test-suite
-    $ ant -Dtestng.directory=$DATA/metamorph test-automated
+  $ cd components/test-suite
+  $ ant -Dtestng.directory=$DATA/metamorph test-automated
 
 where ``$DATA`` is the path to the full data repository.
 
 
 Multiple options can be passed to the :program:`ant` ``test-automated`` target 
-either by setting the ``testng.${option}`` via the command-line. Useful options
+either by setting the ``testng.${option}`` via the command line. Useful options
 are described below.
 
 testng.directory
  
   Mandatory option. Specifies the root of the data directory to be tested::
 
-     $ ant -Dtestng.directory=$DATA/metamorph test-automated
+    $ ant -Dtestng.directory=$DATA/metamorph test-automated
 
   On Windows, the arguments to the test command must be quoted::
 
@@ -116,7 +116,7 @@ and then eventually::
 
 In most cases, test failures  should be logged in the main console output as::
 
-       [testng] [2015-08-18 17:13:13,625] [pool-1-thread-1] 	SizeZ: FAILED (Series 0 (expected 2, actual 1))
+       [testng] [2015-08-18 17:13:13,625] [pool-1-thread-1]     SizeZ: FAILED (Series 0 (expected 2, actual 1))
 
 To identify the file, look for the initialization line preceding the test
 failures under the same thread::

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -9,20 +9,19 @@ contains most of the infrastructure to run automated tests against the data
 repository.
 
 After checking out source code and building all the JAR files (see
-:doc:`building-bioformats`), switch to the test-suite component and run the tests using the :program:`ant test-automated` target::
+:doc:`building-bioformats`), switch to the :file:`test-suite` component and run the tests using the :program:`ant` ``test-automated`` target::
 
     $ cd components/test-suite
     $ ant -Dtestng.directory=$DATA/metamorph test-automated
 
-where $DATA is the path to the full data repository.
+where ``$DATA`` is the path to the full data repository.
 
-.. program:: ant test-automated
 
-Multiple options can be passed to the :program:`ant test-automated` target 
-either by setting the ``testng.${option}`` environment variable or by passing
-:option:`-Dtestng.${option}=value` via the command-line.
+Multiple options can be passed to the :program:`ant` ``test-automated`` target 
+either by setting the ``testng.${option}`` via the command-line. Useful options
+are described below.
 
-.. envvar:: testng.directory
+testng.directory
  
   Mandatory option. Specifies the root of the data directory to be tested::
 
@@ -32,11 +31,11 @@ either by setting the ``testng.${option}`` environment variable or by passing
 
     > ant "-Dtestng.directory=$DATA\metamorph" test-automated
 
-.. envvar:: testng.configDirectory
+testng.configDirectory
 
   Specifies the root of the directory containing the configuration files. This
   directory must have the same hierarchy as the one specified by
-  :envvar:`testng.directory` and contain :file:`.bioformats` configuration
+  ``testng.directory`` and contain :file:`.bioformats` configuration
   files::
 
     $ ant -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config test-automated
@@ -44,13 +43,13 @@ either by setting the ``testng.${option}`` environment variable or by passing
   If no configuration directory is passed, the assumption is that it is the 
   same as the data directory.
 
-.. envvar:: testng.configSuffix
+testng.configSuffix
 
   Specifies an optional suffix for the configuration files::
 
     $ ant -Dtestng.directory=/path/to/data -Dtestng.configSuffix=win test-automated
 
-.. envvar:: testng.memory
+testng.memory
 
   Specifies the amount of memory to be allocated to the |JVM|::
 
@@ -58,7 +57,7 @@ either by setting the ``testng.${option}`` environment variable or by passing
 
   Default: 512m.
 
-.. envvar:: testng.threadCount
+testng.threadCount
 
   Specifies the number of threads to use for testing::
 
@@ -131,7 +130,7 @@ of each thread is recorded under
 :file:`bio-formats-software-pool-$POOL-thread-$THREAD-main-$DATE.log`
 
 Configuration files can be generated for files or directories using the 
-:program:`ant gen-config` target. This generation target supports the same options as :program:`ant test-automated`::
+:program:`ant` ``gen-config`` target. This generation target supports the same options as :program:`ant` ``test-automated``::
 
   $ ant -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config -Dtestng.memory=4g -Dtestng.threadCount=6 gen-config
 

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -22,7 +22,6 @@ either by setting the ``testng.${option}`` via the command line. Useful options
 are described below.
 
 testng.directory
- 
   Mandatory option. Specifies the root of the data directory to be tested::
 
     $ ant -Dtestng.directory=$DATA/metamorph test-automated
@@ -32,7 +31,6 @@ testng.directory
     > ant "-Dtestng.directory=$DATA\metamorph" test-automated
 
 testng.configDirectory
-
   Specifies the root of the directory containing the configuration files. This
   directory must have the same hierarchy as the one specified by
   ``testng.directory`` and contain :file:`.bioformats` configuration
@@ -44,13 +42,11 @@ testng.configDirectory
   same as the data directory.
 
 testng.configSuffix
-
   Specifies an optional suffix for the configuration files::
 
     $ ant -Dtestng.directory=/path/to/data -Dtestng.configSuffix=win test-automated
 
 testng.memory
-
   Specifies the amount of memory to be allocated to the |JVM|::
 
     $ ant -Dtestng.directory=$DATA -Dtestng.memory=4g test-automated
@@ -58,7 +54,6 @@ testng.memory
   Default: 512m.
 
 testng.threadCount
-
   Specifies the number of threads to use for testing::
 
     $ ant -Dtestng.directory=$DATA -Dtestng.threadCount=4 test-automated

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -19,8 +19,8 @@ where $DATA is the path to the full data repository.
 .. program:: ant test-automated
 
 Multiple options can be passed to the :program:`ant test-automated` target 
-either via environment variable of by passing
-:option:`-Dtestng.parameter=value` via the command-line.
+either by setting the ``testng.${option}`` environment variable or by passing
+:option:`-Dtestng.${option}=value` via the command-line.
 
 .. envvar:: testng.directory
  
@@ -127,13 +127,13 @@ failures under the same thread::
 The console output is also recorded under :file:`components/test-suite/target` 
 as :file:`bio-formats-software-test-main-$DATE.log` where "$DATE" is the date 
 on which the tests started in "yyyy-MM-dd_hh-mm-ss" format. The detailed report
-of each thread is recorder under
+of each thread is recorded under
 :file:`bio-formats-software-pool-$POOL-thread-$THREAD-main-$DATE.log`
 
 Configuration files can be generated for files or directories using the 
 :program:`ant gen-config` target. This generation target supports the same options as :program:`ant test-automated`::
 
-  $ ant gen-config -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config -Dtestng.memory=4g -Dtestng.threadCount=6
+  $ ant -Dtestng.directory=/path/to/data -Dtestng.configDirectory=/path/to/config -Dtestng.memory=4g -Dtestng.threadCount=6 gen-config
 
 MATLAB tests
 ------------


### PR DESCRIPTION
See https://trello.com/c/wT2zpjrM/41-add-documentation-for-automated-test-output

This PR reviews and updates the content of the Sphinx documentation about automated tests. Additionally, this downgrade the `FormatReaderTest` memo file size and used files lines to `DEBUG` level so that it does not appear in the main console output (but should still be logged in thread log files).