### PR TITLE
Leica .lei: set pixel type and endianness using the TIFFs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -608,13 +608,22 @@ public class LeicaReader extends FormatReader {
           TiffParser parser = new TiffParser(s);
           parser.setDoCaching(false);
           IFD firstIFD = parser.getFirstIFD();
+          parser.fillInIFD(firstIFD);
 
           ms.sizeX = (int) firstIFD.getImageWidth();
           ms.sizeY = (int) firstIFD.getImageLength();
 
           // override the .lei pixel type, in case a TIFF file was overwritten
           ms.pixelType = firstIFD.getPixelType();
-          ms.littleEndian = firstIFD.isLittleEndian();
+
+          // don't worry about changing the endianness when it
+          // won't affect the pixel data
+          if (FormatTools.getBytesPerPixel(ms.pixelType) > 1) {
+            ms.littleEndian = firstIFD.isLittleEndian();
+          }
+          else {
+            ms.littleEndian = realLittleEndian;
+          }
 
           tileWidth[i] = (int) firstIFD.getTileWidth();
           tileHeight[i] = (int) firstIFD.getTileLength();

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -869,6 +869,7 @@ public class LeicaReader extends FormatReader {
     else {
       listing = Location.getIdMap().keySet().toArray(new String[0]);
     }
+    Arrays.sort(listing);
 
     final List<String> list = new ArrayList<String>();
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -612,6 +612,10 @@ public class LeicaReader extends FormatReader {
           ms.sizeX = (int) firstIFD.getImageWidth();
           ms.sizeY = (int) firstIFD.getImageLength();
 
+          // override the .lei pixel type, in case a TIFF file was overwritten
+          ms.pixelType = firstIFD.getPixelType();
+          ms.littleEndian = firstIFD.isLittleEndian();
+
           tileWidth[i] = (int) firstIFD.getTileWidth();
           tileHeight[i] = (int) firstIFD.getTileLength();
         }
@@ -649,7 +653,6 @@ public class LeicaReader extends FormatReader {
 
       ms.dimensionOrder =
         MetadataTools.makeSaneDimensionOrder(getDimensionOrder());
-      ms.littleEndian = realLittleEndian;
     }
 
     MetadataStore store = makeFilterMetadata();

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -632,6 +632,9 @@ public class LeicaReader extends FormatReader {
           s.close();
         }
       }
+      else {
+        ms.littleEndian = realLittleEndian;
+      }
     }
 
     for (int i=0; i<getSeriesCount(); i++) {


### PR DESCRIPTION
If a TIFF for a particular series was modified/re-exported with a
different pixel type or endianness, then it won't match the values
stored in the .lei file.  This defers to pixel type and endianness
setting for each series to the first corresponding TIFF file.

Fixes https://trac.openmicroscopy.org/ome/ticket/12910.

To test, use the dataset from QA 11114.  Without this change, both series in the .lei file should have pixel type uint8 and be big-endian; reading the second series will result in an exception as noted in the ticket.  With this change, the second series should have type uint16, be little-endian, open without exception, and have reasonable-looking pixel values (you will likely need to open in ImageJ with autoscaling to see this).