### PR TITLE
specification: Correct incorrect catalogue entry

### DIFF
--- a/components/specification/released-schema/2008-02/catalog.xml
+++ b/components/specification/released-schema/2008-02/catalog.xml
@@ -6,7 +6,7 @@
   <uri name="http://www.openmicroscopy.org/Schemas/BinaryFile/2008-02/BinaryFile.xsd" uri="BinaryFile.xsd"/>
   <uri name="http://www.openmicroscopy.org/Schemas/CA/2008-02/CA.xsd" uri="CA.xsd"/>
   <uri name="http://www.openmicroscopy.org/Schemas/CLI/2008-02/CLI.xsd" uri="CLI.xsd"/>
-  <uri name="http://www.openmicroscopy.org/Schemas/DataHistory/2008-09/DataHistory.xsd" uri="DataHistory.xsd"/>
+  <uri name="http://www.openmicroscopy.org/Schemas/DataHistory/2008-02/DataHistory.xsd" uri="DataHistory.xsd"/>
   <uri name="http://www.openmicroscopy.org/Schemas/MLI/2008-02/MLI.xsd" uri="MLI.xsd"/>
   <uri name="http://www.openmicroscopy.org/Schemas/STD/2008-02/STD.xsd" uri="STD.xsd"/>
   <uri name="http://www.openmicroscopy.org/Schemas/SPW/2008-02/SPW.xsd" uri="SPW.xsd"/>


### PR DESCRIPTION
Found while working on catalogue processing and the duplicate/inconsistent filename for the same system ID caused it to throw an exception.

--------

Testing: none.  There's nothing using this particular catalogue at the moment, so just confirm it's matching the `2008-02` schema.