### PR TITLE
SimplePCI .cxd: adjust SizeX if extra bytes are stored in the planes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -384,6 +384,17 @@ public class PCIReader extends FormatReader {
       imageFiles.put(getImageIndex(parent), file);
     }
 
+    int bpp = FormatTools.getBytesPerPixel(m.pixelType);
+    int expectedPlaneSize = m.sizeX * m.sizeY * bpp;
+    String file = imageFiles.get(0);
+    RandomAccessInputStream s = poi.getDocumentStream(file);
+    TiffParser tp = new TiffParser(s);
+    // don't correct the image width if it's stored as a TIFF
+    if (!tp.isValidHeader() && s.length() > expectedPlaneSize) {
+      m.sizeX += (s.length() - expectedPlaneSize) / (m.sizeY * bpp);
+    }
+    s.close();
+
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
 

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -385,13 +385,13 @@ public class PCIReader extends FormatReader {
     }
 
     int bpp = FormatTools.getBytesPerPixel(m.pixelType);
-    int expectedPlaneSize = m.sizeX * m.sizeY * bpp;
+    int expectedPlaneSize = m.sizeX * m.sizeY * bpp * m.sizeC;
     String file = imageFiles.get(0);
     RandomAccessInputStream s = poi.getDocumentStream(file);
     TiffParser tp = new TiffParser(s);
     // don't correct the image width if it's stored as a TIFF
     if (!tp.isValidHeader() && s.length() > expectedPlaneSize) {
-      m.sizeX += (s.length() - expectedPlaneSize) / (m.sizeY * bpp);
+      m.sizeX += (s.length() - expectedPlaneSize) / (m.sizeY * bpp * m.sizeC);
     }
     s.close();
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12886.

To test, use the file from QA 11073.  Without this change, SizeX should be 397, and the images should look incorrect as noted in the file attached to the ticket.  With this change, SizeX should be 398, and the images be an obvious split field of view with moving artifacts (you will likely need to open in ImageJ to see this, as it's 16-bit data).