### PR TITLE
QT: use the previous plane if there is no data for the current plane

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
@@ -215,7 +215,9 @@ public class NativeQTReader extends FormatReader {
       System.arraycopy(temp, 0, t, 0, t.length);
     }
 
-    prevPixels = t;
+    if (t.length > 0) {
+      prevPixels = t;
+    }
     prevPlane = no;
 
     // determine whether we need to strip out any padding bytes
@@ -239,6 +241,9 @@ public class NativeQTReader extends FormatReader {
         System.arraycopy(prevPixels, row * (bytes * getSizeX() + pad), t,
           row * getSizeX() * bytes, getSizeX() * bytes);
       }
+    }
+    if (t.length == 0) {
+      t = prevPixels;
     }
 
     int bpp = FormatTools.getBytesPerPixel(getPixelType());


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12888.

To test, use the file from QA 11074.  Without this change, ```showinf``` on the file will throw an exception as noted in the ticket.  With this change, ```showinf``` should display the entire time series, which can be compared against ```mplayer``` (or some other video player).