### PR TITLE
CZI: fix channel colors when alpha is not recorded

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -917,8 +917,11 @@ public class ZeissCZIReader extends FormatReader {
           String color = channels.get(c).color;
           if (color != null) {
             color = color.replaceAll("#", "");
-            color = color.substring(2, color.length());
+            if (color.length() > 6) {
+              color = color.substring(2, color.length());
+            }
             try {
+              // shift by 8 to allow alpha in the final byte
               store.setChannelColor(
                 new Color((Integer.parseInt(color, 16) << 8) | 0xff), i, c);
             }


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12996.

To test, use the file from QA 11361.  Without this change, the first channel's color should be black; with this change, the channels should be red and green.  This is easiest to see in ImageJ; you'll probably need to open the brightness/contrast window.