### PR TITLE
Leica SCN: do not report more resolutions than there are IFDs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -311,6 +311,10 @@ public class LeicaSCNReader extends BaseTiffReader {
 
     ifds = tiffParser.getIFDs();
 
+    if (ifds.size() < count) {
+      count = ifds.size();
+    }
+
     core.clear();
     int resolution = 0;
     int parent = 0;


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12864.

To test, use the file from QA 11049.  Without this change, ```showinf``` should throw an exception as in the ticket; with this change ```showinf``` should report 3 series (to match ```tiffinfo *.scn | grep -c "TIFF Directory"```), all of which should be viewable with ```showinf```/ImageJ.