### PR TITLE
CZI: fix coordinates of pre-stitched tiles

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -327,7 +327,7 @@ public class ZeissCZIReader extends FormatReader {
               tile.y += (no / getSizeC());
               image.height = scanDim;
             }
-            if (prestitched && realX == getSizeX() && realY == getSizeY()) {
+            if (prestitched != null && prestitched && realX == getSizeX() && realY == getSizeY()) {
               tile.x = 0;
               tile.y = 0;
             }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -327,6 +327,10 @@ public class ZeissCZIReader extends FormatReader {
               tile.y += (no / getSizeC());
               image.height = scanDim;
             }
+            if (prestitched && realX == getSizeX() && realY == getSizeY()) {
+              tile.x = 0;
+              tile.y = 0;
+            }
 
             if (tile.intersects(image)) {
               byte[] rawData = new SubBlock(plane).readPixelData();


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12993.

To test, use the file attached to the thread in the ticket.  Without this change, all 8 series had all 0 pixel values.  With this change, every plane in each series should match what is shown in Zen.  This is probably easiest to test in ImageJ, optionally with the ```Open all series``` and ```Stitch tiles``` options selected.