### PR TITLE
Automated tests: remove SlideBook6Reader class from ImageReader

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1557,7 +1557,7 @@ public class FormatReaderTest {
 
       LOGGER.debug("newFile = {}", newFile);
 
-      IFormatReader check = new FileStitcher();
+      IFormatReader check = new FileStitcher(TestTools.getTestImageReader());
       try {
         check.setId(newFile);
         int nFiles = check.getUsedFiles().length;
@@ -1598,7 +1598,7 @@ public class FormatReaderTest {
       else {
         Arrays.sort(base);
         IFormatReader r =
-          /*config.noStitching() ? new ImageReader() :*/ new FileStitcher();
+          /*config.noStitching() ? TestTools.getTestImageReader() :*/ new FileStitcher(TestTools.getTestImageReader());
 
         int maxFiles = (int) Math.min(base.length, 100);
 
@@ -1842,7 +1842,7 @@ public class FormatReaderTest {
     String msg = null;
     try {
       IFormatReader resolutionReader =
-        new BufferedImageReader(new FileStitcher());
+        new BufferedImageReader(new FileStitcher(TestTools.getTestImageReader()));
       resolutionReader.setFlattenedResolutions(false);
       resolutionReader.setNormalized(true);
       resolutionReader.setOriginalMetadataPopulated(false);
@@ -1988,7 +1988,7 @@ public class FormatReaderTest {
     String msg = null;
     try {
       IFormatReader resolutionReader =
-        new BufferedImageReader(new FileStitcher());
+        new BufferedImageReader(new FileStitcher(TestTools.getTestImageReader()));
       resolutionReader.setFlattenedResolutions(false);
       resolutionReader.setNormalized(true);
       resolutionReader.setOriginalMetadataPopulated(false);
@@ -2340,7 +2340,7 @@ public class FormatReaderTest {
       String tmpdir = System.getProperty("java.io.tmpdir");
       memoDir = new File(tmpdir, System.currentTimeMillis() + ".memo");
       memoDir.mkdir();
-      Memoizer memo = new Memoizer(0, memoDir);
+      Memoizer memo = new Memoizer(TestTools.getTestImageReader(), 0, memoDir);
       memo.setId(reader.getCurrentFile());
       memo.close();
       memoFile = memo.getMemoFile(reader.getCurrentFile());
@@ -2443,11 +2443,8 @@ public class FormatReaderTest {
 
   /** Sets up the current IFormatReader. */
   private void setupReader() {
-    // Remove external SlideBook6Reader class for testing purposes
-    ImageReader ir = new ImageReader();
-    ir.getDefaultReaderClasses().removeClass(SlideBook6Reader.class);
+    ImageReader ir = TestTools.getTestImageReader();
     reader = new BufferedImageReader(new FileStitcher(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File(""))));
-    reader = new BufferedImageReader(new FileStitcher(new Memoizer(Memoizer.DEFAULT_MINIMUM_ELAPSED, new File(""))));
     reader.setMetadataOptions(new DefaultMetadataOptions(MetadataLevel.NO_OVERLAYS));
     reader.setNormalized(true);
     reader.setOriginalMetadataPopulated(false);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2443,6 +2443,10 @@ public class FormatReaderTest {
 
   /** Sets up the current IFormatReader. */
   private void setupReader() {
+    // Remove external SlideBook6Reader class for testing purposes
+    ImageReader ir = new ImageReader();
+    ir.getDefaultReaderClasses().removeClass(SlideBook6Reader.class);
+    reader = new BufferedImageReader(new FileStitcher(new Memoizer(ir, Memoizer.DEFAULT_MINIMUM_ELAPSED, new File(""))));
     reader = new BufferedImageReader(new FileStitcher(new Memoizer(Memoizer.DEFAULT_MINIMUM_ELAPSED, new File(""))));
     reader.setMetadataOptions(new DefaultMetadataOptions(MetadataLevel.NO_OVERLAYS));
     reader.setNormalized(true);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -200,7 +200,7 @@ public class FormatReaderTestFactory {
 
     // remove duplicates
     int index = 0;
-    FileStitcher reader = new FileStitcher();
+    FileStitcher reader = new FileStitcher(TestTools.getTestImageReader());
     while (index < files.size()) {
       String file = (String) files.get(index);
       try {

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -48,6 +48,7 @@ import loci.common.RandomAccessInputStream;
 import loci.formats.IFormatReader;
 import loci.formats.IFormatWriter;
 import loci.formats.ImageReader;
+import loci.formats.in.SlideBook6Reader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -327,7 +328,7 @@ public class TestTools {
       }
     });
 
-    ImageReader typeTester = new ImageReader();
+    ImageReader typeTester = TestTools.getTestImageReader();
 
     for (int i=0; i<subsList.size(); i++) {
       Location file = new Location(subsList.get(i));
@@ -477,5 +478,16 @@ public class TestTools {
     return false;
   }
 
+  /**
+   * Return an ImageReader that is appropriate for testing.
+   * All constructed reader wrappers should use this ImageReader,
+   * as it removes any readers that aren't to be tested.
+   */
+  public static ImageReader getTestImageReader() {
+    // Remove external SlideBook6Reader class for testing purposes
+    ImageReader ir = new ImageReader();
+    ir.getDefaultReaderClasses().removeClass(SlideBook6Reader.class);
+    return ir;
+  }
 
 }


### PR DESCRIPTION
SlideBook6Reader is bundled with Bio-Formats on Windows only and is maintained externally. Until we have a proper API in place allowing reader discovery, this commit should allows to remove it from the list of readers when running automated tests against the data repository.