### PR TITLE
docs: Use urllib conditionally

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -375,10 +375,11 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-
-import urllib
-brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
+linkcheck_ignore = []
 try:
-    linkcheck_ignore = urllib.urlopen(brokenfiles_url).read().splitlines()
+    import urllib
+    brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
+    brokenlinks = urllib.urlopen(brokenfiles_url)
+    linkcheck_ignore.extend(brokenlinks.read().splitlines())
 except IOError:
-    linkcheck_ignore = []
+    print "Could not open list of broken links."


### PR DESCRIPTION
While this shouldn't be encountered in practice (it's a default python2 module?), it was mentioned as a problem by a user on IRC.  This moves the urllib import into the existing try block so that if the import fails, it's not a fatal error.  May also ease future python3 porting, since the docs are likely already buildable directly with a python3 version of sphinx-build.

--------

Testing: Check the jobs are green.