### PR TITLE
Add CZT positions computation for non-hyperstacks

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -358,17 +358,25 @@ public class ROIHandler {
                 t = shapeObject.getTheT().getValue();
               }
               // ImageJ expects 1-based indexing, opposed to 
-              // 0-based indexing in OME  
-              if (images[imageNum].getNChannels() == 1 &&
-              images[imageNum].getNSlices() == 1) {
-                roi.setPosition(t+1);
-              }
-              else {
+              // 0-based indexing in OME
+              // Roi positions differ between hyperstacks and normal stacks
+              ImagePlus imp = images[imageNum];
+              if (imp.isHyperStack()) {
+                // Set position in CZT fashion for hyperstack
                 roi.setPosition(c+1, z+1, t+1);
+              } else {
+                // Number of channels in imp
+                int imageC = images[imageNum].getNChannels();
+                // Number of frames in imp
+                int imageT = images[imageNum].getNSlices();
+                // Determine which dimension is used as position
+                if (imageT > 1) {
+                  roi.setPosition(t+1);
+                } else if (imageC > 1) {
+                  roi.setPosition(t+1);
+                }
               }
-
             }
-            roi.setImage(images[imageNum]);
 
             if (sw == null) {
               roi.setStrokeWidth((float) 1);

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -373,13 +373,14 @@ public class ROIHandler {
               if (c == 0) c = 1;
               if (t == 0) t = 1;
               if (z == 0) z = 1;
-              if (c == 1 && z == 1 && t > 1) {
-                roi.setPosition(0, 0, t);
-              } else if (c == 1 && z > 1 && t == 1) {
-                roi.setPosition(0, z, 0);
-              } else if (c > 1 && z == 1 && t == 1) {
-                roi.setPosition(c, 0, 0);
-              } else {
+              if (imp.getNChannels() == 1 && imp.getNSlices() == 1 && t > 1) {
+                roi.setPosition(t);
+              } else if (imp.getNChannels() == 1 && z > 1 && imp.getNFrames() == 1) {
+                roi.setPosition(z);
+              } else if (c > 1 && imp.getNSlices() == 1 && imp.getNFrames() == 1) {
+                roi.setPosition(c);
+              } else if (imp.getNChannels() > 1 && imp.getNSlices() > 1
+                    && imp.getNFrames() > 1) {
                 roi.setPosition(c, z, t);
               }
             }

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -379,8 +379,7 @@ public class ROIHandler {
                 roi.setPosition(z);
               } else if (imp.getNSlices() == 1 && imp.getNFrames() == 1) {
                 roi.setPosition(c);
-              } else if (imp.getNChannels() > 1 && imp.getNSlices() > 1
-                    && imp.getNFrames() > 1) {
+              } else if (imp.isHyperStack()) {
                 roi.setPosition(c, z, t);
               }
             }

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -374,7 +374,15 @@ public class ROIHandler {
               if (c == 0) c = 1;
               if (t == 0) t = 1;
               if (z == 0) z = 1;
-              roi.setPosition(c, z, t);
+              if (c == 1 && z == 1 && t > 1) {
+                roi.setPosition(t);
+              } else if (c == 1 && z > 1 && t == 1) {
+                roi.setPosition(z);
+              } else if (c > 1 && z == 1 && t == 1) {
+                roi.setPosition(c);
+              } else {
+                roi.setPosition(c, z, t);
+              }
             }
 
             if (sw == null) {

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -367,7 +367,6 @@ public class ROIHandler {
               if (imp.getNSlices() > 1) {
                 z++;
               }
-              
               if (imp.getNFrames() > 1) {
                 t++;
               }

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -374,11 +374,11 @@ public class ROIHandler {
               if (t == 0) t = 1;
               if (z == 0) z = 1;
               if (c == 1 && z == 1 && t > 1) {
-                roi.setPosition(t);
+                roi.setPosition(0, 0, t);
               } else if (c == 1 && z > 1 && t == 1) {
-                roi.setPosition(z);
+                roi.setPosition(0, z, 0);
               } else if (c > 1 && z == 1 && t == 1) {
-                roi.setPosition(c);
+                roi.setPosition(c, 0, 0);
               } else {
                 roi.setPosition(c, z, t);
               }

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -361,21 +361,20 @@ public class ROIHandler {
               // 0-based indexing in OME
               // Roi positions differ between hyperstacks and normal stacks
               ImagePlus imp = images[imageNum];
-              if (imp.isHyperStack()) {
-                // Set position in CZT fashion for hyperstack
-                roi.setPosition(c+1, z+1, t+1);
-              } else {
-                // Number of channels in imp
-                int imageC = images[imageNum].getNChannels();
-                // Number of frames in imp
-                int imageT = images[imageNum].getNSlices();
-                // Determine which dimension is used as position
-                if (imageT > 1) {
-                  roi.setPosition(t+1);
-                } else if (imageC > 1) {
-                  roi.setPosition(t+1);
-                }
+              if (imp.getNChannels() > 1) {
+                c++;
               }
+              if (imp.getNSlices() > 1) {
+                z++;
+              }
+              
+              if (imp.getNFrames() > 1) {
+                t++;
+              }
+              if (c == 0) c = 1;
+              if (t == 0) t = 1;
+              if (z == 0) z = 1;
+              roi.setPosition(c, z, t);
             }
 
             if (sw == null) {

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -373,11 +373,11 @@ public class ROIHandler {
               if (c == 0) c = 1;
               if (t == 0) t = 1;
               if (z == 0) z = 1;
-              if (imp.getNChannels() == 1 && imp.getNSlices() == 1 && t > 1) {
+              if (imp.getNChannels() == 1 && imp.getNSlices() == 1) {
                 roi.setPosition(t);
-              } else if (imp.getNChannels() == 1 && z > 1 && imp.getNFrames() == 1) {
+              } else if (imp.getNChannels() == 1 && imp.getNFrames() == 1) {
                 roi.setPosition(z);
-              } else if (c > 1 && imp.getNSlices() == 1 && imp.getNFrames() == 1) {
+              } else if (imp.getNSlices() == 1 && imp.getNFrames() == 1) {
                 roi.setPosition(c);
               } else if (imp.getNChannels() > 1 && imp.getNSlices() > 1
                     && imp.getNFrames() > 1) {


### PR DESCRIPTION
replace gh-1934

This fix is related to https://github.com/openmicroscopy/openmicroscopy/pull/4045

It improves the heuristic for finding out, whether to call `roi.setPosition(int)` or `roi.setPosition(int, int, int)` based on the dimensionality of the image that the ROI is associated with.

cc @stelfrich

Make sure that this change does not affect the other scenarios