### PR TITLE
Incorrect VoxelSize in MetaMorph Reader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -802,9 +803,11 @@ public class MetamorphReader extends BaseTiffReader {
           }
         } 
         if (uniqueZ.size() > 1 && uniqueZ.size() == getSizeZ()) {
-          Double zRange = uniqueZ.get(uniqueZ.size() - 1) - uniqueZ.get(0);
-          stepSize = Math.abs(zRange);
-          stepSize /= (getSizeZ() - 1);
+          BigDecimal lastZ = BigDecimal.valueOf(uniqueZ.get(uniqueZ.size() - 1));
+          BigDecimal firstZ = BigDecimal.valueOf(uniqueZ.get(0));
+          BigDecimal zRange = (lastZ.subtract(firstZ)).abs();
+          BigDecimal zSize = BigDecimal.valueOf((double)(getSizeZ() - 1));
+          stepSize = zRange.divide(zSize).doubleValue();
         }
       }
       

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -800,16 +800,11 @@ public class MetamorphReader extends BaseTiffReader {
           for (Double z : zPositions) {
             if (!uniqueZ.contains(z)) uniqueZ.add(z);
           }
-        }
-        if (uniqueZ.size() > 1) {
-          CoreMetadata ms0 = core.get(0);   
-          if (getSizeZ() == 0) ms0.sizeZ = 1;
-        
+        } 
+        if (uniqueZ.size() > 1 && uniqueZ.size() == getSizeZ()) {
           Double zRange = uniqueZ.get(uniqueZ.size() - 1) - uniqueZ.get(0);
           stepSize = Math.abs(zRange);
-          if (ms0.sizeZ > 1) {
-            stepSize /= (ms0.sizeZ - 1);
-          }
+          stepSize /= (getSizeZ() - 1);
         }
       }
       

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -778,6 +778,32 @@ public class MetamorphReader extends BaseTiffReader {
       if (zDistances != null) {
         stepSize = zDistances[0];
       }
+      else {
+        Vector<Double> zPositions = new Vector<Double>();
+        Vector<Double> uniqueZ = new Vector<Double>();
+    	  
+        for (IFD ifd : ifds) {
+          String xml = XMLTools.sanitizeXML(ifd.getComment());
+          XMLTools.parseXML(xml, handler);
+
+          zPositions = handler.getZPositions();
+          for (Double z : zPositions) {
+            if (!uniqueZ.contains(z)) uniqueZ.add(z);
+          }
+        }
+        
+        if (uniqueZ.size() > 0) {
+          CoreMetadata ms0 = core.get(0);   
+          if (getSizeZ() == 0) ms0.sizeZ = 1;
+    	  
+          Double zRange = zPositions.get(zPositions.size() - 1) - zPositions.get(0);
+          stepSize = Math.abs(zRange);
+          if (ms0.sizeZ > 1) {
+            stepSize /= (ms0.sizeZ - 1);
+          }
+        }
+      }
+      
       Length physicalSizeZ = FormatTools.getPhysicalSizeZ(stepSize);
       if (physicalSizeZ != null) {
         store.setPixelsPhysicalSizeZ(physicalSizeZ, i);


### PR DESCRIPTION
To fix the physical Z size, the difference between the absolute Z
positions will need to be used.
MetaMorph handler already parses the z positions. The physical z size is
then calculated by subtracting the top and bottom values and dividing by
the number of steps.

Ticket details below:
https://trac.openmicroscopy.org/ome/ticket/12977

Splitting from https://github.com/openmicroscopy/bioformats/pull/1964