### PR TITLE
ImageJ plugin - Group files Exception 

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -492,7 +492,7 @@ public class ImportProcess implements StatusReporter {
 
     BF.status(options.isQuiet(), "Analyzing " + getIdName());
     baseReader.setMetadataFiltered(true);
-    baseReader.setGroupFiles(options.isGroupFiles());
+    baseReader.setGroupFiles(!options.isUngroupFiles() || options.isGroupFiles());
     if(options != null && !options.showROIs()){
         MetadataOptions mo = baseReader.getMetadataOptions();
         if(mo == null){

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -492,7 +492,7 @@ public class ImportProcess implements StatusReporter {
 
     BF.status(options.isQuiet(), "Analyzing " + getIdName());
     baseReader.setMetadataFiltered(true);
-    baseReader.setGroupFiles(!options.isUngroupFiles());
+    baseReader.setGroupFiles(options.isGroupFiles());
     if(options != null && !options.showROIs()){
         MetadataOptions mo = baseReader.getMetadataOptions();
         if(mo == null){
@@ -504,6 +504,8 @@ public class ImportProcess implements StatusReporter {
     }
     baseReader.setId(options.getId());
     
+    boolean mustGroup = baseReader.fileGroupOption(options.getId()) == FormatTools.MUST_GROUP;
+    options.setMustGroup(mustGroup);
   }
 
   /** Performed following ImportStep.STACK notification. */
@@ -515,7 +517,7 @@ public class ImportProcess implements StatusReporter {
 
       // overwrite base filename with file pattern
       String id = options.getId();
-      options.setId(id);
+      fileStitcher.setId(id);
       fileStitcher.setUsingPatternIds(true);
       fileStitcher.setCanChangePattern(false);
     }

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
@@ -77,7 +77,8 @@ public class ImporterOptions extends OptionsList {
   public static final String KEY_VIRTUAL         = "virtual";
   public static final String KEY_WINDOWLESS      = "windowless";
   public static final String KEY_STITCH_TILES    = "stitchTiles";
-
+  public static final String KEY_MUST_GROUP    	 = "mustGroup";
+  
   // possible values for colorMode
   public static final String COLOR_MODE_DEFAULT = "Default";
   public static final String COLOR_MODE_COMPOSITE = "Composite";
@@ -396,6 +397,11 @@ public class ImporterOptions extends OptionsList {
   public boolean doStitchTiles() { return isSet(KEY_STITCH_TILES); }
   public void setStitchTiles(boolean b) { setValue(KEY_STITCH_TILES, b); }
 
+  // mustGroup
+  public String getMustGroupInfo() { return getInfo(KEY_MUST_GROUP); }
+  public boolean doMustGroup() { return isSet(KEY_MUST_GROUP); }
+  public void setMustGroup(boolean b) { setValue(KEY_MUST_GROUP, b); }
+  
   // -- ImporterOptions methods - secondary options accessors and mutators --
 
   // series options

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
@@ -82,8 +82,8 @@ public class ImporterPrompter implements StatusListener {
         ImporterOptions options = process.getOptions();
         if (options != null && options.doMustGroup() && options.isGroupFiles()) {
           IJ.showMessage("Bio-Formats",
-    				 "Image specifications state that files of this given format cannot be handled separately "
-    				 + "and must be grouped according to supporting metadata\n");
+    				 "File Stitiching Options are not available for files of this format. "
+    				 + "Files will be grouped according to image format specifications\n");
         }
         else if (!promptFilePattern()) process.cancel();
         break;

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
@@ -80,7 +80,7 @@ public class ImporterPrompter implements StatusListener {
         break;
       case STACK:
         ImporterOptions options = process.getOptions();
-        if (options != null && options.doMustGroup()) {
+        if (options != null && options.doMustGroup() && options.isGroupFiles()) {
           IJ.showMessage("Bio-Formats",
     				 "Image specifications state that files of this given format cannot be handled separately "
     				 + "and must be grouped according to supporting metadata\n");

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
@@ -83,7 +83,7 @@ public class ImporterPrompter implements StatusListener {
         if (options != null && options.doMustGroup() && options.isGroupFiles()) {
           IJ.showMessage("Bio-Formats",
     				 "File Stitching Options are not available for files of this format.\n"
-    				 + "Files will be grouped according to image format specifications\n");
+    				 + "Files will be grouped according to image format specifications.\n");
         }
         else if (!promptFilePattern()) process.cancel();
         break;

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
@@ -82,7 +82,7 @@ public class ImporterPrompter implements StatusListener {
         ImporterOptions options = process.getOptions();
         if (options != null && options.doMustGroup() && options.isGroupFiles()) {
           IJ.showMessage("Bio-Formats",
-    				 "File Stitiching Options are not available for files of this format. "
+    				 "File Stitching Options are not available for files of this format.\n"
     				 + "Files will be grouped according to image format specifications\n");
         }
         else if (!promptFilePattern()) process.cancel();

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterPrompter.java
@@ -27,6 +27,7 @@
 
 package loci.plugins.in;
 
+import ij.IJ;
 import loci.common.StatusEvent;
 import loci.common.StatusListener;
 import loci.plugins.BF;
@@ -78,7 +79,13 @@ public class ImporterPrompter implements StatusListener {
         if (!promptMain()) process.cancel();
         break;
       case STACK:
-        if (!promptFilePattern()) process.cancel();
+        ImporterOptions options = process.getOptions();
+        if (options != null && options.doMustGroup()) {
+          IJ.showMessage("Bio-Formats",
+    				 "Image specifications state that files of this given format cannot be handled separately "
+    				 + "and must be grouped according to supporting metadata\n");
+        }
+        else if (!promptFilePattern()) process.cancel();
         break;
       case SERIES:
         if (!promptSeries()) process.cancel();

--- a/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
+++ b/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
@@ -339,3 +339,8 @@ default = false
 type = boolean
 label = windowless
 default = false
+
+[mustGroup]
+type = boolean
+label = mustGroup
+default = false


### PR DESCRIPTION
ImageJ plugin - Exception when both 'group files' and 'open individually' options selected

A test case and steps to reproduce are linked from the ticket.
https://trac.openmicroscopy.org/ome/ticket/12941

Splitting from https://github.com/openmicroscopy/bioformats/pull/1964

Issues included:
- IndexOutOfBoundsException when both options selected in Main Dialog
- For certain file formats the regular expression and 'file contains'
file patterns were not being implied
- Entering incorrect values into the Dimensions setting of the
FilePatternDialog resulted in a 'File is not of a supported format'
error

Solution:
- IndexOutOfBoundsException resolved in ImportProcess by reading the
group files option. When both options are selected then group files is
not automatically the inverse of ungroup files
- For file formats that have a fileGroupOption of FormatTools.MUST_GROUP
the second FilePatternDialog is skipped and replaced with an ImageJ
message box informing the user why file pattern options are not
available, stating "Image specifications state that files of this given
format cannot be handled separately and must be grouped according to
supporting metadata". A new importer option flag was added to test and
store the must group condition