### PR TITLE
Container travis with findbugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jdk:
 env:
   - BUILD=maven_findbugs
   - BUILD=cppwrap
-  - BUILD=sphinx
+  - BUILD=sphinx_html
   - BUILD=ant
 
 matrix:
@@ -33,10 +33,10 @@ matrix:
     - env: "BUILD=cppwrap"
 
 before_install:
-  - if [[ $BUILD == 'sphinx' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
+  - if [[ $BUILD == 'sphinx_html' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
 
 install:
-  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx' ]]; then git fetch --tags; fi
+  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx_html' ]]; then git fetch --tags; fi
   - if [[ $BUILD == 'maven_findbugs' ]]; then mvn install -DskipTests=true; fi
 
 script:
@@ -45,9 +45,9 @@ script:
 matrix:
   exclude:
     - jdk: openjdk6
-      env: BUILD=sphinx
+      env: BUILD=sphinx_html
     - jdk: oraclejdk7
-      env: BUILD=sphinx
+      env: BUILD=sphinx_html
     - jdk: oraclejdk7
       env: BUILD=cppwrap
     - jdk: openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       env: BUILD=sphinx_html
     - jdk: oraclejdk7
       env: BUILD=sphinx_html
-    - jdk: oraclejdk7
+    - jdk: oraclejdk8
       env: BUILD=cppwrap
     - jdk: openjdk6
       env: BUILD=cppwrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,31 @@
 language: java
 
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
+cache:
+  directories:
+  - $HOME/.m2
+
+addons:
+  apt_packages:
+    - git
+    - cmake
+    - build-essential
+
 jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk6
 
 env:
-  - BUILD=maven
-  - BUILD=cpp
+  - BUILD=maven_findbugs
   - BUILD=cppwrap
-  - BUILD=flake8
   - BUILD=sphinx
   - BUILD=ant
-  - BUILD=findbugs
 
 matrix:
   fast_finish: true
@@ -20,23 +33,11 @@ matrix:
     - env: "BUILD=cppwrap"
 
 before_install:
-  - if [[ $BUILD == 'cpp' ]]; then sudo add-apt-repository -y ppa:kubuntu-ppa/backports; fi
-  - if [[ $BUILD == 'cpp' ]]; then sudo apt-get -qq update; fi
-  - if [[ $BUILD == 'cpp' ]] || [[ $BUILD == 'cppwrap' ]]; then sudo apt-get install -qq cmake; fi
-  - if [[ $BUILD == 'sphinx' ]]; then sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"; fi
-  - if [[ $BUILD == 'cpp' ]]; then sudo add-apt-repository -y ppa:dhor/myway; fi
-  - sudo apt-get -qq update
-  - if [[ $BUILD != 'sphinx' ]]; then sudo apt-get install -qq python-genshi; fi
-  - if [[ $BUILD == 'cpp' ]] || [[ $BUILD == 'cppwrap' ]]; then sudo apt-get install -qq build-essential libboost1.48-all-dev; fi
-  - if [[ $BUILD == 'cpp' ]]; then sudo apt-get install -qq libgtest-dev libxerces-c-dev libtiff4-dev doxygen graphviz graphicsmagick; fi
-  - if [[ $BUILD == 'sphinx' ]] || [[ $BUILD == 'flake8' ]]; then sudo pip install flake8 Sphinx==1.2.3; fi
-  - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex; fi
-  - if [[ $BUILD == 'sphinx' ]]; then sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre; fi
-  - if [[ $BUILD == 'sphinx' ]]; then sudo fc-cache -rsfv; fi
+  - if [[ $BUILD == 'sphinx' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
 
 install:
-  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx' ]] && [[ $BUILD != 'flake8' ]]; then git fetch --tags; fi
-  - if [[ $BUILD == 'maven' ]]; then mvn install -DskipTests=true; fi
+  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx' ]]; then git fetch --tags; fi
+  - if [[ $BUILD == 'maven_findbugs' ]]; then mvn install -DskipTests=true; fi
 
 script:
   - ./tools/test-build $BUILD
@@ -44,18 +45,10 @@ script:
 matrix:
   exclude:
     - jdk: openjdk6
-      env: BUILD=flake8
-    - jdk: oraclejdk7
-      env: BUILD=flake8
-    - jdk: openjdk6
       env: BUILD=sphinx
     - jdk: oraclejdk7
       env: BUILD=sphinx
-    - jdk: openjdk6
-      env: BUILD=cpp
     - jdk: oraclejdk7
-      env: BUILD=cpp
-    - jdk: oraclejdk8
       env: BUILD=cppwrap
     - jdk: openjdk6
       env: BUILD=cppwrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - BUILD=flake8
   - BUILD=sphinx
   - BUILD=ant
+  - BUILD=findbugs
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jdk:
 
 env:
   - BUILD=maven_findbugs
+  - BUILD=maven
   - BUILD=cppwrap
   - BUILD=sphinx_html
   - BUILD=ant
@@ -52,3 +53,9 @@ matrix:
       env: BUILD=cppwrap
     - jdk: openjdk6
       env: BUILD=cppwrap
+    - jdk: openjdk6
+      env: BUILD=maven_findbugs
+    - jdk: oraclejdk7
+      env: BUILD=maven
+    - jdk: oraclejdk8
+      env: BUILD=maven

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - git
     - cmake
     - build-essential
+    - libboost-all-dev
 
 jdk:
   - oraclejdk8

--- a/tools/test-build
+++ b/tools/test-build
@@ -75,6 +75,14 @@ sphinx()
     )
 }
 
+sphinx_html()
+{
+    (
+        cd docs/sphinx
+        ant -Dsphinx.warnopts=$SPHINXOPTS html
+     )
+ }
+
 # Test Ant build targets
 antbuild()
 {
@@ -117,6 +125,8 @@ do
             flake ;;
         sphinx)
             sphinx ;;
+        sphinx_html)
+            sphinx_html ;;
         ant)
             antbuild ;;
         all)

--- a/tools/test-build
+++ b/tools/test-build
@@ -107,6 +107,8 @@ do
             clean ;;
         maven)
             maven ;;
+        maven_findbugs)
+            maven_findbugs ;;
         cpp)
             cpp ;;
         cppwrap)
@@ -117,8 +119,6 @@ do
             sphinx ;;
         ant)
             antbuild ;;
-        findbugs)
-            maven_findbugs ;;
         all)
             clean && maven_findbugs && cppwrap && sphinx && antbuild;;
         *)

--- a/tools/test-build
+++ b/tools/test-build
@@ -18,6 +18,11 @@ maven()
     clean
 }
 
+findbugs()
+{
+    mvn findbugs:findbugs -Dfindbugs.threshold=medium
+}
+
 cpp()
 {
     (
@@ -113,8 +118,10 @@ do
             sphinx ;;
         ant)
             antbuild ;;
+        findbugs)
+            findbugs ;;
         all)
-            clean && maven && cppwrap && sphinx && antbuild;;
+            clean && maven && findbugs && cppwrap && sphinx && antbuild;;
         *)
             echo "Invalid argument: \"$arg\"" >&2
             exit 1

--- a/tools/test-build
+++ b/tools/test-build
@@ -15,10 +15,9 @@ clean()
 maven()
 {
     mvn
-    clean
 }
 
-findbugs()
+maven_findbugs()
 {
     mvn findbugs:findbugs -Dfindbugs.threshold=medium
 }
@@ -119,9 +118,9 @@ do
         ant)
             antbuild ;;
         findbugs)
-            findbugs ;;
+            maven_findbugs ;;
         all)
-            clean && maven && findbugs && cppwrap && sphinx && antbuild;;
+            clean && maven_findbugs && cppwrap && sphinx && antbuild;;
         *)
             echo "Invalid argument: \"$arg\"" >&2
             exit 1


### PR DESCRIPTION
gh-1965 was merged into the daily build and had priority HIGH
findbugs warnings. If findbugs had been activated in travis,
the build status wouldn't have allowed merging.

A possible next step would be to activate findbugs on every
compile.

**Note:** in order to speed up travis (after slowing it down with
findbugs), the `cpp` and and the `sphinx (pdf)` targets have been
removed. This permitted a move to the container-based travis
builds. These removed components are currently being tested by
jenkins.

See: https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-5.1-merge-build/1009/findbugsResult/