### PR TITLE
Change the install path of cmake specific config files

### DIFF
--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -189,7 +189,7 @@ set(LIBRARY_HEADER ome/bioformats/CoreMetadata.h)
 configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateConfig.cmake.in
                ${CMAKE_CURRENT_BINARY_DIR}/ome-bioformats-config.cmake)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ome-bioformats-config.cmake
-        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake)
+        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/ome-bioformats)
 
 # Dump header list for testing
 header_include_list_write(BIOFORMATS_STATIC_HEADERS BIOFORMATS_GENERATED_HEADERS ome/bioformats ${PROJECT_BINARY_DIR}/cpp/test/ome-bioformats)

--- a/cpp/lib/ome/qtwidgets/CMakeLists.txt
+++ b/cpp/lib/ome/qtwidgets/CMakeLists.txt
@@ -138,7 +138,7 @@ if (OME_QTOPENGL)
   configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateConfig.cmake.in
                  ${CMAKE_CURRENT_BINARY_DIR}/ome-qtwidgets-config.cmake)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ome-qtwidgets-config.cmake
-          DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake)
+          DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/ome-qtwidgets)
 
   # Dump header list for testing
   header_include_list_write(QTWIDGETS_HEADERS "" ome/qtwidgets ${PROJECT_BINARY_DIR}/cpp/test/ome-qtwidgets)

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -170,7 +170,7 @@ set(LIBRARY_HEADER ome/xml/model/OME.h)
 configure_file(${PROJECT_SOURCE_DIR}/cpp/cmake/TemplateConfig.cmake.in
                ${CMAKE_CURRENT_BINARY_DIR}/ome-xml-config.cmake)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ome-xml-config.cmake
-        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake)
+        DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/ome-xml)
 
 # Dump header list for testing
 header_include_list_write(OME_XML_PUBLIC_STATIC_HEADERS


### PR DESCRIPTION
to follow the general practice

I'm currently packaging the bioformats c++ libraries for my arch linux system and came across this. joshmoore (from the #ome IRC channel) said creating a pull request to get comments on this should be ok.
Some projects like to add a version number to the directory in the cmake dir. I hope that just using ome is ok.