### PR TITLE
Fix babel include for upcomming sphinx 1.3.2

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -292,7 +292,7 @@ latex_elements = {
     'utf8extra': '%% Unused',
     'fontenc' : '%% Unused',
     'fontpkg': '%% Unused',
-    'babel': '%% Unused',
+    'babel': '',
     'printindex': '''\\phantomsection
 \\addcontentsline{toc}{part}{\indexname}
 \\printindex''',


### PR DESCRIPTION
With the current sphinx version 1.3.1 the pdf creation fails with a
undefined control sequence error. This bug is allready fixed upstream
but is not released yet. See: https://github.com/sphinx-doc/sphinx/issues/1923

The fix will require to define babel as an empty string, this is what
this commit is for.