### PR TITLE
cpp: ome-xml: Correct Boost.Format use for Boost 1.59

### DIFF
--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -244,7 +244,7 @@ namespace ome
                   ome::common::Logger logger = ome::common::createLogger("${klass.langType}");
                   format fmt("Unsupported %1% value of ‘%2%’ will be stored as “Other”");
                   fmt % "${klass.langType}" % name;
-                  BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt;
+                  BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
                   i = string_map.find("Other");
                 }
               else
@@ -252,7 +252,7 @@ namespace ome
                   ome::common::Logger logger = ome::common::createLogger("${klass.langType}");
                   format fmt("Unsupported %1% value of ‘%2%’ will be stored as “%3%”");
                   fmt % "${klass.langType}" % name % ${klass.langType}(li->second);
-                  BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt;
+                  BOOST_LOG_SEV(logger, ome::logging::trivial::warning) << fmt.str();
                 }
 {% end %}\
             }


### PR DESCRIPTION
The `.str()` method of `boost::format` is now required; the format object does not provide a stream operator.

This is a tiny tweak to allow building with the newly-released Boost 1.59.  It will continue to work with older Boost versions.  Boost 1.59 will be coming to homebrew shortly, and Linux distributions over the next few months, so it's important to be able to continue to build on them.

Testing:
Testing with older versions will occur via the non-superbuild CI builds:
- https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp/
Testing with Boost 1.59 will occur with a PR to update the superbuild to use Boost 1.59.
- https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp-superbuild/
- https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-merge-cpp-superbuild-win/