### PR TITLE
Disable travis on regions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+branches:
+  except:
+    - regions
+
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/


### PR DESCRIPTION
Due to the requirement for having schema files and
similar deployed for testing, travis is being disabled
on this branch.