### PR TITLE
Add PlaneRegion.h to CMakeLists.txt

### DIFF
--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -73,6 +73,7 @@ set(OME_BIOFORMATS_HEADERS
     Modulo.h
     PixelBuffer.h
     PixelProperties.h
+    PlaneRegion.h
     TileBuffer.h
     TileCache.h
     TileCoverage.h


### PR DESCRIPTION
The PlaneRegion.h header file was missing in the CMakeList.txt which
caused the file not to be installed via make install. Wich in turn
resulted in "No such file or directory" compiler errors if one tried to
use the installed libraries.