### PR TITLE
Use netcdf.version variable

### DIFF
--- a/ant/global.properties
+++ b/ant/global.properties
@@ -26,3 +26,4 @@ objenesis.version = 2.1
 minlog.version = 1.2
 testng.version = 6.8
 guava.version = 17.0
+netcdf.version = 4.3.19

--- a/ant/toplevel.properties
+++ b/ant/toplevel.properties
@@ -18,7 +18,7 @@ merged-docs.classpath = ${lib.dir}/jgoodies-forms-1.7.2.jar:\
                         ${lib.dir}/logback-classic-${logback.version}.jar:\
                         ${lib.dir}/logback-core-${logback.version}.jar:\
                         ${lib.dir}/native-lib-loader-2.0.2.jar:\
-                        ${lib.dir}/netcdf-4.3.19.jar:\
+                        ${lib.dir}/netcdf-${netcdf.version}.jar:\
                         ${lib.dir}/jhdf5-13.06.2.jar:\
                         ${lib.dir}/omero_client.jar:\
                         ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
@@ -71,7 +71,7 @@ package.libraries = formats-api.jar \
                   mdbtools-java.jar \
                   metakit.jar \
                   native-lib-loader-2.0.2.jar \
-                  netcdf-4.3.19.jar \
+                  netcdf-${netcdf.version}.jar \
                   jhdf5-13.06.2.jar \
                   ome-xml.jar \
                   perf4j-0.9.13.jar \
@@ -110,7 +110,7 @@ loci-tools.libraries = formats-api.jar \
                        mdbtools-java.jar \
                        metakit.jar \
                        native-lib-loader-2.0.2.jar \
-                       netcdf-4.3.19.jar \
+                       netcdf-${netcdf.version}.jar \
                        jhdf5-13.06.2.jar \
                        ome-jxr.jar \
                        ome-xml.jar \

--- a/components/formats-bsd/build.properties
+++ b/components/formats-bsd/build.properties
@@ -55,7 +55,7 @@ component.cp.no-xml      = ${artifact.dir}/jai_imageio.jar:\
                            ${artifact.dir}/ome-poi.jar:\
                            ${lib.dir}/jgoodies-common-1.7.0.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
-                           ${lib.dir}/netcdf-4.3.19.jar:\
+                           ${lib.dir}/netcdf-${netcdf.version}.jar:\
                            ${lib.dir}/metadata-extractor-2.6.2.jar:\
                            ${lib.dir}/xmpcore-5.1.2.jar:\
                            ${lib.dir}/xercesImpl-2.8.1.jar:\

--- a/components/formats-gpl/build.properties
+++ b/components/formats-gpl/build.properties
@@ -20,7 +20,7 @@ component.classpath      = ${artifact.dir}/formats-common.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
                            ${lib.dir}/joda-time-2.2.jar:\
                            ${lib.dir}/kryo-${kryo.version}.jar:\
-                           ${lib.dir}/netcdf-4.3.19.jar:\
+                           ${lib.dir}/netcdf-${netcdf.version}.jar:\
                            ${lib.dir}/jhdf5-13.06.2.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar:\
@@ -46,7 +46,7 @@ component.cp.no-mdb      = ${artifact.dir}/metakit.jar:\
                            ${artifact.dir}/formats-bsd.jar:\
                            ${lib.dir}/jgoodies-common-1.7.0.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
-                           ${lib.dir}/netcdf-4.3.19.jar:\
+                           ${lib.dir}/netcdf-${netcdf.version}.jar:\
                            ${lib.dir}/jhdf5-13.06.2.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
@@ -58,12 +58,12 @@ component.cp.no-poi      = ${artifact.dir}/mdbtools-java.jar:\
                            ${artifact.dir}/formats-bsd.jar:\
                            ${lib.dir}/jgoodies-common-1.7.0.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
-                           ${lib.dir}/netcdf-4.3.19.jar:\
+                           ${lib.dir}/netcdf-${netcdf.version}.jar:\
                            ${lib.dir}/jhdf5-13.06.2.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar
 
-# Used by TestNG suite that tests the absence of class from netcdf-4.3.19.jar
+# Used by TestNG suite that tests the absence of class from netcdf-${netcdf.version}.jar
 component.cp.no-netcdf   = ${artifact.dir}/mdbtools-java.jar:\
                            ${artifact.dir}/metakit.jar:\
                            ${artifact.dir}/ome-xml.jar:\
@@ -85,7 +85,7 @@ component.cp.no-jhdf     = ${artifact.dir}/formats-common.jar:\
                            ${lib.dir}/jgoodies-forms-1.7.2.jar:\
                            ${lib.dir}/joda-time-2.2.jar:\
                            ${lib.dir}/kryo-${kryo.version}.jar:\
-                           ${lib.dir}/netcdf-4.3.19.jar:\
+                           ${lib.dir}/netcdf-${netcdf.version}.jar:\
                            ${lib.dir}/slf4j-api-${slf4j.version}.jar:\
                            ${lib.dir}/testng-${testng.version}.jar:\
                            ${lib.dir}/JWlz-1.4.0.jar

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>netcdf</artifactId>
-      <version>4.3.19</version>
+      <version>${netcdf.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>2.24.0</kryo.version>
+    <netcdf.version>4.3.19</netcdf.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
 


### PR DESCRIPTION
See https://trello.com/c/srr1vUFa/22-update-netcdf-dependency

This PR bumps the netcdf dependency to 4.3.22 (should still be Java 6 compatible) and uses a version parameter to simplify further updates.