### PR TITLE
Make the About Bio-Formats dialog less wide

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/About.java
+++ b/components/bio-formats-plugins/src/loci/plugins/About.java
@@ -65,8 +65,10 @@ public final class About implements PlugIn {
 
   public static void about() {
     String msg = "<html>" +
-      "Bio-Formats Plugins for ImageJ, revision " + FormatTools.VCS_REVISION +
-      ", built " + FormatTools.DATE + "<br>Release: " + FormatTools.VERSION +
+      "Bio-Formats Plugins for ImageJ" +
+      "<br>Revision: " + FormatTools.VCS_REVISION +
+      "<br>Build date: " + FormatTools.DATE +
+      "<br>Release: " + FormatTools.VERSION +
       "<br>Copyright (C) 2005 - " + FormatTools.YEAR +
       " Open Microscopy Environment:" +
       "<ul>" +


### PR DESCRIPTION
## PR scope
The scope of the PR is limited to cosmetic appearance of a dialog box.

## Testing instructions
* Place the new `bio-formats_plugins.jar` in an ImageJ installation.
* Run Help &#9654; About Plugins &#9654; Bio-Formats Plugins...
* Verify that the dialog is less wide than before, since the 40-character commit hash is now on its own line.