### PR TITLE
Allow fake plates to have multiple screens, including none.

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -901,7 +901,7 @@ public class FakeReader extends FormatReader {
     if (screens==0) {
       ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs);
     } else {
-      ome = xml.createPopulatedScreen(plates, rows, cols, fields, acqs);
+      ome = xml.createPopulatedScreen(screens, plates, rows, cols, fields, acqs);
     }
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     // copy populated SPW metadata into destination MetadataStore

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -93,7 +93,7 @@ import ome.units.UNITS;
  *  <li>showinf '32bit-floating&amp;pixelType=float&amp;sizeZ=3&amp;sizeC=5&amp;sizeT=7&amp;sizeY=50.fake'</li>
  *  <li>showinf '64bit-floating&amp;pixelType=double&amp;sizeZ=3&amp;sizeC=5&amp;sizeT=7&amp;sizeY=50.fake'</li>
  *  <li>showinf 'SPW&amp;plates=2&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
- *  <li>showinf 'Plate&amp;screen=0&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
+ *  <li>showinf 'Plate&amp;screens=0&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
  * </ul></p>
  */
 public class FakeReader extends FormatReader {
@@ -430,7 +430,7 @@ public class FakeReader extends FormatReader {
 
     String acquisitionDate = null;
 
-    int screen = 1;
+    int screens = 1;
     int plates = 0;
     int plateRows = 0;
     int plateCols = 0;
@@ -534,7 +534,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("scaleFactor")) scaleFactor = doubleValue;
       else if (key.equals("exposureTime")) exposureTime = new Time((float) doubleValue, UNITS.S);
       else if (key.equals("acquisitionDate")) acquisitionDate = value;
-      else if (key.equals("screen")) screen = intValue;
+      else if (key.equals("screens")) screens = intValue;
       else if (key.equals("plates")) plates = intValue;
       else if (key.equals("plateRows")) plateRows = intValue;
       else if (key.equals("plateCols")) plateCols = intValue;
@@ -602,7 +602,7 @@ public class FakeReader extends FormatReader {
     if (hasSPW) {
       // generate SPW metadata and override series count to match
       int imageCount =
-        populateSPW(store, screen, plates, plateRows, plateCols, fields, plateAcqs);
+        populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs);
       if (imageCount > 0) seriesCount = imageCount;
       else hasSPW = false; // failed to generate SPW metadata
     }
@@ -893,12 +893,12 @@ public class FakeReader extends FormatReader {
     return !listFakeSeries(path).get(0).equals(path);
   }
 
-  private int populateSPW(MetadataStore store, int screen, int plates, int rows, int cols,
+  private int populateSPW(MetadataStore store, int screens, int plates, int rows, int cols,
     int fields, int acqs)
   {
     final XMLMockObjects xml = new XMLMockObjects();
     OME ome = null;
-    if (screen==0) {
+    if (screens==0) {
       ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs);
     } else {
       ome = xml.createPopulatedScreen(plates, rows, cols, fields, acqs);

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -93,6 +93,7 @@ import ome.units.UNITS;
  *  <li>showinf '32bit-floating&amp;pixelType=float&amp;sizeZ=3&amp;sizeC=5&amp;sizeT=7&amp;sizeY=50.fake'</li>
  *  <li>showinf '64bit-floating&amp;pixelType=double&amp;sizeZ=3&amp;sizeC=5&amp;sizeT=7&amp;sizeY=50.fake'</li>
  *  <li>showinf 'SPW&amp;plates=2&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
+ *  <li>showinf 'SPW&amp;screens=2&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=1&amp;plateAcqs=1.fake'</li>
  *  <li>showinf 'Plate&amp;screens=0&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
  * </ul></p>
  */

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -93,6 +93,7 @@ import ome.units.UNITS;
  *  <li>showinf '32bit-floating&amp;pixelType=float&amp;sizeZ=3&amp;sizeC=5&amp;sizeT=7&amp;sizeY=50.fake'</li>
  *  <li>showinf '64bit-floating&amp;pixelType=double&amp;sizeZ=3&amp;sizeC=5&amp;sizeT=7&amp;sizeY=50.fake'</li>
  *  <li>showinf 'SPW&amp;plates=2&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
+ *  <li>showinf 'Plate&amp;screen=0&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
  * </ul></p>
  */
 public class FakeReader extends FormatReader {
@@ -429,6 +430,7 @@ public class FakeReader extends FormatReader {
 
     String acquisitionDate = null;
 
+    int screen = 1;
     int plates = 0;
     int plateRows = 0;
     int plateCols = 0;
@@ -532,6 +534,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("scaleFactor")) scaleFactor = doubleValue;
       else if (key.equals("exposureTime")) exposureTime = new Time((float) doubleValue, UNITS.S);
       else if (key.equals("acquisitionDate")) acquisitionDate = value;
+      else if (key.equals("screen")) screen = intValue;
       else if (key.equals("plates")) plates = intValue;
       else if (key.equals("plateRows")) plateRows = intValue;
       else if (key.equals("plateCols")) plateCols = intValue;
@@ -599,7 +602,7 @@ public class FakeReader extends FormatReader {
     if (hasSPW) {
       // generate SPW metadata and override series count to match
       int imageCount =
-        populateSPW(store, plates, plateRows, plateCols, fields, plateAcqs);
+        populateSPW(store, screen, plates, plateRows, plateCols, fields, plateAcqs);
       if (imageCount > 0) seriesCount = imageCount;
       else hasSPW = false; // failed to generate SPW metadata
     }
@@ -890,12 +893,16 @@ public class FakeReader extends FormatReader {
     return !listFakeSeries(path).get(0).equals(path);
   }
 
-  private int populateSPW(MetadataStore store, int plates, int rows, int cols,
+  private int populateSPW(MetadataStore store, int screen, int plates, int rows, int cols,
     int fields, int acqs)
   {
     final XMLMockObjects xml = new XMLMockObjects();
-    final OME ome =
-      xml.createPopulatedScreen(plates, rows, cols, fields, acqs);
+    OME ome = null;
+    if (screen==0) {
+      ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs);
+    } else {
+      ome = xml.createPopulatedScreen(plates, rows, cols, fields, acqs);
+    }
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     // copy populated SPW metadata into destination MetadataStore
     getOmeXmlService().convertMetadata(omeXmlMetadata, store);

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -600,6 +600,7 @@ public class FakeReader extends FormatReader {
     boolean hasSPW = plates > 0 && plateRows > 0 &&
       plateCols > 0 && fields > 0 && plateAcqs > 0;
     if (hasSPW) {
+      if (screens<0) screens = 0;
       // generate SPW metadata and override series count to match
       int imageCount =
         populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs);

--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -1512,6 +1512,27 @@ public class XMLMockObjects
   }
 
   /**
+   * Creates several plates but no containing screen.
+   *
+   * @param plates The number of plates to create.
+   * @param rows   The number of rows for plate.
+   * @param cols   The number of columns for plate.
+   * @param fields The number of fields.
+   * @param acqs   The number of plate acquisitions.
+   * @return See above.
+   */
+  public OME createPopulatedPlate(int plates, int rows, int cols, int fields,
+      int acqs)
+  {
+    Plate plate;
+    for (int p = 0; p < plates; p++) {
+      plate = createPlate(plates, p, rows, cols, fields, acqs);
+      ome.addPlate(plate);
+    }
+    return ome;
+  }
+
+  /**
    * Creates a screen with several plates.
    *
    * @param plates The number of plates to create.

--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -932,7 +932,7 @@ public class XMLMockObjects
       screenIndex = 0;
     }
     // ticket:3102
-    plateIndex = numberOfScreens*screenIndex+plateIndex;
+    int totalPlateIndex = numberOfScreens*screenIndex+plateIndex;
     Experiment exp = createExperimentWithMicrobeam(plateIndex);
     ome.addExperiment(exp);
 
@@ -940,9 +940,10 @@ public class XMLMockObjects
       numberOfPlateAcquisition = 0;
     }
     Plate plate = new Plate();
-    plate.setID("Plate:"+plateIndex);
-    plate.setName("Plate Name "+plateIndex);
-    plate.setDescription("Plate Description "+plateIndex);
+    plate.setID("Plate:"+totalPlateIndex);
+    plate.setName("Plate Name "+totalPlateIndex);
+    plate.setDescription(String.format("Plate %d of %d",
+        plateIndex, numberOfPlates));
     plate.setExternalIdentifier("External Identifier");
     plate.setRows(new PositiveInteger(rows));
     plate.setColumns(new PositiveInteger(columns));
@@ -957,10 +958,11 @@ public class XMLMockObjects
     if (numberOfPlateAcquisition > 0) {
       for (int i = 0; i < numberOfPlateAcquisition; i++) {
         pa = new PlateAcquisition();
-        v = i+plateIndex*numberOfPlates*numberOfScreens;
+        v = i+totalPlateIndex*numberOfPlateAcquisition;
         pa.setID("PlateAcquisition:"+v);
         pa.setName("PlateAcquisition Name "+v);
-        pa.setDescription("PlateAcquisition Description "+v);
+        pa.setDescription(String.format("PlateAcquisition %d of %d",
+            i, numberOfPlateAcquisition));
         pa.setEndTime(new Timestamp(TIME));
         pa.setStartTime(new Timestamp(TIME));
         plate.addPlateAcquisition(pa);
@@ -971,13 +973,14 @@ public class XMLMockObjects
     Well well;
     WellSample sample;
     Image image;
-    int i = plateIndex*rows*columns*fields*numberOfPlateAcquisition;
+    int i = totalPlateIndex*rows*columns*fields*numberOfPlateAcquisition;
     Iterator<PlateAcquisition> k;
     int kk = 0;
     for (int row = 0; row < rows; row++) {
       for (int column = 0; column < columns; column++) {
         well = new Well();
-        well.setID(String.format("Well:%d_%d_%d", row, column, plateIndex));
+        well.setID(String.format("Well:%d_%d_%d_%d",
+            screenIndex, plateIndex, row, column));
         well.setRow(new NonNegativeInteger(row));
         well.setColumn(new NonNegativeInteger(column));
         well.setType("Transfection: done");
@@ -990,8 +993,8 @@ public class XMLMockObjects
             sample.setPositionX(new Length(0.0, UNITS.REFERENCEFRAME));
             sample.setPositionY(new Length(1.0, UNITS.REFERENCEFRAME));
             sample.setTimepoint(new Timestamp(TIME));
-            sample.setID(String.format("WellSample:%d_%d_%d_%d",
-                plateIndex, row, column, field));
+            sample.setID(String.format("WellSample:%d_%d_%d_%d_%d",
+                screenIndex, plateIndex, row, column, field));
             sample.setIndex(new NonNegativeInteger(i));
             //create an image. and register it
             image = createImageWithExperiment(i, true, exp);
@@ -1007,13 +1010,13 @@ public class XMLMockObjects
           while (k.hasNext()) {
             pa = k.next();
             for (int field = 0; field < fields; field++) {
-              v = kk+plateIndex*numberOfPlates*numberOfScreens;
+              v = kk+totalPlateIndex*numberOfPlates*numberOfScreens;
               sample = new WellSample();
               sample.setPositionX(new Length(0.0, UNITS.REFERENCEFRAME));
               sample.setPositionY(new Length(1.0, UNITS.REFERENCEFRAME));
               sample.setTimepoint(new Timestamp(TIME));
-              sample.setID(String.format("WellSample:%d_%d_%d_%d_%d",
-                  plateIndex, row, column, field, v));
+              sample.setID(String.format("WellSample:%d_%d_%d_%d_%d_%d",
+                  screenIndex, plateIndex, row, column, field, v));
               sample.setIndex(new NonNegativeInteger(i));
               //create an image. and register it
               //image = createImage(i, true);


### PR DESCRIPTION
This PR adds a flag to the fake filename, `screens=n` to create multiple screens, in particular `screens=0` will allow for no containing Screen to be created when a Plate is created. The omission of the flag maintains the current behaviour, to create a containing Screen, ie it is equivalent to `screens=1`.

Is this sufficient or are there other areas of the codebase that need to accommodate this change? If this is reasonable then there will also need to be a minor change to the docs.

To test, via OMERO,
```
$ touch "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1&screens=0.fake"
$ omero import "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1&screens=0.fake"
```
should import a Plate with no Screen. Importing files
```
$ touch "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake"
$ touch "SPW&plates=1&plateRows=1&plateCols=1&fields=1&plateAcqs=1&screens=1.fake"
```
should each import single Plates each within a Screen, while
```
$ touch "SPW&screens=2&plates=2&plateRows=1&plateCols=1&fields=1&plateAcqs=1.fake"
```
should import two Screens each with two Plates.

