### PR TITLE
Schema publication refactoring

### DIFF
--- a/components/specification/publish
+++ b/components/specification/publish
@@ -293,8 +293,6 @@ done
 # $2=year (may be blank)
 # $3=filter (current or legacy)
 # $4=verbose (true or false)
-# $5=schema set (current or legacy)
-# $6=schema location (current=Schemas, legacy=XMLschemas)
 createlink() {
     name=$(basename "$1")
     release="$2"
@@ -302,39 +300,19 @@ createlink() {
     if [ "$shortname" = "ome" ]; then
         shortname="OME"
     fi
-    if [ "$5" = "legacy" ]; then
-        reldate="2003 ($2)"
+    if [ -z "$2" ]; then
+        release=$(mostrecentversion "$name")
+        reldate=$(parsedate "$release")
     else
-        if [ -z "$2" ]; then
-            release=$(mostrecentversion "$name")
-            reldate=$(parsedate "$release")
-        else
-            reldate=$(parsedate "$2")
-        fi
+        reldate=$(parsedate "$2")
     fi
-    if [ "$5" = "current" ]; then
-        relversion=$(schemaversion "$name" "$release")
-    else
-        relversion=$(schemaversion "$name" "2003-$release")
-    fi
+    relversion=$(schemaversion "$name" "$release")
     reldesc=" The $(schemadesc "$name")"
     if [ "$4" = "false" ]; then
         reldesc=""
     fi
-    if [ "$5" = "current" ]; then
-        link=$(find $root -name "$name" | grep "$release" | head -n1)
-        link=$(echo "$link" | sed -e "s;$root/;;")
-    else
-        link=$(find published/XMLschemas -name "$name" | grep "$release" | head -n1)
-        link=$(echo "$link" | sed -e 's;published/XMLschemas/;;')
-        if [ "$6" = "current" ]; then
-            if [ -z "$2" ]; then
-                link="../XMLschemas/$link"
-            else
-                link="../../XMLschemas/$link"
-            fi
-        fi
-    fi
+    link=$(find $root -name "$name" | grep "$release" | head -n1)
+    link=$(echo "$link" | sed -e "s;$root/;;")
     if [ -n "$2" ]; then
         link=$(echo "$link" | sed -e "s;^${shortname}/;;")
     fi
@@ -420,7 +398,7 @@ EOF
 EOF
 
     for schema in $(find $root -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
-        createlink "$schema" "" "current" "true" "current" "$1"
+        createlink "$schema" "" "current" "true"
     done
 
     cat <<EOF
@@ -430,7 +408,7 @@ EOF
 EOF
 
     for schema in $(find $root -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq); do
-        createlink "$schema" "" "legacy" "true" "current" "$1"
+        createlink "$schema" "" "legacy" "true"
     done
     cat <<EOF
 </ul>
@@ -509,7 +487,7 @@ EOF
 EOF
 
     for year in $(find $root -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
-        createlink "$schema" "$year" "current" "false" "current" "$2"
+        createlink "$schema" "$year" "current" "false"
     done
     cat <<EOF
 </ul>
@@ -518,7 +496,7 @@ EOF
 EOF
 
     for year in $(find $root -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
-        createlink "$schema" "$year" "legacy" "false" "current" "$2"
+        createlink "$schema" "$year" "legacy" "false"
     done
 
     if [ "$1" = "OME" ]; then
@@ -538,9 +516,9 @@ EOF
 for type in $(find ${root} -mindepth 1 -maxdepth 1 -type d | sed -e "s;^${root}/;;"); do
     if [ $type != "Samples" ] && [ $type != "Transforms" ]; then
         echo "HTML [2] -> ${root}/${type}/index.html"
-        createintermediateindex "$type" "current" > "${root}/${type}/index.html"
+        createintermediateindex "$type" > "${root}/${type}/index.html"
     fi
 done
 
 echo "HTML [4] -> ${root}/index.html"
-createmainindex "current" > "${root}/index.html"
+createmainindex > "${root}/index.html"

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -153,12 +153,12 @@ contains() {
 }
 
 devmarker="dev"
-root=published
+root=${1:-published}
 
 
 # Clean up
 
-rm -rf "$root"
+rm -rf "$root/*"
 mkdir -p "$root"
 
 for dir in released-schema/20*
@@ -535,10 +535,10 @@ EOF
 EOF
 }
 
-for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/Schemas/;;'); do
+for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e "s;^${root}/Schemas/;;"); do
     if [ $type != "Samples" ] && [ $type != "Transforms" ]; then
-        echo "HTML [2] -> $root/Schemas/${type}/index.html"
-        createintermediateindex "$type" "current" > "$root/Schemas/${type}/index.html"
+        echo "HTML [2] -> ${root}/Schemas/${type}/index.html"
+        createintermediateindex "$type" "current" > "${root}/Schemas/${type}/index.html"
     fi
 done
 

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -578,9 +578,3 @@ echo "HTML [4] -> ${root}/Schemas/index.html"
 createmainindex "current" > "${root}/Schemas/index.html"
 echo "HTML [5] -> ${root}/XMLschemas/index.html"
 createmainindex "legacy" > "${root}/XMLschemas/index.html"
-
-echo "Add any web-extras"
-if [ -d "web-extra" ]; then
-    rsync --stats -r -t "web-extra/" "${root}"
-fi
-

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -188,8 +188,8 @@ do
                 base="OME"
             fi
 
-            path="${root}/Schemas/${base}/${rel}"
-
+            path="${root}/${base}/${rel}"
+            print $path
             # Copy schema
             mkdir -p "$path"
             cp -v "$schema" "${path}/${name}"
@@ -215,7 +215,7 @@ do
             version=1
         fi
 
-        path="${root}/Schemas/${base}/${rel}"
+        path="${root}/${base}/${rel}"
         reldate=$(parsedate "$rel")
 
         # Copy schema
@@ -269,7 +269,7 @@ done
 # Special cases
 
 # Transforms folder
-path="${root}/Schemas/Transforms/"
+path="${root}/Transforms/"
 dir="transforms"
 mkdir -p "$path"
 for transform in "$dir"/*.xsl
@@ -278,7 +278,7 @@ do
 done
 
 # Samples folder
-path="${root}/Schemas/Samples/"
+path="${root}/Samples/"
 dir="samples"
 mkdir -p "$path"
 for sample in "$dir"/*
@@ -322,15 +322,8 @@ createlink() {
         reldesc=""
     fi
     if [ "$5" = "current" ]; then
-        link=$(find published/Schemas -name "$name" | grep "$release" | head -n1)
-        link=$(echo "$link" | sed -e 's;published/Schemas/;;')
-        if [ "$6" = "legacy" ]; then
-            if [ -z "$2" ]; then
-                link="../Schemas/$link"
-            else
-                link="../../Schemas/$link"
-            fi
-        fi
+        link=$(find $root -name "$name" | grep "$release" | head -n1)
+        link=$(echo "$link" | sed -e "s;$root/;;")
     else
         link=$(find published/XMLschemas -name "$name" | grep "$release" | head -n1)
         link=$(echo "$link" | sed -e 's;published/XMLschemas/;;')
@@ -427,7 +420,7 @@ EOF
 <ul>
 EOF
 
-    for schema in $(find published/Schemas -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
+    for schema in $(find $root -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
         createlink "$schema" "" "current" "true" "current" "$1"
     done
 
@@ -437,7 +430,7 @@ EOF
 <ul>
 EOF
 
-    for schema in $(find published/Schemas -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq); do
+    for schema in $(find $root -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq); do
         createlink "$schema" "" "legacy" "true" "current" "$1"
     done
     cat <<EOF
@@ -494,7 +487,7 @@ EOF
 <ul>
 EOF
 
-    for release in $(ls -1d "$root"/Schemas/$1/20* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
+    for release in $(ls -1d "$root"/$1/20* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         reldate=$(parsedate "$release")
         echo "<li>$reldate - namespace /$release/</li>"
     done
@@ -514,7 +507,7 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
+    for year in $(find $root -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "current" "false" "current" "$2"
     done
     cat <<EOF
@@ -523,7 +516,7 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
+    for year in $(find $root -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "legacy" "false" "current" "$2"
     done
     cat <<EOF
@@ -535,12 +528,12 @@ EOF
 EOF
 }
 
-for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e "s;^${root}/Schemas/;;"); do
+for type in $(find ${root} -mindepth 1 -maxdepth 1 -type d | sed -e "s;^${root}/;;"); do
     if [ $type != "Samples" ] && [ $type != "Transforms" ]; then
-        echo "HTML [2] -> ${root}/Schemas/${type}/index.html"
-        createintermediateindex "$type" "current" > "${root}/Schemas/${type}/index.html"
+        echo "HTML [2] -> ${root}/${type}/index.html"
+        createintermediateindex "$type" "current" > "${root}/${type}/index.html"
     fi
 done
 
-echo "HTML [4] -> ${root}/Schemas/index.html"
-createmainindex "current" > "${root}/Schemas/index.html"
+echo "HTML [4] -> ${root}/index.html"
+createmainindex "current" > "${root}/index.html"

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -163,8 +163,13 @@ mkdir -p "$root"
 
 for dir in released-schema/20*
 do
-    # Don't copy legacy or other material
-    if [ "$dir" = "released-schema/additions" ]; then
+    rel=$(basename "$dir")
+    year=$(echo "$rel" | sed -e 's;^\([0-9][0-9]*\)-.*$;\1;')
+    month=$(echo "$rel" | sed -e 's;^.*-\([0-9][0-9]*\)$;\1;')
+
+    # Don't copy legacy material
+    if [ "$year" = "2003" ]; then
+        echo "Skipping legacy $rel"
         continue
     fi
 
@@ -195,20 +200,11 @@ do
 
     for schema in "$dir"/*.xsd
     do
-        rel=$(basename "$dir")
         base=${schema%.xsd}
         base=$(basename "$base")
         name=$(basename "$schema")
         type="$(schemastatus "$name" "$rel")"
         version="$(schemaversion "$name" "$rel")"
-
-        year=$(echo "$rel" | sed -e 's;^\([0-9][0-9]*\)-.*$;\1;')
-        month=$(echo "$rel" | sed -e 's;^.*-\([0-9][0-9]*\)$;\1;')
-
-        # Skip files only used internally for legacy schema
-        if [ "$rel" = "2003-FC" ] && [ "$base" != "ome" ]; then
-            continue;
-        fi
 
         # For some reason, the OME schema has always been lowercased
         if [ "$base" = "ome" ]; then
@@ -219,15 +215,8 @@ do
             version=1
         fi
 
-        # Special case copying of legacy schemas
-        if [ "$year" = "2003" ]; then
-            path="${root}/XMLschemas/${base}/${month}"
-            path=$(echo "$path" | sed -e 's;/2003-\(.*\);/\1;')
-            reldate="2003 ($month)"
-        else
-            path="${root}/Schemas/${base}/${rel}"
-            reldate=$(parsedate "$rel")
-        fi
+        path="${root}/Schemas/${base}/${rel}"
+        reldate=$(parsedate "$rel")
 
         # Copy schema
         mkdir -p "$path"
@@ -509,12 +498,6 @@ EOF
         reldate=$(parsedate "$release")
         echo "<li>$reldate - namespace /$release/</li>"
     done
-    if [ -d "${root}/XMLschemas/$1" ]; then
-        for release in $(ls -1d "$root"/XMLschemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html  | sort -r | grep FC) $(ls -1d "$root"/XMLschemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
-            reldate="2003 ($release)"
-            echo "<li>$reldate - namespace /$release/$schema</li>"
-        done
-    fi
 
 
     cat <<EOF
@@ -534,10 +517,6 @@ EOF
     for year in $(find published/Schemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "current" "false" "current" "$2"
     done
-    for year in $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
-        createlink "$schema" "$year" "current" "false" "legacy" "$2"
-    done
-
     cat <<EOF
 </ul>
 <h4>Older schemas</h4>
@@ -547,10 +526,6 @@ EOF
     for year in $(find published/Schemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "legacy" "false" "current" "$2"
     done
-    for year in $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
-        createlink "$schema" "$year" "legacy" "false" "legacy" "$2"
-    done
-
     cat <<EOF
 </ul>
 </div>
@@ -567,14 +542,5 @@ for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's
     fi
 done
 
-for type in $(find "${root}/XMLschemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/XMLschemas/;;'); do
-    if [ $type != "Samples" ] && [ $type != "Transforms" ]; then
-        echo "HTML [3] -> $root/XMLschemas/${type}/index.html"
-        createintermediateindex "$type" "legacy" > "$root/XMLschemas/${type}/index.html"
-    fi
-done
-
 echo "HTML [4] -> ${root}/Schemas/index.html"
 createmainindex "current" > "${root}/Schemas/index.html"
-echo "HTML [5] -> ${root}/XMLschemas/index.html"
-createmainindex "legacy" > "${root}/XMLschemas/index.html"

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -402,10 +402,9 @@ EOF
         reldate=$(parsedate "$release")
         echo "<li>$reldate - namespace /$release/</li>"
     done
-    for release in $(ls -1d released-schema/20* | grep 2003 | xargs $XARGSOPTS -n1 basename | sort -r | grep FC | sed -e 's;2003-\(.*\);\1;') $(ls -1d released-schema/20* | grep 2003 | xargs $XARGSOPTS -n1 basename | sort -r | grep -v FC | sed -e 's;2003-\(.*\);\1;'); do
-        reldate="2003 ($release)"
-        echo "<li>$reldate - namespace /$release/*.xsd</li>"
-    done
+
+    # Manually list legacy FC schema
+    echo "<li>2003 (FC) - namespace /FC/</li>"
 
     cat <<EOF
 </ul>
@@ -492,6 +491,8 @@ EOF
         echo "<li>$reldate - namespace /$release/</li>"
     done
 
+    # Manually list legacy FC schema
+    echo "<li>2003 (FC) - namespace /FC/</li>"
 
     cat <<EOF
 </ul>
@@ -519,6 +520,12 @@ EOF
     for year in $(find $root -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "legacy" "false" "current" "$2"
     done
+
+    if [ "$1" = "OME" ]; then
+        # Manually list legacy FC OME xsd
+        legacyurl="http://www.openmicroscopy.org/XMLschemas/OME/FC/ome.xsd"
+        echo "<li>ome.xsd - 2003 (FC), version 1 [<a href=\"$legacyurl\">FC</a>]</li>"
+    fi
     cat <<EOF
 </ul>
 </div>

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -154,7 +154,7 @@ contains() {
 
 devmarker="dev"
 root=${1:-published}
-
+root=${root%/}
 
 # Clean up
 

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -189,7 +189,7 @@ do
             fi
 
             path="${root}/${base}/${rel}"
-            print $path
+
             # Copy schema
             mkdir -p "$path"
             cp -v "$schema" "${path}/${name}"


### PR DESCRIPTION
This PR starts streamlining the schema release process achieved via the `publish` script to allow to compute Git diffs of the public schema content

Major features of this PR are:
- remove the `XMLschemas` generation - we are not regenerating legacy schema files
- remove legacy schemas from being listed on the main index pages
- remove `web-extras`
- remove the `Schemas` namespace in the target directory to simplify diffs
- allow to specify an output directory - defaulting to `published`

To test this PR
- clone https://github.com/sbesson/schemas which is a Git snapshot of the current live schema
- run `./publish /path/to/schemas`
- compute the `git diff` locally to see the difference

