### PR TITLE
cpp: TileInfo: Correct tile row and column count computation

### DIFF
--- a/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
@@ -128,11 +128,11 @@ namespace ome
             }
 
           // Compute row and column counts.
-          nrows = imagewidth / tileheight;
-          if (imagewidth % tileheight)
+          nrows = imageheight / tileheight;
+          if (imageheight % tileheight)
             ++nrows;
-          ncols = imageheight / tilewidth;
-          if (imageheight % tilewidth)
+          ncols = imagewidth / tilewidth;
+          if (imagewidth % tilewidth)
             ++ncols;
           ntiles = nrows * ncols;
         }


### PR DESCRIPTION
The calculation here is wrong.  Unit tests are working on square images so the discrepancy wasn't caught.  Not sure why it was ever thought to be correct, but it at least makes sense now.  We should add unit tests for non-square images as well--needs additional PNG test images adding.

Testing: Use http://nyloc.de/public/test.ome.tif

Apply this patch and build:

```
diff --git a/cpp/lib/ome/bioformats/tiff/IFD.cpp b/cpp/lib/ome/bioformats/tiff/IFD.cpp
index eb87c0d..9a92755 100644
--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -303,6 +303,7 @@ namespace
             }
           else
             {
+              std::cerr << "Reading TIFF tile " << tile << "\n";
               tmsize_t bytesread = TIFFReadEncodedStrip(tiffraw, tile, tilebuf.data(), static_cast<tsize_t>(tilebuf.size()));
               dimension_size_type expectedread = expected_read(buffer, rclip, copysamples);
               if (bytesread < 0)
diff --git a/cpp/lib/ome/bioformats/tiff/TileInfo.cpp b/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
index d483b7d..517e879 100644
--- a/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
@@ -49,6 +49,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <iostream>
+
 namespace ome
 {
   namespace bioformats
@@ -135,6 +137,7 @@ namespace ome
           if (imagewidth % tilewidth)
             ++ncols;
           ntiles = nrows * ncols;
+          std::cerr << "TILES: " << ntiles << "  ROWS: " << nrows << " COLS: " << ncols << '\n';
         }
 
         /// Destructor.
@@ -311,6 +314,7 @@ namespace ome
                   // Compute tile index for the row/column/sample indexes
                   dimension_size_type index = (sample * impl->ntiles) + (row * impl->ncols) + col;
                   ret.push_back(index);
+                  std::cerr << "TILE " << index << " = (" << sample <<" * " << impl->ntiles << ") + (" << row << " * " << impl->ncols << ") + " << col << '\n';
                 }
           }
 
diff --git a/cpp/libexec/info/ImageInfo.cpp b/cpp/libexec/info/ImageInfo.cpp
index 9d3127b..1a2fc69 100644
--- a/cpp/libexec/info/ImageInfo.cpp
+++ b/cpp/libexec/info/ImageInfo.cpp
@@ -119,6 +119,13 @@ namespace info
       readOriginalMetadata(stream);
     if (opts.showomexml)
       readOMEXMLMetadata(stream);
+
+    std::cout << "Test read...#\n";
+    ome::bioformats::VariantPixelBuffer buf;
+    ome::bioformats::dimension_size_type oldseries = reader->getSeries();
+    reader->setSeries(0);
+    reader->openBytes(0, buf);
+    reader->setSeries(oldseries);
   }
 
   void

```

Run `./bf-test info test.ome.tiff` and you should see it complete without throwing an exception.  It will also dump the tile calculations and indexes as it reads; you'll see the indexes are all in the range 0..2159 (720 strips × 3 planes) This is testing we can read an entire plane from the tiff image into a pixel buffer.  Previously it would screw up the strip indexing when reading past the first plane.  It will now complete successfully.