### PR TITLE
Dicom max pixel value bug

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -128,8 +128,9 @@ public class DicomReader extends FormatReader {
   private byte[][] lut;
   private short[][] shortLut;
   private long[] offsets;
-  private int maxPixelValue;
-
+  private int maxPixelRange;
+  private int centerPixelValue;
+  
   private double rescaleSlope = 1.0, rescaleIntercept = 0.0;
 
   private boolean isJP2K = false;
@@ -406,7 +407,8 @@ public class DicomReader extends FormatReader {
         }
       }
       else if (bpp == 2) {
-        if (maxPixelValue == -1) maxPixelValue = 65535;
+        int maxPixelValue = maxPixelRange + (centerPixelValue/2);
+        if (maxPixelRange == -1 || centerPixelValue == -1 || centerPixelValue < (maxPixelRange/2)) maxPixelValue = 65535;
         boolean little = isLittleEndian();
         for (int i=0; i<buf.length; i+=2) {
           short s = DataTools.bytesToShort(buf, i, 2, little);
@@ -432,7 +434,8 @@ public class DicomReader extends FormatReader {
       lut = null;
       offsets = null;
       shortLut = null;
-      maxPixelValue = 0;
+      maxPixelRange = 0;
+      centerPixelValue = 0;
       rescaleSlope = 1.0;
       rescaleIntercept = 0.0;
       pixelSizeX = pixelSizeY = null;
@@ -563,6 +566,18 @@ public class DicomReader extends FormatReader {
         case SLICE_SPACING:
         case RESCALE_INTERCEPT:
         case WINDOW_CENTER:
+            String winCenter = in.readString(elementLength);
+            if (winCenter.trim().length() == 0) centerPixelValue = -1;
+            else {
+              try {
+                centerPixelValue = new Double(winCenter.trim()).intValue();
+              }
+              catch (NumberFormatException e) {
+                centerPixelValue = -1;
+              }
+            }
+            addInfo(tag, winCenter);
+            break;
         case RESCALE_SLOPE:
           addInfo(tag, in.readString(elementLength));
           break;
@@ -580,13 +595,13 @@ public class DicomReader extends FormatReader {
         case 537262910:
         case WINDOW_WIDTH:
           String t = in.readString(elementLength);
-          if (t.trim().length() == 0) maxPixelValue = -1;
+          if (t.trim().length() == 0) maxPixelRange = -1;
           else {
             try {
-              maxPixelValue = new Double(t.trim()).intValue();
+              maxPixelRange = new Double(t.trim()).intValue();
             }
             catch (NumberFormatException e) {
-              maxPixelValue = -1;
+              maxPixelRange = -1;
             }
           }
           addInfo(tag, t);

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -408,7 +408,9 @@ public class DicomReader extends FormatReader {
       }
       else if (bpp == 2) {
         int maxPixelValue = maxPixelRange + (centerPixelValue/2);
-        if (maxPixelRange == -1 || centerPixelValue == -1 || centerPixelValue < (maxPixelRange/2)) maxPixelValue = 65535;
+        if (maxPixelRange == -1 || centerPixelValue < (maxPixelRange/2)) {
+          maxPixelValue = 65535;
+        }
         boolean little = isLittleEndian();
         for (int i=0; i<buf.length; i+=2) {
           short s = DataTools.bytesToShort(buf, i, 2, little);
@@ -570,7 +572,7 @@ public class DicomReader extends FormatReader {
             if (winCenter.trim().length() == 0) centerPixelValue = -1;
             else {
               try {
-                centerPixelValue = new Double(winCenter.trim()).intValue();
+                centerPixelValue = new Double(winCenter).intValue();
               }
               catch (NumberFormatException e) {
                 centerPixelValue = -1;

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -407,9 +407,9 @@ public class DicomReader extends FormatReader {
         }
       }
       else if (bpp == 2) {
-        int maxPixelValue = maxPixelRange + (centerPixelValue/2);
+        long maxPixelValue = maxPixelRange + (centerPixelValue/2);
         if (maxPixelRange == -1 || centerPixelValue < (maxPixelRange/2)) {
-          maxPixelValue = 65535;
+          maxPixelValue = FormatTools.defaultMinMax(getPixelType())[1];
         }
         boolean little = isLittleEndian();
         for (int i=0; i<buf.length; i+=2) {


### PR DESCRIPTION
Bug: DICOM incorrect maxPixelValue
DICOM incorrect maxPixelValue
For DICOM images using photometric interpretation MONOCHROME1,
bioformats needs to invert the pixel the data. For 16 bit data we had
been using the WINDOW_WIDTH property as a max pixel value, instead this
actually provides us with the pixel range and is not clipped to 0.

Code has been updated to try and read the WINDOW_CENTER value (the
central value in the range) in order to work out an appropriate scale.
If this is not available or not a sensible value then we will use the
full max pixel range.

OME-Users message:
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/00
5629.html

QA: https://www.openmicroscopy.org/qa2/qa/feedback/11401/

For info on the WINDOW_WIDTH and WINDOW_CENTER properties:
https://www.dabsoft.ch/dicom/3/C.11.2.1.2/

For info on the photometric interpretations:
https://www.medicalconnections.co.uk/kb/Photometric_Interpretations