### PR TITLE
FileStitcher: call setId on all readers in ExternalSeries

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1260,8 +1260,8 @@ public class FileStitcher extends ReaderWrapper {
         }
         else readers[i] = new DimensionSwapper();
         readers[i].setGroupFiles(false);
+        readers[i].setId(files[i]);
       }
-      readers[0].setId(files[0]);
 
       ag = new AxisGuesser(this.pattern, readers[0].getDimensionOrder(),
         readers[0].getSizeZ(), readers[0].getSizeT(),


### PR DESCRIPTION
This PR fixes a problem where the `ExternalSeries` constructor in `FileStitcher` initializes only the first of its readers. A simple way to trigger the bug is to call `reopenFile` on a `FileStitcher` whose ID is a pattern that expands to more than one element, such as `foo<1,2>.tif`. This leads to a `java.lang.IllegalStateException` as soon as the first reader with a null ID is encountered.