### PR TITLE
cpp: bioformats: Add n-dimensional array lookup calculations

### DIFF
--- a/cpp/lib/ome/bioformats/CMakeLists.txt
+++ b/cpp/lib/ome/bioformats/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories(${OME_TOPLEVEL_INCLUDES}
 
 set(OME_BIOFORMATS_SOURCES
     CoreMetadata.cpp
+    Dimension.cpp
     FormatException.cpp
     FormatTools.cpp
     MetadataConfigurable.cpp
@@ -60,6 +61,7 @@ set(OME_BIOFORMATS_SOURCES
 
 set(OME_BIOFORMATS_HEADERS
     CoreMetadata.h
+    Dimension.h
     FileInfo.h
     FormatException.h
     MetadataMap.h

--- a/cpp/lib/ome/bioformats/Dimension.cpp
+++ b/cpp/lib/ome/bioformats/Dimension.cpp
@@ -1,0 +1,346 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <set>
+
+#include <ome/bioformats/Dimension.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+
+    void
+    Dimension::check(size_type previous_begin,
+                     size_type previous_end)
+    {
+      if (extent == 0)
+        {
+          boost::format fmt("Dimension %1% extent is of zero length");
+          fmt % name;
+          throw std::logic_error(fmt.str());
+        }
+
+      if (begin >= extent ||
+          end > extent ||
+          begin > end)
+        {
+          boost::format fmt("Dimension %1% subrange %2%–%3% outside valid range %4%–%5%");
+          fmt % name % begin % end % 0U % extent;
+          throw std::logic_error(fmt.str());
+        }
+
+      if (begin < previous_begin ||
+          end > previous_end)
+        {
+          boost::format fmt("Dimension %1% subrange %2%–%3% outside valid subrange %4%–%5%");
+          fmt % name % begin % end % previous_begin % previous_end;
+          throw std::logic_error(fmt.str());
+        }
+    }
+
+    DimensionSet::DimensionSet(const logical_order_type& dimensions):
+      _logical_order(dimensions),
+      _storage_order(),
+      _detail(dimensions.size()),
+      _base(0U)
+    {
+      init();
+    }
+
+    DimensionSet::DimensionSet(const logical_order_type&         dimensions,
+                               const indexed_storage_order_type& order):
+      _logical_order(dimensions),
+      _storage_order(),
+      _detail(dimensions.size()),
+      _base(0U)
+    {
+      init();
+      storage_order(order);
+    }
+
+    DimensionSet::DimensionSet(const logical_order_type&       dimensions,
+                               const named_storage_order_type& order):
+      _logical_order(dimensions),
+      _storage_order(),
+      _detail(dimensions.size()),
+      _base(0U)
+    {
+      init();
+      storage_order(order);
+    }
+
+    void
+    DimensionSet::init()
+    {
+      _storage_order.reserve(_logical_order.size());
+      _detail.resize(_logical_order.size());
+
+      std::set<std::string> used;
+
+      for (uint32_t i = 0; i < _logical_order.size(); ++i)
+        {
+          // Check for duplicate dimensions
+          if (used.find(_logical_order[i].name) != used.end())
+            {
+              boost::format fmt("Dimension %1% used multiple times");
+              fmt % _logical_order[i].name;
+              throw std::logic_error(fmt.str());
+            }
+          used.insert(_logical_order[i].name);
+
+          // Set default storage order (matches logical order).
+          _storage_order.push_back(IndexedDimensionStorage(i, Dimension::ASCENDING));
+        }
+
+      // Set strides and offset.
+      compute_logical_strides();
+      compute_storage_strides();
+      compute_storage_offset();
+    }
+
+    void
+    DimensionSet::storage_order(const indexed_storage_order_type& order)
+    {
+      if (order.size() != size())
+        {
+          boost::format fmt("Storage order dimension count %1% for order does not match set dimension count %2%");
+          fmt % order.size() % size();
+          throw std::logic_error(fmt.str());
+        }
+
+      // Check for duplicates using set of indices.
+      std::set<index_type> used;
+      for (index_type i = 0; i < order.size(); ++i)
+        {
+          const indexed_storage_order_type::value_type& o(order.at(i));
+          // Check dimension is valid.
+          if (o.dimension >= size())
+            {
+              boost::format fmt("Storage order dimension %1% index %2% out of valid range %3%–%4%");
+              fmt % i % o.dimension % 0 % (size() -1);
+              throw std::logic_error(fmt.str());
+            }
+          // Check for duplicate dimensions.
+          if (used.find(o.dimension) != used.end())
+            {
+              boost::format fmt("Dimension %1% used multiple times");
+              fmt % o.dimension;
+              throw std::logic_error(fmt.str());
+            }
+          used.insert(o.dimension);
+        }
+      _storage_order = order;
+
+      // Recompute strides and offset.
+      compute_storage_strides();
+      compute_storage_offset();
+    }
+
+    void
+    DimensionSet::storage_order(const named_storage_order_type& order)
+    {
+      std::map<std::string, index_type> nmap(name_map(_logical_order));
+      indexed_storage_order_type iorder;
+
+      // Convert named order to indexed order.
+      for (named_storage_order_type::const_iterator o = order.begin();
+           o != order.end();
+           ++o)
+        {
+          std::map<std::string, index_type>::const_iterator i(nmap.find(o->dimension));
+          if (i == nmap.end())
+            {
+              boost::format fmt("Dimension name ‘%1%’ invalid");
+              fmt % o->dimension;
+              throw std::logic_error(fmt.str());
+            }
+          iorder.push_back(indexed_storage_order_type::value_type(i->second, o->direction));
+        }
+
+      storage_order(iorder);
+    }
+
+    void
+    DimensionSet::compute_logical_strides()
+    {
+      difference_type stride = 1;
+
+      // For each dimension in logical order, assign stride from
+      // previous dimension and multiply stride by dimension size.
+      // Note this is the subrange size, not the extent size.  Also
+      // note there is no logical offset since the logical dimensions
+      // are all in an ascending direction, making the base zero.
+      for (logical_order_type::iterator dim = _logical_order.begin();
+           dim != _logical_order.end();
+           ++dim)
+        {
+          dim->stride = stride;
+          stride *= dim->size();
+        }
+    }
+
+    void
+    DimensionSet::compute_storage_strides()
+    {
+      difference_type stride = 1;
+
+      // For each dimension in storage order, assign stride from
+      // previous dimension and multiply stride by dimension size.
+      // Note this is the extent size, not the subrange size.  If the
+      // direction of the dimension is descending, then the stride is
+      // negative to cause backward traversal.
+      for (indexed_storage_order_type::const_iterator dim = _storage_order.begin();
+           dim != _storage_order.end();
+           ++dim)
+        {
+          difference_type sign = +1;
+          if (dim->direction == Dimension::DESCENDING)
+            sign = -1;
+
+          _detail.at(dim->dimension).stride = stride * sign;
+          stride *= dimension(dim->dimension).extent;
+        }
+    }
+
+    void
+    DimensionSet::compute_storage_offset()
+    {
+      // Descending dimension offset.
+      difference_type descending_offset = 0U;
+
+      // If all dimensions are ascending, then the offset is zero.
+      bool all_ascending = true;
+      for (indexed_storage_order_type::const_iterator dim = _storage_order.begin();
+           dim != _storage_order.end();
+           ++dim)
+        {
+          if (dim->direction == Dimension::DESCENDING)
+            all_ascending = false;
+        }
+      if (!all_ascending)
+        {
+          // For each dimension in storage order where the dimension
+          // is descending, compute the offset as the (extent size -1)
+          // multiplied by the stride for this dimenesion.  The base
+          // offset is the sum of the offsets for all dimensions.
+          for (indexed_storage_order_type::const_iterator dim = _storage_order.begin();
+               dim != _storage_order.end();
+               ++dim)
+            {
+              if (dim->direction == Dimension::DESCENDING)
+                {
+                  DimensionStorageDetail& detail = _detail.at(dim->dimension);
+                  detail.descending_offset = (dimension(dim->dimension).extent - 1) *
+                    detail.stride;
+                  // Subtract because the offset is negative due to the negative stride.
+                  descending_offset -= detail.descending_offset;
+                }
+            }
+        }
+
+      _base = descending_offset;
+    }
+
+    DimensionSet
+    DimensionSet::subrange(const indexed_subrange_type& subrange) const
+    {
+      // Check for duplicates using set of indices.
+      std::set<index_type> used;
+
+      DimensionSet ret(*this);
+
+      for(indexed_subrange_type::const_iterator sub = subrange.begin();
+          sub != subrange.end();
+          ++sub)
+        {
+          Dimension& dim(ret._logical_order.at(sub->dimension));
+          // Range is relative to existing subrange; add to existing
+          // range start to make absolute.
+          dim = Dimension(dim, dim.begin + sub->begin, dim.begin + sub->end);
+
+          // Check for duplicate dimensions.
+          if (used.find(sub->dimension) != used.end())
+            {
+              boost::format fmt("Dimension %1% used multiple times in subrange");
+              fmt % sub->dimension;
+              throw std::logic_error(fmt.str());
+            }
+          used.insert(sub->dimension);
+
+          if(sub->end < sub->begin || sub->end == sub->begin ||
+             sub->end > dim.extent)
+            {
+              boost::format fmt("Dimension %1% subrange %2%–%3% invalid");
+              fmt % sub->dimension % sub->begin % sub->end;
+              throw std::logic_error(fmt.str());
+            }
+        }
+
+      // Recompute logical strides.
+      ret.compute_logical_strides();
+
+      return ret;
+    }
+
+    DimensionSet
+    DimensionSet::subrange(const named_subrange_type& subrange) const
+    {
+      std::map<std::string, index_type> nmap(name_map(_logical_order));
+      indexed_subrange_type isubrange;
+
+      // Convert named subrange to indexed subrange.
+      for (named_subrange_type::const_iterator s = subrange.begin();
+           s != subrange.end();
+           ++s)
+        {
+          std::map<std::string, index_type>::const_iterator i(nmap.find(s->dimension));
+          if (i == nmap.end())
+            {
+              boost::format fmt("Dimension name ‘%1%’ invalid");
+              fmt % s->dimension;
+              throw std::logic_error(fmt.str());
+            }
+          isubrange.push_back(indexed_subrange_type::value_type(i->second, s->begin, s->end));
+        }
+
+      // Note that duplicate dimensions will be caught here.
+      return this->subrange(isubrange);
+    }
+
+  }
+}

--- a/cpp/lib/ome/bioformats/Dimension.cpp
+++ b/cpp/lib/ome/bioformats/Dimension.cpp
@@ -73,7 +73,7 @@ namespace ome
         }
     }
 
-    DimensionSet::DimensionSet(const logical_order_type& dimensions):
+    DimensionSpace::DimensionSpace(const logical_order_type& dimensions):
       _logical_order(dimensions),
       _storage_order(),
       _detail(dimensions.size()),
@@ -82,8 +82,8 @@ namespace ome
       init();
     }
 
-    DimensionSet::DimensionSet(const logical_order_type&         dimensions,
-                               const indexed_storage_order_type& order):
+    DimensionSpace::DimensionSpace(const logical_order_type&         dimensions,
+                                   const indexed_storage_order_type& order):
       _logical_order(dimensions),
       _storage_order(),
       _detail(dimensions.size()),
@@ -93,8 +93,8 @@ namespace ome
       storage_order(order);
     }
 
-    DimensionSet::DimensionSet(const logical_order_type&       dimensions,
-                               const named_storage_order_type& order):
+    DimensionSpace::DimensionSpace(const logical_order_type&       dimensions,
+                                   const named_storage_order_type& order):
       _logical_order(dimensions),
       _storage_order(),
       _detail(dimensions.size()),
@@ -105,7 +105,7 @@ namespace ome
     }
 
     void
-    DimensionSet::init()
+    DimensionSpace::init()
     {
       _storage_order.reserve(_logical_order.size());
       _detail.resize(_logical_order.size());
@@ -134,11 +134,11 @@ namespace ome
     }
 
     void
-    DimensionSet::storage_order(const indexed_storage_order_type& order)
+    DimensionSpace::storage_order(const indexed_storage_order_type& order)
     {
       if (order.size() != size())
         {
-          boost::format fmt("Storage order dimension count %1% for order does not match set dimension count %2%");
+          boost::format fmt("Storage order dimension count %1% for order does not match space dimension count %2%");
           fmt % order.size() % size();
           throw std::logic_error(fmt.str());
         }
@@ -172,7 +172,7 @@ namespace ome
     }
 
     void
-    DimensionSet::storage_order(const named_storage_order_type& order)
+    DimensionSpace::storage_order(const named_storage_order_type& order)
     {
       std::map<std::string, index_type> nmap(name_map(_logical_order));
       indexed_storage_order_type iorder;
@@ -196,7 +196,7 @@ namespace ome
     }
 
     void
-    DimensionSet::compute_logical_strides()
+    DimensionSpace::compute_logical_strides()
     {
       difference_type stride = 1;
 
@@ -215,7 +215,7 @@ namespace ome
     }
 
     void
-    DimensionSet::compute_storage_strides()
+    DimensionSpace::compute_storage_strides()
     {
       difference_type stride = 1;
 
@@ -238,7 +238,7 @@ namespace ome
     }
 
     void
-    DimensionSet::compute_storage_offset()
+    DimensionSpace::compute_storage_offset()
     {
       // Descending dimension offset.
       difference_type descending_offset = 0U;
@@ -276,13 +276,13 @@ namespace ome
       _base = descending_offset;
     }
 
-    DimensionSet
-    DimensionSet::subrange(const indexed_subrange_type& subrange) const
+    DimensionSpace
+    DimensionSpace::subrange(const indexed_subrange_type& subrange) const
     {
       // Check for duplicates using set of indices.
       std::set<index_type> used;
 
-      DimensionSet ret(*this);
+      DimensionSpace ret(*this);
 
       for(indexed_subrange_type::const_iterator sub = subrange.begin();
           sub != subrange.end();
@@ -317,8 +317,8 @@ namespace ome
       return ret;
     }
 
-    DimensionSet
-    DimensionSet::subrange(const named_subrange_type& subrange) const
+    DimensionSpace
+    DimensionSpace::subrange(const named_subrange_type& subrange) const
     {
       std::map<std::string, index_type> nmap(name_map(_logical_order));
       indexed_subrange_type isubrange;

--- a/cpp/lib/ome/bioformats/Dimension.h
+++ b/cpp/lib/ome/bioformats/Dimension.h
@@ -1,0 +1,957 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_BIOFORMATS_DIMENSION_H
+#define OME_BIOFORMATS_DIMENSION_H
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <map>
+#include <iostream>
+
+#include <boost/format.hpp>
+
+#include <ome/compat/cstdint.h>
+
+namespace ome
+{
+  namespace bioformats
+  {
+
+    /**
+     * Dimension specification.
+     *
+     * A description of a single dimension, at a minimum the name of
+     * the dimension and its extent (size).  It may also include a
+     * subrange within the extent, used as a window to address a
+     * selected subrange of the full range.
+     *
+     * Type definitions are for use in related classes and functions.
+     */
+    struct Dimension
+    {
+      /// Size type for dimension extents.
+      typedef uint32_t size_type;
+      /// Index type for dimension indices.
+      typedef uint32_t index_type;
+      /// Signed difference type for difference between dimension indices.
+      typedef int32_t difference_type;
+      /// Direction of dimension progression.
+      enum direction
+        {
+          ASCENDING, ///< Ascending progression.
+          DESCENDING ///< Descending progression.
+        };
+
+      /// Dimension name.
+      std::string name;
+      /// Dimension size.
+      size_type extent;
+      /// Start index.
+      size_type begin;
+      /// End index.
+      size_type end;
+      /// Logical stride.
+      size_type stride;
+
+      /**
+       * Constructor (extent).
+       *
+       * @param name the dimension name.
+       * @param extent the dimension size (extent).
+       */
+      Dimension(const std::string& name,
+                size_type          extent = 1U):
+        name(name),
+        extent(extent),
+        begin(0U),
+        end(extent),
+        stride(1)
+      {
+        check(begin, end);
+      }
+
+      /**
+       * Constructor (range).
+       *
+       * If the begin and end indices are both the same value, this
+       * dimension exists logically fixed at the specified index, but
+       * has no storage.
+       *
+       * @param name the dimension name.
+       * @param extent the dimension size (extent).
+       * @param begin the starting index.
+       * @param end the ending index + 1.
+       */
+      Dimension(const std::string& name,
+                size_type          extent,
+                size_type          begin,
+                size_type          end):
+        name(name),
+        extent(extent),
+        begin(begin),
+        end(end),
+        stride(1)
+      {
+        check(begin, end);
+      }
+
+      /**
+       * Copy constructor (range).
+       *
+       * If the begin and end indices are both the same value, this
+       * dimension exists logically fixed at the specified index, but
+       * has no storage.
+       *
+       * @param dim the dimension to copy.
+       * @param begin the starting index.
+       * @param end the ending index + 1.
+       */
+      Dimension(const Dimension& dim,
+                size_type        begin,
+                size_type        end):
+        name(dim.name),
+        extent(dim.extent),
+        begin(begin),
+        end(end),
+        stride(1)
+      {
+        check(dim.begin, dim.end);
+      }
+
+      /**
+       * Check dimension extent and range.
+       *
+       * The extent must be greater than zero.
+       *
+       * The begin and end values marking the usable range within the
+       * total extent of the dimension must lie within zero and the
+       * extent size.  If this is a subrange of an existing subrange,
+       * it must lie within the existing subrange; i.e. it is not
+       * possible to expand a subrange, only to reduce it further.
+       *
+       * @param previous_begin the previous begin value (or else zero).
+       * @param previous_end the previous end value (or else current extent size).
+       * @throws std::logic_error if the subrange is invalid.
+       */
+      void
+      check(size_type previous_begin,
+            size_type previous_end);
+
+      /**
+       * Get usable size.
+       *
+       * This is determined by the begin and end values defining the
+       * usable range.
+       *
+       * @note Use extent for the full range.
+       *
+       * @returns the usable size.
+       */
+      size_type
+      size() const
+      {
+        return end - begin;
+      }
+
+      /**
+       * Compare dimensions by name.
+       *
+       * @param rhs the Dimension to compare.
+       * @returns @c true if lexicographically less than @c rhs.
+       */
+      bool
+      operator< (const Dimension& rhs)
+      {
+        return name < rhs.name;
+      }
+
+      /**
+       * Check validity of dimension.
+       * @returns @c true if invalid, @c false if valid.
+       */
+      bool
+      operator! () const
+      {
+        return name.empty() || extent == 0;
+      }
+    };
+
+    /**
+     * Dimension storage specification (by index).
+     *
+     * Specify the storage order of a single dimension in terms of the
+     * logical dimension index.
+     *
+     * @note Intended for use in an array where the array order
+     * denotes the storage order.
+     */
+    struct IndexedDimensionStorage
+    {
+      /// Logical dimension index.
+      Dimension::index_type dimension;
+      /// Direction of dimension progression (forward or backward).
+      Dimension::direction direction;
+
+      /**
+       * Constructor.
+       *
+       * @param dimension the logical dimension index.
+       * @param direction the direction of dimension progression.
+       */
+      IndexedDimensionStorage(Dimension::index_type dimension,
+                              Dimension::direction  direction):
+        dimension(dimension),
+        direction(direction)
+      {}
+    };
+
+    /**
+     * Dimension storage specification (by name).
+     *
+     * Specify the storage order of a single dimension in terms of the
+     * logical dimension name.
+     *
+     * @note Intended for use in an array where the array order
+     * denotes the storage order.
+     */
+    struct NamedDimensionStorage
+    {
+      /// Logical dimension name.
+      std::string dimension;
+      /// Direction of dimension progression (forward or backward).
+      Dimension::direction direction;
+
+      /**
+       * Constructor.
+       *
+       * @param dimension the logical dimension name.
+       * @param direction the direction of dimension progression.
+       */
+      NamedDimensionStorage(const std::string&   dimension,
+                            Dimension::direction direction):
+        dimension(dimension),
+        direction(direction)
+      {}
+    };
+
+    /**
+     * Dimension subrange (by index).
+     *
+     * Restrict the range of a dimension to a subrange of its full
+     * extent, as a half-open range of logical indices.
+     */
+    struct IndexedDimensionSubrange
+    {
+      /// Logical dimension index.
+      Dimension::index_type dimension;
+      /// Starting index in this dimension.
+      Dimension::index_type begin;
+      /// End index in this dimension.
+      Dimension::index_type end;
+
+      /**
+       * Constructor.
+       *
+       * @param dimension the logical dimension index.
+       * @param begin the starting index in this dimension.
+       * @param end the ending index +1 in this dimension.
+       */
+      IndexedDimensionSubrange(Dimension::index_type dimension,
+                               Dimension::index_type begin,
+                               Dimension::index_type end):
+        dimension(dimension),
+        begin(begin),
+        end(end)
+      {}
+    };
+
+    /**
+     * Dimension subrange (by name).
+     *
+     * Restrict the range of a dimension to a subrange of its full
+     * extent, as a half-open range of logical indices.
+     */
+    struct NamedDimensionSubrange
+    {
+      /// Logical dimension name.
+      std::string dimension;
+      /// Starting index in this dimension.
+      Dimension::index_type begin;
+      /// End index in this dimension.
+      Dimension::index_type end;
+
+      /**
+       * Constructor.
+       *
+       * @param dimension the logical dimension name.
+       * @param begin the starting index in this dimension.
+       * @param end the ending index +1 in this dimension.
+       */
+      NamedDimensionSubrange(const std::string&    dimension,
+                             Dimension::index_type begin,
+                             Dimension::index_type end):
+        dimension(dimension),
+        begin(begin),
+        end(end)
+      {}
+    };
+
+    /**
+     * Dimension storage details (in logical order).
+     */
+    struct DimensionStorageDetail
+    {
+      /// Element stride to increment index forward by one.
+      Dimension::difference_type stride;
+      /// Descending offset (nonzero for descending dimensions).
+      Dimension::difference_type descending_offset;
+
+      /// Constructor.
+      DimensionStorageDetail():
+        stride(1),
+        descending_offset(0)
+      {}
+    };
+
+    /**
+     * Collection of dimensions.
+     *
+     * This class implements the calculations needed to convert
+     * between a logical linear array index and logical coordinates in
+     * each dimension, and between logical coordinates and linear
+     * storage array index.
+     *
+     * The concept implemented is that a set of dimensions are
+     * referred to in a defined logical order.  This logical order is
+     * the order in which the end user or programmer will index
+     * dimensions, for example the coordinates to refer to a specific
+     * location in (x,y,z) might be (0,4,2).  The logical order
+     * however, need not be the same as the storage order (the
+     * physical layout in memory).  The storage order may be specified
+     * independently, and allows for the logical dimensions to be
+     * stored in an arbitrary order, each of which may progress in a
+     * forward or reverse direction.
+     *
+     * For the logical order and storage order, the stride for each
+     * dimension and base index are computed, to allow for fast
+     * translation between linear logical and storage indices and
+     * logical coordinates as an intermediate representation between
+     * the two.
+     *
+     * This class does not implement any storage; it is purely for
+     * implementing the calculations needed by a multi-dimensional
+     * array class or for any other calulation involving multiple
+     * dimensions.
+     *
+     * @see Boost.MultiArray for a compile-time templated alternative
+     * which will likely have higher performance, with the caveat that
+     * it requires the number of dimensions to be fixed at compile
+     * time.  This class trades off performance for run-time
+     * flexibility.
+     */
+    class DimensionSet
+    {
+    public:
+      /// @copydoc Dimension::size_type
+      typedef Dimension::size_type size_type;
+      /// @copydoc Dimension::index_type
+      typedef Dimension::index_type index_type;
+      /// @copydoc Dimension::difference_type
+      typedef Dimension::difference_type difference_type;
+
+      /// Index type for coordinate within a dimension.
+      typedef std::vector<index_type> coord_type;
+      /// Signed difference type for difference between coordinates.
+      typedef std::vector<difference_type> coord_difference_type;
+
+      /// Dimensions in logical order.
+      typedef std::vector<Dimension>                logical_order_type;
+      /// Dimensions in storage order (by index).
+      typedef std::vector<IndexedDimensionStorage>  indexed_storage_order_type;
+      /// Dimensions in storage order (by name).
+      typedef std::vector<NamedDimensionStorage>    named_storage_order_type;
+      /// Storage order details.
+      typedef std::vector<DimensionStorageDetail>   detail_type;
+      /// Dimension extents subrange (by index).
+      typedef std::vector<IndexedDimensionSubrange> indexed_subrange_type;
+      /// Dimension extents subrange (by name).
+      typedef std::vector<NamedDimensionSubrange>   named_subrange_type;
+
+    private:
+      /// Dimensions in logical order (user-addressable order).
+      std::vector<Dimension> _logical_order;
+      /// Dimensions in indexed storage order (describing physical memory layout).
+      indexed_storage_order_type _storage_order;
+      /// Dimension details in logical order (describing physical strides and offsets).
+      detail_type _detail;
+      /// Base offset.
+      index_type _base;
+
+    public:
+      /**
+       * Construct with default storage order.
+       *
+       * The logical dimension order and storage order may not be
+       * modified after construction.  The storage order (physical
+       * memory layout) defaults to the logical dimension order, with
+       * each dimension having ascending progression.
+       *
+       * @param dimensions the dimensions contained in this set, in
+       * logical order.  Dimension names must be unique within the set,
+       * and not repeated.
+       * @throws std::logic_error if the unique constraint is violated.
+       */
+      DimensionSet(const logical_order_type& dimensions);
+
+      /**
+       * Construct with indexed storage order.
+       *
+       * The logical dimension order and storage order may not be
+       * modified after construction.  The storage order is specified
+       * in terms of the index each dimension in the @c dimensions
+       * parameter.
+       *
+       * @param dimensions the dimensions contained in this set, in
+       * logical order.  Dimension names must be unique within the set,
+       * and not repeated.
+       * @param order the storage order (by dimension index in @c
+       * dimensions).  Dimension indices must not be repeated.
+       * @throws std::logic_error if the unique constraint is violated.
+       */
+      DimensionSet(const logical_order_type&         dimensions,
+                   const indexed_storage_order_type& order);
+
+      /**
+       * Construct with named storage order.
+       *
+       * The logical dimension order and storage order may not be
+       * modified after construction.  The storage order is specified
+       * in terms of the name of each dimension in the @c dimensions
+       * parameter.
+       *
+       * @param dimensions the dimensions contained in this set, in
+       * logical order.  Dimension names must be unique within the set,
+       * and not repeated.
+       * @param order the storage order (by dimension name in @c
+       * dimensions).  Dimension indices must not be repeated.
+       * @throws std::logic_error if the unique constraint is violated.
+       */
+      DimensionSet(const logical_order_type&       dimensions,
+                   const named_storage_order_type& order);
+
+    private:
+      /**
+       * Initialisation common to all constructor variants.
+       *
+       * @note A workaround for lack of delegating constructors pre-C++11.
+       */
+      void
+      init();
+
+      /**
+       * Set storage order (by index).
+       *
+       * The dimension list must not contain duplicate dimension indices.
+       *
+       * @param order the storage order.
+       */
+      void
+      storage_order(const indexed_storage_order_type& order);
+
+      /**
+       * Set storage order (by name).
+       *
+       * The dimension list must not contain duplicate dimension names.
+       *
+       * @param order the storage order.
+       */
+      void
+      storage_order(const named_storage_order_type& order);
+
+      /**
+       * Get mapping between dimension name and index for a logical dimension ordering.
+       *
+       * @param order the logical dimension ordering for which to create the mapping.
+       * @returns the mapping.
+       */
+      static
+      std::map<std::string, index_type>
+      name_map(const logical_order_type& order)
+      {
+        std::map<std::string, index_type> ret;
+
+        for (index_type i = 0; i < order.size(); ++i)
+          {
+            const Dimension& dim(order[i]);
+            ret.insert(std::make_pair(dim.name, i));
+          }
+
+        return ret;
+      }
+
+      /**
+       * Get mapping between dimension index and name for a logical dimension ordering.
+       *
+       * @param order the logical dimension ordering for which to create the mapping.
+       * @returns the mapping.
+       */
+      static
+      std::map<index_type, std::string>
+      index_map(const logical_order_type& order)
+      {
+        std::map<index_type, std::string> ret;
+
+        for (index_type i = 0; i < order.size(); ++i)
+          {
+            const Dimension& dim(order[i]);
+            ret.insert(std::make_pair(i, dim.name));
+          }
+
+        return ret;
+      }
+
+      /**
+       * Compute logical strides for each dimension.
+       *
+       * This is computed for each dimension in progessing logical
+       * order.
+       *
+       * @note The strides are not recomputed after any subsetting.
+       */
+      void
+      compute_logical_strides();
+
+      /**
+       * Compute storage strides for each dimension.
+       *
+       * This is computed for each dimension in progessing storage
+       * order.
+       *
+       * @note The strides are not recomputed after any subsetting.
+       */
+      void
+      compute_storage_strides();
+
+      /**
+       * Compute storage origin offset.
+       *
+       * This is computed as the sum of the calculated offsets for
+       * each descending dimension.
+       *
+       * @note The origin offset is not recomputed after any
+       * subsetting.
+       */
+      void
+      compute_storage_offset();
+
+    public:
+      /**
+       * The number of dimensions in the set.
+       *
+       * @returns the number of dimensions.
+       */
+      size_type
+      size() const
+      {
+        return _logical_order.size();
+      }
+
+      /**
+       * The number of elements (product of all dimension sizes).
+       *
+       * @note This is the product of the subrange size of each
+       * dimension, not the full range.  That is to say, it is the
+       * total number of accessible elements, which might be less than
+       * the total number of elements.
+       *
+       * @returns the number of elements.
+       */
+      size_type
+      num_elements() const
+      {
+        size_type n = 1;
+
+        for (std::vector<Dimension>::const_iterator dim = _logical_order.begin();
+             dim != _logical_order.end();
+             ++dim)
+          n *= dim->size();
+
+        return n;
+      }
+
+      /**
+       * Get the logical order of dimensions.
+       *
+       * @returns the logical order of dimensions.
+       */
+      const logical_order_type&
+      logical_order() const
+      {
+        return _logical_order;
+      }
+
+      /**
+       * Get the storage order of dimensions.
+       *
+       * @note the list is in storage order; to get the dimension
+       * details, look up the dimension in its logical order by the
+       * dimension index.
+       *
+       * @returns the storage order of dimensions.
+       */
+      const indexed_storage_order_type&
+      storage_order() const
+      {
+        return _storage_order;
+      }
+
+      /**
+       * Get a dimension by its index.
+       *
+       * @param dimension_index the logical index.
+       * @returns a reference to the dimension.
+       * @throws std::logic_error if the index is invalid.
+       */
+      const Dimension&
+      dimension(index_type dimension_index) const
+      {
+        if (dimension_index >= size())
+          {
+            boost::format fmt("Dimension index %1% out of valid range %2%–%3%");
+            fmt % dimension_index % 0 % (size() - 1);
+            throw std::logic_error(fmt.str());
+          }
+
+        return _logical_order[dimension_index];
+      }
+
+      /**
+       * Compute the logical index from logical coordinate.
+       *
+       * The logical coordinate values must be within the permitted
+       * subrange defined for each dimension (indexed relative from
+       * zero within the subrange).  If the indices fall outside the
+       * permitted subranges, the result is undefined.
+       *
+       * @param coord the logical coordinate.
+       * @returns the logical index corresponding to the specified
+       * coordinate.
+       */
+      index_type
+      logical_index(const coord_type& coord) const
+      {
+        DimensionSet::difference_type ret = 0;
+
+        // For each dimension in logical order, multiply the
+        // coordinate value by the stride for the dimension and return
+        // the sum for all dimensions.
+        for(size_type d = 0; d < size(); ++d)
+          ret += coord.at(d) * dimension(d).stride;
+
+        return ret;
+      }
+
+      /**
+       * Compute the logical coordinate from logical index.
+       *
+       * The logical index must correspond to a valid coordinate
+       * within the permitted subrange defined for each dimension,
+       * otherwise the result is undefined.
+       *
+       * @param index the logical index.
+       * @param coord the logical coordinate corresponding to the
+       * specified index.
+       */
+      void
+      logical_coord(index_type  index,
+                    coord_type& coord) const
+      {
+        // Note a coord reference is used rather than returning it for
+        // efficiency--it avoids allocating storage for a vector which
+        // is not ideal when called repeatedly.
+        coord.resize(size(), 0U);
+
+        // For each dimension in reverse logical order, compute the
+        // coordinate value by dividing by the stride for the
+        // dimension, then repeat using the remainder.
+        for(size_type d = 0; d < size(); ++d)
+          {
+            size_type rd = size() - d;
+            --rd;
+
+            coord.at(rd) = index / dimension(rd).stride;
+            index %= dimension(rd).stride;
+          }
+      }
+
+      /**
+       * Compute the storage index from logical coordinate.
+       *
+       * The logical coordinate values must be within the permitted
+       * subrange defined for each dimension (indexed relative from
+       * zero within the subrange).  If the indices fall outside the
+       * permitted subranges, the result is undefined.
+       *
+       * @param coord the logical coordinate.
+       * @returns the storage index corresponding to the specified
+       * coordinate.
+       */
+      index_type
+      storage_index(const coord_type& coord) const
+      {
+        if (_logical_order.size() != coord.size())
+          {
+            boost::format fmt("Coordinate dimension count %1% does not match set dimension count %2%");
+            fmt % coord.size() % size();
+            throw std::logic_error(fmt.str());
+          }
+
+        difference_type pos = _base;
+
+        // For each dimension in logical order, multiply the
+        // coordinate value by the stride for the dimension and return
+        // the sum for all dimensions.  When using subranges, the
+        // subrange start is added to the coordinate to ensure that
+        // the calculation is using coordinates in the full range,
+        // rather than within the subrange window.
+        for (std::vector<Dimension>::size_type d = 0; d < size(); ++d)
+          {
+            const Dimension& dim(dimension(d));
+            const DimensionStorageDetail& detail = _detail.at(d);
+            pos += detail.stride * (coord.at(d) + dim.begin);
+          }
+
+        return pos;
+      }
+
+      /**
+       * Compute the logical coordinate from storage index.
+       *
+       * The storage index must correspond to a valid coordinate
+       * within the permitted subrange defined for each dimension,
+       * otherwise the result is undefined.
+       *
+       * @param index the storage index.
+       * @param coord the logical coordinate corresponding to the
+       * specified index.
+       */
+      void
+      storage_coord(index_type  index,
+                    coord_type& coord) const
+      {
+        // Note a coord reference is used rather than returning it for
+        // efficiency--it avoids allocating storage for a vector which
+        // is not ideal when called repeatedly.
+        coord.resize(size(), 0U);
+
+        // For each dimension in reverse logical order, compute the
+        // coordinate value by dividing by the stride for the
+        // dimension, then repeat using the remainder.  When using
+        // subranges, the subrange start is subtracted from the
+        // coordinate to ensure that the calculation is using
+        // coordinates in the full range, but returning the coordinate
+        // within the subrange window.
+        difference_type remainder = index;
+        for (std::vector<Dimension>::size_type d = 0; d < size(); ++d)
+          {
+            index_type id = size() - d - 1;
+            const IndexedDimensionStorage& sdim(_storage_order.at(id));
+            const Dimension& dim(dimension(sdim.dimension));
+            const DimensionStorageDetail& dimdetail(_detail.at(sdim.dimension));
+
+            if (dimdetail.stride < 0)
+              {
+                difference_type v = dim.extent * abs(dimdetail.stride);
+                v -= remainder;
+                v -= 1;
+                coord.at(sdim.dimension) = v / abs(dimdetail.stride);
+              }
+            else
+              {
+                coord.at(sdim.dimension) = remainder / dimdetail.stride;
+              }
+            coord.at(sdim.dimension) -= dim.begin;
+            remainder %= abs(dimdetail.stride);
+          }
+      }
+
+      /**
+       * Create a subrange from this dimension set (by index).
+       *
+       * The subrange must be equal to or less than any subrange
+       * already set; it is not possible to expand the range.
+       *
+       * @param subrange the dimensions to reduce in permitted range.
+       * @returns a new dimension set using the specified subrange.
+       */
+      DimensionSet
+      subrange(const indexed_subrange_type& subrange) const;
+
+      /**
+       * Create a subrange from this dimension set (by name).
+       *
+       * The subrange must be equal to or less than any subrange
+       * already set; it is not possible to expand the range.
+       *
+       * @param subrange the dimensions to reduce in permitted range.
+       * @returns a new dimension set using the specified subrange.
+       */
+      DimensionSet
+      subrange(const named_subrange_type& subrange) const;
+
+      template<class charT, class traits>
+      friend std::basic_ostream<charT,traits>&
+      operator<< (std::basic_ostream<charT,traits>& os,
+                  const DimensionSet& set);
+    };
+
+    /**
+     * Output DimensionSet to output stream.
+     *
+     * @param os the output stream.
+     * @param set the DimensionSet to output.
+     * @returns the output stream.
+     */
+    template<class charT, class traits>
+    inline std::basic_ostream<charT,traits>&
+    operator<< (std::basic_ostream<charT,traits>& os,
+                const DimensionSet& set)
+    {
+      os << "Logical dimensions:      (";
+      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
+           dim != set._logical_order.end();
+           ++dim)
+        {
+          os << dim->name;
+          if (dim + 1 < set._logical_order.end())
+            os << ',';
+        }
+      os << ")\nLogical extents:         (";
+      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
+           dim != set._logical_order.end();
+           ++dim)
+        {
+          os << dim->extent;
+          if (dim + 1 < set._logical_order.end())
+            os << ',';
+        }
+      os << ")\nLogical ranges:          (";
+      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
+           dim != set._logical_order.end();
+           ++dim)
+        {
+          os << '[' << dim->begin << ',' << dim->end << ')';
+          if (dim + 1 < set._logical_order.end())
+            os << ',';
+        }
+      os << ")\nLogical sizes:           (";
+      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
+           dim != set._logical_order.end();
+           ++dim)
+        {
+          os << dim->size();
+          if (dim + 1 < set._logical_order.end())
+            os << ',';
+        }
+      os << ")\nLogical strides:         (";
+      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
+           dim != set._logical_order.end();
+           ++dim)
+        {
+          os << dim->stride;
+          if (dim + 1 < set._logical_order.end())
+            os << ',';
+        }
+      os << ")\nSize:                    " << set.size()
+         << "\nElements:                " << set.num_elements()
+         << "\nStorage dimensions:      (";
+      for (DimensionSet::indexed_storage_order_type::const_iterator dim = set._storage_order.begin();
+           dim != set._storage_order.end();
+           ++dim)
+        {
+          const Dimension& ldim(set.dimension(dim->dimension));
+          os << ldim.name;
+          if (dim + 1 < set._storage_order.end())
+            os << ',';
+        }
+      os << ")\nStorage extents:         (";
+      for (DimensionSet::indexed_storage_order_type::const_iterator dim = set._storage_order.begin();
+           dim != set._storage_order.end();
+           ++dim)
+        {
+          const Dimension& ldim(set.dimension(dim->dimension));
+          os << (dim->direction == Dimension::ASCENDING ? '+' : '-') << ldim.extent;
+          if (dim + 1 < set._storage_order.end())
+            os << ',';
+        }
+      os << ")\nBase:                    " << set._base
+         << "\nStrides:                 (";
+      for (std::vector<DimensionStorageDetail>::const_iterator detail = set._detail.begin();
+           detail != set._detail.end();
+           ++detail)
+        {
+          os << detail->stride;
+          if (detail + 1 < set._detail.end())
+            os << ',';
+        }
+      os << ")\nDescending offsets:      (";
+      for (std::vector<DimensionStorageDetail>::const_iterator detail = set._detail.begin();
+           detail != set._detail.end();
+           ++detail)
+        {
+          os << detail->descending_offset;
+          if (detail + 1 < set._detail.end())
+            os << ',';
+        }
+      os << ")\n";
+      return os;
+    }
+
+  }
+}
+
+#endif // OME_BIOFORMATS_DIMENSION_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/bioformats/Dimension.h
+++ b/cpp/lib/ome/bioformats/Dimension.h
@@ -359,8 +359,8 @@ namespace ome
      * each dimension, and between logical coordinates and linear
      * storage array index.
      *
-     * The concept implemented is that a set of dimensions are
-     * referred to in a defined logical order.  This logical order is
+     * The concept implemented is that an abstrace space is set of
+     * dimensions in a defined logical order.  This logical order is
      * the order in which the end user or programmer will index
      * dimensions, for example the coordinates to refer to a specific
      * location in (x,y,z) might be (0,4,2).  The logical order
@@ -387,7 +387,7 @@ namespace ome
      * time.  This class trades off performance for run-time
      * flexibility.
      */
-    class DimensionSet
+    class DimensionSpace
     {
     public:
       /// @copydoc Dimension::size_type
@@ -434,12 +434,13 @@ namespace ome
        * memory layout) defaults to the logical dimension order, with
        * each dimension having ascending progression.
        *
-       * @param dimensions the dimensions contained in this set, in
-       * logical order.  Dimension names must be unique within the set,
-       * and not repeated.
-       * @throws std::logic_error if the unique constraint is violated.
+       * @param dimensions the dimensions contained in this space, in
+       * logical order.  Dimension names must be unique within the
+       * space, and not repeated.
+       * @throws std::logic_error if the unique constraint is
+       * violated.
        */
-      DimensionSet(const logical_order_type& dimensions);
+      DimensionSpace(const logical_order_type& dimensions);
 
       /**
        * Construct with indexed storage order.
@@ -449,15 +450,16 @@ namespace ome
        * in terms of the index each dimension in the @c dimensions
        * parameter.
        *
-       * @param dimensions the dimensions contained in this set, in
-       * logical order.  Dimension names must be unique within the set,
-       * and not repeated.
+       * @param dimensions the dimensions contained in this space, in
+       * logical order.  Dimension names must be unique within the
+       * space, and not repeated.
        * @param order the storage order (by dimension index in @c
        * dimensions).  Dimension indices must not be repeated.
-       * @throws std::logic_error if the unique constraint is violated.
+       * @throws std::logic_error if the unique constraint is
+       * violated.
        */
-      DimensionSet(const logical_order_type&         dimensions,
-                   const indexed_storage_order_type& order);
+      DimensionSpace(const logical_order_type&         dimensions,
+                     const indexed_storage_order_type& order);
 
       /**
        * Construct with named storage order.
@@ -467,15 +469,16 @@ namespace ome
        * in terms of the name of each dimension in the @c dimensions
        * parameter.
        *
-       * @param dimensions the dimensions contained in this set, in
-       * logical order.  Dimension names must be unique within the set,
-       * and not repeated.
+       * @param dimensions the dimensions contained in this space, in
+       * logical order.  Dimension names must be unique within the
+       * space, and not repeated.
        * @param order the storage order (by dimension name in @c
        * dimensions).  Dimension indices must not be repeated.
-       * @throws std::logic_error if the unique constraint is violated.
+       * @throws std::logic_error if the unique constraint is
+       * violated.
        */
-      DimensionSet(const logical_order_type&       dimensions,
-                   const named_storage_order_type& order);
+      DimensionSpace(const logical_order_type&       dimensions,
+                     const named_storage_order_type& order);
 
     private:
       /**
@@ -487,7 +490,7 @@ namespace ome
       init();
 
       /**
-       * Set storage order (by index).
+       * Space storage order (by index).
        *
        * The dimension list must not contain duplicate dimension indices.
        *
@@ -497,7 +500,7 @@ namespace ome
       storage_order(const indexed_storage_order_type& order);
 
       /**
-       * Set storage order (by name).
+       * Space storage order (by name).
        *
        * The dimension list must not contain duplicate dimension names.
        *
@@ -584,7 +587,7 @@ namespace ome
 
     public:
       /**
-       * The number of dimensions in the set.
+       * The number of dimensions in the space.
        *
        * @returns the number of dimensions.
        */
@@ -678,7 +681,7 @@ namespace ome
       index_type
       logical_index(const coord_type& coord) const
       {
-        DimensionSet::difference_type ret = 0;
+        DimensionSpace::difference_type ret = 0;
 
         // For each dimension in logical order, multiply the
         // coordinate value by the stride for the dimension and return
@@ -739,7 +742,7 @@ namespace ome
       {
         if (_logical_order.size() != coord.size())
           {
-            boost::format fmt("Coordinate dimension count %1% does not match set dimension count %2%");
+            boost::format fmt("Coordinate dimension count %1% does not match space dimension count %2%");
             fmt % coord.size() % size();
             throw std::logic_error(fmt.str());
           }
@@ -814,131 +817,131 @@ namespace ome
       }
 
       /**
-       * Create a subrange from this dimension set (by index).
+       * Create a subrange from this space (by index).
        *
        * The subrange must be equal to or less than any subrange
        * already set; it is not possible to expand the range.
        *
        * @param subrange the dimensions to reduce in permitted range.
-       * @returns a new dimension set using the specified subrange.
+       * @returns a new space using the specified subrange.
        */
-      DimensionSet
+      DimensionSpace
       subrange(const indexed_subrange_type& subrange) const;
 
       /**
-       * Create a subrange from this dimension set (by name).
+       * Create a subrange from this space (by name).
        *
        * The subrange must be equal to or less than any subrange
        * already set; it is not possible to expand the range.
        *
        * @param subrange the dimensions to reduce in permitted range.
-       * @returns a new dimension set using the specified subrange.
+       * @returns a new space using the specified subrange.
        */
-      DimensionSet
+      DimensionSpace
       subrange(const named_subrange_type& subrange) const;
 
       template<class charT, class traits>
       friend std::basic_ostream<charT,traits>&
       operator<< (std::basic_ostream<charT,traits>& os,
-                  const DimensionSet& set);
+                  const DimensionSpace&             space);
     };
 
     /**
-     * Output DimensionSet to output stream.
+     * Output DimensionSpace to output stream.
      *
      * @param os the output stream.
-     * @param set the DimensionSet to output.
+     * @param space the DimensionSpace to output.
      * @returns the output stream.
      */
     template<class charT, class traits>
     inline std::basic_ostream<charT,traits>&
     operator<< (std::basic_ostream<charT,traits>& os,
-                const DimensionSet& set)
+                const DimensionSpace&             space)
     {
       os << "Logical dimensions:      (";
-      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
-           dim != set._logical_order.end();
+      for (std::vector<Dimension>::const_iterator dim = space._logical_order.begin();
+           dim != space._logical_order.end();
            ++dim)
         {
           os << dim->name;
-          if (dim + 1 < set._logical_order.end())
+          if (dim + 1 < space._logical_order.end())
             os << ',';
         }
       os << ")\nLogical extents:         (";
-      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
-           dim != set._logical_order.end();
+      for (std::vector<Dimension>::const_iterator dim = space._logical_order.begin();
+           dim != space._logical_order.end();
            ++dim)
         {
           os << dim->extent;
-          if (dim + 1 < set._logical_order.end())
+          if (dim + 1 < space._logical_order.end())
             os << ',';
         }
       os << ")\nLogical ranges:          (";
-      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
-           dim != set._logical_order.end();
+      for (std::vector<Dimension>::const_iterator dim = space._logical_order.begin();
+           dim != space._logical_order.end();
            ++dim)
         {
           os << '[' << dim->begin << ',' << dim->end << ')';
-          if (dim + 1 < set._logical_order.end())
+          if (dim + 1 < space._logical_order.end())
             os << ',';
         }
       os << ")\nLogical sizes:           (";
-      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
-           dim != set._logical_order.end();
+      for (std::vector<Dimension>::const_iterator dim = space._logical_order.begin();
+           dim != space._logical_order.end();
            ++dim)
         {
           os << dim->size();
-          if (dim + 1 < set._logical_order.end())
+          if (dim + 1 < space._logical_order.end())
             os << ',';
         }
       os << ")\nLogical strides:         (";
-      for (std::vector<Dimension>::const_iterator dim = set._logical_order.begin();
-           dim != set._logical_order.end();
+      for (std::vector<Dimension>::const_iterator dim = space._logical_order.begin();
+           dim != space._logical_order.end();
            ++dim)
         {
           os << dim->stride;
-          if (dim + 1 < set._logical_order.end())
+          if (dim + 1 < space._logical_order.end())
             os << ',';
         }
-      os << ")\nSize:                    " << set.size()
-         << "\nElements:                " << set.num_elements()
+      os << ")\nSize:                    " << space.size()
+         << "\nElements:                " << space.num_elements()
          << "\nStorage dimensions:      (";
-      for (DimensionSet::indexed_storage_order_type::const_iterator dim = set._storage_order.begin();
-           dim != set._storage_order.end();
+      for (DimensionSpace::indexed_storage_order_type::const_iterator dim = space._storage_order.begin();
+           dim != space._storage_order.end();
            ++dim)
         {
-          const Dimension& ldim(set.dimension(dim->dimension));
+          const Dimension& ldim(space.dimension(dim->dimension));
           os << ldim.name;
-          if (dim + 1 < set._storage_order.end())
+          if (dim + 1 < space._storage_order.end())
             os << ',';
         }
       os << ")\nStorage extents:         (";
-      for (DimensionSet::indexed_storage_order_type::const_iterator dim = set._storage_order.begin();
-           dim != set._storage_order.end();
+      for (DimensionSpace::indexed_storage_order_type::const_iterator dim = space._storage_order.begin();
+           dim != space._storage_order.end();
            ++dim)
         {
-          const Dimension& ldim(set.dimension(dim->dimension));
+          const Dimension& ldim(space.dimension(dim->dimension));
           os << (dim->direction == Dimension::ASCENDING ? '+' : '-') << ldim.extent;
-          if (dim + 1 < set._storage_order.end())
+          if (dim + 1 < space._storage_order.end())
             os << ',';
         }
-      os << ")\nBase:                    " << set._base
+      os << ")\nBase:                    " << space._base
          << "\nStrides:                 (";
-      for (std::vector<DimensionStorageDetail>::const_iterator detail = set._detail.begin();
-           detail != set._detail.end();
+      for (std::vector<DimensionStorageDetail>::const_iterator detail = space._detail.begin();
+           detail != space._detail.end();
            ++detail)
         {
           os << detail->stride;
-          if (detail + 1 < set._detail.end())
+          if (detail + 1 < space._detail.end())
             os << ',';
         }
       os << ")\nDescending offsets:      (";
-      for (std::vector<DimensionStorageDetail>::const_iterator detail = set._detail.begin();
-           detail != set._detail.end();
+      for (std::vector<DimensionStorageDetail>::const_iterator detail = space._detail.begin();
+           detail != space._detail.end();
            ++detail)
         {
           os << detail->descending_offset;
-          if (detail + 1 < set._detail.end())
+          if (detail + 1 < space._detail.end())
             os << ',';
         }
       os << ")\n";

--- a/cpp/test/ome-bioformats/CMakeLists.txt
+++ b/cpp/test/ome-bioformats/CMakeLists.txt
@@ -47,6 +47,12 @@ if(BUILD_TESTS)
     bf_add_test(ome-bioformats/headers ome-bioformats-headers)
   endif(extended-tests)
 
+  add_executable(dimension dimension.cpp)
+  target_link_libraries(dimension ome-bioformats)
+  target_link_libraries(dimension ome-test)
+
+  bf_add_test(ome-bioformats/dimension dimension)
+
   add_executable(formatreader formatreader.cpp)
   target_link_libraries(formatreader ome-bioformats)
   target_link_libraries(formatreader ome-test)

--- a/cpp/test/ome-bioformats/dimension.cpp
+++ b/cpp/test/ome-bioformats/dimension.cpp
@@ -1,0 +1,1056 @@
+/*
+ * #%L
+ * OME-BIOFORMATS C++ library for image IO.
+ * %%
+ * Copyright © 2015 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <algorithm>
+#include <cmath>
+
+#include <boost/range/size.hpp>
+
+#include <ome/bioformats/Dimension.h>
+
+#include <ome/test/test.h>
+
+using ome::bioformats::Dimension;
+using ome::bioformats::DimensionSet;
+using ome::bioformats::IndexedDimensionStorage;
+using ome::bioformats::NamedDimensionStorage;
+using ome::bioformats::IndexedDimensionSubrange;
+using ome::bioformats::NamedDimensionSubrange;
+
+namespace
+{
+
+  // Print a 2D array.
+  // planecoord is the index into the higher dimension (>=2) indices;
+  // the lowest two dimensions will be rendered in a 2D grid.
+  void dump_array(const DimensionSet& set,
+                  DimensionSet::coord_type planecoord,
+                  uint32_t index_size,
+                  DimensionSet::index_type (DimensionSet::*get_index)(const DimensionSet::coord_type& coord) const)
+  {
+    if (set.size() == 0)
+      return;
+
+    uint32_t ylabsize = 1;
+    uint32_t yvalsize = 1;
+    uint32_t nx = 1;
+    uint32_t ny = 1;
+
+    const DimensionSet::logical_order_type& logical(set.logical_order());
+    nx = logical.at(0).size();
+    if (set.size() > 1)
+      {
+        ylabsize = logical.at(1).name.size();
+        ny = logical.at(1).size();
+
+        yvalsize = static_cast<uint32_t>(std::floor(std::log10(static_cast<float>(logical.at(1).size()-1)))) + 1;
+      }
+
+    // Header
+    std::string sepy;
+    std::string sepy2;
+    if (set.size() > 1)
+      {
+        sepy = std::string(ylabsize + yvalsize + 2, ' ');
+        sepy2 = std::string(ylabsize + 1, ' ');
+      }
+    std::string xthickline;
+    std::string xthinline;
+    std::string ythickline;
+    std::string ythinline;
+    for (uint32_t i = 0; i < index_size; ++i)
+      {
+        xthickline += "━";
+        xthinline += "─";
+      }
+    for (uint32_t i = 0; i < yvalsize; ++i)
+      {
+        ythickline += "━";
+        ythinline += "─";
+      }
+
+    // Column label
+    std::cout << sepy << logical.at(0).name << '\n';
+
+    // Top line
+    std::cout << sepy << "┏";
+    for (uint32_t i = 0; i < nx; ++i)
+      {
+        std::cout << xthickline;
+        if (i + 1 < nx)
+          std::cout << "┯";
+      }
+    std::cout << "┓\n";
+
+    // Column values
+    std::cout << sepy << "┃";
+    for (uint32_t i = 0; i < nx; ++i)
+      {
+        std::cout << std::setw(index_size) << std::right << i;
+        if (i + 1 < nx)
+          std::cout << "│";
+      }
+    std::cout << "┃\n";
+
+    // Mid line
+    if (set.size() > 1)
+      {
+        std::cout << logical.at(1).name << ' ' << "┏";
+        for (uint32_t i = 0; i < 1; ++i)
+          {
+            std::cout << ythickline;
+            if (i + 1 < 1)
+              std::cout << "┯";
+          }
+        std::cout << "╋";
+        for (uint32_t i = 0; i < nx; ++i)
+          {
+            std::cout << xthickline;
+            if (i + 1 < nx)
+              std::cout << "┿";
+          }
+        std::cout << "┫\n";
+      }
+    else
+      {
+        std::cout << sepy << "┣";
+        for (uint32_t i = 0; i < nx; ++i)
+          {
+            std::cout << xthickline;
+            if (i + 1 < nx)
+              std::cout << "┿";
+          }
+        std::cout << "┫\n";
+      }
+
+    DimensionSet::coord_type index;
+    index.push_back(0);
+    if (set.size() > 1)
+      index.push_back(0);
+    std::copy(planecoord.begin(), planecoord.end(),
+              std::back_inserter(index));
+
+    // Loop over rows.
+    if (set.size() > 1)
+      {
+        for (uint32_t y = 0; y < ny; ++y)
+          {
+            if (set.size() > 1)
+              index.at(1) = y;
+
+            // Row values
+            if (set.size() > 1)
+              {
+                std::cout << sepy2 << "┃";
+                for (uint32_t i = 0; i < 1; ++i)
+                  {
+                    std::cout << std::setw(yvalsize) << std::right << y;
+                    if (i + 1 < 1)
+                      std::cout << "│";
+                  }
+                std::cout << "┃";
+                for (uint32_t x = 0; x < nx; ++x)
+                  {
+                    index.at(0) = x;
+                    std::cout << std::setw(index_size) << (set.*get_index)(index);
+                    if (x + 1 < nx)
+                      std::cout << "│";
+                  }
+                std::cout << "┃\n";
+              }
+
+            // Row line
+            if (y + 1 < ny && set.size() > 1)
+              {
+                std::cout << sepy2 << "┠";
+                for (uint32_t i = 0; i < 1; ++i)
+                  {
+                    std::cout << ythinline;
+                    if (i + 1 < 1)
+                      std::cout << "┼";
+                  }
+                std::cout << "╂";
+                for (uint32_t i = 0; i < nx; ++i)
+                  {
+                    std::cout << xthinline;
+                    if (i + 1 < nx)
+                      std::cout << "┼";
+                  }
+                std::cout << "┨\n";
+              }
+          }
+      }
+    else
+      {
+        std::cout << sepy << "┃";
+        for (uint32_t x = 0; x < nx; ++x)
+          {
+            index.at(0) = x;
+            std::cout << std::setw(index_size) << (set.*get_index)(index);
+            if (x + 1 < nx)
+              std::cout << "│";
+          }
+        std::cout << "┃\n";
+      }
+
+    // Bottom line
+    if (set.size() > 1)
+      {
+        std::cout << sepy2 << "┗";
+        for (uint32_t i = 0; i < 1; ++i)
+          {
+            std::cout << ythickline;
+            if (i + 1 < 1)
+              std::cout << "┷";
+          }
+        std::cout << "┻";
+        for (uint32_t i = 0; i < nx; ++i)
+          {
+            std::cout << xthickline;
+            if (i + 1 < nx)
+              std::cout << "┷";
+          }
+        std::cout << "┛\n";
+      }
+    else
+      {
+        std::cout << sepy << "┗";
+        for (uint32_t i = 0; i < nx; ++i)
+          {
+            std::cout << xthickline;
+            if (i + 1 < nx)
+              std::cout << "┷";
+          }
+        std::cout << "┛\n";
+      }
+  }
+
+  // Print an nD array.
+  void
+  dump_array(const DimensionSet& set,
+             bool                storage = true)
+  {
+    DimensionSet::index_type (DimensionSet::*get_index)(const DimensionSet::coord_type& coord) const = &DimensionSet::storage_index;
+    if (!storage)
+      get_index = &DimensionSet::logical_index;
+
+    // Maximum length of index for display.
+    uint32_t index_size = 1;
+    {
+      DimensionSet::coord_type idx;
+      for(Dimension::index_type i = 0; i < set.num_elements(); ++i)
+        {
+          set.logical_coord(i, idx);
+          index_size = std::max(index_size,
+                                static_cast<uint32_t>(std::floor(std::log10(static_cast<float>((set.*get_index)(idx))))) + 1);
+        }
+    }
+
+    if (set.size() < 3) // Render as 1D or 2D plane
+      {
+        DimensionSet::coord_type planecoord; // Intentionally empty.
+        dump_array(set, planecoord, index_size, get_index);
+      }
+    else // Render as multiple 2D planes
+      {
+        const DimensionSet::logical_order_type& logical(set.logical_order());
+
+        std::vector<Dimension> dims;
+        for (uint32_t i = 2; i < logical.size(); ++i)
+          dims.push_back(logical.at(i));
+        DimensionSet set2(dims);
+
+        DimensionSet::coord_type coord;
+        for(Dimension::index_type i = 0; i < set2.num_elements(); ++i)
+          {
+            set2.logical_coord(i, coord);
+            for (uint32_t j = 0; j < coord.size(); ++j)
+              {
+                const Dimension& dim(logical.at(j + 2));
+                std::cout << dim.name << '=' << coord.at(j);
+                if (j + 1 < coord.size())
+                  std::cout << ", ";
+              }
+            std::cout << '\n';
+            dump_array(set, coord, index_size, get_index);
+            std::cout << '\n';
+          }
+      }
+  }
+
+  // Print a vector-type object with comma separators.
+  template<typename T>
+  struct dump_vector
+  {
+    const T& v;
+
+    dump_vector(const T& v):
+      v(v)
+    {}
+  };
+
+  template<typename T>
+  std::ostream&
+  operator << (std::ostream& os, const dump_vector<T>& vec)
+  {
+    for (typename T::const_iterator i = vec.v.begin();
+         i != vec.v.end();
+         ++i)
+      {
+        os << *i;
+        if (i + 1 != vec.v.end())
+          os << ',';
+      }
+    return os;
+  }
+
+  // Compute all direction permutations for a given number of
+  // dimensions.
+  std::vector<std::vector<Dimension::direction> >
+  direction_permutations(Dimension::index_type count)
+  {
+    // Combinations of dimension progression directions.
+    std::vector<std::vector<Dimension::direction> > directions;
+    {
+      for (Dimension::index_type i = 0U; i < (1U << count); ++i)
+        {
+          std::vector<Dimension::direction> direction;
+          for (Dimension::index_type j = 0U; j < count; ++j)
+            {
+              if (!(i & (1 << j)))
+                direction.push_back(Dimension::ASCENDING);
+              else
+                direction.push_back(Dimension::DESCENDING);
+            }
+          directions.push_back(direction);
+        }
+    }
+
+    return directions;
+  }
+
+  // Compute all order permutations (by index) for a given set of
+  // dimensions.
+  std::vector<std::vector<IndexedDimensionStorage> >
+  indexed_order_permutations(const std::vector<Dimension>& dims)
+  {
+    Dimension::index_type count = dims.size();
+
+    // Combinations of dimension progression directions.
+    std::vector<std::vector<Dimension::direction> > directions(direction_permutations(count));
+
+    // Combinations of dimension storage ordering.
+    std::vector<std::vector<Dimension::index_type> > orders;
+    {
+      std::vector<Dimension::index_type> order;
+      for(Dimension::index_type i = 0; i < count; ++i)
+        order.push_back(i);
+
+      do
+        {
+          orders.push_back(order);
+        }
+      while(std::next_permutation(order.begin(), order.end()));
+    }
+
+    std::vector<std::vector<IndexedDimensionStorage> > ret;
+
+    for(std::vector<std::vector<Dimension::index_type> >::const_iterator i = orders.begin();
+        i != orders.end();
+        ++i)
+      {
+        for(std::vector<std::vector<Dimension::direction> >::const_iterator j = directions.begin();
+            j != directions.end();
+            ++j)
+          {
+            std::vector<IndexedDimensionStorage> storage;
+            for (Dimension::index_type k = 0; k < count; ++k)
+              storage.push_back(IndexedDimensionStorage(i->at(k), j->at(k)));
+            ret.push_back(storage);
+          }
+      }
+
+    return ret;
+  }
+
+  // Compute all order permutations (by name) for a given set of
+  // dimensions.
+  std::vector<std::vector<NamedDimensionStorage> >
+  named_order_permutations(const std::vector<Dimension>& dims)
+  {
+    Dimension::index_type count = dims.size();
+
+    // Combinations of dimension progression directions.
+    std::vector<std::vector<Dimension::direction> > directions(direction_permutations(count));
+
+    // Combinations of dimension storage ordering.
+    std::vector<std::vector<std::string> > orders;
+    {
+      std::vector<std::string> order;
+      for(Dimension::index_type i = 0; i < count; ++i)
+        order.push_back(dims.at(i).name);
+      std::sort(order.begin(), order.end());
+
+      do
+        {
+          orders.push_back(order);
+        }
+      while(std::next_permutation(order.begin(), order.end()));
+    }
+
+    std::vector<std::vector<NamedDimensionStorage> > ret;
+
+    for(std::vector<std::vector<std::string> >::const_iterator i = orders.begin();
+        i != orders.end();
+        ++i)
+      {
+        for(std::vector<std::vector<Dimension::direction> >::const_iterator j = directions.begin();
+            j != directions.end();
+            ++j)
+          {
+            std::vector<NamedDimensionStorage> storage;
+            for (Dimension::index_type k = 0; k < count; ++k)
+              storage.push_back(NamedDimensionStorage(i->at(k), j->at(k)));
+            ret.push_back(storage);
+          }
+      }
+
+    return ret;
+  }
+
+  // Get all storage order permutations from a dimension list and list
+  // of indexed or named storage orders, realised in the form of
+  // constructed DimensionSet objects.
+  template<typename Storage>
+  std::vector<DimensionSet>
+  order_permutations(std::vector<Dimension>             dims,
+                     std::vector<std::vector<Storage> > orders)
+  {
+    {
+      DimensionSet setdef(dims);
+
+      std::cout << "DimensionSet default parameters:\n"
+                << setdef
+                << "\nDimensionSet logical layout:\n\n";
+      dump_array(setdef, false);
+      std::cout << "\nDimensionSet default storage layout:\n\n";
+      dump_array(setdef, true);
+      std::cout << '\n';
+    }
+
+    std::vector<DimensionSet> ret;
+
+    typedef typename std::vector<std::vector<Storage> > storage_type;
+    for(typename storage_type::const_iterator order = orders.begin();
+        order != orders.end();
+        ++order)
+      {
+        ret.push_back(DimensionSet(dims, *order));
+      }
+
+    return ret;
+  }
+
+  // Test all DimensionSet permutations provided.  This will ensure
+  // round-trip from logical coordinate to storage index and back is
+  // working, but does not validate the correctness of the
+  // algorithm--it only checks it's behaviour is consistent.  It will
+  // also print the array structure and (for subrange sets) the
+  // subrange structure in addition to the full range.
+  void
+  test_orders(std::vector<DimensionSet> dims)
+  {
+    for(std::vector<DimensionSet>::const_iterator dim = dims.begin();
+        dim != dims.end();
+        ++dim)
+      {
+        // Check if subranges are in use, and if so, print the original
+        // set as well as the reduced set for visual comparison.
+        const DimensionSet& set(*dim);
+
+        DimensionSet::logical_order_type logical(set.logical_order());
+        DimensionSet::logical_order_type logical_full;
+        const DimensionSet::indexed_storage_order_type& storage(set.storage_order());
+        bool subrange = false;
+        for (DimensionSet::logical_order_type::const_iterator i = logical.begin();
+             i != logical.end();
+             ++i)
+          {
+            if (i->extent != i->size())
+              subrange = true;
+            logical_full.push_back(Dimension(i->name, i->extent));
+          }
+        DimensionSet full_set(logical_full, storage);
+
+        std::cout << "DimensionSet with storage order:\n"
+                  << set;
+        if (subrange)
+          {
+            std::cout << "\nDimensionSet storage layout (original):\n\n";
+            dump_array(full_set);
+            std::cout << "\nDimensionSet storage layout (subrange):\n\n";
+          }
+        else
+          {
+            std::cout << "\nDimensionSet storage layout:\n\n";
+          }
+        dump_array(set);
+        std::cout << '\n';
+
+        DimensionSet::coord_type pos1, pos3;
+        for(Dimension::index_type i = 0; i < set.num_elements(); ++i)
+          {
+            set.logical_coord(i, pos1);
+
+            uint32_t pos2 =  set.storage_index(pos1);
+            set.storage_coord(pos2, pos3);
+            std::cout << dump_vector<DimensionSet::coord_type>(pos1)
+                      << " → " << std::setw(2) << std::right << pos2 << " → "
+                      << dump_vector<DimensionSet::coord_type>(pos3) << '\n';
+            // Check round trip results in same indices.
+            ASSERT_EQ(pos1, pos3);
+
+            // Check the subrange (which may be the full range)
+            {
+              DimensionSet::coord_type full_index = pos1;
+              for (std::vector<Dimension>::size_type d = 0; d < set.size(); ++d)
+                {
+                  full_index[d] += logical[d].begin;
+                }
+              ASSERT_EQ(full_set.storage_index(full_index), pos2);
+            }
+          }
+        std::cout << '\n';
+      }
+  }
+
+}
+
+// Dimension construction and failure cases.
+TEST(Dimension, Construct)
+{
+  Dimension x("X");
+  ASSERT_EQ(std::string("X"), x.name);
+  ASSERT_EQ(1U, x.extent);
+
+  Dimension t("T", 43U);
+
+  ASSERT_EQ(std::string("T"), t.name);
+  ASSERT_EQ(43U, t.extent);
+  ASSERT_EQ(0U, t.begin);
+  ASSERT_EQ(43U, t.end);
+
+  // Zero extent size is invalid.
+  ASSERT_THROW(Dimension("InvalidSize", 0), std::logic_error);
+}
+
+// Dimension subrange construction and failure cases.
+TEST(Dimension, ConstructSubrange)
+{
+  Dimension x("X", 64);
+  ASSERT_EQ(64U, x.extent);
+  ASSERT_EQ(64U, x.size());
+
+  Dimension x2(x, 16, 48);
+  ASSERT_EQ(64U, x2.extent);
+  ASSERT_EQ(32U, x2.size());
+  ASSERT_EQ(16U, x2.begin);
+  ASSERT_EQ(48U, x2.end);
+
+  // Outside full range.
+  ASSERT_THROW(Dimension("X", 64U, 32U, 128U), std::logic_error);
+  // Outside subrange.
+  ASSERT_THROW(Dimension(x2, 0U, 56U), std::logic_error);
+}
+
+// Dimension comparison by lexical ordering.
+TEST(Dimension, Compare)
+{
+  Dimension x("X");
+  Dimension t("T");
+
+  ASSERT_TRUE(t < x);
+  ASSERT_FALSE(x < t);
+
+  Dimension y("Y", 32);
+  Dimension c("C", 84);
+
+  ASSERT_TRUE(c < y);
+  ASSERT_FALSE(y < c);
+}
+
+// DimensionSet construction and failure cases.
+TEST(DimensionSet, Construct)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 3),
+      Dimension("Y", 4),
+      Dimension("Z", 2)
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  DimensionSet set(dims);
+
+  ASSERT_EQ(3U, set.size());
+
+  // Duplicate dimension names are invalid.
+  dims.push_back(Dimension("Y", 54));
+  ASSERT_THROW(DimensionSet set2(dims), std::logic_error);
+}
+
+// Round-trip of logical index to logical coordinate.
+TEST(DimensionSet, LogicalIndex)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 3),
+      Dimension("Y", 4),
+      Dimension("Z", 2)
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  DimensionSet set(dims);
+
+  for (DimensionSet::size_type i = 0; i < set.num_elements(); ++i)
+    {
+      DimensionSet::coord_type coord;
+      set.logical_coord(i, coord);
+      DimensionSet::size_type i2 = set.logical_index(coord);
+
+      std::cout << std::setw(2) << std::right << i << " → "
+                << dump_vector<DimensionSet::coord_type>(coord)
+                << " → " << std::setw(2) << std::right << i2 << '\n';
+
+      ASSERT_EQ(i, i2);
+    }
+}
+
+// Round-trip of logical coordinate to storage index.
+TEST(DimensionSet, StorageIndex)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 3),
+      Dimension("Y", 4),
+      Dimension("Z", 2)
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  DimensionSet set(dims);
+
+  for (DimensionSet::index_type i = 0; i < set.num_elements(); ++i)
+    {
+      DimensionSet::coord_type coord;
+      set.logical_coord(i, coord);
+      DimensionSet::index_type i2 = set.logical_index(coord);
+      DimensionSet::index_type i3 = set.storage_index(coord);
+
+      std::cout << std::setw(2) << std::right << i << " → "
+                << dump_vector<DimensionSet::coord_type>(coord)
+                << " → " << std::setw(2) << std::right << i3 << '\n';
+
+      ASSERT_EQ(i, i2);
+      ASSERT_EQ(i, i3);
+    }
+
+  // Failure if incorrect length.
+  DimensionSet::coord_type coord;
+  coord.push_back(2U);
+  coord.push_back(1U);
+  ASSERT_THROW(set.storage_index(coord), std::logic_error);
+}
+
+// Storage order failure cases (by index).
+TEST(DimensionSet, IndexedStorageOrderFail)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 3),
+      Dimension("Y", 4),
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  std::vector<IndexedDimensionStorage> order1;
+  order1.push_back(IndexedDimensionStorage(0, Dimension::DESCENDING));
+
+  // Missing dimension.
+  ASSERT_THROW(DimensionSet(dims, order1), std::logic_error);
+
+  order1.push_back(IndexedDimensionStorage(1, Dimension::ASCENDING));
+
+  // All dimensions correct.
+  ASSERT_NO_THROW(DimensionSet(dims, order1));
+
+  order1.push_back(IndexedDimensionStorage(1, Dimension::ASCENDING));
+
+  // Extra duplicated dimension.
+  ASSERT_THROW(DimensionSet(dims, order1), std::logic_error);
+
+  std::vector<IndexedDimensionStorage> order2;
+  order2.push_back(IndexedDimensionStorage(0, Dimension::DESCENDING));
+  order2.push_back(IndexedDimensionStorage(2, Dimension::DESCENDING));
+
+  // Invalid dimension.
+  ASSERT_THROW(DimensionSet(dims, order2), std::logic_error);
+}
+
+// Storage order failure cases (by name).
+TEST(DimensionSet, NamedStorageOrderFail)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 3),
+      Dimension("Y", 4),
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  std::vector<NamedDimensionStorage> order1;
+  order1.push_back(NamedDimensionStorage("X", Dimension::DESCENDING));
+
+  // Missing dimension.
+  ASSERT_THROW(DimensionSet(dims, order1), std::logic_error);
+
+  order1.push_back(NamedDimensionStorage("Y", Dimension::ASCENDING));
+
+  // All dimensions correct.
+  ASSERT_NO_THROW(DimensionSet(dims, order1));
+
+  order1.push_back(NamedDimensionStorage("Y", Dimension::ASCENDING));
+
+  // Extra duplicated dimension.
+  ASSERT_THROW(DimensionSet(dims, order1), std::logic_error);
+
+  std::vector<NamedDimensionStorage> order2;
+  order2.push_back(NamedDimensionStorage("X", Dimension::DESCENDING));
+  order2.push_back(NamedDimensionStorage("Invalid", Dimension::DESCENDING));
+
+  // Invalid dimension.
+  ASSERT_THROW(DimensionSet(dims, order2), std::logic_error);
+}
+
+// Storage ordering (single dimension by index).
+TEST(DimensionSet, StorageOrderIndexedD1)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("Single", 12));
+
+  // Test all 2 combinations
+  test_orders(order_permutations(dims, named_order_permutations(dims)));
+}
+
+// Storage ordering (two dimensions by index).
+TEST(DimensionSet, StorageOrderIndexedD2)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("X", 3));
+  dims.push_back(Dimension("Y", 4));
+
+  // Test all 8 combinations
+  test_orders(order_permutations(dims, indexed_order_permutations(dims)));
+}
+
+// Storage ordering (two dimensions by name).
+TEST(DimensionSet, StorageOrderNamedD2)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("X", 3));
+  dims.push_back(Dimension("Y", 4));
+
+  // Test all 8 combinations
+  test_orders(order_permutations(dims, named_order_permutations(dims)));
+}
+
+// Storage ordering (three dimensions by index).
+TEST(DimensionSet, StorageOrderD3)
+{
+  static Dimension static_dims[] =
+    {
+      Dimension("X", 5),
+      Dimension("Y", 4),
+      Dimension("T", 3)
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  // Test all 48 combinations
+  test_orders(order_permutations(dims, indexed_order_permutations(dims)));
+}
+
+// Storage ordering (nine dimensions by index).
+TEST(DimensionSet, StorageOrderD9)
+{
+  static Dimension static_dims[] =
+    {
+      Dimension("PixelX", 10),
+      Dimension("PixelY", 10),
+      Dimension("Z", 3),
+      Dimension("T", 2),
+      Dimension("C", 2),
+      Dimension("Lifetime", 3),
+      Dimension("Angle", 2),
+      Dimension("TileX", 2),
+      Dimension("TileY", 2)
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  DimensionSet s1(dims);
+
+  std::cout << "DimensionSet s1 default parameters:\n"
+            << s1
+            << "\nDimensionSet s1 default storage layout:\n\n";
+  dump_array(s1);
+  std::cout << '\n';
+
+  std::cout << "s1-1: " << s1 << '\n';
+  std::vector<IndexedDimensionStorage> order;
+  order.push_back(IndexedDimensionStorage(0, Dimension::ASCENDING));
+  order.push_back(IndexedDimensionStorage(5, Dimension::DESCENDING));
+  order.push_back(IndexedDimensionStorage(1, Dimension::ASCENDING));
+  order.push_back(IndexedDimensionStorage(2, Dimension::ASCENDING));
+  order.push_back(IndexedDimensionStorage(3, Dimension::ASCENDING));
+  order.push_back(IndexedDimensionStorage(6, Dimension::ASCENDING));
+  order.push_back(IndexedDimensionStorage(8, Dimension::ASCENDING));
+  order.push_back(IndexedDimensionStorage(7, Dimension::DESCENDING));
+  order.push_back(IndexedDimensionStorage(4, Dimension::ASCENDING));
+
+  DimensionSet s2(dims, order);
+
+  std::cout << "DimensionSet s2 modified parameters:\n"
+            << s2
+            << "\nDimensionSet s2 modified storage layout:\n\n";
+  dump_array(s2);
+  std::cout << '\n';
+}
+
+// Subrange failure cases (by index).
+TEST(DimensionSet, IndexedSubrangeFail)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 16),
+      Dimension("Y", 32),
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  DimensionSet::indexed_subrange_type subrange1;
+  subrange1.push_back(IndexedDimensionSubrange(0, 4, 12));
+
+  // Missing dimension is OK.
+  ASSERT_NO_THROW(DimensionSet(dims).subrange(subrange1));
+
+  subrange1.push_back(IndexedDimensionSubrange(1, 24, 32));
+
+  // All dimensions present.
+  ASSERT_NO_THROW(DimensionSet(dims).subrange(subrange1));
+
+  subrange1.push_back(IndexedDimensionSubrange(1, 28, 32));
+
+  // Extra duplicated dimension.
+  ASSERT_THROW(DimensionSet(dims).subrange(subrange1), std::logic_error);
+
+  DimensionSet::indexed_subrange_type subrange2;
+  subrange2.push_back(IndexedDimensionSubrange(0, 4, 12));
+  subrange2.push_back(IndexedDimensionSubrange(2, 90, 12));
+
+  // Invalid dimension.
+  ASSERT_THROW(DimensionSet(dims).subrange(subrange2), std::logic_error);
+}
+
+// Subrange failure cases (by name).
+TEST(DimensionSet, NamedSubrangeFail)
+{
+  const Dimension static_dims[] =
+    {
+      Dimension("X", 16),
+      Dimension("Y", 32),
+    };
+
+  std::vector<Dimension> dims(static_dims, static_dims+boost::size(static_dims));
+
+  DimensionSet::named_subrange_type subrange1;
+  subrange1.push_back(NamedDimensionSubrange("X", 4, 12));
+
+  // Missing dimension is OK.
+  ASSERT_NO_THROW(DimensionSet(dims).subrange(subrange1));
+
+  subrange1.push_back(NamedDimensionSubrange("Y", 24, 32));
+
+  // All dimensions present.
+  ASSERT_NO_THROW(DimensionSet(dims).subrange(subrange1));
+
+  subrange1.push_back(NamedDimensionSubrange("Y", 28, 32));
+
+  // Extra duplicated dimension.
+  ASSERT_THROW(DimensionSet(dims).subrange(subrange1), std::logic_error);
+
+  DimensionSet::named_subrange_type subrange2;
+  subrange2.push_back(NamedDimensionSubrange("X", 4, 12));
+  subrange2.push_back(NamedDimensionSubrange("Invalid", 90, 12));
+
+  // Invalid dimension.
+  ASSERT_THROW(DimensionSet(dims).subrange(subrange2), std::logic_error);
+}
+
+// Subrange storage ordering (one dimension by index).
+TEST(DimensionSet, SubrangeIndexedD1)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("Single", 12));
+
+  std::vector<DimensionSet> sets(order_permutations(dims, named_order_permutations(dims)));
+  DimensionSet::indexed_subrange_type subrange;
+  subrange.push_back(IndexedDimensionSubrange(0, 5, 9));
+
+  std::vector<DimensionSet> subrange_sets;
+  for(std::vector<DimensionSet>::const_iterator i = sets.begin();
+      i != sets.end();
+      ++i)
+    {
+      subrange_sets.push_back(i->subrange(subrange));
+    }
+
+  test_orders(subrange_sets);
+
+  DimensionSet::indexed_subrange_type subrange2;
+  subrange2.push_back(IndexedDimensionSubrange(0, 1, 3));
+
+  std::vector<DimensionSet> subrange_sets2;
+  for(std::vector<DimensionSet>::const_iterator i = subrange_sets.begin();
+      i != subrange_sets.end();
+      ++i)
+    {
+      subrange_sets2.push_back(i->subrange(subrange2));
+    }
+
+  test_orders(subrange_sets2);
+}
+
+// Subrange storage ordering (two dimensions by index).
+TEST(DimensionSet, SubrangeIndexedD2)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("X", 3));
+  dims.push_back(Dimension("Y", 4));
+
+  std::vector<DimensionSet> sets(order_permutations(dims, named_order_permutations(dims)));
+  DimensionSet::indexed_subrange_type subrange;
+  subrange.push_back(IndexedDimensionSubrange(0, 0, 2));
+  subrange.push_back(IndexedDimensionSubrange(1, 1, 3));
+
+  std::vector<DimensionSet> subrange_sets;
+  for(std::vector<DimensionSet>::const_iterator i = sets.begin();
+      i != sets.end();
+      ++i)
+    {
+      subrange_sets.push_back(i->subrange(subrange));
+    }
+
+  test_orders(subrange_sets);
+}
+
+// Subrange storage ordering (two dimensions by name).
+TEST(DimensionSet, SubrangeNamedD2)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("X", 3));
+  dims.push_back(Dimension("Y", 4));
+
+  std::vector<DimensionSet> sets(order_permutations(dims, named_order_permutations(dims)));
+  DimensionSet::named_subrange_type subrange;
+  // Single dimension only; X is unchanged.
+  subrange.push_back(NamedDimensionSubrange("Y", 1, 3));
+
+  std::vector<DimensionSet> subrange_sets;
+  for(std::vector<DimensionSet>::const_iterator i = sets.begin();
+      i != sets.end();
+      ++i)
+    {
+      subrange_sets.push_back(i->subrange(subrange));
+    }
+
+  test_orders(subrange_sets);
+}
+
+// Subrange storage ordering (four dimensions by index).
+TEST(DimensionSet, SubrangeIndexedD4)
+{
+  std::vector<Dimension> dims;
+  dims.push_back(Dimension("X", 8));
+  dims.push_back(Dimension("Y", 8));
+  dims.push_back(Dimension("Z", 3));
+  dims.push_back(Dimension("C", 2));
+
+  std::vector<DimensionSet> sets(order_permutations(dims, named_order_permutations(dims)));
+  DimensionSet::indexed_subrange_type subrange;
+  subrange.push_back(IndexedDimensionSubrange(0, 0, 8));
+  subrange.push_back(IndexedDimensionSubrange(1, 3, 6));
+  subrange.push_back(IndexedDimensionSubrange(2, 0, 2));
+  subrange.push_back(IndexedDimensionSubrange(3, 1, 2));
+
+  std::vector<DimensionSet> subrange_sets;
+  for(std::vector<DimensionSet>::const_iterator i = sets.begin();
+      i != sets.end();
+      ++i)
+    {
+      subrange_sets.push_back(i->subrange(subrange));
+    }
+
+  test_orders(subrange_sets);
+
+  DimensionSet::indexed_subrange_type subrange2;
+  subrange2.push_back(IndexedDimensionSubrange(0, 4, 7));
+  subrange2.push_back(IndexedDimensionSubrange(1, 1, 3));
+
+  std::vector<DimensionSet> subrange_sets2;
+  for(std::vector<DimensionSet>::const_iterator i = sets.begin();
+      i != sets.end();
+      ++i)
+    {
+      subrange_sets2.push_back(i->subrange(subrange).subrange(subrange2));
+    }
+
+  test_orders(subrange_sets2);
+}

--- a/cpp/test/ome-bioformats/dimension.cpp
+++ b/cpp/test/ome-bioformats/dimension.cpp
@@ -543,7 +543,7 @@ namespace
                       << " → " << std::setw(2) << std::right << pos2 << " → "
                       << dump_vector<DimensionSet::coord_type>(pos3) << '\n';
             // Check round trip results in same indices.
-            ASSERT_EQ(pos1, pos3);
+            ASSERT_TRUE(pos1 == pos3);
 
             // Check the subrange (which may be the full range)
             {
@@ -552,7 +552,7 @@ namespace
                 {
                   full_index[d] += logical[d].begin;
                 }
-              ASSERT_EQ(full_set.storage_index(full_index), pos2);
+              ASSERT_TRUE(full_set.storage_index(full_index) == pos2);
             }
           }
         std::cout << '\n';

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -37,7 +37,7 @@ from datetime import datetime
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.)
-extensions = ['sphinx.ext.extlinks', 'edit_on_github']
+extensions = ['sphinx.ext.extlinks', 'sphinx.ext.pngmath', 'edit_on_github']
 
 ## Configuration for the edit_on_github extension
 edit_on_github_project = 'openmicroscopy/bioformats'

--- a/docs/sphinx/developers/cpp/ndim.txt
+++ b/docs/sphinx/developers/cpp/ndim.txt
@@ -9,7 +9,7 @@ Rationale
 The existing Bio-Formats API uses n-dimensional array calculations for
 several purposes, but is currently restricted to a fixed dimension
 count in all cases.  In order to extend the data model and API to
-support higher numbers of dimensions, a means of generalising the
+support higher numbers of dimensions, a means of generalizing the
 existing calculations to support an arbitrary dimension count is
 required.
 
@@ -30,7 +30,7 @@ to 9 dimensions at compile time, and due to being a template-heavy
 implementation is also not implementable in Java.  Having
 n-dimensional support common to both languages would be advantageous.
 Being able to support an arbitrary number of dimensions does imply a
-tradeoff when compared with the templated implementation; it will be
+trade-off when compared with the templated implementation; it will be
 more flexible but slower, except perhaps at low dimension counts
 compared with fixed 9D calculations.  This is the common case for the
 existing data model, however, where typically three dimensions are
@@ -104,7 +104,7 @@ Classes
   TIFF ``Orientation`` tag and EXIF metadata can be represented
   directly in the ordering and can transparently reflect and rotate
   the pixel data if desired.  It will also allow for the removal of
-  the Modulo extension since these subdidiary dimensions can now be
+  the Modulo extension since these subsidiary dimensions can now be
   represented directly as first-class addressable dimensions.
 
 Calculations
@@ -142,7 +142,7 @@ would contain (*x*, *y*, *z*, *c*) values.
 
 The coordinate may be implemented as e.g. a :cpp:class:`vector` (C++)
 or an array or :cpp:class:`List` (Java).  Any of these representations
-will permit the storage of an arbitary number of integers.
+will permit the storage of an arbitrary number of integers.
 
 Logical index
 ^^^^^^^^^^^^^
@@ -168,9 +168,9 @@ logical order (from largest stride to smallest stride) as follows:
 
   I_l = I_l \operatorname{mod} S_{l_i}
 
-This is primarily useful for testing the implementation; it's unlikely
-this will be useful for most situations, where the storage index
-should be preferred.
+This is primarily useful for testing the implementation; it is
+unlikely this will be useful for most situations, where the storage
+index should be preferred.
 
 Storage index
 ^^^^^^^^^^^^^
@@ -180,7 +180,7 @@ The storage index is the index into the multi-dimensional array
 storage order as specified.  Here, the storage order may differ from
 the logical order, and the dimensions may also have descending
 progression instead of ascending progression.  The storage index is
-computed from a logical coordinate, and is the precalculated base
+computed from a logical coordinate, and is the pre-calculated base
 offset plus the sum of (storage-stride × dimension-index) for each
 dimension:
 
@@ -192,7 +192,7 @@ The inverse is also provided, calculating the logical coordinate from
 a storage index.  This is calculated for each dimension in *reverse*
 storage order (from largest stride to smallest stride).  If the
 dimension progression is descending, the index in each dimension is
-calulated as follows:
+calculated as follows:
 
 .. math::
 
@@ -220,7 +220,7 @@ subrange-begin start position in each dimension.
 
 The calculations described above work the same with subvolumes.  The
 only difference is that the subrange-begin values for each dimension
-much be added to the logical coordinate when computing a storage
+must be added to the logical coordinate when computing a storage
 index, and be subtracted from the logical coordinate when computed
 from a storage index.  Since the base for logical indexes is always
 zero, and the coordinates in the subrange are relative to the subrange
@@ -228,7 +228,7 @@ start, no adjustment is necessary for logical index calculations.  The
 storage index calculations are adjusted as shown below:
 
 The storage index is computed from a logical coordinate, and is the
-precalculated base offset plus the sum of (storage-stride ×
+pre-calculated base offset plus the sum of (storage-stride ×
 (dimension-index + dimension-start)) for each dimension:
 
 .. math::
@@ -237,10 +237,10 @@ precalculated base offset plus the sum of (storage-stride ×
 
 The inverse is also provided, calculating the logical coordinate from
 a storage index.  This is calculated for each dimension in *reverse*
-storage order (from largest stride to smallest stride), substracting
+storage order (from largest stride to smallest stride), subtracting
 the subrange-begin value from the computed index in each dimension.
 If the dimension progression is descending, the index in each
-dimension is calulated as follows:
+dimension is calculated as follows:
 
 .. math::
 
@@ -279,13 +279,13 @@ Applications
   coordinates, so that the user specifies exactly which plane they
   need using the dimension indexes appropriate for the series.  This
   will also allow the API to work with future n-dimensional image data
-  while remaining compatible with the three dimensional logic used
-  currently.  Two logical coordinates to specify the begin and end of
-  a subrange to fetch (or logical coordinate and extent)will extend
-  these methods from transferring 2D regions to transferring
-  n-dimensional regions in a single call.  There is room for
-  signifiant optimisation here: by looking at the strides and begin
-  offsets in each dimension (in storage order), the data can be
+  while remaining compatible with the three-dimensional (``CZT``)
+  logic used currently.  Two logical coordinates to specify the begin
+  and end of a subrange to fetch (or logical coordinate and extent)
+  will extend these methods from transferring 2D regions to
+  transferring n-dimensional regions in a single call.  There is room
+  for significant optimization here: by looking at the strides and
+  begin offsets in each dimension (in storage order), the data can be
   transferred in the largest possible contiguous blocks.
 
 - Add n-dimensional pixel buffer class

--- a/docs/sphinx/developers/cpp/ndim.txt
+++ b/docs/sphinx/developers/cpp/ndim.txt
@@ -1,0 +1,315 @@
+.. _bf-cpp-ndim:
+
+n-dimensional array support
+===========================
+
+Rationale
+---------
+
+The existing Bio-Formats API uses n-dimensional array calculations for
+several purposes, but is currently restricted to a fixed dimension
+count in all cases.  In order to extend the data model and API to
+support higher numbers of dimensions, a means of generalising the
+existing calculations to support an arbitrary dimension count is
+required.
+
+Current uses include:
+
+- data model pixels ``DimensionOrder`` and dimension extents, and
+  channel ``SamplesPerPixel``; also the ``Modulo`` annotations
+- plane index to and from ``CZT`` and ``CZTmCmZmT`` coordinates
+  (:cpp:class:`FormatReader` methods and ``FormatTools`` helper
+  functions)
+- calculations internal to readers including plane indexes and
+  subchannel plane indexing for e.g. planar RGB/BGR images
+
+For the C++ implementation, the :cpp:class:`PixelBuffer` class
+implements a 9D array which supports the existing ``DimensionOrder``
+and ``Modulo`` requirements, plus subchannels.  However, it is fixed
+to 9 dimensions at compile time, and due to being a template-heavy
+implementation is also not implementable in Java.  Having
+n-dimensional support common to both languages would be advantageous.
+Being able to support an arbitrary number of dimensions does imply a
+tradeoff when compared with the templated implementation; it will be
+more flexible but slower, except perhaps at low dimension counts
+compared with fixed 9D calculations.  This is the common case for the
+existing data model, however, where typically three dimensions are
+used in practice (four with modulo up to a maximum of six).
+
+Classes
+-------
+
+:cpp:class:`Dimension`
+  A description of a single dimensional "axis"; this may be spatial,
+  temporal or an abstract dimension.  The following properties are
+  required:
+
+  name
+    The name of the dimension; must be unique within a space
+  extent
+    The size of the dimension; must be greater than zero
+
+  The following properties are optional:
+
+  subrange-begin
+    The starting index of the addressable range; defaults to zero
+  subrange-end
+    The ending index of the addressable range; defaults to the extent
+
+  This class currently contains only the detail required for
+  performing calculations.  It could be extended with additional
+  metadata, such as that contained within the existing
+  :cpp:class:`Modulo` class, in order to provide the Modulo metadata
+  for all dimensions (logical start/stop/step values or labels, unit
+  and scale, description).
+
+:cpp:class:`DimensionSpace`
+  An abstract space containing one or more :cpp:class:`Dimension`
+  objects.  This class provides the methods to perform n-dimension
+  calculations within the specified abstract space.  The following
+  properties are required:
+
+  dimensions
+    An ordered list of :cpp:class:`Dimension` objects; the order
+    defines the *logical* dimension order
+  storage-order
+    The order of the dimensions in storage (e.g. memory or disc), and
+    the direction of progression; this defines the *storage* order
+
+  From the defined logical dimension order and storage order within a
+  space, the following properties are computed for each dimension:
+
+  logical-stride
+    The number of elements to increment the element index by to move
+    forward in this dimension by one element (in logical order)
+  storage-stride
+    The number of elements to increment the element index by to move
+    forward in this dimension by one element (in storage order)
+  descending-offset
+    The offset to add to the stride; this is used for descending
+    progression (when the dimension runs backwards, the starting offset
+    is not zero)
+
+  The following properties are computed for the space
+
+  base
+    The sum of the descending-offset values for all dimensions
+
+  This class can directly represent the existing ``DimensionOrder``,
+  and ``SizeX``, ``SizeY``, ``SizeZ``, ``SizeT``, and ``SizeC``
+  values.  These are a subset of the functionality; this class can
+  represent arbitrary dimensions as well as lifting the restriction
+  that the ``XY`` dimensions must be the first dimensions and that
+  they must also have ascending progression; this means that e.g. the
+  TIFF ``Orientation`` tag and EXIF metadata can be represented
+  directly in the ordering and can transparently reflect and rotate
+  the pixel data if desired.  It will also allow for the removal of
+  the Modulo extension since these subdidiary dimensions can now be
+  represented directly as first-class addressable dimensions.
+
+Calculations
+------------
+
+The following terms are used:
+
+:math:`n`
+  Number of dimensions
+:math:`E`
+  Dimension extent
+:math:`C`
+  Logical coordinate
+:math:`I_l`
+  Logical index
+:math:`I_s`
+  Storage index
+:math:`S_l`
+  Logical stride
+:math:`S_s`
+  Storage stride
+:math:`O`
+  Base offset
+:math:`B`
+  Subrange start offset
+
+Logical coordinate
+^^^^^^^^^^^^^^^^^^
+
+The logical coordinate describes a position in a space.  It contains
+the same number of values as the number of dimensions in the space,
+and the order of these values is the logical dimension order.  For
+example, if the logical dimension order is ``X,Y,Z,C``, a coordinate
+would contain (*x*, *y*, *z*, *c*) values.
+
+The coordinate may be implemented as e.g. a :cpp:class:`vector` (C++)
+or an array or :cpp:class:`List` (Java).  Any of these representations
+will permit the storage of an arbitary number of integers.
+
+Logical index
+^^^^^^^^^^^^^
+
+The logical index is the index into the multi-dimensional array
+(offset from the starting position), where the storage order is the
+same as the logical order, and all dimensions have ascending
+progression.  This is the default if no storage order is specified.
+The logical index is computed from a logical coordinate, and is the
+sum of (logical-stride × dimension-index) for each dimension:
+
+.. math::
+
+  I_l = \sum\limits_{i=0}^{n-1} (S_{l_i} \cdot C_i)
+
+The inverse is also provided, calculating the logical coordinate from
+a logical index.  This is calculated for each dimension in *reverse*
+logical order (from largest stride to smallest stride) as follows:
+
+.. math::
+
+  C_i = \frac{I_l}{S_{l_i}}
+
+  I_l = I_l \operatorname{mod} S_{l_i}
+
+This is primarily useful for testing the implementation; it's unlikely
+this will be useful for most situations, where the storage index
+should be preferred.
+
+Storage index
+^^^^^^^^^^^^^
+
+The storage index is the index into the multi-dimensional array
+(offset from the starting position), where the storage order is the
+storage order as specified.  Here, the storage order may differ from
+the logical order, and the dimensions may also have descending
+progression instead of ascending progression.  The storage index is
+computed from a logical coordinate, and is the precalculated base
+offset plus the sum of (storage-stride × dimension-index) for each
+dimension:
+
+.. math::
+
+  I_s = O + \sum\limits_{i=0}^{n-1} (S_{s_i} \cdot C_i)
+
+The inverse is also provided, calculating the logical coordinate from
+a storage index.  This is calculated for each dimension in *reverse*
+storage order (from largest stride to smallest stride).  If the
+dimension progression is descending, the index in each dimension is
+calulated as follows:
+
+.. math::
+
+  C_i = \frac{(E_i \cdot \lvert S_{s_i} \rvert) - S_{s_i} - 1}{\lvert S_{s_i} \rvert}
+
+  I_s = I_s \operatorname{mod} \lvert S_{s_i} \rvert
+
+If the dimension progression is ascending, the index in each
+dimension is calculated as follows:
+
+.. math::
+
+  C_i = \frac{I_s}{S_{s_i}}
+
+  I_s = I_s \operatorname{mod} S_{s_i}
+
+Subranges and subvolumes
+------------------------
+
+It is possible to restrict the total hypervolume within a space to a
+subvolume, by specifying subrange-begin and subrange-end values to set
+a subrange in each single dimension.  This effectively creates a
+window into the full range, logically indexed from zero at the
+subrange-begin start position in each dimension.
+
+The calculations described above work the same with subvolumes.  The
+only difference is that the subrange-begin values for each dimension
+much be added to the logical coordinate when computing a storage
+index, and be subtracted from the logical coordinate when computed
+from a storage index.  Since the base for logical indexes is always
+zero, and the coordinates in the subrange are relative to the subrange
+start, no adjustment is necessary for logical index calculations.  The
+storage index calculations are adjusted as shown below:
+
+The storage index is computed from a logical coordinate, and is the
+precalculated base offset plus the sum of (storage-stride ×
+(dimension-index + dimension-start)) for each dimension:
+
+.. math::
+
+  I_s = O + \sum\limits_{i=0}^{n-1} (S_{s_i} \cdot (C_i + B_i))
+
+The inverse is also provided, calculating the logical coordinate from
+a storage index.  This is calculated for each dimension in *reverse*
+storage order (from largest stride to smallest stride), substracting
+the subrange-begin value from the computed index in each dimension.
+If the dimension progression is descending, the index in each
+dimension is calulated as follows:
+
+.. math::
+
+  C_i = \frac{(E_i \cdot \lvert S_{s_i} \rvert) - S_{s_i} - 1}{\lvert S_{s_i} \rvert} - B_i
+
+  I_s = I_s \operatorname{mod} \lvert S_{s_i} \rvert
+
+If the dimension progression is ascending, the index in each
+dimension is calculated as follows:
+
+.. math::
+
+  C_i = \frac{I_s}{S_{s_i}} - B_i
+
+  I_s = I_s \operatorname{mod} S_{s_i}
+
+Applications
+------------
+
+- Replace :cpp:class:`FormatReader` :cpp:func:`getIndex` and
+  :cpp:func:`getCZTCoords` methods
+
+  These can be replaced by a generic n-dimensional implementation
+  using :cpp:class:`DimensionSpace` to perform the calculations; this
+  could be contained within :cpp:class:`CoreMetadata` for each series.
+
+  The existing ``FormatTools`` helpers can also be implemented in
+  terms of :cpp:class:`DimensionSpace`.
+
+- Replace :cpp:class:`FormatReader` and :cpp:class:`FormatWriter`
+  :cpp:func:`openBytes` and :cpp:func:`saveBytes` methods
+
+  These methods work in terms of plane indexes, but unfortunately move
+  the burden of correctly computing the plane indexes onto the end
+  user.  These could be replaced by methods which use logical
+  coordinates, so that the user specifies exactly which plane they
+  need using the dimension indexes appropriate for the series.  This
+  will also allow the API to work with future n-dimensional image data
+  while remaining compatible with the three dimensional logic used
+  currently.  Two logical coordinates to specify the begin and end of
+  a subrange to fetch (or logical coordinate and extent)will extend
+  these methods from transferring 2D regions to transferring
+  n-dimensional regions in a single call.  There is room for
+  signifiant optimisation here: by looking at the strides and begin
+  offsets in each dimension (in storage order), the data can be
+  transferred in the largest possible contiguous blocks.
+
+- Add n-dimensional pixel buffer class
+
+  This will replace the C++ :cpp:class:`PixelBuffer` class;
+  conceptually similar to the existing class but implemented in terms
+  of :cpp:class:`DimensionSpace` calculations rather than
+  Boost.MultiArray.  It will also be implementable in Java to provide
+  a shared pixel buffer API between both languages.  On the Java side,
+  internally this will contain a raw byte array as used by the
+  existing APIs, but will additionally have the higher n-dimensional
+  metadata describing its layout.  This permits the passing of pixel
+  data without having to pass the descriptive metadata separately or
+  out-of-band.
+
+  :cpp:class:`FormatReader` and :cpp:class:`FormatWriter`
+  :cpp:func:`openBytes` and :cpp:func:`saveBytes` methods can then be
+  implemented in terms of :cpp:class:`PixelBuffer` for passing data.
+
+- Internal use by readers and writers
+
+  Individual readers and writers may need to perform format-specific
+  calculations; they are free to use :cpp:class:`DimensionSpace` for
+  any purpose.  This type of logic is often implemented repeatedly for
+  similar operations in many different readers; this will allow for
+  consolidation of these into a single implementation, which should
+  reduce the potential for bugs.

--- a/docs/sphinx/developers/cpp/ndim.txt
+++ b/docs/sphinx/developers/cpp/ndim.txt
@@ -284,9 +284,17 @@ Applications
   and end of a subrange to fetch (or logical coordinate and extent)
   will extend these methods from transferring 2D regions to
   transferring n-dimensional regions in a single call.  There is room
-  for significant optimization here: by looking at the strides and
-  begin offsets in each dimension (in storage order), the data can be
-  transferred in the largest possible contiguous blocks.
+  for significant optimization here: by looking at the extents,
+  strides and begin offsets in each dimension (in storage order), the
+  data can be transferred in the largest possible contiguous blocks.
+
+  Note that the Java :cpp:class:`FormatReader` :cpp:func:`readPlane`
+  method has a ``scanlinePad`` argument to cope with scanlines which
+  have slack space at the end.  This only works in the ``X`` dimension
+  though.  The :cpp:class:`DimensionSpace` subvolume logic will allow
+  this to work, transparently, in n-dimensions.  For example, in ``Y``
+  for tiles.  The subrange may be assigned to another buffer to obtain
+  a packed copy of only the subrange.
 
 - Add n-dimensional pixel buffer class
 
@@ -304,6 +312,18 @@ Applications
   :cpp:class:`FormatReader` and :cpp:class:`FormatWriter`
   :cpp:func:`openBytes` and :cpp:func:`saveBytes` methods can then be
   implemented in terms of :cpp:class:`PixelBuffer` for passing data.
+
+- Internal use by the C++ TIFF code
+
+  The C++ implementation currently implements strip and tile copying
+  from libtiff buffers to and from :cpp:class:`PixelBuffer`.  This
+  will allow this logic to be removed entirely and replaced with a
+  simple assignment to copy the data between the libtiff buffer and
+  the pixel buffer.  The subrange logic will permit unaddressable
+  regions where the image bounds do not lie on strip or tile
+  boundaries, and as noted above, the extent, stride and offset data
+  may be used for efficient copying of contiguous blocks where
+  possible.
 
 - Internal use by readers and writers
 

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -52,6 +52,7 @@ Using Bio-Formats as a native C++ library
     cpp/overview
     cpp/conversion
     cpp/tutorial
+    cpp/ndim
     cpp/bf-env
     cpp/schema
     cpp/commands/bf-test


### PR DESCRIPTION
This adds a DimensionSet class containing a list of Dimension objects.  It may be used to calculate offsets in arbitrary n-dimentional spaces:

- calculate logical offsets (logical index ↔ logical coordinate)
- calculate storage offsets (logical coordinate ↔ storage index)
- separate logical dimension order from storage order and direction
- optionally work on a relative window into an n-dimensional space (subrange)

This implements the basic logic used in Boost.MultiArray.  However, the number of dimensions is not fixed at compile-time, so this can handle calculations with an arbitrary number of dimensions.  The intent is that this will allow the replacement of the PixelBuffer class (which uses Boost.MultiArray) with a custom n-dimensional array type using this class as a basis for the index calculations.  This will make the PixelBuffer class handle arbitrary dimensions, and will also simplify the interface, making it more usable (it currently exposes the guts of the Boost.MultiArray implementation).  This also allows for this to be re-implemented in Java fairly trivially, so Java could potentially use an nDim pixel buffer in place of raw byte arrays at some future point, making the two implementations the same in this respect; the Boost.MultiArray logic is C++-specific and will not port to Java due to the heavy template usage.

In addition to PixelBuffer, this may also be used to replace the hardcoded getIndex/getCZTCoords methods and functions; this can be used directly in CoreMetadata to supplement/replace sizes and (eventually) modulo since it has an extent list of all dimensions.  This can be used to implement getIndex/getCZTCoords or it could be given directly to the user for their use, obsoleting these methods entirely.  It can also be used in any reader/writer needing to do format-specific calculations relating to dimensions.

Everything is documented, and the internal logic is extensively commented.

CI testing: Unit tests are provided for most of the functionality; the jobs should remain green

Review:
- Run `./bf-test ./cpp/test/ome-bioformats/dimension` and pipe to less or a file for review.
- For each test you'll see something like this:

```
DimensionSet with storage order:
Logical dimensions:      (X,Y)
Logical extents:         (3,4)
Logical ranges:          ([0,3),[0,4))
Logical sizes:           (3,4)
Logical strides:         (1,3)
Size:                    2
Elements:                12
Storage dimensions:      (X,Y)
Storage extents:         (+3,+4)
Base:                    0
Strides:                 (1,3)
Descending offsets:      (0,0)

DimensionSet storage layout:

    X
    ┏━━┯━━┯━━┓
    ┃ 0│ 1│ 2┃
Y ┏━╋━━┿━━┿━━┫
  ┃0┃ 0│ 1│ 2┃
  ┠─╂──┼──┼──┨
  ┃1┃ 3│ 4│ 5┃
  ┠─╂──┼──┼──┨
  ┃2┃ 6│ 7│ 8┃
  ┠─╂──┼──┼──┨
  ┃3┃ 9│10│11┃
  ┗━┻━━┷━━┷━━┛

0,0 →  0 → 0,0
1,0 →  1 → 1,0
2,0 →  2 → 2,0
0,1 →  3 → 0,1
1,1 →  4 → 1,1
2,1 →  5 → 2,1
0,2 →  6 → 0,2
1,2 →  7 → 1,2
2,2 →  8 → 2,2
0,3 →  9 → 0,3
1,3 → 10 → 1,3
2,3 → 11 → 2,3
```

- The first section is a description of the `DimensionSet`.  The first part is the user-specified details such as dimension names and sizes, and subranges.  The rest are the computed strides and offsets to handle the mapping from logical to storage coordinates.
- The second section is is a visual representation of the mapping.  The row and column numbers are the logical coordinates; when there are more than two dimensions, higher dimensions are shown as multiple planes.  The grid values are the storage indices corresponding to these logical coordinates.
- The last section is a linear list of the mappings, including round-trip back to verify the logic works both ways; this is checked by the unit tests so doesn't require manual validation.

What to verify:
- The logic in the `logical_index` and `storage_index` methods; also the `subrange` methods and stride/offset methods.
- Could any of the performance-critical methods be improved; this is essentially `logical_index` and `storage_index`; the others such as subranges and stride/offset calculations only happen once so are not as critical.  The critical ones and their dependent bits should all be inlined.
- That the storage indices are valid.  While this is easy for the simple 1D case (it's a 1:1 mapping) we also:
  - use multiple dimensions
  - vary dimension direction which will use negative strides and nonzero offsets
  - use subranges to provide a window into the nD array; these can be verified by adding the begin value from the range to the logical index, and looking it up in the original layout (the tests display the original and subrange layouts for this purpose)--the number of combinations here is very large; verifying a small selection should be sufficient to verify the correctness of the algorithm