### PR TITLE
DICOM: use the last row and column tags instead of the first

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -550,12 +550,16 @@ public class DicomReader extends FormatReader {
           break;
         case ROWS:
           int y = in.readShort();
-          m.sizeY = y;
+          if (y > getSizeY()) {
+            m.sizeY = y;
+          }
           addInfo(tag, getSizeY());
           break;
         case COLUMNS:
           int x = in.readShort();
-          m.sizeX = x;
+          if (x > getSizeX()) {
+            m.sizeX = x;
+          }
           addInfo(tag, getSizeX());
           break;
         case PHOTOMETRIC_INTERPRETATION:

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -549,13 +549,13 @@ public class DicomReader extends FormatReader {
           addInfo(tag, config);
           break;
         case ROWS:
-          if (getSizeY() == 0) m.sizeY = in.readShort();
-          else in.skipBytes(2);
+          int y = in.readShort();
+          m.sizeY = y;
           addInfo(tag, getSizeY());
           break;
         case COLUMNS:
-          if (getSizeX() == 0) m.sizeX = in.readShort();
-          else in.skipBytes(2);
+          int x = in.readShort();
+          m.sizeX = x;
           addInfo(tag, getSizeX());
           break;
         case PHOTOMETRIC_INTERPRETATION:


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13023.

To test, use the file from QA 11381.  Without this change, the image size was 1280x2048 and the images should have diagonal stripes.  With this change, the image size should be larger in both dimensions, and there should be an obvious artifact (which can be compared against almost any other DICOM viewer).

This may conflict with gh-1989; I'll exclude this one if that turns out to be the case.