### PR TITLE
ScanR: return blank planes instead of skipping missing wells

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -519,7 +519,7 @@ public class ScanrReader extends FormatReader {
       if (next == originalIndex &&
         missingWellFiles == nSlices * nTimepoints * nChannels * nPos)
       {
-        wellNumbers.remove(well);
+        next += nSlices * nTimepoints * nChannels * nPos;
       }
     }
     nWells = wellNumbers.size();


### PR DESCRIPTION
See https://trello.com/c/6HeWtnVY/2-idr0009-simpson-secretion-embl-secretion-primary-and-secondary-screen.

/cc @joshmoore, @eleanorwilliams 