### PR TITLE
Add documentation page on the autogenerated documentation

### DIFF
--- a/docs/sphinx/developers/format-documentation.txt
+++ b/docs/sphinx/developers/format-documentation.txt
@@ -51,7 +51,7 @@ defined for each section:
     BSD license
 
   export
-    A `yes/no` flag specifying whether the format can be exported
+    A `yes/no` flag specifying whether Bio-Formats can write this format
 
   versions
     A comma-separated list of all versions supported for this format
@@ -65,21 +65,9 @@ defined for each section:
     have for this format
 
   pixelRating
-    See :term:`Ratings legend and definitions`. Available choices are: 
-    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
-
   metadataRating
-    See :term:`Ratings legend and definitions`. Available choices are: 
-    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
-
   opennessRating
-    See :term:`Ratings legend and definitions`. Available choices are: 
-    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
-
   presenceRating
-    See :term:`Ratings legend and definitions`. Available choices are: 
-    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
-
   utilityRating
     See :term:`Ratings legend and definitions`. Available choices are: 
     `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`

--- a/docs/sphinx/developers/format-documentation.txt
+++ b/docs/sphinx/developers/format-documentation.txt
@@ -31,66 +31,68 @@ The :file:`format-pages.txt` is an INI file where each section corresponds to
 a particular format given by the section header. Multiple key/values should be 
 defined for each section:
 
-pagename
-  The name of the output reStructuredText file. If unspecified, the section 
-  header will be used to generate the filename.
+.. glossary::
 
-extensions
-  The list of extensions supported for the format
+  pagename
+    The name of the output reStructuredText file. If unspecified, the section 
+    header will be used to generate the filename.
 
-owner
-  The owner of the file format
+  extensions
+    The list of extensions supported for the format
 
-developer
-  The developer of the file format
+  owner
+    The owner of the file format
 
-bsd
-  A `yes/no` flag specifying whether the format readers/writers are under the
-  BSD license
+  developer
+    The developer of the file format
 
-export
-  A `yes/no` flag specifying whether the format can be exported
+  bsd
+    A `yes/no` flag specifying whether the format readers/writers are under the
+    BSD license
 
-versions
-  A comma-separated list of all versions supported for this format
+  export
+    A `yes/no` flag specifying whether the format can be exported
 
-weHave
-  A bullet-point list describing the supporting material we have for this
-  format including specification and sample datasets
+  versions
+    A comma-separated list of all versions supported for this format
 
-weWant
-  A bullet-point list describing the supporting material we would like to have
-  for this format
+  weHave
+    A bullet-point list describing the supporting material we have for this
+    format including specification and sample datasets
 
-pixelRating
-  See :term:`Ratings legend and definitions`. Available choices are: 
-  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+  weWant
+    A bullet-point list describing the supporting material we would like to 
+    have for this format
 
-metadataRating
-  See :term:`Ratings legend and definitions`. Available choices are: 
-  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+  pixelRating
+    See :term:`Ratings legend and definitions`. Available choices are: 
+    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
 
-opennessRating
-  See :term:`Ratings legend and definitions`. Available choices are: 
-  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+  metadataRating
+    See :term:`Ratings legend and definitions`. Available choices are: 
+    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
 
-presenceRating
-  See :term:`Ratings legend and definitions`. Available choices are: 
-  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+  opennessRating
+    See :term:`Ratings legend and definitions`. Available choices are: 
+    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
 
-utilityRating
-  See :term:`Ratings legend and definitions`. Available choices are: 
-  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+  presenceRating
+    See :term:`Ratings legend and definitions`. Available choices are: 
+    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
 
-reader
-  A string or a comma-separated list of all readers for this format
+  utilityRating
+    See :term:`Ratings legend and definitions`. Available choices are: 
+    `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
 
-notes
-  A set of notes to be added
+  reader
+    A string or a comma-separated list of all readers for this format
+
+  notes
+    Additional relevant information e.g. that we cannot distribute 
+    specification documents to third parties
 
 Readers
 -------
-
 
 After checking out source code and building all the JAR files (see
 :doc:`building-bioformats`), the metadata pages for each reader can be 
@@ -103,5 +105,6 @@ This target will loop through all Bio-Formats readers (BSD and GPL), parse
 their metadata support and create an intermediate :file:`meta-support.txt`
 file.
 In a second step, this :file:`meta-support.txt` file is converted into one
-reStructuredText page for each reader stored under :file:`metadata/<reader>.txt` as well as a metadata summary reStructuredText
+reStructuredText page for each reader stored under 
+:file:`metadata/<reader>.txt` as well as a metadata summary reStructuredText
 file using Velocity_.

--- a/docs/sphinx/developers/format-documentation.txt
+++ b/docs/sphinx/developers/format-documentation.txt
@@ -86,7 +86,7 @@ reader
   A string or a comma-separated list of all readers for this format
 
 notes
-  A set of notes to be aded
+  A set of notes to be added
 
 Readers
 -------

--- a/docs/sphinx/developers/format-documentation.txt
+++ b/docs/sphinx/developers/format-documentation.txt
@@ -1,0 +1,107 @@
+Adding format/reader documentation pages
+========================================
+
+.. _Velocity: http://velocity.apache.org/
+
+Most documentation pages for the supported formats and readers are
+auto-generated. These pages should not be modified directly. This page
+explains how to amend/extend this part of the Bio-Formats documentation.
+
+The :sourcedir:`Bio-Formats testing framework <components/autogen>` component
+contains most of the infrastructure to run automated tests against the data
+repository.
+
+Formats
+-------
+
+After checking out source code and building all the JAR files (see
+:doc:`building-bioformats`), the supported formats pages can be generated
+using the :program:`ant` ``gen-format-pages`` target under the :file:`autogen`
+component::
+
+  $ ant -f components/autogen/build.xml gen-format-pages
+
+This target will read the metadata for each format stored under
+:source:`format-pages.txt <components/autogen/src/format-pages.txt>` and
+generate a reStructuredText file for each format stored under
+:file:`formats/<formatname>.txt` as well as an index page for all supported
+formats using Velocity_.
+
+The :file:`format-pages.txt` is an INI file where each section corresponds to
+a particular format given by the section header. Multiple key/values should be 
+defined for each section:
+
+pagename
+  The name of the output reStructuredText file. If unspecified, the section 
+  header will be used to generate the filename.
+
+extensions
+  The list of extensions supported for the format
+
+owner
+  The owner of the file format
+
+developer
+  The developer of the file format
+
+bsd
+  A `yes/no` flag specifying whether the format readers/writers are under the
+  BSD license
+
+export
+  A `yes/no` flag specifying whether the format can be exported
+
+versions
+  A comma-separated list of all versions supported for this format
+
+weHave
+  A bullet-point list describing the supporting material we have for this
+  format including specification and sample datasets
+
+weWant
+  A bullet-point list describing the supporting material we would like to have
+  for this format
+
+pixelRating
+  See :term:`Ratings legend and definitions`. Available choices are: 
+  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+
+metadataRating
+  See :term:`Ratings legend and definitions`. Available choices are: 
+  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+
+opennessRating
+  See :term:`Ratings legend and definitions`. Available choices are: 
+  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+
+presenceRating
+  See :term:`Ratings legend and definitions`. Available choices are: 
+  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+
+utilityRating
+  See :term:`Ratings legend and definitions`. Available choices are: 
+  `Poor`, `Fair`, `Good`, `Very Good`, `Outstanding`
+
+reader
+  A string or a comma-separated list of all readers for this format
+
+notes
+  A set of notes to be aded
+
+Readers
+-------
+
+
+After checking out source code and building all the JAR files (see
+:doc:`building-bioformats`), the metadata pages for each reader can be 
+generated using the :program:`ant` ``gen-meta-support`` target under the
+:file:`autogen` component::
+
+  $ ant -f components/autogen/build.xml gen-meta-support
+
+This target will loop through all Bio-Formats readers (BSD and GPL), parse
+their metadata support and create an intermediate :file:`meta-support.txt`
+file.
+In a second step, this :file:`meta-support.txt` file is converted into one
+reStructuredText page for each reader stored under :file:`metadata/<reader>.txt` as well as a metadata summary reStructuredText
+file using Velocity_.

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -65,10 +65,10 @@ Contributing to Bio-Formats
     :maxdepth: 1
 
     commit-testing
-    format-documentation
     testing-notes
     generating-test-images
     reader-guide
+    format-documentation
     service
     xsd-fu
     useful-scripts

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -65,6 +65,7 @@ Contributing to Bio-Formats
     :maxdepth: 1
 
     commit-testing
+    format-documentation
     testing-notes
     generating-test-images
     reader-guide


### PR DESCRIPTION
See https://trello.com/c/bGwmDei8/8-document-how-to-add-update-format-pages

This PR adds a first version of a developer documentation page explaining how the formats and readers pages are generated and can be modified.

/cc @hflynn 