### PR TITLE
Physical Z Size for Andor Tiff

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -312,7 +312,7 @@ public class FluoviewReader extends BaseTiffReader {
         if (dimensionOrder.indexOf("Z") == -1) {
           dimensionOrder += "Z";
         }
-        if (voxelZ == 1) {
+        if (Double.compare(voxelZ, 1) == 0) {
           voxelZ = voxel;
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 
@@ -42,7 +43,6 @@ import loci.formats.tiff.TiffParser;
 import loci.formats.tiff.TiffRational;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.Timestamp;
-
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Frequency;
 import ome.units.quantity.Length;
@@ -336,7 +336,8 @@ public class FluoviewReader extends BaseTiffReader {
           BigDecimal firstZ = BigDecimal.valueOf(uniqueZ.get(0));
           BigDecimal zRange = (lastZ.subtract(firstZ)).abs();
           BigDecimal zSize = BigDecimal.valueOf((double)(getSizeZ() - 1));
-          voxelZ = zRange.divide(zSize).doubleValue();
+          MathContext mc = new MathContext(10, RoundingMode.HALF_UP);
+          voxelZ = zRange.divide(zSize, mc).doubleValue();
           // Need to convert from millimetre to micrometre
           voxelZ *= Math.pow(10, 3);
         }


### PR DESCRIPTION
User reported bug:

http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005658.html

Using the stamps data (position data for dimensions other than X and Y)
to retrieve a list of physical z values. By identifying the unique
values and ensuring we have a correct number of values, we can average
the correct physical z size.