### PR TITLE
source-archive: Make tar source release

### DIFF
--- a/tools/source-archive.py
+++ b/tools/source-archive.py
@@ -7,6 +7,8 @@ import os
 from subprocess import call
 import sys
 import zipfile
+import tarfile
+import StringIO
 
 # This script archives the base tree and repacks it into a single zip which is
 # the source release, taking care to preserve timestamps and exectute
@@ -86,7 +88,7 @@ if __name__ == "__main__":
         '--output', "%s/%s-base.zip" % (options.target, prefix),
         'HEAD'])
     if base_archive_status != 0:
-        raise Exception('Failed to create git base archive')
+        raise Exception('Failed to create git zip base archive')
 
     zips = list(["%s/%s-base.zip" % (options.target, prefix)])
 
@@ -146,3 +148,73 @@ if __name__ == "__main__":
             options.bioformats_vcsshortrevision,
             options.bioformats_vcsrevision,
             options.bioformats_vcsdate_unix, options.bioformats_vcsdate))
+
+    # Repeat for tar archive
+    base_archive_status = call([
+        'git', 'archive', '--format', 'tar',
+        '--prefix', "%s/" % (prefix),
+        '--output', "%s/%s-base.tar" % (options.target, prefix),
+        'HEAD'])
+    if base_archive_status != 0:
+        raise Exception('Failed to create git tar base archive')
+
+    tars = list(["%s/%s-base.tar" % (options.target, prefix)])
+
+    # Create destination tar file
+    print("  - creating %s/%s.tar" % (options.target, prefix))
+    sys.stdout.flush()
+    basetar = tarfile.open("%s/%s.tar" % (options.target, prefix), 'w',
+                           format=tarfile.PAX_FORMAT)
+
+    # Repack each of the separate tars into the destination tar
+    for name in tars:
+        subtar = tarfile.open(name, 'r')
+        print("  - repacking %s" % (name))
+        sys.stdout.flush()
+        # Iterate over the TarInfo objects from the archive
+        for info in subtar.getmembers():
+            # Skip unwanted git and travis files
+            if (os.path.basename(info.name) == '.gitignore' or
+                    os.path.basename(info.name) == '.travis.yml'):
+                continue
+            # Skip files for which we don't have source in this repository,
+            # for GPL compliance
+            if (options.release.endswith("-dfsg") and
+                (os.path.splitext(info.name)[1] == ".jar" or
+                 os.path.splitext(info.name)[1] == ".dll" or
+                 os.path.splitext(info.name)[1] == ".dylib" or
+                 os.path.splitext(info.name)[1] == ".so")):
+                continue
+            if (options.release.endswith("-dfsg") and
+                info.name.startswith(
+                    "%s/components/xsd-fu/python/genshi" % (prefix))):
+                continue
+            print("File: %s" % (info.name))
+            # Repack a single tar object; preserve the metadata
+            # directly via the TarInfo object and rewrite the content
+            basetar.addfile(info, subtar.extractfile(info.name))
+
+        # Close tar or else the remove will fail on Windows
+        subtar.close()
+
+        # Remove repacked tar
+        os.remove(name)
+
+    # Embed release number
+    antversionbuf = StringIO.StringIO(GITVERSION_XML % (
+        options.bioformats_version, options.bioformats_shortversion,
+        options.bioformats_vcsshortrevision,
+        options.bioformats_vcsrevision,
+        options.bioformats_vcsdate))
+    antversion = tarfile.TarInfo("%s/ant/gitversion.xml" % (prefix))
+    antversion.size = antversionbuf.len
+    basetar.addfile(antversion, antversionbuf)
+
+    cmakeversionbuf = StringIO.StringIO(GITVERSION_CMAKE % (
+        options.bioformats_version, options.bioformats_shortversion,
+        options.bioformats_vcsshortrevision,
+        options.bioformats_vcsrevision,
+        options.bioformats_vcsdate_unix, options.bioformats_vcsdate))
+    cmakeversion = tarfile.TarInfo("%s/cpp/cmake/GitVersion.cmake" % (prefix))
+    cmakeversion.size = cmakeversionbuf.len
+    basetar.addfile(cmakeversion, cmakeversionbuf)


### PR DESCRIPTION
This script creates both a zip and tar source release.  The zip file is unfortunately incompatible with some extractors, making it break the superbuild on a number of platforms using libarchive to extract.  This includes Ubuntu and BSD systems using the current release of libarchive when using "cmake -E tar xfv" to extract the zips (done in the superbuild).  Since fixing these platforms won't happen in the short-term, making an archive they can extract is a simpler solution.  The content is exactly the same as the zip.

Using a current CMake downloaded from cmake.org for e.g. Windows or Linux works fine since they use a newer (unreleased) copy of libarchive git, where the bug is fixed.  Unfortunately for Ubuntu and BSD systems (and likely others) which provide cmake linked against their stable libarchive, they use a version of libarchive with the bug and this breaks the superbuild.  Ideally, I'd like to switch to using the tar source release for the 5.1.5 superbuild.

--------

Testing:

```
# Make release
ant release
cd artifacts

# Unpack all archives
unzip bioformats-5.1.4-DEV.zip
unzip bioformats-dfsg-5.1.4-DEV.zip
mv bioformats-5.1.4-DEV bioformats-5.1.4-DEV-zip
mv bioformats-dfsg-5.1.4-DEV bioformats-dfsg-5.1.4-DEV-zip
tar xfv bioformats-5.1.4-DEV.tar
tar xfv bioformats-dfsg-5.1.4-DEV.tar

# Compare
diff -urN bioformats-5.1.4-DEV-zip bioformats-5.1.4-DEV
diff -urN bioformats-dfsg-5.1.4-DEV-zip bioformats-dfsg-5.1.4-DEV

# Check that files which are executable in git have execute permissions

# Check appended generated content
# This will match the content in the -zip directories, checked above
cat bioformats-5.1.4-DEV/ant/gitversion.xml
cat bioformats-5.1.4-DEV/cpp/cmake/GitVersion.cmake
cat bioformats-dfsg-5.1.4-DEV/ant/gitversion.xml
cat bioformats-dfsg-5.1.4-DEV/cpp/cmake/GitVersion.cmake
```