### PR TITLE
Generated format pages: cleanup

### DIFF
--- a/components/autogen/src/doc/FormatPage.vm
+++ b/components/autogen/src/doc/FormatPage.vm
@@ -42,6 +42,9 @@ Readers:
 Reader: ${item} (:$readerextlink:`Source Code <${item}.java>`, :doc:`Supported Metadata Fields </metadata/${item}>`)
 #end
 
+#if ($writer)
+Writer: ${writer} (:$writerextlink:`Source Code <${writer}.java>`)
+#end
 
 #if ($software)
 Freely Available Software:
@@ -84,15 +87,9 @@ Presence: |$presenceRating|
 
 Utility: |$utilityRating|
 
-
+#if (($privateSpecification) or ($notes))
 **Additional Information**
-
-
-#if ($writer)
-Writer: ${writer} (:$writerextlink:`Source Code <${writer}.java>`)
 #end
-
-Notes:
 
 #if ($privateSpecification)
 **Please note that while we have specification documents for this

--- a/components/autogen/src/doc/FormatPage.vm
+++ b/components/autogen/src/doc/FormatPage.vm
@@ -23,7 +23,11 @@ Owner: $owner
 
 BSD-licensed: |$bsd|
 
-Export: |$export|
+#if ($writer)
+Export: |yes|
+#else
+Export: |no|
+#end
 
 Officially Supported Versions: $versions
 

--- a/components/autogen/src/doc/FormatTable.vm
+++ b/components/autogen/src/doc/FormatTable.vm
@@ -37,7 +37,11 @@ Supported Formats
 #set ($openness = $format.get("opennessRating"))
 #set ($presence = $format.get("presenceRating"))
 #set ($utility = $format.get("utilityRating"))
-#set ($export = $format.get("export"))
+#if ($format.get("writer"))
+  #set ($export = "yes")
+#else
+  #set ($export = "no")
+#end
 #set ($bsd = $format.get("bsd"))
    * - :doc:`$pagename`
      - $extensions

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -3,7 +3,6 @@ extensions = .sld
 owner = `Intelligent Imaging Innovations`_
 developer = `Intelligent Imaging Innovations`_
 bsd = no
-export = no
 versions = 4.1, 4.2, 5.0, 5.5, 6.0
 weHave = * Numerous SlideBook datasets
 weWant = * A SlideBook specification document \n
@@ -38,7 +37,6 @@ pagename = photoshop-psd
 extensions = .psd
 developer = `Adobe <http://www.adobe.com/>`_
 bsd = no
-export = no
 versions = 1.0
 weHave = * a PSD specification document (v3.0.4, 16 July 1995) \n
 * a few PSD files
@@ -54,7 +52,6 @@ reader = PSDReader
 extensions = .aim
 developer = `SCANCO Medical AG <http://www.scanco.ch>`_
 bsd = no
-export = no
 weHave = * one .aim file
 weWant = * an .aim specification document \n
 * more .aim files
@@ -69,7 +66,6 @@ reader = AIMReader
 extensions = .al3d
 owner = `Alicona Imaging <http://www.alicona.com/>`_
 bsd = no
-export = no
 versions = 1.0
 weHave = * an `AL3D specification document <http://www.alicona.com/home/fileadmin/alicona/downloads/AL3DFormat.pdf>`_ (v1.0, from 2003, in PDF) \n
 * a few AL3D datasets
@@ -89,7 +85,6 @@ notes = Known deficiencies: \n
 extensions = .cif
 owner = `Amnis <http://www.amnis.com/>`_
 bsd = yes
-export = no
 weHave = * a few sample datasets
 pixelsRating = Good
 metadataRating = Fair
@@ -103,7 +98,6 @@ extensions = .gel
 owner = `GE Healthcare Life Sciences <http://www.gelifesciences.com/>`_
 developer = Molecular Dynamics
 bsd = no
-export = no
 weHave = * a GEL specification document (Revision 2, from 2001 Mar 15, in PDF) \n
 * a few GEL datasets
 pixelsRating = Very good
@@ -120,7 +114,6 @@ notes = .. seealso:: \n
 extensions = .am, .amiramesh, .grey, .hx, .labels
 developer = `Visage Imaging <http://www.amiravis.com/>`_
 bsd = no
-export = no
 weHave = * a few Amira Mesh datasets
 weWant = * more Amira Mesh datasets
 pixelsRating = Very good
@@ -134,7 +127,6 @@ reader = AmiraReader
 extensions = .img, .hdr
 developer = `Mayo Foundation Biomedical Imaging Resource <http://www.mayo.edu/bir>`_
 bsd = no
-export = no
 weHave = * `an Analyze 7.5 specification document <http://web.archive.org/web/20070927191351/http://www.mayo.edu/bir/PDF/ANALYZE75.pdf>`_ \n
 * several Analyze 7.5 datasets
 pixelsRating = Very good
@@ -150,7 +142,6 @@ extensions = .tif
 owner = `Andor Technology <http://www.andor.com/>`_
 developer = Andor Bioimaging Department
 bsd = no
-export = no
 weHave = * an ABD-TIFF specification document (from 2005 November, in PDF) \n
 * a few ABD-TIFF datasets
 pixelsRating = Very good
@@ -167,7 +158,6 @@ Fluoview TIFF format.
 extensions = .png
 developer = `The Animated PNG Project <http://www.animatedpng.com/>`_
 bsd = yes
-export = yes
 software = `Firefox 3+ <http://www.mozilla.com/firefox>`_ \n
 `Opera 9.5+ <http://www.opera.com/download>`_ \n
 `KSquirrel <http://ksquirrel.sourceforge.net/download.php>`_
@@ -179,12 +169,12 @@ opennessRating = Outstanding
 presenceRating = Good
 utilityRating = Poor
 reader = APNGReader
+writer = APNGWriter
 
 [Aperio AFI]
 extensions = .afi, .svs
 owner = `Aperio <http://www.aperio.com/>`_
 bsd = no
-export = no
 versions =
 weHave = * several AFI datasets
 pixelsRating = Very good
@@ -200,7 +190,6 @@ notes = .. seealso:: \n
 extensions = .svs
 owner = `Aperio <http://www.aperio.com/>`_
 bsd = no
-export = no
 versions = 8.0, 8.2, 9.0
 weHave = * many SVS datasets \n
 * an SVS specification document \n
@@ -219,7 +208,6 @@ notes = .. seealso:: \n
 extensions = .htd, .pnl
 developer = `Applied Precision <http://www.api.com>`_
 bsd = no
-export = no
 weHave = * a few CellWorX datasets
 weWant = * a CellWorX specification document \n
 * more CellWorX datasets
@@ -235,7 +223,6 @@ pagename = avi
 extensions = .avi
 developer = `Microsoft <http://www.microsoft.com/>`_
 bsd = yes
-export = yes
 software = `AVI Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/avi-reader.html>`_ \n
 `AVI Writer plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/avi.html>`_
 weHave = * several AVI datasets
@@ -250,6 +237,7 @@ opennessRating = Fair
 presenceRating = Outstanding
 utilityRating = Poor
 reader = AVIReader
+writer = AVIWriter
 notes = * Bio-Formats can save image stacks as AVI (uncompressed). \n
 * The following codecs are supported for reading: \n
 \n
@@ -266,7 +254,6 @@ notes = * Bio-Formats can save image stacks as AVI (uncompressed). \n
 extensions = .arf
 owner = `INDEC BioSystems <http://www.indecbiosystems.com/>`_
 bsd = no
-export = no
 weHave = * one ARF dataset \n
 * a `specification document <http://www.indecbiosystems.com/imagingworkbench/ApplicationNotes/IWAppNote11-ARF_File_Format.pdf>`_
 weWant = * more ARF datasets
@@ -281,7 +268,6 @@ reader = ARFReader
 extensions = .exp, .tif
 owner = `BD Biosciences <http://www.bdbiosciences.com>`_
 bsd = no
-export = no
 weHave = * a few BD Pathway datasets
 weWant = * more BD Pathway datasets
 pixelsRating = Very good
@@ -295,7 +281,6 @@ reader = BDReader
 extensions = .sdt
 owner = `Becker-Hickl <http://www.becker-hickl.de/>`_
 bsd = no
-export = no
 weHave = * an SDT specification document (from 2008 April, in PDF) \n
 * an SDT specification document (from 2006 June, in PDF) \n
 * Becker & Hickl's `SPCImage <http://www.becker-hickl.de/software/tcspc/softwaretcspcspecial.htm>`_ software \n
@@ -313,7 +298,6 @@ reader = SDTReader
 extensions = .1sc
 owner = `Bio-Rad <http://www.bio-rad.com>`_
 bsd = no
-export = no
 weHave = * software that can read Bio-Rad Gel files \n
 * several Bio-Rad Gel files
 weWant = * a Bio-Rad Gel specification \n
@@ -330,7 +314,6 @@ extensions = .pic, .raw, .xml
 owner = `Carl Zeiss, Inc. <http://www.zeiss.com/>`_
 developer = Bio-Rad
 bsd = no
-export = no
 software = `Bio-Rad PIC reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/biorad.html>`_
 weHave = * a PIC specification document (v4.5, in PDF) \n
 * an older PIC specification document (v4.2, from 1996 December 16, in DOC) \n
@@ -353,7 +336,6 @@ extensions = .scn
 owner = `Bio-Rad <http://www.bio-rad.com>`_
 developer = Bio-Rad
 bsd = no
-export = no
 weHave = * a few Bio-Rad .scn files
 pixelsRating = Very good
 metadataRating = Fair
@@ -366,7 +348,6 @@ reader = BioRadSCNReader
 extensions = .ims
 owner = `Bitplane <http://www.bitplane.com/>`_
 bsd = no
-export = no
 versions = 2.7, 3.0, 5.5
 weHave = * an `Imaris (RAW) specification document <http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) \n
 * an `Imaris 5.5 (HDF) specification document <http://open.bitplane.com/Default.aspx?tabid=268>`_ \n
@@ -390,7 +371,6 @@ notes = - There are three distinct Imaris formats: \n
 [Bruker MRI]
 developer = `Bruker <http://www.bruker.com/>`_
 bsd = no
-export = no
 software = `Bruker plugin for ImageJ <http://rsbweb.nih.gov/ij/plugins/bruker.html>`_
 weHave = * a few Bruker MRI datasets
 weWant = * an official specification document
@@ -405,7 +385,6 @@ reader = BrukerReader
 extensions = .img
 owner = Burleigh Instruments
 bsd = no
-export = no
 weHave = * Pascal code that can read Burleigh files (from ImageSXM) \n
 * a few Burleigh files
 weWant = * a Burleigh file format specification \n
@@ -421,7 +400,6 @@ reader = BurleighReader
 extensions = .cr2, .crw
 developer = `Canon <http://canon.com>`_
 bsd = no
-export = no
 software = `IrfanView <http://www.irfanview.com/>`_
 weHave = * a few example datasets
 weWant = * an official specification document
@@ -436,7 +414,6 @@ reader = DNGReader
 extensions = .tif, .txt, .xml
 developer = `Vale Lab <http://valelab.ucsf.edu/>`_
 bsd = yes
-export = no
 software = `Micro-Manager <http://micro-manager.org/>`_
 weHave = * many Micro-manager datasets
 pixelsRating = Outstanding
@@ -450,7 +427,6 @@ reader = MicromanagerReader
 extensions = .ch5
 developer = `CellH5 <http://cellh5.org/>`_
 bsd = no
-export = no
 software = `CellH5 <http://cellh5.org/>`_
 weHave = * a few CellH5 datasets
 pixelsRating = Very good
@@ -464,7 +440,6 @@ reader = CellH5Reader
 extensions = .c01
 developer = `Thermo Fisher Scientific <http://www.thermofisher.com/>`_
 bsd = no
-export = no
 weHave = * a few Cellomics .c01 datasets
 weWant = * a Cellomics .c01 specification document \n
 * more Cellomics .c01 datasets
@@ -479,7 +454,6 @@ reader = CellomicsReader
 extensions = .vsi
 developer = `Olympus <http://www.olympus.com/>`_
 bsd = no
-export = no
 weHave = * a few example datasets
 weWant = * an official specification document
 pixelsRating = Fair
@@ -493,7 +467,6 @@ reader = CellSensReader
 extensions = .xml, .tif
 owner = `Yokogawa <http://www.yokogawa.com/>`_
 bsd = no
-export = no
 weHave = * a few example datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -506,7 +479,6 @@ reader = CellVoyagerReader
 extensions = .dv, .r3d
 owner = `GE Healthcare (formerly Applied Precision) <http://www.gelifesciences.com/webapp/wcs/stores/servlet/catalog/en/GELifeSciences-UK/brands/deltavision/>`_
 bsd = no
-export = no
 software = `DeltaVision Opener plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/track/delta.html>`_
 weHave = * a DV specification document (v2.10 or newer, in HTML) \n
 * numerous DV datasets
@@ -528,7 +500,6 @@ notes = - The Deltavision format is based on the Medical Research Council (MRC) 
 extensions = .dcm, .dicom
 developer = `National Electrical Manufacturers Association <http://www.nema.org/>`_
 bsd = yes
-export = no
 software = `OsiriX Medical Imaging Software <http://www.osirix-viewer.com/>`_ \n
 `ezDICOM <http://www.sph.sc.edu/comd/rorden/ezdicom.html>`_ \n
 `Wikipedia's list of freeware health software <http://en.wikipedia.org/wiki/List_of_freeware_health_software>`_
@@ -557,7 +528,6 @@ several attempts to fix the problem blind. \n
 extensions = .v
 developer = `Siemens <http://www.siemens.com>`_
 bsd = no
-export = no
 weHave = * a few ECAT7 files
 weWant = * an ECAT7 specification document \n
 * more ECAT7 files
@@ -573,7 +543,6 @@ pagename = eps
 extensions = .eps, .epsi, .ps
 developer = `Adobe <http://www.adobe.com/>`_
 bsd = yes
-export = yes
 software = `EPS Writer plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/eps-writer.html>`_
 weHave = * a few EPS datasets \n
 * the ability to produce new datasets
@@ -591,7 +560,6 @@ notes = * Bio-Formats can save individual planes as EPS. \n
 extensions = .flex, .mea, .res
 developer = `Evotec Technologies, now PerkinElmer <http://www.perkinelmer.com/>`_
 bsd = no
-export = no
 weHave = * many Flex datasets
 weWant = * a freely redistributable LuraWave LWF decoder
 pixelsRating = Outstanding
@@ -610,7 +578,6 @@ license code is required to decode wavelet-compressed Flex files. \n
 extensions = .tiff
 developer = `FEI <http://www.fei.com>`_
 bsd = no
-export = no
 weHave = * a few FEI TIFF datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -623,7 +590,6 @@ reader = FEITiffReader
 extensions = .img
 developer = `FEI <http://www.fei.com/>`_
 bsd = no
-export = no
 weHave = * a few FEI files
 weWant = * a specification document \n
 * more FEI files
@@ -639,7 +605,6 @@ pagename = fits
 extensions = .fits
 developer = `National Radio Astronomy Observatory <http://www.nrao.edu/>`_
 bsd = yes
-export = no
 weHave = * a `FITS specification document <http://archive.stsci.edu/fits/fits_standard/>`_ (NOST 100-2.0, from 1999 March 29, in HTML) \n
 * several FITS datasets
 pixelsRating = Very good
@@ -656,7 +621,6 @@ notes = .. seealso:: \n
 extensions = .dm2
 developer = `Gatan <http://www.gatan.com>`_
 bsd = no
-export = no
 versions = 2
 weHave = * Pascal code that can read DM2 files (from ImageSXM) \n
 * a few DM2 files
@@ -673,7 +637,6 @@ reader = GatanDM2Reader
 extensions = .dm3
 owner = `Gatan <http://www.gatan.com/>`_
 bsd = no
-export = no
 versions = 3
 software = `DM3 Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/DM3_Reader.html>`_ \n
 `EMAN <http://blake.bcm.edu/EMAN/>`_
@@ -694,7 +657,6 @@ extensions = .gif
 owner = `Unisys <http://www.unisys.com/>`_
 developer = `CompuServe <http://www.compuserve.com/>`_
 bsd = yes
-export = no
 software = `Animated GIF Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/agr.html>`_ \n
 `GIF Stack Writer plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/gif-stack-writer.html>`_
 weHave = * a `GIF specification document <http://tronche.com/computer-graphics/gif/>`_ (Version 89a, from 1990, in HTML) \n
@@ -711,7 +673,6 @@ reader = GIFReader
 extensions = .naf
 developer = `Hamamatsu <http://www.hamamatsu.com/>`_
 bsd = no
-export = no
 weHave = * a few NAF files
 weWant = * a specification document \n
 * more NAF files
@@ -726,7 +687,6 @@ reader = NAFReader
 extensions = .his
 owner = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read HIS files (from ImageSXM) \n
 * several HIS files
 weWant = * an HIS specification \n
@@ -742,7 +702,6 @@ reader = HISReader
 extensions = .ndpi
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
-export = no
 software = `NDP.view <http://www.olympusamerica.com/seg_section/seg_vm_downloads.asp>`_
 samples = `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu/>`_
 weHave = * many example datasets
@@ -758,7 +717,6 @@ reader = NDPIReader
 extensions = .vms
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
-export = no
 samples = `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu-vms/>`_
 weHave = * a few example datasets \n
 * `developer documentation from the OpenSlide project <http://openslide.org/Hamamatsu%20format/>`_
@@ -775,7 +733,6 @@ reader = HamamatsuVMSReader
 extensions = .txt, .tif, .bmp, .jpg
 developer = `Hitachi <http://www.hitachi-hta.com/sites/default/files/technotes/Hitachi_4800_STEM.pdf>`_
 bsd = no
-export = no
 weHave = * several Hitachi S-4800 datasets
 pixelsRating = Very good
 metadataRating = Very good
@@ -788,7 +745,6 @@ reader = HitachiReader
 extensions = .i2i
 developer = `Biomedical Imaging Group, UMass Medical School <http://invitro.umassmed.edu/>`_
 bsd = no
-export = no
 weHave = * several example datasets \n
 * a specification document \n
 * an ImageJ plugin that can read I2I data
@@ -804,7 +760,6 @@ pagename = ics
 extensions = .ics, .ids
 developer = P. Dean et al.
 bsd = yes
-export = yes
 versions = 1.0, 2.0
 software = `Libics (ICS reference library) <http://libics.sourceforge.net/>`_ \n
 `ICS Opener plugin for ImageJ <http://valelab.ucsf.edu/%7Enstuurman/IJplugins/Ics_Opener.html>`_ \n
@@ -832,7 +787,6 @@ Commercial applications that can support ICS include: \n
 extensions = .fff
 owner = `Hasselblad <http://www.hasselbladusa.com/>`_
 bsd = no
-export = no
 weHave = * one Imacon file
 weWant = * more Imacon files
 pixelsRating = Poor
@@ -846,7 +800,6 @@ reader = ImaconReader
 extensions = .seq
 owner = `Media Cybernetics <http://www.mediacy.com/>`_
 bsd = no
-export = no
 weHave = * the `Image-Pro Plus <http://www.mediacy.com/index.aspx?page=IPP>`_ software \n
 * a few SEQ datasets \n
 * the ability to produce more datasets
@@ -862,7 +815,6 @@ reader = SEQReader
 extensions = .ipw
 owner = `Media Cybernetics <http://www.mediacy.com/>`_
 bsd = no
-export = no
 weHave = * the `Image-Pro Plus <http://www.mediacy.com/index.aspx?page=IPP>`_ software \n
 * a few IPW datasets \n
 * the ability to produce more datasets
@@ -884,7 +836,6 @@ POI <http://jakarta.apache.org/poi/>`_ library to read IPW files.
 extensions = .hed, .img
 developer = `Image Science <http://www.imagescience.de>`_
 bsd = no
-export = no
 software = `em2em <http://www.imagescience.de/em2em.html>`_
 weHave = * one example dataset \n
 * official file format documentation
@@ -903,7 +854,6 @@ extensions = .mod
 owner = `Boulder Laboratory for 3-Dimensional Electron Microscopy of Cells <http://bio3d.colorado.edu>`_
 developer = `Boulder Laboratory for 3-Dimensional Electron Microscopy of Cells <http://bio3d.colorado.edu>`_
 bsd = no
-export = no
 software = `IMOD <http://bio3d.colorado.edu/imod/>`_
 weHave = * a few sample datasets \n
 * `official documentation <http://bio3d.colorado.edu/imod/doc/binspec.html>`_
@@ -919,7 +869,6 @@ extensions = .liff
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 developer = `Improvision <http://www.improvision.com/>`_
 bsd = no
-export = no
 versions = 2.0, 5.0
 weHave = * an Openlab specification document (from 2000 February 8, in DOC) \n
 * Improvision's XLIFFFileImporter code for reading Openlab LIFF v5 files (from 2006, in C++) \n
@@ -940,7 +889,6 @@ extensions = .raw
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 developer = `Improvision <http://www.improvision.com/>`_
 bsd = no
-export = no
 weHave = * an `Openlab Raw specification document <http://cellularimaging.perkinelmer.com/support/technical_notes/detail.php?id=344>`_ (from 2004 November 09, in HTML) \n
 * a few Openlab Raw datasets
 pixelsRating = Outstanding
@@ -957,7 +905,6 @@ extensions = .tif
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 developer = `Improvision <http://www.improvision.com/>`_
 bsd = no
-export = no
 weHave = * an Improvision TIFF specification document \n
 * a few Improvision TIFF datasets
 pixelsRating = Very good
@@ -975,7 +922,6 @@ extensions = .obf, .msr
 owner = `MPI-BPC <http://www.mpibpc.mpg.de/>`_
 developer = `Department of NanoBiophotonics, MPI-BPC <https://imspector.mpibpc.mpg.de/index.html>`_
 bsd = yes
-export = no
 weHave = * a few .msr datasets \n
 * `a specification document <https://imspector.mpibpc.mpg.de/documentation/fileformat.html>`_
 pixelsRating = Very good
@@ -989,7 +935,6 @@ reader = OBFReader
 extensions = .xdce, .tif
 developer = `GE <http://gelifesciences.com/>`_
 bsd = no
-export = no
 weHave = * a few InCell 1000 datasets
 weWant = * an InCell 1000 specification document \n
 * more InCell 1000 datasets
@@ -1004,7 +949,6 @@ reader = InCellReader
 extensions = .frm
 developer = `GE <http://gelifesciences.com/>`_
 bsd = no
-export = no
 samples = `Broad Bioimage Benchmark Collection <http://www.broadinstitute.org/bbbc/BBBC013/>`_
 weHave = * a few example datasets
 weWant = * an official specification document
@@ -1018,7 +962,6 @@ reader = InCell3000Reader
 [INR]
 extensions = .inr
 bsd = no
-export = no
 weHave = * several sample .inr datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -1030,7 +973,6 @@ reader = INRReader
 [Inveon]
 extensions = .hdr
 bsd = no
-export = no
 weHave = a few Inveon datasets
 pixelsRating = Very good
 metadataRating = Very good
@@ -1043,7 +985,6 @@ reader = InveonReader
 extensions = .ipm
 owner = `BioVision Technologies <http://biovis.com/>`_
 bsd = no
-export = no
 weHave = * a few IPLab-Mac datasets \n
 * a specification document
 weWant = * more IPLab-Mac datasets
@@ -1060,7 +1001,6 @@ extensions = .ipl
 owner = was `BD Biosystems <http://www.bdbiosciences.com/>`_, now `BioVision Technologies <http://www.biovis.com/iplab.htm>`_
 developer = Scanalytics
 bsd = no
-export = no
 software = `IPLab Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/iplab-reader.html>`_
 weHave = * an IPLab specification document (v3.6.5, from 2004 December 1, in PDF) \n
 * several IPLab datasets
@@ -1084,7 +1024,6 @@ notes = Commercial applications that support IPLab include: \n
 extensions = .dat, .img, .par
 owner = `JEOL <http://www.jeol.com>`_
 bsd = no
-export = no
 weHave = * Pascal code that reads JEOL files (from ImageSXM) \n
 * a few JEOL files
 weWant = * an official specification document \n
@@ -1100,7 +1039,6 @@ reader = JEOLReader
 extensions = .jp2
 developer = `Independent JPEG Group <http://www.ijg.org/>`_
 bsd = yes
-export = yes
 software = `JJ2000 (JPEG 2000 library for Java) <http://code.google.com/p/jj2000/>`_
 weHave = * a JPEG 2000 specification document (free draft from 2000, no longer available online) \n
 * a few .jp2 files
@@ -1118,7 +1056,6 @@ JPEG stands for "Joint Photographic Experts Group".
 extensions = .jpg
 developer = `Independent JPEG Group <http://www.ijg.org/>`_
 bsd = yes
-export = yes
 weHave = * a `JPEG specification document <http://www.w3.org/Graphics/JPEG/jfif3.pdf>`_ (v1.04, from 1992 September 1, in PDF) \n
 * numerous JPEG datasets \n
 * the ability to produce more datasets
@@ -1140,7 +1077,6 @@ JPEG stands for "Joint Photographic Experts Group". \n
 extensions = .jpk
 developer = `JPK Instruments <http://www.jpk.com>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read JPK files (from ImageSXM) \n
 * a few JPK files
 weWant = * an official specification document \n
@@ -1156,7 +1092,6 @@ reader = JPKReader
 extensions = .jpx
 developer = `JPEG Committee <http://www.jpeg.org/jpeg2000/>`_
 bsd = no
-export = no
 weHave = * a few .jpx files
 pixelsRating = Very good
 metadataRating = Very good
@@ -1171,7 +1106,6 @@ extensions = .xv
 owner = `AccuSoft <http://www.accusoft.com/company/>`_
 developer = `Khoral <http://www.khoral.com/company/>`_
 bsd = no
-export = no
 samples = `VIFF Images <http://netghost.narod.ru/gff/sample/images/viff/index.htm>`_
 weHave = * several VIFF datasets
 pixelsRating = Good
@@ -1185,7 +1119,6 @@ reader = KhorosReader
 extensions = .bip
 developer = `Kodak/Carestream <http://carestream.com>`_
 bsd = no
-export = no
 weHave = * a few .bip datasets
 weWant = * an official specification document
 pixelsRating = Very good
@@ -1201,7 +1134,6 @@ notes = .. seealso:: \n
 extensions = .fli
 developer = `Lambert Instruments <http://www.lambert-instruments.com>`_
 bsd = no
-export = no
 weHave = * an LI-FLIM specification document \n
 * several example LI-FLIM datasets
 pixelsRating = Very good
@@ -1218,7 +1150,6 @@ extensions = .lif
 owner = `Leica <http://www.leica.com/>`_
 developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
 bsd = no
-export = no
 versions = 1.0, 2.0
 software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
 weHave = * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
@@ -1244,7 +1175,6 @@ Commercial applications that support LIF include: \n
 extensions = .msr
 developer = `LaVision BioTec <http://www.lavisionbiotec.com/>`_
 bsd = no
-export = no
 weHave = * a few .msr files
 pixelsRating = Fair
 metadataRating = Fair
@@ -1258,7 +1188,6 @@ extensions = .lei, .tif
 owner = `Leica <http://www.leica.com/>`_
 developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
 bsd = no
-export = no
 software = `Leica LCS Lite <ftp://ftp.llt.de/softlib/LCSLite/LCSLite2611537.exe>`_
 weHave = * an LEI specification document (beta 2.000, from no later than 2004 February 17, in PDF) \n
 * many LEI datasets
@@ -1282,7 +1211,6 @@ Commercial applications that support LEI include: \n
 extensions = .scn
 developer = `Leica Microsystems <http://www.leica-microsystems.com/>`_
 bsd = no
-export = no
 versions = 2012-03-10
 weHave = * a few sample datasets
 weWant = * an official specification document \n
@@ -1298,7 +1226,6 @@ reader = LeicaSCNReader
 extensions = .sxm
 owner = `Zeiss <http://www.zeiss.de>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read LEO files (from ImageSXM) \n
 * a few LEO files
 weWant = * an official specification document \n
@@ -1314,7 +1241,6 @@ reader = LEOReader
 extensions = .l2d, .tif, .scn
 owner = `LiCor Biosciences <http://www.licor.com/>`_
 bsd = no
-export = no
 weHave = * a few L2D datasets
 weWant = * an official specification document \n
 * more L2D datasets
@@ -1332,7 +1258,6 @@ pagename = lim
 extensions = .lim
 owner = `Laboratory Imaging <http://www.lim.cz/>`_
 bsd = no
-export = no
 weHave = * several LIM files \n
 * the ability to produce more LIM files
 weWant = * an official specification document
@@ -1352,7 +1277,6 @@ Commercial applications that support LIM include: \n
 extensions = .tiff
 owner = `Molecular Devices <http://www.moleculardevices.com/>`_
 bsd = no
-export = no
 weHave = * a few Metamorph 7.5 TIFF datasets
 pixelsRating = Very good
 metadataRating = Very good
@@ -1365,7 +1289,6 @@ reader = MetamorphTiffReader
 extensions = .stk, .nd
 owner = `Molecular Devices <http://www.moleculardevices.com/>`_
 bsd = no
-export = no
 weHave = * an STK specification document (from 2006 November 21, in DOC) \n
 * an older STK specification document (from 2005 March 25, in DOC) \n
 * an ND specification document (from 2002 January 24, in PDF) \n
@@ -1390,7 +1313,6 @@ notes = Commercial applications that support STK include: \n
 extensions = .tif
 developer = `Maia Scientific <http://www.selectscience.net/supplier/maia-scientific/?compID=6088>`_
 bsd = no
-export = no
 weHave = * several MIAS datasets
 pixelsRating = Very good
 metadataRating = Poor
@@ -1403,7 +1325,6 @@ reader = MIASReader
 extensions = .mnc
 developer = `McGill University <http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC>`_
 bsd = no
-export = no
 software = `MINC <http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC>`_
 weHave = * a few MINC files
 pixelsRating = Very good
@@ -1417,7 +1338,6 @@ reader = MINCReader
 extensions = .mrw
 developer = `Minolta <http://www.konicaminolta.com/>`_
 bsd = no
-export = no
 software = `dcraw <http://www.cybercom.net/%7Edcoffin/dcraw/>`_
 weHave = * several .mrw files
 pixelsRating = Very good
@@ -1432,7 +1352,6 @@ pagename = mng
 extensions = .mng
 developer = `MNG Development Group <http://www.libpng.org/pub/mng/mngnews.html>`_
 bsd = yes
-export = no
 software = `libmng (MNG reference library) <http://sourceforge.net/projects/libmng/>`_
 samples = `MNG sample files <http://sourceforge.net/projects/libmng/files/libmng-testsuites/MNGsuite-1.0/MNGsuite.zip/download>`_
 weHave = * the `libmng-testsuites <http://downloads.sourceforge.net/libmng/MNGsuite-20030305.zip>`_ package (from 2003 March 05, in C) \n
@@ -1451,7 +1370,6 @@ notes = .. seealso:: \n
 extensions = .stp
 owner = Molecular Imaging Corp, San Diego CA (closed)
 bsd = no
-export = no
 weHave = * Pascal code that reads Molecular Imaging files (from ImageSXM) \n
 * a few Molecular Imaging files
 weWant = * an official specification document \n
@@ -1468,7 +1386,6 @@ pagename = mrc
 extensions = .mrc
 developer = `MRC Laboratory of Molecular Biology <http://www2.mrc-lmb.cam.ac.uk/>`_
 bsd = no
-export = no
 samples = `golgi.mrc <http://bio3d.colorado.edu/imod/files/imod_data.tar.gz>`_
 weHave = * an `MRC specification document <http://bio3d.colorado.edu/imod/doc/mrc_format.txt>`_ (in TXT) \n
 * a few MRC datasets
@@ -1490,7 +1407,6 @@ pagename = nef
 extensions = .nef, .tif
 developer = `Nikon <http://www.nikon.com/>`_
 bsd = no
-export = no
 samples = `neffile1.zip <http://www.outbackphoto.com/workshop/NEF_conversion/neffile1.zip>`_ \n
 `Sample NEF images <http://www.nikondigital.org/articles/library/nikon_d2x_first_impressions.htm>`_
 weHave = * a NEF specification document (v0.1, from 2003, in PDF) \n
@@ -1509,7 +1425,6 @@ notes = .. seealso:: \n
 extensions = .img, .hdr
 developer = `National Institutes of Health <http://www.nih.gov/>`_
 bsd = no
-export = no
 samples = `Official test data <http://nifti.nimh.nih.gov/nifti-1/data>`_
 weHave = * `NIfTI specification documents <http://nifti.nimh.nih.gov/nifti-1/>`_ \n
 * several NIfTI datasets
@@ -1524,7 +1439,6 @@ reader = NiftiReader
 extensions = .tiff
 developer = `Nikon <http://www.nikon.com>`_
 bsd = no
-export = no
 weHave = * a few Nikon Elements TIFF files
 weWant = * more Nikon Elements TIFF files
 pixelsRating = Good
@@ -1538,7 +1452,6 @@ reader = NikonElementsTiffReader
 extensions = .tiff
 developer = `Nikon <http://www.nikon.com/>`_
 bsd = no
-export = no
 weHave = * a few Nikon EZ-C1 TIFF files
 pixelsRating = Very good
 metadataRating = Very good
@@ -1551,7 +1464,6 @@ reader = NikonTiffReader
 extensions = .nd2
 developer = `Nikon USA <http://www.nikonusa.com/>`_
 bsd = no
-export = no
 software = `NIS-Elements Viewer from Nikon <http://www.nikoninstruments.com/Products/Software/NIS-Elements-Advanced-Research/NIS-Elements-Viewer>`_
 weHave = * many ND2 datasets
 weWant = * an official specification document
@@ -1581,7 +1493,6 @@ pagename = nrrd
 extensions = .nrrd, .nhdr, .raw, .txt
 developer = `Teem developers <http://teem.sourceforge.net/>`_
 bsd = yes
-export = no
 software = `nrrd (NRRD reference library) <http://teem.sourceforge.net/nrrd/>`_
 samples = `Diffusion tensor MRI datasets <http://www.sci.utah.edu/%7Egk/DTI-data/>`_
 weHave = * an `nrrd specification document <http://teem.sourceforge.net/nrrd/format.html>`_ (v1.9, from 2005 December 24, in HTML) \n
@@ -1597,7 +1508,6 @@ reader = NRRDReader
 extensions = .apl, .mtb, .tnb, .tif, .obsep
 owner = `Olympus <http://www.olympus.com/>`_
 bsd = no
-export = no
 weHave = * a few CellR datasets
 weWant = * more Cellr datasets \n
 * an official specification document
@@ -1612,7 +1522,6 @@ reader = APLReader
 extensions = .oib, .oif
 owner = `Olympus <http://www.olympus.com/>`_
 bsd = no
-export = no
 versions = 1.0, 2.0
 software = `FV-Viewer from Olympus <http://www.olympus.co.uk/microscopy/22_FluoView_FV1000__Confocal_Microscope.htm>`_
 weHave = * an OIF specification document (v2.0.0.0, from 2008, in PDF) \n
@@ -1648,7 +1557,6 @@ Commercial applications that support this format include: \n
 extensions = .tif
 owner = `Olympus <http://www.olympus.com/>`_
 bsd = no
-export = no
 software = `DIMIN <http://www.dimin.net/>`_
 weHave = * a FluoView specification document (from 2002 November 14, in DOC) \n
 * Olympus' FluoView Image File Reference Suite (from 2002 March 1, in DOC) \n
@@ -1670,7 +1578,6 @@ extensions = .xml, .dat, .tif
 owner = `Olympus <http://www.olympus.com/>`_
 developer = `Olympus <http://www.olympus.com/>`_
 bsd = no
-export = no
 weHave = * several ScanR datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -1683,7 +1590,6 @@ reader = ScanrReader
 extensions = .tiff
 developer = `Olympus <http://www.olympus-sis.com/>`_
 bsd = no
-export = no
 weHave = * a few example SIS TIFF files
 pixelsRating = Good
 metadataRating = Good
@@ -1697,7 +1603,6 @@ indexExtensions = .ome.tiff
 extensions = `.ome.tiff <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
-export = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06
 weHave = * an :model_doc:`OME-TIFF specification document <ome-tiff/specification.html>` (from 2006 October 19, in HTML) \n
 * many OME-TIFF datasets \n
@@ -1724,7 +1629,6 @@ indexExtensions = .ome
 extensions = `.ome <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
-export = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06
 weHave = * `OME-XML specification documents <http://www.openmicroscopy.org/Schemas/>`_ \n
 * many OME-XML datasets \n
@@ -1748,7 +1652,6 @@ Commercial applications that support OME-XML include: \n
 extensions = .top
 owner = `Oxford Instruments <http://www.oxinst.com>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read Oxford Instruments files (from ImageSXM) \n
 * a few Oxford Instruments files
 weWant = * an official specification document \n
@@ -1764,7 +1667,6 @@ reader = OxfordInstrumentsReader
 extensions = .pcx
 developer = ZSoft Corporation
 bsd = yes
-export = no
 weHave = * several .pcx files \n
 * the ability to generate additional .pcx files
 pixelsRating = Very good
@@ -1779,7 +1681,6 @@ notes = Commercial applications that support PCX include `Zeiss LSM Image Browse
 extensions = .pcoraw, .rec
 developer = `PCO <http://www.pco.de/>`_
 bsd = no
-export = no
 weHave = * a few example datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -1792,7 +1693,6 @@ reader = PCORAWReader
 extensions = .bin
 developer = `PicoQuant <http://www.picoquant.com/>`_
 bsd = no
-export = no
 software = `SymphoTime64 <http://www.picoquant.com/products/category/software/symphotime-64-fluorescence-lifetime-imaging-and-correlation-software>`_
 weHave = * a few example datasets
 pixelsRating = Good
@@ -1806,7 +1706,6 @@ reader = PQBinReader
 extensions = .pds
 developer = `Perkin Elmer <http://www.perkinelmer.com>`_
 bsd = no
-export = no
 weHave = * a few PDS datasets
 weWant = * an official specification document \n
 * more PDS datasets
@@ -1821,7 +1720,6 @@ reader = PDSReader
 extensions = .im3
 developer = `PerkinElmer <http://www.perkinelmer.com/>`_
 bsd = yes
-export = no
 weHave = * a few sample datasets
 pixelsRating = Good
 metadataRating = Fair
@@ -1834,7 +1732,6 @@ reader = IM3Reader
 extensions = .tiff, .xml
 developer = `PerkinElmer <http://www.perkinelmer.com/>`_
 bsd = no
-export = no
 weHave = * a few sample datasets
 weWant = * an official specification document \n
 * more sample datasets
@@ -1850,7 +1747,6 @@ indexExtensions = .tif, .2, .3, .4
 extensions = .tif, .2, .3, .4, etc.
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 bsd = no
-export = no
 weHave = * several UltraView datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -1874,7 +1770,6 @@ pagename = pgm
 extensions = .pgm
 developer = Netpbm developers
 bsd = yes
-export = no
 software = `Netpbm graphics filter <http://netpbm.sourceforge.net/>`_
 weHave = * a `PGM specification document <http://netpbm.sourceforge.net/doc/pgm.html>`_ (from 2003 October 3, in HTML) \n
 * a few PGM files
@@ -1889,7 +1784,6 @@ reader = PGMReader
 extensions = .tif, .tiff
 developer = `Adobe <http://www.adobe.com>`_
 bsd = no
-export = no
 weHave = * a Photoshop TIFF specification document \n
 * a few Photoshop TIFF files
 pixelsRating = Good
@@ -1903,7 +1797,6 @@ reader = PhotoshopTiffReader
 extensions = .pict
 developer = `Apple Computer <http://www.apple.com>`_
 bsd = yes
-export = no
 weHave = * many PICT datasets
 pixelsRating = Very good
 metadataRating = Fair
@@ -1924,7 +1817,6 @@ pagename = png
 extensions = .png
 developer = `PNG Development Group <http://www.libpng.org/pub/png/pngnews.html>`_
 bsd = yes
-export = yes
 software = `PNG Writer plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/png-writer.html>`_
 weHave = * a `PNG specification document <http://www.libpng.org/pub/png/spec/iso/>`_ (W3C/ISO/IEC version, from 2003 November 10, in HTML) \n
 * several PNG datasets
@@ -1934,6 +1826,7 @@ opennessRating = Outstanding
 presenceRating = Outstanding
 utilityRating = Poor
 reader = APNGReader
+writer = APNGWriter
 notes = Bio-Formats uses the `Java Image I/O <http://docs.oracle.com/javase/6/docs/technotes/guides/imageio/>`_  \n
 API to read and write PNG files. \n
 \n
@@ -1945,7 +1838,6 @@ pagename = prairie-tech-tiff
 extensions = .tif, .xml, .cfg
 developer = `Prairie Technologies <http://www.prairie-technologies.com/>`_
 bsd = no
-export = no
 weHave = * many Prairie datasets
 pixelsRating = Very good
 metadataRating = Good
@@ -1959,7 +1851,6 @@ extensions = .afm
 owner = `KLA-Tencor Corporation <http://www.kla-tencor.com/surface-profilometry-and-metrology.html>`_
 developer = Quesant Instrument Corporation
 bsd = no
-export = no
 weHave = * Pascal code that can read Quesant files (from ImageSXM) \n
 * several Quesant files
 weWant = * an official specification document \n
@@ -1975,7 +1866,6 @@ reader = QuesantReader
 extensions = .mov
 owner = `Apple Computer <http://www.apple.com/>`_
 bsd = yes
-export = yes
 software = `QuickTime Player <http://www.apple.com/quicktime/download/>`_
 weHave = * a `QuickTime specification document <http://developer.apple.com/documentation/Quicktime/QTFF/>`_ (from 2001 March 1, in HTML) \n
 * several QuickTime datasets \n
@@ -2023,7 +1913,6 @@ h263   H.263                               -                  read & write \n
 extensions = .sm2, .sm3
 owner = `RHK Technologies <http://www.rhk-tech.com>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read RHK files (from ImageSXM) \n
 * a few RHK files
 weWant = * an official specification document \n
@@ -2038,7 +1927,6 @@ reader = RHKReader
 [SBIG]
 owner = `Santa Barbara Instrument Group (SBIG) <http://www.sbig.com>`_
 bsd = no
-export = no
 weHave = * an `official SBIG specification document <http://sbig.impulse.net/pdffiles/file.format.pdf>`_ \n
 * a few SBIG files
 weWant = * more SBIG files
@@ -2053,7 +1941,6 @@ reader = SBIGReader
 extensions = .xqd, .xqf
 owner = `Seiko <http://www.seiko.co.jp/en/index.php>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read Seiko files (from ImageSXM) \n
 * a few Seiko files
 weWant = * an official specification document \n
@@ -2069,7 +1956,6 @@ reader = SeikoReader
 extensions = .tiff
 developer = `Hamamatsu <http://hcimage.com/simple-pci-legacy/>`_
 bsd = no
-export = no
 weHave = * a few SimplePCI TIFF datasets
 weWant = * more SimplePCI TIFF datasets
 pixelsRating = Very good
@@ -2083,7 +1969,6 @@ reader = SimplePCITiffReader
 extensions = .cxd
 developer = `Compix <http://hcimage.com>`_
 bsd = no
-export = no
 weHave = * several SimplePCI files
 pixelsRating = Outstanding
 metadataRating = Good
@@ -2099,7 +1984,6 @@ POI library <http://jakarta.apache.org/poi/>`_ to read CXD files. \n
 
 [SM Camera]
 bsd = no
-export = no
 weHave = * Pascal code that can read SM-Camera files (from ImageSXM) \n
 * a few SM-Camera files
 weWant = * an official specification document \n
@@ -2115,7 +1999,6 @@ reader = SMCameraReader
 extensions = .spi, .stk
 developer = `Wadsworth Center <http://www.wadsworth.org/spider_doc/spider/docs/spider.html>`_
 bsd = no
-export = no
 software = `SPIDER <http://www.wadsworth.org/spider_doc/spider/docs/spider.html>`_
 weHave = * a few example datasets \n
 * `official file format documentation <http://www.wadsworth.org/spider_doc/spider/docs/image_doc.html>`_
@@ -2130,7 +2013,6 @@ reader = SpiderReader
 extensions = .tga
 developer = `Truevision <http://www.truevision.com>`_
 bsd = no
-export = no
 weHave = * a Targa specification document \n
 * a few Targa files
 pixelsRating = Very good
@@ -2143,7 +2025,6 @@ reader = TargaReader
 [Text]
 extensions = .txt
 bsd = yes
-export = no
 pixelsRating = Good
 metadataRating = Poor
 opennessRating = Fair
@@ -2158,7 +2039,6 @@ extensions = .tif
 owner = `Adobe <http://www.adobe.com>`_
 developer = Aldus and Microsoft
 bsd = yes
-export = yes
 samples = `LZW TIFF data gallery <http://marlin.life.utsa.edu/Data_Gallery.html>`_ \n
 `Big TIFF <http://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
 weHave = * a `TIFF specification document <http://partners.adobe.com/asn/developer/PDFS/TN/TIFF6.pdf>`_ (v6.0, from 1992 June 3, in PDF) \n
@@ -2182,7 +2062,6 @@ Bio-Formats can save image stacks as TIFF or BigTIFF. \n
 extensions = .vws
 developer = `TILL Photonics <http://www.till-photonics.com/>`_
 bsd = no
-export = no
 weHave = * several TillVision datasets
 weWant = * an official specification document
 pixelsRating = Good
@@ -2196,7 +2075,6 @@ reader = TillVisionReader
 extensions = .tfr, .ffr, .zfr, .zfp, .2fl
 owner = `TopoMetrix (now Veeco) <http://www.veeco.com/>`_
 bsd = no
-export = no
 weHave = * Pascal code that reads Topometrix files (from ImageSXM) \n
 * a few Topometrix files
 weWant = * an official specification document \n
@@ -2211,7 +2089,6 @@ reader = TopometrixReader
 [Trestle]
 extensions = .tif, .sld, .jpg
 bsd = no
-export = no
 samples = `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Trestle/>`_
 weHave = * a few example datasets \n
 * `developer documentation from the OpenSlide project <http://openslide.org/Trestle%20format/>`_
@@ -2225,7 +2102,6 @@ reader = TrestleReader
 [UBM]
 extensions = .pr3
 bsd = no
-export = no
 weHave = * Pascal code that can read UBM files (from ImageSXM) \n
 * one UBM file
 weWant = * an official specification document \n
@@ -2241,7 +2117,6 @@ reader = UBMReader
 extensions = .dat, .hdr
 owner = `Unisoku <http://www.unisoku.com>`_
 bsd = no
-export = no
 weHave = * Pascal code that can read Unisoku files (from ImageSXM) \n
 * a few Unisoku files
 weWant = * an official specification document \n
@@ -2257,7 +2132,6 @@ reader = UnisokuReader
 extensions = .fdf
 developer = `Varian, Inc. <http://www.varianinc.com>`_
 bsd = no
-export = no
 weHave = * a few Varian FDF datasets
 weWant = * an official specification document \n
 * more Varian FDF datasets
@@ -2272,7 +2146,6 @@ reader = VarianFDFReader
 extensions = .hdf
 developer = `Veeco <http://www.veeco.com>`_
 bsd = no
-export = no
 weHave = * a few sample datasets
 pixelsRating = Good
 metadataRating = Fair
@@ -2284,7 +2157,6 @@ reader = VeecoReader
 [VG SAM]
 extensions = .dti
 bsd = no
-export = no
 weHave = * a few VG-SAM files
 weWant = * an official specification document \n
 * more VG-SAM files
@@ -2299,7 +2171,6 @@ reader = VGSAMReader
 extensions = .xys, .html
 developer = `VisiTech International <http://www.visitech.co.uk/>`_
 bsd = no
-export = no
 weHave = * several VisiTech datasets
 weWant = * an official specification document
 pixelsRating = Very good
@@ -2313,7 +2184,6 @@ reader = VisitechReader
 extensions = .acff
 developer = `PerkinElmer <http://www.perkinelmer.com/pages/020/cellularimaging/products/volocity.xhtml>`_
 bsd = no
-export = no
 weHave = * several Volocity library clipping datasets
 weWant = * any datasets that do not open correctly \n
 * an official specification document
@@ -2329,7 +2199,6 @@ notes = RGB .acff files are not yet supported.  See :ticket:`6413`.
 extensions = .mvd2
 developer = `PerkinElmer <http://www.perkinelmer.com/pages/020/cellularimaging/products/volocity.xhtml>`_
 bsd = no
-export = no
 samples = `PerkinElmer Downloads <http://cellularimaging.perkinelmer.com/downloads/>`_
 weHave = * many example Volocity datasets
 weWant = * an official specification document \n
@@ -2347,7 +2216,6 @@ extensions = .wat
 owner = `Oxford Instruments <http://www.oxinst.com>`_
 developer = WA Technology
 bsd = no
-export = no
 weHave = * Pascal code that can read WA-TOP files (from ImageSXM) \n
 * a few WA-TOP files
 weWant = * an official specification document \n
@@ -2363,7 +2231,6 @@ reader = WATOPReader
 extensions = .bmp
 developer = Microsoft and IBM
 bsd = yes
-export = no
 software = `BMP Writer plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/bmp-writer.html>`_
 weHave = * many BMP datasets
 pixelsRating = Very good
@@ -2381,7 +2248,6 @@ notes = Compressed BMP files are currently not supported. \n
 extensions = .wlz
 developer = `MRC Human Genetics Unit <http://www.emouseatlas.org/emap/analysis_tools_resources/software/woolz.html>`_
 bsd = no
-export = yes
 software = `Woolz <http://www.emouseatlas.org/emap/analysis_tools_resources/software/woolz.html>`_
 weHave = * a few Woolz datasets
 pixelsRating = Very good
@@ -2397,7 +2263,6 @@ extensions = .lms
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 bsd = no
-export = no
 weHave = * one example dataset
 pixelsRating = Good
 metadataRating = Poor
@@ -2414,7 +2279,6 @@ extensions = .xml, .tiff
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 bsd = no
-export = no
 software = `Zeiss ZEN Lite <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen-lite.html>`_
 weHave = * many example datasets
 weWant = * an official specification document
@@ -2431,7 +2295,6 @@ extensions = .zvi
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision-for-biology.html>`_
 bsd = no
-export = no
 versions = 1.0, 2.0
 software = `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/en_de/downloads/axiovision.html>`_
 weHave = * a ZVI specification document (v2.0.5, from 2010 August, in PDF) \n
@@ -2463,7 +2326,6 @@ indexExtensions = .czi
 extensions = `.czi <http://www.zeiss.com/czi>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/czi>`_
 bsd = no
-export = no
 software = `Zeiss ZEN <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen.html>`_
 weHave = * many example datasets \n
 * official specification documents
@@ -2480,7 +2342,6 @@ pagename = zeiss-lsm
 extensions = .lsm, .mdb
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 bsd = no
-export = no
 software = `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_ \n
 `LSM Toolbox plugin for ImageJ <http://imagejdocu.tudor.lu/Members/ppirrotte/lsmtoolbox>`_ \n
 `LSM Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/lsm-reader.html>`_ \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -435,6 +435,7 @@ opennessRating = Outstanding
 presenceRating = Fair
 utilityRating = Very good
 reader = CellH5Reader
+writer = CellH5Writer
 
 [Cellomics]
 extensions = .c01

--- a/docs/sphinx/developers/format-documentation.txt
+++ b/docs/sphinx/developers/format-documentation.txt
@@ -50,9 +50,6 @@ defined for each section:
     A `yes/no` flag specifying whether the format readers/writers are under the
     BSD license
 
-  export
-    A `yes/no` flag specifying whether Bio-Formats can write this format
-
   versions
     A comma-separated list of all versions supported for this format
 

--- a/docs/sphinx/formats/3i-slidebook.txt
+++ b/docs/sphinx/formats/3i-slidebook.txt
@@ -49,12 +49,7 @@ Presence: |Very good|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 We strongly encourage users to export their .sld files to OME-TIFF 

--- a/docs/sphinx/formats/abd-tiff.txt
+++ b/docs/sphinx/formats/abd-tiff.txt
@@ -45,12 +45,7 @@ Presence: |Fair|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/aim.txt
+++ b/docs/sphinx/formats/aim.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/alicona-3d.txt
+++ b/docs/sphinx/formats/alicona-3d.txt
@@ -45,12 +45,7 @@ Presence: |Poor|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Known deficiencies: 

--- a/docs/sphinx/formats/amersham-biosciences-gel.txt
+++ b/docs/sphinx/formats/amersham-biosciences-gel.txt
@@ -45,12 +45,7 @@ Presence: |Fair|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/amira-mesh.txt
+++ b/docs/sphinx/formats/amira-mesh.txt
@@ -45,10 +45,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/amnis-flowsight.txt
+++ b/docs/sphinx/formats/amnis-flowsight.txt
@@ -44,10 +44,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/analyze-75.txt
+++ b/docs/sphinx/formats/analyze-75.txt
@@ -45,10 +45,4 @@ Presence: |Good|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/animated-png.txt
+++ b/docs/sphinx/formats/animated-png.txt
@@ -53,6 +53,7 @@ Utility: |Poor|
 **Additional Information**
 
 
+Writer: APNGWriter (:bsd-writer:`Source Code <APNGWriter.java>`)
 
 Notes:
 

--- a/docs/sphinx/formats/animated-png.txt
+++ b/docs/sphinx/formats/animated-png.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: APNGReader (:bsd-reader:`Source Code <APNGReader.java>`, :doc:`Supported Metadata Fields </metadata/APNGReader>`)
 
+Writer: APNGWriter (:bsd-writer:`Source Code <APNGWriter.java>`)
 
 Freely Available Software:
 
@@ -49,12 +50,5 @@ Presence: |Good|
 
 Utility: |Poor|
 
-
-**Additional Information**
-
-
-Writer: APNGWriter (:bsd-writer:`Source Code <APNGWriter.java>`)
-
-Notes:
 
 

--- a/docs/sphinx/formats/aperio-afi.txt
+++ b/docs/sphinx/formats/aperio-afi.txt
@@ -43,12 +43,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .. seealso:: 

--- a/docs/sphinx/formats/aperio-svs-tiff.txt
+++ b/docs/sphinx/formats/aperio-svs-tiff.txt
@@ -45,12 +45,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/applied-precision-cellworx.txt
+++ b/docs/sphinx/formats/applied-precision-cellworx.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/avi.txt
+++ b/docs/sphinx/formats/avi.txt
@@ -56,6 +56,7 @@ Utility: |Poor|
 **Additional Information**
 
 
+Writer: AVIWriter (:bsd-writer:`Source Code <AVIWriter.java>`)
 
 Notes:
 

--- a/docs/sphinx/formats/avi.txt
+++ b/docs/sphinx/formats/avi.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: AVIReader (:bsd-reader:`Source Code <AVIReader.java>`, :doc:`Supported Metadata Fields </metadata/AVIReader>`)
 
+Writer: AVIWriter (:bsd-writer:`Source Code <AVIWriter.java>`)
 
 Freely Available Software:
 
@@ -52,13 +53,7 @@ Presence: |Outstanding|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-Writer: AVIWriter (:bsd-writer:`Source Code <AVIWriter.java>`)
-
-Notes:
 
 
 * Bio-Formats can save image stacks as AVI (uncompressed). 

--- a/docs/sphinx/formats/axon-raw-format.txt
+++ b/docs/sphinx/formats/axon-raw-format.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/bd-pathway.txt
+++ b/docs/sphinx/formats/bd-pathway.txt
@@ -45,10 +45,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/becker-hickl-spcimage.txt
+++ b/docs/sphinx/formats/becker-hickl-spcimage.txt
@@ -47,12 +47,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/bio-rad-gel.txt
+++ b/docs/sphinx/formats/bio-rad-gel.txt
@@ -47,10 +47,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/bio-rad-pic.txt
+++ b/docs/sphinx/formats/bio-rad-pic.txt
@@ -50,12 +50,7 @@ Presence: |Very good|
 
 Utility: |Very good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/bio-rad-scn.txt
+++ b/docs/sphinx/formats/bio-rad-scn.txt
@@ -45,10 +45,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/bitplane-imaris.txt
+++ b/docs/sphinx/formats/bitplane-imaris.txt
@@ -54,12 +54,7 @@ Presence: |Fair|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 - There are three distinct Imaris formats: 

--- a/docs/sphinx/formats/bruker-mri.txt
+++ b/docs/sphinx/formats/bruker-mri.txt
@@ -46,10 +46,4 @@ Presence: |Good|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/burleigh.txt
+++ b/docs/sphinx/formats/burleigh.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/canon-dng.txt
+++ b/docs/sphinx/formats/canon-dng.txt
@@ -48,10 +48,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/cellh5.txt
+++ b/docs/sphinx/formats/cellh5.txt
@@ -14,7 +14,7 @@ Developer: `CellH5 <http://cellh5.org/>`_
 
 BSD-licensed: |no|
 
-Export: |no|
+Export: |yes|
 
 Officially Supported Versions: 
 
@@ -50,6 +50,7 @@ Utility: |Very good|
 **Additional Information**
 
 
+Writer: CellH5Writer (:bfwriter:`Source Code <CellH5Writer.java>`)
 
 Notes:
 

--- a/docs/sphinx/formats/cellh5.txt
+++ b/docs/sphinx/formats/cellh5.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: CellH5Reader (:bfreader:`Source Code <CellH5Reader.java>`, :doc:`Supported Metadata Fields </metadata/CellH5Reader>`)
 
+Writer: CellH5Writer (:bfwriter:`Source Code <CellH5Writer.java>`)
 
 Freely Available Software:
 
@@ -46,12 +47,5 @@ Presence: |Fair|
 
 Utility: |Very good|
 
-
-**Additional Information**
-
-
-Writer: CellH5Writer (:bfwriter:`Source Code <CellH5Writer.java>`)
-
-Notes:
 
 

--- a/docs/sphinx/formats/cellomics.txt
+++ b/docs/sphinx/formats/cellomics.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/cellsens-vsi.txt
+++ b/docs/sphinx/formats/cellsens-vsi.txt
@@ -45,10 +45,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/cellvoyager.txt
+++ b/docs/sphinx/formats/cellvoyager.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/deltavision.txt
+++ b/docs/sphinx/formats/deltavision.txt
@@ -47,12 +47,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/dicom.txt
+++ b/docs/sphinx/formats/dicom.txt
@@ -54,12 +54,7 @@ Presence: |Good|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 * DICOM stands for "Digital Imaging and Communication in Medicine". 

--- a/docs/sphinx/formats/ecat7.txt
+++ b/docs/sphinx/formats/ecat7.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/eps.txt
+++ b/docs/sphinx/formats/eps.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: EPSReader (:bsd-reader:`Source Code <EPSReader.java>`, :doc:`Supported Metadata Fields </metadata/EPSReader>`)
 
+Writer: EPSWriter (:bsd-writer:`Source Code <EPSWriter.java>`)
 
 Freely Available Software:
 
@@ -47,13 +48,7 @@ Presence: |Very good|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-Writer: EPSWriter (:bsd-writer:`Source Code <EPSWriter.java>`)
-
-Notes:
 
 
 * Bio-Formats can save individual planes as EPS. 

--- a/docs/sphinx/formats/evotecperkinelmer-opera-flex.txt
+++ b/docs/sphinx/formats/evotecperkinelmer-opera-flex.txt
@@ -44,12 +44,7 @@ Presence: |Poor|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 The LuraWave LWF decoder library (i.e. lwf\_jsdk2.6.jar) with 

--- a/docs/sphinx/formats/fei-tiff.txt
+++ b/docs/sphinx/formats/fei-tiff.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/fei.txt
+++ b/docs/sphinx/formats/fei.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/fits.txt
+++ b/docs/sphinx/formats/fits.txt
@@ -44,12 +44,7 @@ Presence: |Good|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .. seealso:: 

--- a/docs/sphinx/formats/gatan-digital-micrograph-2.txt
+++ b/docs/sphinx/formats/gatan-digital-micrograph-2.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/gatan-digital-micrograph.txt
+++ b/docs/sphinx/formats/gatan-digital-micrograph.txt
@@ -49,12 +49,7 @@ Presence: |Fair|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Commercial applications that support .dm3 files include `Datasqueeze <http://www.datasqueezesoftware.com/>`_.

--- a/docs/sphinx/formats/gif.txt
+++ b/docs/sphinx/formats/gif.txt
@@ -51,10 +51,4 @@ Presence: |Outstanding|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/hamamatsu-aquacosmos-naf.txt
+++ b/docs/sphinx/formats/hamamatsu-aquacosmos-naf.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/hamamatsu-his.txt
+++ b/docs/sphinx/formats/hamamatsu-his.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/hamamatsu-ndpi.txt
+++ b/docs/sphinx/formats/hamamatsu-ndpi.txt
@@ -51,10 +51,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/hamamatsu-vms.txt
+++ b/docs/sphinx/formats/hamamatsu-vms.txt
@@ -50,10 +50,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/hitachi-s-4800.txt
+++ b/docs/sphinx/formats/hitachi-s-4800.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/i2i.txt
+++ b/docs/sphinx/formats/i2i.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/ics.txt
+++ b/docs/sphinx/formats/ics.txt
@@ -20,6 +20,7 @@ Officially Supported Versions: 1.0, 2.0
 
 Reader: ICSReader (:bsd-reader:`Source Code <ICSReader.java>`, :doc:`Supported Metadata Fields </metadata/ICSReader>`)
 
+Writer: ICSWriter (:bsd-writer:`Source Code <ICSWriter.java>`)
 
 Freely Available Software:
 
@@ -48,13 +49,7 @@ Presence: |Very good|
 
 Utility: |Very good|
 
-
 **Additional Information**
-
-
-Writer: ICSWriter (:bsd-writer:`Source Code <ICSWriter.java>`)
-
-Notes:
 
 
 * ICS version 1.0 datasets have two files - an .ics file that contains 

--- a/docs/sphinx/formats/imacon.txt
+++ b/docs/sphinx/formats/imacon.txt
@@ -45,10 +45,4 @@ Presence: |Poor|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/imagepro-sequence.txt
+++ b/docs/sphinx/formats/imagepro-sequence.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/imagepro-workspace.txt
+++ b/docs/sphinx/formats/imagepro-workspace.txt
@@ -50,12 +50,7 @@ Presence: |Poor|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Bio-Formats uses a modified version of the `Apache Jakarta 

--- a/docs/sphinx/formats/imagic.txt
+++ b/docs/sphinx/formats/imagic.txt
@@ -48,12 +48,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .. seealso:: 

--- a/docs/sphinx/formats/imod.txt
+++ b/docs/sphinx/formats/imod.txt
@@ -49,10 +49,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/improvision-openlab-liff.txt
+++ b/docs/sphinx/formats/improvision-openlab-liff.txt
@@ -47,12 +47,7 @@ Presence: |Good|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/improvision-openlab-raw.txt
+++ b/docs/sphinx/formats/improvision-openlab-raw.txt
@@ -45,12 +45,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .. seealso:: 

--- a/docs/sphinx/formats/improvision-tiff.txt
+++ b/docs/sphinx/formats/improvision-tiff.txt
@@ -45,12 +45,7 @@ Presence: |Fair|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/imspector-obf.txt
+++ b/docs/sphinx/formats/imspector-obf.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/incell-1000.txt
+++ b/docs/sphinx/formats/incell-1000.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/incell-3000.txt
+++ b/docs/sphinx/formats/incell-3000.txt
@@ -48,10 +48,4 @@ Presence: |Fair|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/inr.txt
+++ b/docs/sphinx/formats/inr.txt
@@ -43,10 +43,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/inveon.txt
+++ b/docs/sphinx/formats/inveon.txt
@@ -43,10 +43,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/iplab-mac.txt
+++ b/docs/sphinx/formats/iplab-mac.txt
@@ -45,12 +45,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/iplab.txt
+++ b/docs/sphinx/formats/iplab.txt
@@ -49,12 +49,7 @@ Presence: |Fair|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/jeol.txt
+++ b/docs/sphinx/formats/jeol.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/jpeg-2000.txt
+++ b/docs/sphinx/formats/jpeg-2000.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: JPEG2000Reader (:bsd-reader:`Source Code <JPEG2000Reader.java>`, :doc:`Supported Metadata Fields </metadata/JPEG2000Reader>`)
 
+Writer: JPEG2000Writer (:bsd-writer:`Source Code <JPEG2000Writer.java>`)
 
 Freely Available Software:
 
@@ -47,13 +48,7 @@ Presence: |Good|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-Writer: JPEG2000Writer (:bsd-writer:`Source Code <JPEG2000Writer.java>`)
-
-Notes:
 
 
 Bio-Formats uses the `JAI Image I/O Tools <https://java.net/projects/jai-imageio>`_ library to read JP2 files. 

--- a/docs/sphinx/formats/jpeg.txt
+++ b/docs/sphinx/formats/jpeg.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: JPEGReader (:bsd-reader:`Source Code <JPEGReader.java>`, :doc:`Supported Metadata Fields </metadata/JPEGReader>`)
 
+Writer: JPEGWriter (:bsd-writer:`Source Code <JPEGWriter.java>`)
 
 
 
@@ -45,13 +46,7 @@ Presence: |Outstanding|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-Writer: JPEGWriter (:bsd-writer:`Source Code <JPEGWriter.java>`)
-
-Notes:
 
 
 Bio-Formats can save individual planes as JPEG. 

--- a/docs/sphinx/formats/jpk.txt
+++ b/docs/sphinx/formats/jpk.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/jpx.txt
+++ b/docs/sphinx/formats/jpx.txt
@@ -44,10 +44,4 @@ Presence: |Good|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/khoros-viff-bitmap.txt
+++ b/docs/sphinx/formats/khoros-viff-bitmap.txt
@@ -48,10 +48,4 @@ Presence: |Poor|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/kodak-bip.txt
+++ b/docs/sphinx/formats/kodak-bip.txt
@@ -44,12 +44,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .. seealso:: 

--- a/docs/sphinx/formats/lambert-instruments-flim.txt
+++ b/docs/sphinx/formats/lambert-instruments-flim.txt
@@ -44,12 +44,7 @@ Presence: |Fair|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/lavision-imspector.txt
+++ b/docs/sphinx/formats/lavision-imspector.txt
@@ -44,10 +44,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/leica-lcs-lei.txt
+++ b/docs/sphinx/formats/leica-lcs-lei.txt
@@ -48,12 +48,7 @@ Presence: |Very good|
 
 Utility: |Very good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/leica-lif.txt
+++ b/docs/sphinx/formats/leica-lif.txt
@@ -49,12 +49,7 @@ Presence: |Good|
 
 Utility: |Very good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/leica-scn.txt
+++ b/docs/sphinx/formats/leica-scn.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/leo.txt
+++ b/docs/sphinx/formats/leo.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/li-cor-l2d.txt
+++ b/docs/sphinx/formats/li-cor-l2d.txt
@@ -45,12 +45,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 L2D datasets cannot be imported into OME using server-side import. 

--- a/docs/sphinx/formats/lim.txt
+++ b/docs/sphinx/formats/lim.txt
@@ -45,12 +45,7 @@ Presence: |Poor|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Bio-Formats only supports uncompressed LIM files. 

--- a/docs/sphinx/formats/metamorph-75-tiff.txt
+++ b/docs/sphinx/formats/metamorph-75-tiff.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/metamorph-stack-stk.txt
+++ b/docs/sphinx/formats/metamorph-stack-stk.txt
@@ -46,12 +46,7 @@ Presence: |Very good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/mias-maia-scientific.txt
+++ b/docs/sphinx/formats/mias-maia-scientific.txt
@@ -44,10 +44,4 @@ Presence: |Poor|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/micro-manager.txt
+++ b/docs/sphinx/formats/micro-manager.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/minc-mri.txt
+++ b/docs/sphinx/formats/minc-mri.txt
@@ -47,10 +47,4 @@ Presence: |Good|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/minolta-mrw.txt
+++ b/docs/sphinx/formats/minolta-mrw.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/mng.txt
+++ b/docs/sphinx/formats/mng.txt
@@ -50,12 +50,7 @@ Presence: |Fair|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .. seealso:: 

--- a/docs/sphinx/formats/molecular-imaging.txt
+++ b/docs/sphinx/formats/molecular-imaging.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/mrc.txt
+++ b/docs/sphinx/formats/mrc.txt
@@ -47,12 +47,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Commercial applications that support MRC include: 

--- a/docs/sphinx/formats/nef.txt
+++ b/docs/sphinx/formats/nef.txt
@@ -48,12 +48,7 @@ Presence: |Poor|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/nifti.txt
+++ b/docs/sphinx/formats/nifti.txt
@@ -48,10 +48,4 @@ Presence: |Good|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/nikon-elements-tiff.txt
+++ b/docs/sphinx/formats/nikon-elements-tiff.txt
@@ -45,10 +45,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/nikon-ez-c1-tiff.txt
+++ b/docs/sphinx/formats/nikon-ez-c1-tiff.txt
@@ -44,10 +44,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/nikon-nis-elements-nd2.txt
+++ b/docs/sphinx/formats/nikon-nis-elements-nd2.txt
@@ -47,12 +47,7 @@ Presence: |Very good|
 
 Utility: |Very good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 There are two distinct versions of ND2: an old version, which uses 

--- a/docs/sphinx/formats/nrrd.txt
+++ b/docs/sphinx/formats/nrrd.txt
@@ -51,10 +51,4 @@ Presence: |Fair|
 Utility: |Very good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/olympus-cellrapl.txt
+++ b/docs/sphinx/formats/olympus-cellrapl.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/olympus-fluoview-fv1000.txt
+++ b/docs/sphinx/formats/olympus-fluoview-fv1000.txt
@@ -51,12 +51,7 @@ Presence: |Good|
 
 Utility: |Very good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/olympus-fluoview-tiff.txt
+++ b/docs/sphinx/formats/olympus-fluoview-tiff.txt
@@ -48,12 +48,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/olympus-scanr.txt
+++ b/docs/sphinx/formats/olympus-scanr.txt
@@ -45,10 +45,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/olympus-sis-tiff.txt
+++ b/docs/sphinx/formats/olympus-sis-tiff.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/ome-tiff.txt
+++ b/docs/sphinx/formats/ome-tiff.txt
@@ -20,6 +20,7 @@ Officially Supported Versions: 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-
 
 Reader: OMETiffReader (:bsd-reader:`Source Code <OMETiffReader.java>`, :doc:`Supported Metadata Fields </metadata/OMETiffReader>`)
 
+Writer: OMETiffWriter (:bsd-writer:`Source Code <OMETiffWriter.java>`)
 
 
 
@@ -45,13 +46,7 @@ Presence: |Fair|
 
 Utility: |Outstanding|
 
-
 **Additional Information**
-
-
-Writer: OMETiffWriter (:bsd-writer:`Source Code <OMETiffWriter.java>`)
-
-Notes:
 
 
 Bio-Formats can save image stacks as OME-TIFF. 

--- a/docs/sphinx/formats/ome-xml.txt
+++ b/docs/sphinx/formats/ome-xml.txt
@@ -20,6 +20,7 @@ Officially Supported Versions: 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-
 
 Reader: OMEXMLReader (:bsd-reader:`Source Code <OMEXMLReader.java>`, :doc:`Supported Metadata Fields </metadata/OMEXMLReader>`)
 
+Writer: OMEXMLWriter (:bsd-writer:`Source Code <OMEXMLWriter.java>`)
 
 
 
@@ -45,13 +46,7 @@ Presence: |Fair|
 
 Utility: |Outstanding|
 
-
 **Additional Information**
-
-
-Writer: OMEXMLWriter (:bsd-writer:`Source Code <OMEXMLWriter.java>`)
-
-Notes:
 
 
 Bio-Formats uses the :model_doc:`OME-XML Java library <ome-xml/java-library.html>` 

--- a/docs/sphinx/formats/oxford-instruments.txt
+++ b/docs/sphinx/formats/oxford-instruments.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/pcoraw.txt
+++ b/docs/sphinx/formats/pcoraw.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/pcx-pc-paintbrush.txt
+++ b/docs/sphinx/formats/pcx-pc-paintbrush.txt
@@ -44,12 +44,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_.

--- a/docs/sphinx/formats/perkin-elmer-densitometer.txt
+++ b/docs/sphinx/formats/perkin-elmer-densitometer.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/perkinelmer-nuance.txt
+++ b/docs/sphinx/formats/perkinelmer-nuance.txt
@@ -44,10 +44,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/perkinelmer-operetta.txt
+++ b/docs/sphinx/formats/perkinelmer-operetta.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/perkinelmer-ultraview.txt
+++ b/docs/sphinx/formats/perkinelmer-ultraview.txt
@@ -43,12 +43,7 @@ Presence: |Fair|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Other associated extensions include: .tim, .zpo, .csv, .htm, 

--- a/docs/sphinx/formats/pgm.txt
+++ b/docs/sphinx/formats/pgm.txt
@@ -48,10 +48,4 @@ Presence: |Good|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/photoshop-psd.txt
+++ b/docs/sphinx/formats/photoshop-psd.txt
@@ -46,10 +46,4 @@ Presence: |Good|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/photoshop-tiff.txt
+++ b/docs/sphinx/formats/photoshop-tiff.txt
@@ -45,10 +45,4 @@ Presence: |Good|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/picoquant-bin.txt
+++ b/docs/sphinx/formats/picoquant-bin.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/pict-macintosh-picture.txt
+++ b/docs/sphinx/formats/pict-macintosh-picture.txt
@@ -43,12 +43,7 @@ Presence: |Very good|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 `QuickTime for Java 

--- a/docs/sphinx/formats/png.txt
+++ b/docs/sphinx/formats/png.txt
@@ -51,6 +51,7 @@ Utility: |Poor|
 **Additional Information**
 
 
+Writer: APNGWriter (:bsd-writer:`Source Code <APNGWriter.java>`)
 
 Notes:
 

--- a/docs/sphinx/formats/png.txt
+++ b/docs/sphinx/formats/png.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: APNGReader (:bsd-reader:`Source Code <APNGReader.java>`, :doc:`Supported Metadata Fields </metadata/APNGReader>`)
 
+Writer: APNGWriter (:bsd-writer:`Source Code <APNGWriter.java>`)
 
 Freely Available Software:
 
@@ -47,13 +48,7 @@ Presence: |Outstanding|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-Writer: APNGWriter (:bsd-writer:`Source Code <APNGWriter.java>`)
-
-Notes:
 
 
 Bio-Formats uses the `Java Image I/O <http://docs.oracle.com/javase/6/docs/technotes/guides/imageio/>`_  

--- a/docs/sphinx/formats/prairie-tech-tiff.txt
+++ b/docs/sphinx/formats/prairie-tech-tiff.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/quesant.txt
+++ b/docs/sphinx/formats/quesant.txt
@@ -48,10 +48,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/quicktime-movie.txt
+++ b/docs/sphinx/formats/quicktime-movie.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: NativeQTReader (:bsd-reader:`Source Code <NativeQTReader.java>`, :doc:`Supported Metadata Fields </metadata/NativeQTReader>`)
 
+Writer: QTWriter (:bsd-writer:`Source Code <QTWriter.java>`)
 
 Freely Available Software:
 
@@ -52,13 +53,7 @@ Presence: |Outstanding|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-Writer: QTWriter (:bsd-writer:`Source Code <QTWriter.java>`)
-
-Notes:
 
 
 Bio-Formats has two modes of operation for QuickTime: 

--- a/docs/sphinx/formats/rhk.txt
+++ b/docs/sphinx/formats/rhk.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/sbig.txt
+++ b/docs/sphinx/formats/sbig.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/seiko.txt
+++ b/docs/sphinx/formats/seiko.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/simplepci-hcimage-tiff.txt
+++ b/docs/sphinx/formats/simplepci-hcimage-tiff.txt
@@ -45,10 +45,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/simplepci-hcimage.txt
+++ b/docs/sphinx/formats/simplepci-hcimage.txt
@@ -43,12 +43,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Bio-Formats uses a modified version of the `Apache Jakarta 

--- a/docs/sphinx/formats/sm-camera.txt
+++ b/docs/sphinx/formats/sm-camera.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/spider.txt
+++ b/docs/sphinx/formats/spider.txt
@@ -48,10 +48,4 @@ Presence: |Good|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/targa.txt
+++ b/docs/sphinx/formats/targa.txt
@@ -45,10 +45,4 @@ Presence: |Good|
 Utility: |Poor|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/text.txt
+++ b/docs/sphinx/formats/text.txt
@@ -41,12 +41,7 @@ Presence: |Fair|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Reads tabular pixel data produced by a variety of software.

--- a/docs/sphinx/formats/tiff.txt
+++ b/docs/sphinx/formats/tiff.txt
@@ -21,6 +21,7 @@ Officially Supported Versions:
 
 Reader: TiffReader (:bsd-reader:`Source Code <TiffReader.java>`, :doc:`Supported Metadata Fields </metadata/TiffReader>`)
 
+Writer: TiffWriter (:bsd-writer:`Source Code <TiffWriter.java>`)
 
 
 Sample Datasets:
@@ -50,13 +51,7 @@ Presence: |Outstanding|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-Writer: TiffWriter (:bsd-writer:`Source Code <TiffWriter.java>`)
-
-Notes:
 
 
 Bio-Formats can also read BigTIFF files (TIFF files larger than 4 GB). 

--- a/docs/sphinx/formats/tillphotonics-tillvision.txt
+++ b/docs/sphinx/formats/tillphotonics-tillvision.txt
@@ -45,10 +45,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/topometrix.txt
+++ b/docs/sphinx/formats/topometrix.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/trestle.txt
+++ b/docs/sphinx/formats/trestle.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/ubm.txt
+++ b/docs/sphinx/formats/ubm.txt
@@ -46,10 +46,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/unisoku.txt
+++ b/docs/sphinx/formats/unisoku.txt
@@ -47,10 +47,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/varian-fdf.txt
+++ b/docs/sphinx/formats/varian-fdf.txt
@@ -46,10 +46,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/veeco-afm.txt
+++ b/docs/sphinx/formats/veeco-afm.txt
@@ -44,10 +44,4 @@ Presence: |Fair|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/vg-sam.txt
+++ b/docs/sphinx/formats/vg-sam.txt
@@ -45,10 +45,4 @@ Presence: |Poor|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/visitech-xys.txt
+++ b/docs/sphinx/formats/visitech-xys.txt
@@ -45,10 +45,4 @@ Presence: |Poor|
 Utility: |Good|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/volocity-library-clipping.txt
+++ b/docs/sphinx/formats/volocity-library-clipping.txt
@@ -45,12 +45,7 @@ Presence: |Poor|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 RGB .acff files are not yet supported.  See :ticket:`6413`.

--- a/docs/sphinx/formats/volocity.txt
+++ b/docs/sphinx/formats/volocity.txt
@@ -48,12 +48,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 .mvd2 files are `Metakit database files <http://equi4.com/metakit/>`_.

--- a/docs/sphinx/formats/wa-top.txt
+++ b/docs/sphinx/formats/wa-top.txt
@@ -48,10 +48,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/windows-bitmap.txt
+++ b/docs/sphinx/formats/windows-bitmap.txt
@@ -46,12 +46,7 @@ Presence: |Outstanding|
 
 Utility: |Poor|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 Compressed BMP files are currently not supported. 

--- a/docs/sphinx/formats/woolz.txt
+++ b/docs/sphinx/formats/woolz.txt
@@ -20,6 +20,7 @@ Officially Supported Versions:
 
 Reader: WlzReader (:bfreader:`Source Code <WlzReader.java>`, :doc:`Supported Metadata Fields </metadata/WlzReader>`)
 
+Writer: WlzWriter (:bfwriter:`Source Code <WlzWriter.java>`)
 
 Freely Available Software:
 
@@ -46,12 +47,5 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
-**Additional Information**
-
-
-Writer: WlzWriter (:bfwriter:`Source Code <WlzWriter.java>`)
-
-Notes:
 
 

--- a/docs/sphinx/formats/zeiss-axio-csm.txt
+++ b/docs/sphinx/formats/zeiss-axio-csm.txt
@@ -44,12 +44,7 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 
 This should not be confused with the more common Zeiss LSM format, 

--- a/docs/sphinx/formats/zeiss-axiovision-tiff.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-tiff.txt
@@ -49,10 +49,4 @@ Presence: |Fair|
 Utility: |Fair|
 
 
-**Additional Information**
-
-
-
-Notes:
-
 

--- a/docs/sphinx/formats/zeiss-axiovision-zvi.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-zvi.txt
@@ -52,12 +52,7 @@ Presence: |Good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/zeiss-czi.txt
+++ b/docs/sphinx/formats/zeiss-czi.txt
@@ -47,12 +47,7 @@ Presence: |Fair|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/formats/zeiss-lsm.txt
+++ b/docs/sphinx/formats/zeiss-lsm.txt
@@ -52,12 +52,7 @@ Presence: |Very good|
 
 Utility: |Good|
 
-
 **Additional Information**
-
-
-
-Notes:
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -239,7 +239,7 @@ Supported Formats
      - |Outstanding|
      - |Fair|
      - |Very good|
-     - |no|
+     - |yes|
      - |no|
    * - :doc:`formats/cellomics`
      - .c01


### PR DESCRIPTION
Follow-up of gh-1988 and gh-1996, this PR does some additional cleanup for the format pages auto-generation

- removes the `export` flag in `src/format-pages.txt`
- use the `writer` field instead to determine whether Bio-Formats can write the data
- moves the `Writer: ` block under the `Reader: ` for clarity in individual format pages
- removes the  `Notes:` heading and make the `Additional information` header conditional to the existence of notes
- registers the `CellH5Writer` in `src/format-pages.txt`

All format pages have been regenerated. Apart from CellH5 which should mention export, there should be no notable difference apart from a general tidying up.