### PR TITLE
cpp: Remove additional warnings

### DIFF
--- a/components/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -129,7 +129,6 @@ public class ${klass.name} extends ${klass.parentName}
 	public ${klass.name}(Element element, OMEModel model)
 	    throws EnumerationException
 	{
-                // comment
 		update(element, model);
 	}
 

--- a/components/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -129,6 +129,7 @@ public class ${klass.name} extends ${klass.parentName}
 	public ${klass.name}(Element element, OMEModel model)
 	    throws EnumerationException
 	{
+                // comment
 		update(element, model);
 	}
 

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -182,7 +182,6 @@ if (NOT MSVC)
       -Wmissing-declarations
       -Wno-long-long
       -Wnon-virtual-dtor
-      -Wold-style-cast
       -Woverlength-strings
       -Woverloaded-virtual
       -Wredundant-decls
@@ -190,6 +189,9 @@ if (NOT MSVC)
       -Wswitch-default
       -Wunused-variable
       -Wwrite-strings
+      -Wno-variadic-macros
+      -Wno-unused-local-typedef
+      -Wno-language-extension-token
       -fstrict-aliasing)
   if (extra-warnings)
     list(APPEND test_flags
@@ -197,6 +199,7 @@ if (NOT MSVC)
         -Wdocumentation
         -Wfloat-equal
         -Wmissing-prototypes
+        -Wold-style-cast
         -Wunreachable-code)
   endif (extra-warnings)
   if (fatal-warnings)

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -139,8 +139,8 @@ namespace
     void
     startElement(const XMLCh* const         uri,
                  const XMLCh* const         localname,
-                 const XMLCh* const         qname,
-                 const xercesc::Attributes& attrs)
+                 const XMLCh* const         /* qname */,
+                 const xercesc::Attributes& /* attrs */)
     {
       if (ome::common::xml::String(localname) == "OME")
         {

--- a/cpp/lib/ome/qtwidgets/CMakeLists.txt
+++ b/cpp/lib/ome/qtwidgets/CMakeLists.txt
@@ -62,6 +62,7 @@ if (OME_QTOPENGL)
       GLContainer.h
       GLWindow.h
       GLView2D.h
+      glm.h
       NavigationDock2D.h
       TexelProperties.h)
 

--- a/cpp/lib/ome/qtwidgets/GLView2D.cpp
+++ b/cpp/lib/ome/qtwidgets/GLView2D.cpp
@@ -43,15 +43,10 @@
 #include <ome/qtwidgets/GLView2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/gl/v20/V20Image2D.h>
 #include <ome/qtwidgets/gl/v20/V20Grid2D.h>
 #include <ome/qtwidgets/gl/v20/V20Axis2D.h>
-
-#define GLM_FORCE_RADIANS
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/type_ptr.hpp>
-#include <glm/gtx/rotate_vector.hpp>
 
 #include <iostream>
 

--- a/cpp/lib/ome/qtwidgets/GLView2D.h
+++ b/cpp/lib/ome/qtwidgets/GLView2D.h
@@ -43,14 +43,13 @@
 
 #include <ome/compat/memory.h>
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/GLWindow.h>
 #include <ome/qtwidgets/gl/Image2D.h>
 #include <ome/qtwidgets/gl/Grid2D.h>
 #include <ome/qtwidgets/gl/Axis2D.h>
 
 #include <QElapsedTimer>
-
-#include <glm/glm.hpp>
 
 namespace ome
 {

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -43,15 +43,10 @@
 #include <ome/qtwidgets/NavigationDock2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/gl/v20/V20Image2D.h>
 #include <ome/qtwidgets/gl/v20/V20Grid2D.h>
 #include <ome/qtwidgets/gl/v20/V20Axis2D.h>
-
-#define GLM_FORCE_RADIANS
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/type_ptr.hpp>
-#include <glm/gtx/rotate_vector.hpp>
 
 #include <iostream>
 

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.h
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.h
@@ -43,6 +43,7 @@
 
 #include <ome/compat/memory.h>
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/GLWindow.h>
 #include <ome/qtwidgets/gl/Image2D.h>
 #include <ome/qtwidgets/gl/Grid2D.h>
@@ -52,8 +53,6 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QSlider>
 #include <QtWidgets/QSpinBox>
-
-#include <glm/glm.hpp>
 
 namespace ome
 {

--- a/cpp/lib/ome/qtwidgets/gl/Axis2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Axis2D.h
@@ -39,8 +39,6 @@
 #ifndef OME_QTWIDGETS_GL_AXIS2D_H
 #define OME_QTWIDGETS_GL_AXIS2D_H
 
-#include <glm/glm.hpp>
-
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
@@ -51,6 +49,7 @@
 
 #include <ome/compat/memory.h>
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/glsl/v110/GLFlatShader2D.h>
 
 namespace ome

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.h
@@ -39,8 +39,6 @@
 #ifndef OME_QTWIDGETS_GL_GRID2D_H
 #define OME_QTWIDGETS_GL_GRID2D_H
 
-#include <glm/glm.hpp>
-
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
@@ -50,6 +48,8 @@
 #include <ome/bioformats/FormatReader.h>
 
 #include <ome/compat/memory.h>
+
+#include <ome/qtwidgets/glm.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/qtwidgets/gl/Image2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Image2D.h
@@ -39,8 +39,6 @@
 #ifndef OME_QTWIDGETS_GL_IMAGE2D_H
 #define OME_QTWIDGETS_GL_IMAGE2D_H
 
-#include <glm/glm.hpp>
-
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
@@ -50,6 +48,8 @@
 #include <ome/bioformats/FormatReader.h>
 
 #include <ome/compat/memory.h>
+
+#include <ome/qtwidgets/glm.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/qtwidgets/glm.h
+++ b/cpp/lib/ome/qtwidgets/glm.h
@@ -1,8 +1,8 @@
 /*
  * #%L
- * OME-XML C++ library for working with OME-XML metadata structures.
+ * OME-QTWIDGETS C++ library for display of Bio-Formats pixel data and metadata.
  * %%
- * Copyright © 2015 Open Microscopy Environment:
+ * Copyright © 2014 - 2015 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -36,51 +36,20 @@
  * #L%
  */
 
-#include <ome/xml/Document.h>
-#include <ome/xml/OMEEntityResolver.h>
+#ifndef OME_QTWIDGETS_GLM_H
+#define OME_QTWIDGETS_GLM_H
 
-namespace
-{
+#define GLM_FORCE_RADIANS
 
-  ome::xml::OMEEntityResolver&
-  get_resolver()
-  {
-    static ome::xml::OMEEntityResolver resolver;
-    return resolver;
-  }
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/rotate_vector.hpp>
 
-}
+#endif // OME_QTWIDGETS_GLM_H
 
-namespace ome
-{
-  namespace xml
-  {
-
-    ome::common::xml::dom::Document
-    createDocument(const boost::filesystem::path&                file,
-                   const ome::common::xml::dom::ParseParameters& params)
-    {
-      ome::xml::OMEEntityResolver& resolver = get_resolver();
-      return ome::common::xml::dom::createDocument(file, resolver, params);
-    }
-
-    ome::common::xml::dom::Document
-    createDocument(const std::string&                            text,
-                   const ome::common::xml::dom::ParseParameters& params,
-                   const std::string&                            id)
-    {
-      ome::xml::OMEEntityResolver& resolver = get_resolver();
-      return ome::common::xml::dom::createDocument(text, resolver, params, id);
-    }
-
-    ome::common::xml::dom::Document
-    createDocument(std::istream&                                 stream,
-                   const ome::common::xml::dom::ParseParameters& params,
-                   const std::string&                            id)
-    {
-      ome::xml::OMEEntityResolver& resolver = get_resolver();
-      return ome::common::xml::dom::createDocument(stream, resolver, params, id);
-    }
-
-  }
-}
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/lib/ome/qtwidgets/glsl/v110/GLFlatShader2D.cpp
+++ b/cpp/lib/ome/qtwidgets/glsl/v110/GLFlatShader2D.cpp
@@ -36,10 +36,9 @@
  * #L%
  */
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/glsl/v110/GLFlatShader2D.h>
 #include <ome/qtwidgets/gl/Util.h>
-
-#include <glm/gtc/type_ptr.hpp>
 
 #include <iostream>
 

--- a/cpp/lib/ome/qtwidgets/glsl/v110/GLFlatShader2D.h
+++ b/cpp/lib/ome/qtwidgets/glsl/v110/GLFlatShader2D.h
@@ -43,7 +43,7 @@
 #include <QOpenGLBuffer>
 #include <QtGui/QOpenGLFunctions>
 
-#include <glm/glm.hpp>
+#include <ome/qtwidgets/glm.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/qtwidgets/glsl/v110/GLImageShader2D.cpp
+++ b/cpp/lib/ome/qtwidgets/glsl/v110/GLImageShader2D.cpp
@@ -36,11 +36,9 @@
  * #L%
  */
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/glsl/v110/GLImageShader2D.h>
 #include <ome/qtwidgets/gl/Util.h>
-
-#define GLM_FORCE_RADIANS
-#include <glm/gtc/type_ptr.hpp>
 
 #include <iostream>
 #include <sstream>

--- a/cpp/lib/ome/qtwidgets/glsl/v110/GLImageShader2D.h
+++ b/cpp/lib/ome/qtwidgets/glsl/v110/GLImageShader2D.h
@@ -43,9 +43,9 @@
 #include <QOpenGLBuffer>
 #include <QtGui/QOpenGLFunctions>
 
-#include <glm/glm.hpp>
-
 #include <ome/bioformats/Types.h>
+
+#include <ome/qtwidgets/glm.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/qtwidgets/glsl/v110/GLLineShader2D.cpp
+++ b/cpp/lib/ome/qtwidgets/glsl/v110/GLLineShader2D.cpp
@@ -36,10 +36,9 @@
  * #L%
  */
 
+#include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/glsl/v110/GLLineShader2D.h>
 #include <ome/qtwidgets/gl/Util.h>
-
-#include <glm/gtc/type_ptr.hpp>
 
 #include <iostream>
 

--- a/cpp/lib/ome/qtwidgets/glsl/v110/GLLineShader2D.h
+++ b/cpp/lib/ome/qtwidgets/glsl/v110/GLLineShader2D.h
@@ -43,7 +43,7 @@
 #include <QOpenGLBuffer>
 #include <QtGui/QOpenGLFunctions>
 
-#include <glm/glm.hpp>
+#include <ome/qtwidgets/glm.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/Document.h
+++ b/cpp/lib/ome/xml/Document.h
@@ -39,7 +39,6 @@
 #ifndef OME_XML_MODEL_DOCUMENT_H
 #define OME_XML_MODEL_DOCUMENT_H
 
-#include <ome/common/xml/EntityResolver.h>
 #include <ome/common/xml/dom/Document.h>
 
 namespace ome

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -131,8 +131,6 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
-  const TileTestParameters& params = GetParam();
-
   std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList;
   for (TIFF::const_iterator i = tiff->begin();
        i != tiff->end();

--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -132,8 +132,6 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
-  const TileTestParameters& params = GetParam();
-
   std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList;
   for (TIFF::const_iterator i = tiff->begin();
        i != tiff->end();

--- a/cpp/test/ome-bioformats/tilecache.cpp
+++ b/cpp/test/ome-bioformats/tilecache.cpp
@@ -63,7 +63,7 @@ TEST(TileCache, Insert)
       ASSERT_TRUE(static_cast<bool>(cc.find(i)));
     }
 
-  ASSERT_EQ(16, c.size());
+  ASSERT_EQ(16U, c.size());
 }
 
 TEST(TileCache, InsertFail)
@@ -83,13 +83,12 @@ TEST(TileCache, InsertFail)
 TEST(TileCache, IndexOperator)
 {
   TileCache c;
-  const TileCache& cc(c);
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
       ASSERT_FALSE(static_cast<bool>(c[i]));
     }
-  ASSERT_EQ(16, c.size());
+  ASSERT_EQ(16U, c.size());
 
   c.clear();
   for (dimension_size_type i = 0; i < 16; ++i)
@@ -98,7 +97,7 @@ TEST(TileCache, IndexOperator)
       ASSERT_TRUE(static_cast<bool>(c[i]));
     }
 
-  ASSERT_EQ(16, c.size());
+  ASSERT_EQ(16U, c.size());
 }
 
 TEST(TileCache, Remove)
@@ -129,8 +128,8 @@ TEST(TileCache, Clear)
       ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
 
-  ASSERT_EQ(16, c.size());
+  ASSERT_EQ(16U, c.size());
 
   c.clear();
-  ASSERT_EQ(0, c.size());
+  ASSERT_EQ(0U, c.size());
 }

--- a/cpp/test/ome-bioformats/tilecoverage.cpp
+++ b/cpp/test/ome-bioformats/tilecoverage.cpp
@@ -60,7 +60,7 @@ TEST(TileCoverage, InsertGrid)
         ASSERT_TRUE(c.insert(r));
       }
   // One region after automatic coalescing
-  ASSERT_EQ(1, c.size());
+  ASSERT_EQ(1U, c.size());
 }
 
 TEST(TileCoverage, InsertGridSeparate)
@@ -73,7 +73,7 @@ TEST(TileCoverage, InsertGridSeparate)
         ASSERT_TRUE(c.insert(r, false));
       }
   // Full set of regions
-  ASSERT_EQ((4096 / 32) * (4096 / 16), c.size());
+  ASSERT_EQ((4096U / 32U) * (4096U / 16U), c.size());
 }
 
 TEST(TileCoverage, InsertFail)
@@ -99,13 +99,13 @@ TEST(TileCoverage, Remove)
         ASSERT_TRUE(c.insert(r, false));
       }
   // Full set of regions
-  ASSERT_EQ((4096 / 32) * (4096 / 16), c.size());
+  ASSERT_EQ((4096U / 32U) * (4096U / 16U), c.size());
 
   PlaneRegion remove(64, 64, 32, 16);
   ASSERT_TRUE(c.remove(remove));
 
   // Full set of regions - 1
-  ASSERT_EQ(((4096 / 32) * (4096 / 16)) - 1, c.size());
+  ASSERT_EQ(((4096U / 32U) * (4096U / 16U)) - 1U, c.size());
 }
 
 TEST(TileCoverage, RemoveFail)
@@ -117,12 +117,12 @@ TEST(TileCoverage, RemoveFail)
         PlaneRegion r(x, y, 32, 16);
         ASSERT_TRUE(c.insert(r));
       }
-  ASSERT_EQ(1, c.size());
+  ASSERT_EQ(1U, c.size());
 
   PlaneRegion remove(64, 64, 32, 16);
   ASSERT_FALSE(c.remove(remove));
 
-  ASSERT_EQ(1, c.size());
+  ASSERT_EQ(1U, c.size());
 }
 
 TEST(TileCoverage, Clear)
@@ -134,11 +134,11 @@ TEST(TileCoverage, Clear)
         PlaneRegion r(x, y, 32, 16);
         ASSERT_TRUE(c.insert(r, false));
       }
-  ASSERT_EQ((4096 / 32) * (4096 / 16), c.size());
+  ASSERT_EQ((4096U / 32U) * (4096U / 16U), c.size());
 
   c.clear();
 
-  ASSERT_EQ(0, c.size());
+  ASSERT_EQ(0U, c.size());
 }
 
 // Non-coalesced contiguous tiles
@@ -153,11 +153,11 @@ TEST(TileCoverage, CoverageComplete1)
       }
 
   PlaneRegion area1(32,32,32,32);
-  ASSERT_EQ(32 * 32, c.coverage(area1));
+  ASSERT_EQ(32U * 32U, c.coverage(area1));
   ASSERT_TRUE(c.covered(area1));
 
   PlaneRegion area2(54,23,21,53);
-  ASSERT_EQ(21 * 53, c.coverage(area2));
+  ASSERT_EQ(21U * 53U, c.coverage(area2));
   ASSERT_TRUE(c.covered(area2));
 }
 
@@ -173,11 +173,11 @@ TEST(TileCoverage, CoverageComplete2)
       }
 
   PlaneRegion area1(32,32,32,32);
-  ASSERT_EQ(32 * 32, c.coverage(area1));
+  ASSERT_EQ(32U * 32U, c.coverage(area1));
   ASSERT_TRUE(c.covered(area1));
 
   PlaneRegion area2(54,23,21,53);
-  ASSERT_EQ(21 * 53, c.coverage(area2));
+  ASSERT_EQ(21U * 53U, c.coverage(area2));
   ASSERT_TRUE(c.covered(area2));
 }
 
@@ -190,20 +190,20 @@ TEST(TileCoverage, CoverageIncomplete1)
 
   // No overlap
   PlaneRegion area1(32,32,32,32);
-  ASSERT_EQ(0, c.coverage(area1));
+  ASSERT_EQ(0U, c.coverage(area1));
   ASSERT_FALSE(c.covered(area1));
 
   // No overlap
   PlaneRegion area2(64,64,32,32);
-  ASSERT_EQ(0, c.coverage(area2));
+  ASSERT_EQ(0U, c.coverage(area2));
   ASSERT_FALSE(c.covered(area2));
 
   // Partial overlap
   PlaneRegion area3(20,20,43,43);
-  ASSERT_EQ((32 - 20) * (32 - 20), c.coverage(area3));
+  ASSERT_EQ((32U - 20U) * (32U - 20U), c.coverage(area3));
   ASSERT_FALSE(c.covered(area3));
 
   // Complete overlap
-  ASSERT_EQ(16 * 16, c.coverage(r));
+  ASSERT_EQ(16U * 16U, c.coverage(r));
   ASSERT_TRUE(c.covered(r));
 }

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -476,7 +476,7 @@ struct SetIndexDeathTestVisitor : public boost::static_visitor<>
     badidx[2] = badidx[3] = badidx[4] = badidx[5] = badidx[6] = badidx[7] = badidx[8] = 0;
 
     ASSERT_DEATH_IF_SUPPORTED(v->at(badidx) = value_type(4), "Assertion.*failed");
-    ASSERT_DEATH_IF_SUPPORTED(value_type obs = cv->at(badidx), "Assertion.*failed");
+    ASSERT_DEATH_IF_SUPPORTED(cv->at(badidx), "Assertion.*failed");
   }
 };
 

--- a/cpp/test/ome-common/boolean.cpp
+++ b/cpp/test/ome-common/boolean.cpp
@@ -42,20 +42,23 @@
 
 using ome::common::boolean;
 
-// Verify underlying bit pattern is 0xFF
-void
-verify_true(const boolean& value)
+namespace
 {
-  const uint8_t& raw(*reinterpret_cast<const uint8_t *>(&value));
-  ASSERT_EQ(std::numeric_limits<uint8_t>::max(), raw);
-}
+  // Verify underlying bit pattern is 0xFF
+  void
+  verify_true(const boolean& value)
+  {
+    const uint8_t& raw(*reinterpret_cast<const uint8_t *>(&value));
+    ASSERT_EQ(std::numeric_limits<uint8_t>::max(), raw);
+  }
 
-// Verify underlying bit pattern is 0x00
-void
-verify_false(const boolean& value)
-{
-  const uint8_t& raw(*reinterpret_cast<const uint8_t *>(&value));
-  ASSERT_EQ(std::numeric_limits<uint8_t>::min(), raw);
+  // Verify underlying bit pattern is 0x00
+  void
+  verify_false(const boolean& value)
+  {
+    const uint8_t& raw(*reinterpret_cast<const uint8_t *>(&value));
+    ASSERT_EQ(std::numeric_limits<uint8_t>::min(), raw);
+  }
 }
 
 TEST(Boolean, NumericLimits)

--- a/cpp/test/ome-common/variant.cpp
+++ b/cpp/test/ome-common/variant.cpp
@@ -103,7 +103,7 @@ TEST(Variant, MPLVectorNonNumeric)
   non_numeric_variant v1(std::string("String value"));
   ASSERT_EQ(std::string("String value"), boost::get<std::string>(v1));
   non_numeric_variant v2(false);
-  ASSERT_EQ(false, boost::get<bool>(v2));
+  ASSERT_FALSE(boost::get<bool>(v2));
 }
 
 #include <ome/compat/cstdint.h>
@@ -159,7 +159,7 @@ TEST(Variant, MPLVectorTransformList)
   strings.push_back("s3");
 
   list_variant v1(strings);
-  ASSERT_EQ(3, boost::get<std::vector< std::string> >(v1).size());
+  ASSERT_EQ(3U, boost::get<std::vector< std::string> >(v1).size());
 
   std::vector<uint8_t> ints;
   ints.push_back(3);
@@ -168,5 +168,5 @@ TEST(Variant, MPLVectorTransformList)
   ints.push_back(43);
 
   list_variant v2(ints);
-  ASSERT_EQ(4, boost::get<std::vector<uint8_t> >(v2).size());
+  ASSERT_EQ(4U, boost::get<std::vector<uint8_t> >(v2).size());
 }

--- a/cpp/test/ome-xml/model.cpp
+++ b/cpp/test/ome-xml/model.cpp
@@ -131,13 +131,10 @@ public:
 
 TEST_P(ModelTest, Parse)
 {
-  const ModelTestParameters& params = GetParam();
 }
 
 TEST_P(ModelTest, Update)
 {
-  const ModelTestParameters& params = GetParam();
-
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
@@ -148,8 +145,6 @@ TEST_P(ModelTest, Update)
 
 TEST_P(ModelTest, CreateXML)
 {
-  const ModelTestParameters& params = GetParam();
-
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
@@ -166,8 +161,6 @@ TEST_P(ModelTest, CreateXML)
 
 TEST_P(ModelTest, CreateXMLRoundTrip)
 {
-  const ModelTestParameters& params = GetParam();
-
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;


### PR DESCRIPTION
Ignore these warnings:

-  -Wvariadic-macros
-  -Wunused-local-typedef
-  -Wlanguage-extension-token
-  -Wold-style-cast

These had an exeedingly large number of false positives, particularly in external library headers, and these masked real warnings by the sheer volume.

With these warnings ignored, a number of real warnings were exposed which are fixed here.  This should significantly reduce the size of the build log.

--------

Testing: no special testing required; check CPP jobs are green.