### PR TITLE
Add dm4 to the supported extensions and other doc improvements

### DIFF
--- a/components/autogen/build.xml
+++ b/components/autogen/build.xml
@@ -20,6 +20,14 @@ Type "ant -p" for a list of targets.
     </java>
   </target>
 
+  <target name="gen-structure-table" depends="compile"
+    description="generate dataset structure table">
+    <java classname="MakeDatasetStructureTable"
+      classpath="${classes.dir}:${component.runtime-cp}" fork="true" failonerror="true">
+       <arg value="../../docs/sphinx/formats/dataset-table.txt"/>
+    </java>
+  </target>
+
   <target name="gen-original-meta-support" depends="compile"
     description="generate docs for Bio-Formats original metadata support">
     <java classname="OriginalMetadataAutogen"

--- a/components/autogen/src/MakeDatasetStructureTable.java
+++ b/components/autogen/src/MakeDatasetStructureTable.java
@@ -23,7 +23,6 @@
  * #L%
  */
 
-package loci.formats.tools;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -61,9 +60,14 @@ public class MakeDatasetStructureTable {
     out.println("choose if you want");
     out.println("to open/import a dataset in a particular format.");
     out.println();
+    out.println(".. only:: html");
+    out.println();
+    out.println("    You can sort this table by clicking on any of the headings.");
+    out.println();
     out.println(".. tabularcolumns:: |p{4cm}|p{3cm}|p{8cm}|");
     out.println();
     out.println(".. list-table::");
+    out.println("   :class: sortable");
     out.println("   :header-rows: 1");
     out.println();
     out.println("   * - Format name");
@@ -153,7 +157,10 @@ public class MakeDatasetStructureTable {
     printHeader();
 
     for (IFormatReader reader : allReaders) {
-      printFormatEntry(reader);
+      try {
+        printFormatEntry(reader);
+      } catch (IllegalStateException e) {
+      }
     }
 
     printFooter();

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -635,7 +635,7 @@ utilityRating = Good
 reader = GatanDM2Reader
 
 [Gatan Digital Micrograph]
-extensions = .dm3
+extensions = .dm3, .dm4
 owner = `Gatan <http://www.gatan.com/>`_
 bsd = no
 versions = 3

--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -113,11 +113,4 @@ Type "ant -p" for a list of targets.
     </testng>
     <fail if="failedTest"/>
   </target>
-
-  <target name="gen-structure-table" depends="compile"
-    description="generate the dataset structure table">
-    <java classname="loci.formats.tools.MakeDatasetStructureTable"
-      args="../../docs/sphinx/formats/dataset-table.txt" failonerror="true" />
-  </target>
-
 </project>

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -130,7 +130,7 @@ public class CellVoyagerReader extends FormatReader
 		this.suffixNecessary = false;
 		this.suffixSufficient = false;
 		this.hasCompanionFiles = true;
-		this.datasetDescription = "Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stich together several TIF files.";
+		this.datasetDescription = "Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stitch together several TIF files.";
 		this.domains = new String[] { FormatTools.HISTOLOGY_DOMAIN, FormatTools.LM_DOMAIN, FormatTools.HCS_DOMAIN };
 	}
 

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -104,7 +104,7 @@ public class GatanReader extends FormatReader {
 
   /** Constructs a new Gatan reader. */
   public GatanReader() {
-    super("Gatan Digital Micrograph", "dm3");
+    super("Gatan Digital Micrograph", new String[] {"dm3", "dm4"});
     domains = new String[] {FormatTools.EM_DOMAIN};
     suffixNecessary = false;
   }

--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -71,7 +71,7 @@ public class SlideBook6Reader  extends FormatReader {
 	public static final long SLD_MAGIC_BYTES_3 = 0xf6010101L;
 
 	private static final String URL_3I_SLD =
-			"http://www.openmicroscopy.org/site/support/bio-formats/formats/3i-slidebook6.html";
+			"http://www.openmicroscopy.org/site/support/bio-formats/formats/3i-slidebook.html";
 	private static final String NO_3I_MSG = "3i SlideBook SlideBook6Reader library not found. " +
 			"Please see " + URL_3I_SLD + " for details.";
 	private static final String GENERAL_3I_MSG = "3i SlideBook SlideBook6Reader library problem. " +

--- a/docs/sphinx/developers/format-documentation.txt
+++ b/docs/sphinx/developers/format-documentation.txt
@@ -76,6 +76,20 @@ defined for each section:
     Additional relevant information e.g. that we cannot distribute 
     specification documents to third parties
 
+Dataset structure table
+-----------------------
+
+After checking out source code and building all the JAR files (see
+:doc:`building-bioformats`), the summary table listing the extensions for each
+reader can be  generated using the :program:`ant` ``gen-structure-table``
+target under the :file:`autogen` component::
+
+  $ ant -f components/autogen/build.xml gen-structure-table
+
+This target will loop through all Bio-Formats readers (BSD and GPL), read
+their extensions and descriptions and create a reStructuredText file with a
+table summary of all file extensions.
+
 Readers
 -------
 

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -147,7 +147,7 @@ to open/import a dataset in a particular format.
      - .dm2
      - Single file
    * - Gatan Digital Micrograph
-     - .dm3, .dm4
+     - .dm3
      - Single file
    * - Graphics Interchange Format
      - .gif

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -100,7 +100,7 @@ to open/import a dataset in a particular format.
      - One .vsi file and an optional directory with a similar name that contains at least one subdirectory with .ets files
    * - CellVoyager
      - .tif, .xml
-     - Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stich together several TIF files.
+     - Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stitch together several TIF files.
    * - CellWorx
      - .pnl, .htd, .log
      - One .htd file plus one or more .pnl or .tif files and optionally one or more .log files
@@ -147,7 +147,7 @@ to open/import a dataset in a particular format.
      - .dm2
      - Single file
    * - Gatan Digital Micrograph
-     - .dm3
+     - .dm3, .dm4
      - Single file
    * - Graphics Interchange Format
      - .gif

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -53,6 +53,9 @@ to open/import a dataset in a particular format.
    * - Animated PNG
      - .png
      - Single file
+   * - Aperio AFI
+     - .afi
+     - One .afi file and several similarly-named .svs files
    * - Aperio SVS
      - .svs
      - Single file
@@ -68,6 +71,9 @@ to open/import a dataset in a particular format.
    * - Bio-Rad PIC
      - .pic, .xml, .raw
      - One or more .pic files and an optional lse.xml file
+   * - Bio-Rad SCN
+     - .scn
+     - Single file
    * - Bitplane Imaris
      - .ims
      - Single file
@@ -86,9 +92,15 @@ to open/import a dataset in a particular format.
    * - Canon RAW
      - .cr2, .crw, .jpg, .thm, .wav
      - Single file
+   * - CellH5 (HDF)
+     - .ch5
+     - Single file
    * - CellSens VSI
      - .vsi, .ets
      - One .vsi file and an optional directory with a similar name that contains at least one subdirectory with .ets files
+   * - CellVoyager
+     - .tif, .xml
+     - Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stich together several TIF files.
    * - CellWorx
      - .pnl, .htd, .log
      - One .htd file plus one or more .pnl or .tif files and optionally one or more .log files
@@ -125,6 +137,9 @@ to open/import a dataset in a particular format.
    * - Flexible Image Transport System
      - .fits, .fts
      - Single file
+   * - FlowSight
+     - .cif
+     - Single file
    * - Fuji LAS 3000
      - .img, .inf
      - Single file
@@ -132,7 +147,7 @@ to open/import a dataset in a particular format.
      - .dm2
      - Single file
    * - Gatan Digital Micrograph
-     - .dm3
+     - .dm3, .dm4
      - Single file
    * - Graphics Interchange Format
      - .gif
@@ -155,6 +170,9 @@ to open/import a dataset in a particular format.
    * - Hitachi
      - .txt
      - One .txt file plus one similarly-named .tif, .bmp, or .jpg file
+   * - I2I
+     - .i2i
+     - Single file
    * - IMAGIC
      - .hed, .img
      - One .hed file plus one similarly-named .img file
@@ -191,6 +209,9 @@ to open/import a dataset in a particular format.
    * - InCell 3000
      - .frm
      - Single file
+   * - Inveon
+     - .hdr
+     - One .hdr file plus one similarly-named file
    * - JEOL
      - .dat, .img, .par
      - A single .dat file or an .img file with a similarly-named .par file
@@ -220,6 +241,9 @@ to open/import a dataset in a particular format.
      - Single file
    * - Laboratory Imaging
      - .lim
+     - Single file
+   * - Lavision Imspector
+     - .msr
      - Single file
    * - Leica
      - .lei, .tif, .tiff, .raw
@@ -284,8 +308,11 @@ to open/import a dataset in a particular format.
    * - Nikon TIFF
      - .tif, .tiff
      - Single file
+   * - OBF
+     - .obf, .msr
+     - OBF file
    * - OME-TIFF
-     - .ome.tif, .ome.tiff
+     - .ome.tif, .ome.tiff, .companion.ome
      - One or more .ome.tiff files
    * - OME-XML
      - .ome
@@ -317,6 +344,9 @@ to open/import a dataset in a particular format.
    * - Oxford Instruments
      - .top
      - Single file
+   * - PCO-RAW
+     - .pcoraw, .rec
+     - A single .pcoraw file with a similarly-named .rec file
    * - PCX
      - .pcx
      - Single file
@@ -329,17 +359,23 @@ to open/import a dataset in a particular format.
    * - Perkin Elmer Densitometer
      - .hdr, .img
      - One .hdr file and a similarly-named .img file
+   * - Perkin-Elmer Nuance IM3
+     - .im3
+     - Single file
    * - PerkinElmer
      - .ano, .cfg, .csv, .htm, .rec, .tim, .zpo, .tif
      - One .htm file, several other metadata files (.tim, .ano, .csv, …) and either .tif files or .2, .3, .4, etc. files
    * - PerkinElmer Operetta
      - .tif, .tiff, .xml
      - Directory with XML file and one .tif/.tiff file per plane
-   * - Portable Gray Map
-     - .pgm
+   * - PicoQuant Bin
+     - .bin
+     - Single file
+   * - Portable Any Map
+     - .pbm, .pgm, .ppm
      - Single file
    * - Prairie TIFF
-     - .tif, .tiff, .cfg, .xml
+     - .tif, .tiff, .cfg, .env, .xml
      - One .xml file, one .cfg file, and one or more .tif/.tiff files
    * - Pyramid TIFF
      - .tif, .tiff
@@ -374,6 +410,12 @@ to open/import a dataset in a particular format.
    * - Simulated data
      - .fake
      - Single file
+   * - SlideBook 6 SLD (native)
+     - .sld
+     - Single file
+   * - Slidebook TIFF
+     - .tif, .tiff
+     - Single file
    * - Tagged Image File Format
      - .tif, .tiff, .tf2, .tf8, .btf
      - Single file
@@ -404,6 +446,9 @@ to open/import a dataset in a particular format.
    * - Varian FDF
      - .fdf
      - Single file
+   * - Veeco
+     - .hdf
+     - Single file
    * - Visitech XYS
      - .xys, .html
      - One .html file plus one or more .xys files
@@ -419,11 +464,17 @@ to open/import a dataset in a particular format.
    * - Windows Bitmap
      - .bmp
      - Single file
+   * - Woolz
+     - .wlz
+     - Single file
    * - Zeiss AxioVision TIFF
      - .tif, .xml
      - Single file
    * - Zeiss CZI
      - .czi
+     - Single file
+   * - Zeiss LMS
+     - .lms
      - Single file
    * - Zeiss Laser-Scanning Microscopy
      - .lsm, .mdb

--- a/docs/sphinx/formats/gatan-digital-micrograph.txt
+++ b/docs/sphinx/formats/gatan-digital-micrograph.txt
@@ -1,10 +1,10 @@
 .. index:: Gatan Digital Micrograph
-.. index:: .dm3
+.. index:: .dm3, .dm4
 
 Gatan Digital Micrograph
 ===============================================================================
 
-Extensions: .dm3
+Extensions: .dm3, .dm4
 
 
 Owner: `Gatan <http://www.gatan.com/>`_

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -341,7 +341,7 @@ Supported Formats
      - |no|
      - |yes|
    * - :doc:`formats/gatan-digital-micrograph`
-     - .dm3
+     - .dm3, .dm4
      - |Very good|
      - |Good|
      - |Fair|


### PR DESCRIPTION
See https://trello.com/c/2y71bKRs/24-gatan-dm4-support. This PR:

- migrates the dataset structure creation class to the `components/autogen` component
- registers the `dm4` extension in `GatanReader` and in `format-pages.txt`
- fix URL in `SlideBook6Reader` post format pages unification
- regenerates the format pages and dataset structure table

A CI-related task will be to add the `gen-structure-table` to the BIOFORMATS-*-docs-autogen job to keep this table in sync with the latest state of the readers.