### PR TITLE
Fix activation of test-jar profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -790,7 +790,7 @@
           <!-- NB: Cannot use ${project.build.testSourceDirectory} because
                Maven only limitedly interpolates this section of the POM.
                See: http://maven.apache.org/pom.html#Activation -->
-          <exists>${basedir}/src/test/java</exists>
+          <exists>${basedir}/test</exists>
         </file>
       </activation>
       <build>


### PR DESCRIPTION
The conditional for deciding when to build the tests JAR was wrong, because it was keyed to `src/test/java/` instead of `test/`.

Consequently, no `*-tests.jar` files were being produced.

To test, perform a clean Maven build, and then verify that the `*-tests` artifacts are now present. I.e.:

```bash
$ mvn clean
...
$ mvn
...

$ for t in components/*/test/; do echo $t; done
components/bio-formats-plugins/test/
components/formats-api/test/
components/formats-bsd/test/
components/formats-common/test/
components/formats-gpl/test/
components/metakit/test/
components/ome-jxr/test/
components/ome-xml/test/

$ ls -l **/target/*-tests.jar
-rw-r--r--  1 curtis  staff   32732 Oct  6 10:45 components/bio-formats-plugins/target/bio-formats_plugins-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff    6621 Oct  6 10:42 components/formats-api/target/formats-api-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff  155070 Oct  6 10:45 components/formats-bsd/target/formats-bsd-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff   83597 Oct  6 10:42 components/formats-common/target/formats-common-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff  135476 Oct  6 10:45 components/formats-gpl/target/formats-gpl-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff   22528 Oct  6 10:45 components/metakit/target/metakit-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff   24056 Oct  6 10:46 components/ome-jxr/target/ome-jxr-5.1.5-SNAPSHOT-tests.jar
-rw-r--r--  1 curtis  staff   16959 Oct  6 10:42 components/ome-xml/target/ome-xml-5.1.5-SNAPSHOT-tests.jar
```