### PR TITLE
screen-reader-2.0 perf

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1189,7 +1189,7 @@ public abstract class FormatReader extends FormatHandler
   /* @see IFormatReader#setMetadataStore(MetadataStore) */
   @Override
   public void setMetadataStore(MetadataStore store) {
-    FormatTools.assertId(currentId, false, 1);
+    //FormatTools.assertId(currentId, false, 1);
     if (store == null) {
       throw new IllegalArgumentException("Metadata object cannot be null; " +
         "use loci.formats.meta.DummyMetadata instead");

--- a/components/formats-api/src/loci/formats/IMetadataConfigurable.java
+++ b/components/formats-api/src/loci/formats/IMetadataConfigurable.java
@@ -38,8 +38,9 @@ import loci.formats.in.MetadataLevel;
 import loci.formats.in.MetadataOptions;
 
 /**
- *
- * @author callan
+ * An attempt should be made by all implementations to propagate calls to
+ * {@link #setMetadataOptions(MetadataOptions)} to dependent internal
+ * instances.
  */
 public interface IMetadataConfigurable{
 

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -670,7 +670,7 @@ public class ImageReader implements IFormatReader {
   /* @see IFormatReader#setMetadataStore(MetadataStore) */
   @Override
   public void setMetadataStore(MetadataStore store) {
-    FormatTools.assertId(currentId, false, 2);
+    //FormatTools.assertId(currentId, false, 2);
     for (int i=0; i<readers.length; i++) readers[i].setMetadataStore(store);
   }
 

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
+import loci.formats.in.DefaultMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataStore;
@@ -118,12 +119,14 @@ public class ImageReader implements IFormatReader {
   /** Constructs a new ImageReader from the given list of reader classes. */
   public ImageReader(ClassList<IFormatReader> classList) {
     // add readers to the list
+    MetadataOptions options = new DefaultMetadataOptions();
     List<IFormatReader> list = new ArrayList<IFormatReader>();
     Class<? extends IFormatReader>[] c = classList.getClasses();
     for (int i=0; i<c.length; i++) {
       IFormatReader reader = null;
       try {
         reader = c[i].newInstance();
+        reader.setMetadataOptions(options);
       }
       catch (IllegalAccessException exc) { }
       catch (InstantiationException exc) { }

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -126,6 +126,8 @@ public class ImageReader implements IFormatReader {
       IFormatReader reader = null;
       try {
         reader = c[i].newInstance();
+        // TODO: this allows each instance to unnecessarily
+        // create its own MetadataOptions instance first.
         reader.setMetadataOptions(options);
       }
       catch (IllegalAccessException exc) { }

--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -222,7 +222,11 @@ public class ImageReader implements IFormatReader {
     return getReaders()[0].getSupportedMetadataLevels();
   }
 
-  /* @see loci.formats.IMetadataConfigurable#getMetadataOptions() */
+  /**
+   * Assumes that all the readers have the same {@link MetadataOption}
+   * instance set. This <em>may</em> not hold if a caller has actively
+   * retrieved one of the readers and called {@link #setMetadataOptions(MetadataOptions)}.
+   */
   @Override
   public MetadataOptions getMetadataOptions() {
     return getReaders()[0].getMetadataOptions();

--- a/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
@@ -36,14 +36,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- *
- * @author callan
+ * {@link MetadataOptions} instance which is created by most reader classes
+ * on construction. Optimally, this initial instance will be passed down through
+ * any reader stack and further instances will not need to be created.
  */
 public class DefaultMetadataOptions implements MetadataOptions {
 
   private MetadataLevel level;
 
-  private final Map<String, String> extensibleOptions = new HashMap<String, String>();
+  private final Map<String, Object > extensibleOptions = new HashMap<String, Object>();
 
   /**
    * Construct a new DefaultMetadataOptions.
@@ -78,12 +79,12 @@ public class DefaultMetadataOptions implements MetadataOptions {
   }
 
   @Override
-  public String getMetadataOption(String key) {
+  public Object getMetadataOption(String key) {
     return extensibleOptions.get(key);
   }
 
   @Override
-  public String setMetadataOption(String key, String value) {
+  public Object setMetadataOption(String key, Object value) {
     return extensibleOptions.put(key, value);
   }
 

--- a/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
@@ -32,6 +32,9 @@
 
 package loci.formats.in;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  *
  * @author callan
@@ -39,6 +42,8 @@ package loci.formats.in;
 public class DefaultMetadataOptions implements MetadataOptions {
 
   private MetadataLevel level;
+
+  private final Map<String, String> extensibleOptions = new HashMap<String, String>();
 
   /**
    * Construct a new DefaultMetadataOptions.
@@ -70,6 +75,16 @@ public class DefaultMetadataOptions implements MetadataOptions {
   @Override
   public void setMetadataLevel(MetadataLevel level) {
     this.level = level;
+  }
+
+  @Override
+  public String getMetadataOption(String key) {
+    return extensibleOptions.get(key);
+  }
+
+  @Override
+  public String setMetadataOption(String key, String value) {
+    return extensibleOptions.put(key, value);
   }
 
 }

--- a/components/formats-api/src/loci/formats/in/MetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/MetadataOptions.java
@@ -33,8 +33,7 @@
 package loci.formats.in;
 
 /**
- * 
- * @author callan
+ *
  */
 public interface MetadataOptions {
 
@@ -48,12 +47,12 @@ public interface MetadataOptions {
 
   /**
    * Retrieve a value which may have been set via
-   * {@link #setMetadataOption(String, String)}. Consumers must be ready for
+   * {@link #setMetadataOption(String, Object)}. Consumers must be ready for
    * nulls but an exception will not be thrown.
    *
-   * @return String value or null if the key is not present.
+   * @return value or null if the key is not present.
    */
-  String getMetadataOption(String key);
+  Object getMetadataOption(String key);
 
   /**
    * Place an arbitrary key/value pair in this instance for influencing
@@ -61,9 +60,9 @@ public interface MetadataOptions {
    * for details.
    *
    * @param key May not be null.
-   * @param value null value unsets the key.
+   * @param value A null value unsets the key.
    * @return previous value if any.
    */
-  String setMetadataOption(String key, String value);
+  Object setMetadataOption(String key, Object value);
 
 }

--- a/components/formats-api/src/loci/formats/in/MetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/MetadataOptions.java
@@ -46,4 +46,24 @@ public interface MetadataOptions {
    */
   MetadataLevel getMetadataLevel();
 
+  /**
+   * Retrieve a value which may have been set via
+   * {@link #setMetadataOption(String, String)}. Consumers must be ready for
+   * nulls but an exception will not be thrown.
+   *
+   * @return String value or null if the key is not present.
+   */
+  String getMetadataOption(String key);
+
+  /**
+   * Place an arbitrary key/value pair in this instance for influencing
+   * the behavior of readers. See the individual reader documentation
+   * for details.
+   *
+   * @param key May not be null.
+   * @param value null value unsets the key.
+   * @return previous value if any.
+   */
+  String setMetadataOption(String key, String value);
+
 }

--- a/components/formats-api/src/loci/formats/services/OMEXMLService.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLService.java
@@ -38,6 +38,7 @@ import loci.common.services.Service;
 import loci.common.services.ServiceException;
 import loci.formats.CoreMetadata;
 import loci.formats.Modulo;
+import loci.formats.in.MetadataLevel;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
@@ -256,6 +257,14 @@ public interface OMEXMLService extends Service {
    * (source) into a metadata store (destination).
    */
   public void convertMetadata(MetadataRetrieve src, MetadataStore dest);
+
+  /**
+   * Copies information from a metadata retrieval object
+   * (source) into a metadata store (destination) applying
+   * the {@link MetadataLevel}.
+   */
+  public void convertMetadata(MetadataRetrieve src, MetadataStore dest,
+    MetadataLevel level);
 
   /**
    * Remove all of the BinData elements from the given OME-XML metadata object.

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -52,6 +52,7 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.Modulo;
+import loci.formats.in.MetadataLevel;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataConverter;
 import loci.formats.meta.MetadataRetrieve;
@@ -61,16 +62,15 @@ import loci.formats.meta.OriginalMetadataAnnotation;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.ome.OMEXMLMetadataImpl;
 import ome.xml.meta.OMEXMLMetadataRoot;
+import ome.xml.model.Annotation;
 import ome.xml.model.BinData;
 import ome.xml.model.Channel;
 import ome.xml.model.Image;
 import ome.xml.model.MetadataOnly;
-import ome.xml.model.OME;
 import ome.xml.model.OMEModel;
 import ome.xml.model.OMEModelImpl;
 import ome.xml.model.OMEModelObject;
 import ome.xml.model.Pixels;
-import ome.xml.model.Annotation;
 import ome.xml.model.StructuredAnnotations;
 import ome.xml.model.XMLAnnotation;
 
@@ -824,6 +824,11 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   @Override
   public void convertMetadata(MetadataRetrieve src, MetadataStore dest) {
     MetadataConverter.convertMetadata(src, dest);
+  }
+
+  public void convertMetadata(MetadataRetrieve src, MetadataStore dest,
+    MetadataLevel level) {
+    MetadataConverter.convertMetadata(src, dest, level);
   }
 
   /** @see OMEXMLService#removeBinData(OMEXMLMetadata) */

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1169,7 +1169,7 @@ public class FileStitcher extends ReaderWrapper {
    *
    * @return An array of size 2, dimensioned {file index, image index}.
    */
-  protected int[] computeIndices(int no) throws FormatException, IOException {
+  public int[] computeIndices(int no) throws FormatException, IOException {
     if (noStitch) return new int[] {0, no};
     int sno = getCoreIndex();
     ExternalSeries s = externals[getExternalSeries()];

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -630,6 +630,19 @@ public class FileStitcher extends ReaderWrapper {
     return group;
   }
 
+  /* @see IFormatReader#setMetadataOptions(MetadataOptions) */
+  @Override
+  public void setMetadataOptions(MetadataOptions options) {
+    super.setMetadataOptions(options);
+    if (externals != null) {
+      for (ExternalSeries s : externals) {
+        for (DimensionSwapper r : s.getReaders()) {
+          r.setMetadataOptions(options);
+        }
+      }
+    }
+  }
+
   /* @see IFormatReader#setNormalized(boolean) */
   @Override
   public void setNormalized(boolean normalize) {

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1280,6 +1280,7 @@ public class FileStitcher extends ReaderWrapper {
         else readers[i] = new DimensionSwapper();
         readers[i].setGroupFiles(false);
         readers[i].setId(files[i]);
+        readers[i].setMetadataOptions(getMetadataOptions());
       }
 
       ag = new AxisGuesser(this.pattern, readers[0].getDimensionOrder(),

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -526,10 +526,9 @@ public class Memoizer extends ReaderWrapper {
    */
   public void configure(MetadataOptions options) {
     String k = Memoizer.class.getName();
-    options.setMetadataOption(k + ".cacheDirectory", this.directory == null
-            ? null : this.directory.toString());
-    options.setMetadataOption(k + ".inPlace", "" + this.doInPlaceCaching);
-    options.setMetadataOption(k + ".minimumElapsed", "" + this.minimumElapsed);
+    options.setMetadataOption(k + ".cacheDirectory", this.directory);
+    options.setMetadataOption(k + ".inPlace", this.doInPlaceCaching);
+    options.setMetadataOption(k + ".minimumElapsed", this.minimumElapsed);
   }
 
   /**
@@ -547,16 +546,24 @@ public class Memoizer extends ReaderWrapper {
       return null;
     }
     String k = Memoizer.class.getName();
-    String elapsed = options.getMetadataOption(k + ".minimumElapsed");
-    String inplace = options.getMetadataOption(k + ".inPlace");
-    String cachedir = options.getMetadataOption(k + ".cacheDirectory");
+    Object elapsed = options.getMetadataOption(k + ".minimumElapsed");
+    Object inplace = options.getMetadataOption(k + ".inPlace");
+    Object cachedir = options.getMetadataOption(k + ".cacheDirectory");
+    if (!(elapsed instanceof Long)) {
+        LOGGER.warn("config: minimumElapsed wrong type: {}", elapsed);
+        return r;
+    } else if (!(inplace instanceof Boolean)) {
+        LOGGER.warn("config: inplace wrong type: {}", inplace);
+        return r;
+    } else if (cachedir != null && !(cachedir instanceof File)) {
+        LOGGER.warn("config: cachedir wrong type: {}", cachedir);
+        return r;
+    }
 
-    if (elapsed == null) {
-      return r;
-    } else if (Boolean.valueOf(inplace)) {
-      return new Memoizer(r, Long.valueOf(elapsed));
+    if (((Boolean) inplace).booleanValue()) {
+      return new Memoizer(r, (Long) inplace);
     } else{
-      return new Memoizer(r, Long.valueOf(elapsed), new File(cachedir));
+      return new Memoizer(r, (Long) elapsed, (File) cachedir);
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -738,9 +738,6 @@ public class Memoizer extends ReaderWrapper {
         long start = System.currentTimeMillis();
         super.setId(id);
 
-        // but only persist the minimum information
-        convertMetadata(all, min);
-        reader.setMetadataStore(min);
         try {
           long elapsed = System.currentTimeMillis() - start;
           handleMetadataStore(null); // Between setId and saveMemo
@@ -748,6 +745,9 @@ public class Memoizer extends ReaderWrapper {
             LOGGER.debug("skipping save memo. elapsed millis: {}", elapsed);
             return; // EARLY EXIT!
           }
+          // but only persist the minimum information
+          convertMetadata(all, min);
+          reader.setMetadataStore(min);
           savedToMemo = saveMemo(); // Should never throw.
         } finally {
           super.setMetadataStore(all);

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -77,6 +77,7 @@ public class FilePatternReader extends FormatReader {
       }
     }
     helper = new FileStitcher(new ImageReader(newClasses));
+    helper.setMetadataOptions(getMetadataOptions());
 
     suffixSufficient = true;
   }

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -340,6 +340,9 @@ public class ScreenReader extends FormatReader {
     // After setReaderClassList
     reader = new DimensionSwapper(stitcher);
     reader.setMetadataStore(omexmlMeta);
+    // Note: by passing this in we allow lower-level readers
+    // to change our settings here.
+    reader.setMetadataOptions(getMetadataOptions());
 
     for (int well=0; well<files.length; well++) {
       if (files[well] == null || files[well][0] == null) {

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -111,6 +111,7 @@ public class ScreenReader extends FormatReader {
     super.reopenFile();
     if (reader != null) {
       reader.reopenFile();
+      reader.setMetadataOptions(getMetadataOptions());
     }
   }
 
@@ -325,9 +326,10 @@ public class ScreenReader extends FormatReader {
 
     core.clear();
 
-    FileStitcher stitcher = new FileStitcher(new ImageReader(validReaders), true);
-    stitcher.setReaderClassList(validReaders);
+    ImageReader iReader = new ImageReader(validReaders);
+    FileStitcher stitcher = new FileStitcher(iReader, true);
     stitcher.setCanChangePattern(false);
+    // After setReaderClassList
     reader = new DimensionSwapper(stitcher);
     reader.setMetadataStore(omexmlMeta);
 

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -182,8 +182,8 @@ public class ScreenReader extends FormatReader {
     final List<String> allFiles = new ArrayList<String>();
     try {
       for (String file : files[spotIndex]) {
+        reader.close();
         reader.setId(file);
-
         if (plateMetadataFiles != null) {
           for (String f : plateMetadataFiles) {
             allFiles.add(f);
@@ -346,6 +346,7 @@ public class ScreenReader extends FormatReader {
         continue;
       }
       LOGGER.debug("Initializing pattern {} for spot {}", files[well], well);
+      reader.close();
       reader.setId(files[well][0]);
 
       // At this point, we have a concrete reader. Use it

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -51,6 +51,7 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.Memoizer;
 import loci.formats.MetadataTools;
 import loci.formats.MissingLibraryException;
 import loci.formats.meta.MetadataStore;
@@ -113,6 +114,8 @@ public class ScreenReader extends FormatReader {
     classes.addClass(chosenReader);
     reader = new ImageReader(classes);
     reader.setMetadataOptions(new DefaultMetadataOptions(MetadataLevel.MINIMUM));
+    // Inplace memoize whatever files are opened internally if possible.
+    reader = new Memoizer(reader, 0);
   }
 
   /* @see loci.formats.IFormatReader#isSingleFile(String) */

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -114,8 +114,8 @@ public class ScreenReader extends FormatReader {
     classes.addClass(chosenReader);
     reader = new ImageReader(classes);
     reader.setMetadataOptions(new DefaultMetadataOptions(MetadataLevel.MINIMUM));
-    // Inplace memoize whatever files are opened internally if possible.
-    reader = new Memoizer(reader, 0);
+    // memoize whatever files are opened internally if possible.
+    reader = Memoizer.wrap(getMetadataOptions(), reader);
   }
 
   /* @see loci.formats.IFormatReader#isSingleFile(String) */


### PR DESCRIPTION
This follows on from gh-1969 and replaces gh-2006. The intent is to speed up the performance of the new `ScreenReader` class for cases where there are many (4K+) files each of which takes a significant amount of time to open.

Especially the introduction of the `Memoizer` *inside* of `ScreenReader` may not be a general solution, but until we can inject some form of context, this may be the only type of solution possible.

NB: one further idea would be to write `Reader` subclasses and inject them via `ClassList` but that has its own issues.