### PR TITLE
Remove activation profile for building test JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,13 @@
               <exclude>**/*.h</exclude>
             </excludes>
           </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>test-jar</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>
@@ -780,33 +787,6 @@
           <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
         </snapshotRepository>
       </distributionManagement>
-    </profile>
-
-    <!-- Build test artifact when tests are present. -->
-    <profile>
-      <id>test-jar</id>
-      <activation>
-        <file>
-          <!-- NB: Cannot use ${project.build.testSourceDirectory} because
-               Maven only limitedly interpolates this section of the POM.
-               See: http://maven.apache.org/pom.html#Activation -->
-          <exists>${basedir}/test</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-jar-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
     <!-- Run integration tests when "-P run-its" is passed.

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,7 @@
           <version>2.4</version>
           <!-- Always add classpath to JAR manifests. -->
           <configuration>
+            <skipIfEmpty>true</skipIfEmpty>
             <archive>
               <manifest>
                 <addClasspath>true</addClasspath>


### PR DESCRIPTION
Follow-up of https://github.com/openmicroscopy/bioformats/pull/2011.

The PR inadvertently broke https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest-maven/507/. The reason is that the activation of the `test-jar` profile deactivated the profile marked as "active by default" (see http://maven.apache.org/guides/introduction/introduction-to-profiles.html) which defines the default deployment configuration. Thus the `mvn clean deploy` command is currently broken whereas `mvn clean deploy -Platest-build` will deploy artifacts as expected.

This commit proposes to remove the requirement for a conditional activation profile in favor of building test JARs unconditionally for every component. Components like xsd-fu with no `test` directory will simply create dummy test JARs (like the `xsd-fu` JAR itself).

/cc @melissalinkert @ctrueden 