### PR TITLE
Metadata improvements

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1766,14 +1766,14 @@ Commercial applications that support this format include: \n
 .. seealso:: \n
   `PerkinElmer UltraView system overview <http://www.perkinelmer.com/pages/020/cellularimaging/products/ultraviewvoxsystemsoverview.xhtml>`_
 
-[PGM (Portable Gray Map)]
+[Portable Any Map]
 pagename = pgm
-extensions = .pgm
+extensions = .pbm, .pgm, .ppm
 developer = Netpbm developers
 bsd = yes
 software = `Netpbm graphics filter <http://netpbm.sourceforge.net/>`_
 weHave = * a `PGM specification document <http://netpbm.sourceforge.net/doc/pgm.html>`_ (from 2003 October 3, in HTML) \n
-* a few PGM files
+* a few PGM, PPM and PGM files
 pixelsRating = Very good
 metadataRating = Good
 opennessRating = Outstanding

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -987,7 +987,7 @@ pagename = iplab-mac
 extensions = .ipm
 owner = `BioVision Technologies <http://biovis.com/>`_
 bsd = no
-weHave = * a few iVision-Mac datasets \n
+weHave = * a few iVision-Mac datasets\n
 * a specification document
 weWant = * more iVision-Mac datasets
 pixelsRating = Very good

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -638,7 +638,7 @@ reader = GatanDM2Reader
 extensions = .dm3, .dm4
 owner = `Gatan <http://www.gatan.com/>`_
 bsd = no
-versions = 3
+versions = 3, 4
 software = `DM3 Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/DM3_Reader.html>`_ \n
 `EMAN <http://blake.bcm.edu/EMAN/>`_
 weHave = * Gatan's ImageReader2003 code (from 2003, in C++) \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1775,7 +1775,7 @@ developer = Netpbm developers
 bsd = yes
 software = `Netpbm graphics filter <http://netpbm.sourceforge.net/>`_
 weHave = * a `PGM specification document <http://netpbm.sourceforge.net/doc/pgm.html>`_ (from 2003 October 3, in HTML) \n
-* a few PGM, PPM and PGM files
+* a few PBM, PPM and PGM files
 pixelsRating = Very good
 metadataRating = Good
 opennessRating = Outstanding

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -982,13 +982,14 @@ presenceRating = Poor
 utilityRating = Fair
 reader = InveonReader
 
-[IPLab-Mac]
+[IVision]
+pagename = iplab-mac
 extensions = .ipm
 owner = `BioVision Technologies <http://biovis.com/>`_
 bsd = no
-weHave = * a few IPLab-Mac datasets \n
+weHave = * a few iVision-Mac datasets \n
 * a specification document
-weWant = * more IPLab-Mac datasets
+weWant = * more iVision-Mac datasets
 pixelsRating = Very good
 metadataRating = Good
 opennessRating = Very good
@@ -996,6 +997,7 @@ presenceRating = Poor
 utilityRating = Fair
 privateSpecification = true
 reader = IvisionReader
+notes = iVision-Mac was formerly called IPLab for Macintosh.
 
 [IPLab]
 extensions = .ipl

--- a/components/formats-bsd/src/loci/formats/in/MNGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MNGReader.java
@@ -49,8 +49,8 @@ import loci.formats.gui.AWTImageTools;
 import loci.formats.meta.MetadataStore;
 
 /**
- * MNGReader is the file format reader for Multiple Network Graphics (MNG)
- * files.  Does not support JNG (JPEG Network Graphics).
+ * MNGReader is the file format reader for Multiple-image Network Graphics
+ * (MNG) files.  Does not support JNG (JPEG Network Graphics).
  */
 public class MNGReader extends BIFormatReader {
 
@@ -68,7 +68,7 @@ public class MNGReader extends BIFormatReader {
 
   /** Constructs a new MNG reader. */
   public MNGReader() {
-    super("Multiple Network Graphics", "mng");
+    super("Multiple-image Network Graphics", "mng");
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
   }
 

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -284,7 +284,7 @@ to open/import a dataset in a particular format.
    * - Molecular Imaging
      - .stp
      - Single file
-   * - Multiple Network Graphics
+   * - Multiple-image Network Graphics
      - .mng
      - Single file
    * - NIfTI

--- a/docs/sphinx/formats/gatan-digital-micrograph.txt
+++ b/docs/sphinx/formats/gatan-digital-micrograph.txt
@@ -16,7 +16,7 @@ BSD-licensed: |no|
 
 Export: |no|
 
-Officially Supported Versions: 3
+Officially Supported Versions: 3, 4
 
 Reader: GatanReader (:bfreader:`Source Code <GatanReader.java>`, :doc:`Supported Metadata Fields </metadata/GatanReader>`)
 

--- a/docs/sphinx/formats/iplab-mac.txt
+++ b/docs/sphinx/formats/iplab-mac.txt
@@ -1,7 +1,7 @@
-.. index:: IPLab-Mac
+.. index:: IVision
 .. index:: .ipm
 
-IPLab-Mac
+IVision
 ===============================================================================
 
 Extensions: .ipm
@@ -25,12 +25,12 @@ Reader: IvisionReader (:bfreader:`Source Code <IvisionReader.java>`, :doc:`Suppo
 
 We currently have:
 
-* a few IPLab-Mac datasets 
+* a few iVision-Mac datasets
 * a specification document
 
 We would like to have:
 
-* more IPLab-Mac datasets
+* more iVision-Mac datasets
 
 **Ratings**
 
@@ -50,3 +50,4 @@ Utility: |Fair|
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**
 
+iVision-Mac was formerly called IPLab for Macintosh.

--- a/docs/sphinx/formats/pgm.txt
+++ b/docs/sphinx/formats/pgm.txt
@@ -1,10 +1,10 @@
-.. index:: PGM (Portable Gray Map)
-.. index:: .pgm
+.. index:: Portable Any Map
+.. index:: .pbm, .pgm, .ppm
 
-PGM (Portable Gray Map)
+Portable Any Map
 ===============================================================================
 
-Extensions: .pgm
+Extensions: .pbm, .pgm, .ppm
 
 Developer: Netpbm developers
 
@@ -29,7 +29,7 @@ Freely Available Software:
 We currently have:
 
 * a `PGM specification document <http://netpbm.sourceforge.net/doc/pgm.html>`_ (from 2003 October 3, in HTML) 
-* a few PGM files
+* a few PGM, PPM and PGM files
 
 We would like to have:
 

--- a/docs/sphinx/formats/pgm.txt
+++ b/docs/sphinx/formats/pgm.txt
@@ -29,7 +29,7 @@ Freely Available Software:
 We currently have:
 
 * a `PGM specification document <http://netpbm.sourceforge.net/doc/pgm.html>`_ (from 2003 October 3, in HTML) 
-* a few PGM, PPM and PGM files
+* a few PBM, PPM and PGM files
 
 We would like to have:
 

--- a/docs/sphinx/metadata/MNGReader.txt
+++ b/docs/sphinx/metadata/MNGReader.txt
@@ -2,7 +2,7 @@
 MNGReader
 *******************************************************************************
 
-This page lists supported metadata fields for the Bio-Formats Multiple Network Graphics format reader.
+This page lists supported metadata fields for the Bio-Formats Multiple-image Network Graphics format reader.
 
 These fields are from the :model_doc:`OME data model <>`.
 Bio-Formats standardizes each format's original metadata to and from the OME
@@ -16,7 +16,7 @@ Of the 475 fields documented in the :doc:`metadata summary table </metadata-summ
 Supported fields
 ===============================================================================
 
-These fields are fully supported by the Bio-Formats Multiple Network Graphics format reader:
+These fields are fully supported by the Bio-Formats Multiple-image Network Graphics format reader:
   * :schema:`Channel : ID <OME-2015-01/ome_xsd.html#Channel_ID>`
   * :schema:`Channel : SamplesPerPixel <OME-2015-01/ome_xsd.html#Channel_SamplesPerPixel>`
   * :schema:`Image : AcquisitionDate <OME-2015-01/ome_xsd.html#Image_AcquisitionDate>`

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -962,7 +962,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/pgm`
-     - .pgm
+     - .pbm, .pgm, .ppm
      - |Very good|
      - |Good|
      - |Outstanding|


### PR DESCRIPTION
See https://trello.com/c/tpoKZjRa/35-metadata-pages-follow-up

Minor generated documentation improvements for 5.1.5 /cc @hflynn 

None of the format pages have been renamed to prevent breaking URLs, but `Portable Any Map` and `iVision` format pages should likely be renamed to reflect the new name in 5.2.x