### PR TITLE
octave - drop unecessary String::toString and char()

### DIFF
--- a/components/formats-gpl/matlab/bfGetFileExtensions.m
+++ b/components/formats-gpl/matlab/bfGetFileExtensions.m
@@ -48,7 +48,7 @@ for i = 1:numel(readers)
     else
         fileExt{i, 1} = arrayfun(@char, suffixes, 'Unif', false);
     end
-    fileExt{i, 2} = char(readers(i).getFormat().toString);
+    fileExt{i, 2} = char(readers(i).getFormat());
 end
 
 % Concatenate all unique formats


### PR DESCRIPTION
This has two commits.  The first is an issue reported on the Octave mailing list by Philip Nienhuis (no github account)

> bfGetFileExtensions.m:
> ----------------------
> ...when run in Octave chokes on
>    fileExt{i, 2} = char(readers(i).getFormat().toString)
> 
> error: sq_string cannot be indexed with .
> error: evaluating argument list element number 1
> 
> ....probably because readers(i).getFormat() is already (un)boxed to a char string.
> See attached patch1 for a fix.

According to [Matlab documentation](http://uk.mathworks.com/help/matlab/matlab_external/handling-data-returned-from-a-java-method.html#f61197), `java.lang.String` objects should be automatically converted into char arrays:

> When a method call returns data of type java.lang.Object, MATLAB converts its value, depending on its actual type, according to the following table.

Since a char array is a Matlab type, it does not have a `toString()` method. I am surprised that it works so I may be  misunderstanding Matlab documentation.  However, Octave does it as stated which causes the issue.

Since these String are automatically converted to char array, calls to `char()` are unnecessary. The second commit removes those.