### PR TITLE
matlab and octave: add flexibility to the filename of bioformats jar.

### DIFF
--- a/components/formats-gpl/matlab/bfCheckJavaPath.m
+++ b/components/formats-gpl/matlab/bfCheckJavaPath.m
@@ -50,11 +50,12 @@ ip.parse(varargin{:});
 % Check if a Bio-Formats JAR file is in the Java class path
 % Can be in either static or dynamic Java class path
 jPath = javaclasspath('-all');
-bfJarFiles = {'bioformats_package.jar', 'loci_tools.jar'};
+jars = cell2mat (cell2mat (regexp (jPath, '[\\/]{1}([^/\\]+)\.jar$', 'tokens')));
+bfJarFiles = {'bioformats_package', 'loci_tools'};
 hasBFJar =  false(numel(bfJarFiles), 1);
 for i = 1: numel(bfJarFiles);
-    isBFJar =  @(x) ~isempty(regexp(x, ['.*' bfJarFiles{i} '$'], 'once'));
-    hasBFJar(i) = any(cellfun(isBFJar, jPath));
+    isBFJar =  @(x) ~isempty(regexp(x, bfJarFiles{i}, 'once'));
+    hasBFJar(i) = any(cellfun(isBFJar, jars));
 end
 
 % Check conflicting JARs are not loaded


### PR DESCRIPTION
This issue was reported on the Octave mailing list by Philip Nienhuis (no github account). I used his patch to prepare the commit.

> bfCheckJavaPath.m:
> ------------------
> ...rigidly checks for a jar strictly named bioformats_package.jar or loci_tools.jar.
> Several Linux distros rename the jars by appending a version number. On my boxes (Linux and Windows) I usually do the same (to keep track of versions) and found that bioformats_package-5.1.4.jar isn't detected. So I attached a patch for that (patch2) that just checks for any jar with bioformats_package of loci_tools in the name.

Please note that the Octave package does not includes the jar file. It must be downloaded separately (including the jar file in the Octave package would not make much sense since Octave requires the jar file to be on the java static classpath).

To my knowledge, bioformats is not packaged by any Linux distro.  What I have found is that Linux distros do add a version number but then also have an unversioned file which is a symlink to one of the versioned files (this is what I do on my own system).

> An often better approach to this sort of check is to try one of the methods in the jar in question with a try-catch around it (e.g., the version number call). That way the jar names don't matter, just the presence of the jar, and you'll know if it is the right version that is first in the javaclasspath.
> Anyway, some lines down, this function expects bioformats_package.jar (or loci_tools.jar) to live in some predefined location. All well, but if it isn't there the javaaddpath call crashes. So, my advice is to put a try-catch around it with a sensible message.

I also prefer this approach and indeed, that's how I wrote [Octave's PKG_ADD for the bioformats package](https://github.com/openmicroscopy/bioformats/blob/develop/components/formats-gpl/octave/PKG_ADD#L12).  This script is executed when the bioformats package is loaded by Octave and errors if it can't create a FakeReader (maybe there's a better things to check?).

As such, an alternative fix for this would be to replace `bfCheckJavaPath` with a modified `PKG_ADD`.