### PR TITLE
Add version history for 5.1.5

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -23,6 +23,8 @@ Version history
          are present
    - Fluoview and Andor TIFF
        - fixed physical Z size calculation
+   - Imspector OBF
+       - updated to parse OME-XML metadata (thanks to Bjoern Thiel)
 * Documentation updates, including:
    - substantial updates to the format pages
        - improved linking of reader/writer classes to each format page

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,35 @@
 Version history
 ===============
 
+5.1.5 (2015 October 12)
+-----------------------
+
+* Bug fixes, including:
+   - ImageJ plugins
+       - fixed use of "Group files..." and "Open files individually" options
+       - fixed placement of ROIs
+       - fixed size of the "About Plugins > Bio-Formats Plugins" window
+   - xsd-fu (code generation)
+       - removed OMERO-specific logic
+   - Metamorph
+       - fixed physical Z size calculation
+   - Gatan DM3/DM4
+       - fixed physical pixel size parsing
+   - BMP
+       - added support for RLE compression
+   - DICOM
+       - updated to respect the WINDOW_CENTER tag
+       - fixed image dimensions when multiple sets of width and height values
+         are present
+   - Fluoview and Andor TIFF
+       - fixed physical Z size calculation
+* Documentation updates, including:
+   - substantial updates to the format pages
+       - improved linking of reader/writer classes to each format page
+       - improved supported metadata pages for each format
+       - updated format page formatting for clarity
+       - added developer documentation for adding and modifying format pages
+
 5.1.4 (2015 September 7)
 ------------------------
 


### PR DESCRIPTION
See https://trello.com/c/z0ZIeT8e/22-version-history-prs

I didn't add C++ changes, on the assumption that those will be written up separately due to the difference in release dates.  Happy to add text in this PR though if that's preferable.