### PR TITLE
Add C++ version history for 5.1.5

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -4,8 +4,7 @@ Version history
 5.1.5 (2015 October 12)
 -----------------------
 
-* Java changes:
-   - Bug fixes, including:
+* Java bug fixes, including:
    - ImageJ plugins
        - fixed use of "Group files..." and "Open files individually" options
        - fixed placement of ROIs

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -4,7 +4,8 @@ Version history
 5.1.5 (2015 October 12)
 -----------------------
 
-* Bug fixes, including:
+* Java changes:
+   - Bug fixes, including:
    - ImageJ plugins
        - fixed use of "Group files..." and "Open files individually" options
        - fixed placement of ROIs
@@ -25,6 +26,14 @@ Version history
        - fixed physical Z size calculation
    - Imspector OBF
        - updated to parse OME-XML metadata (thanks to Bjoern Thiel)
+* C++ changes:
+   - TIFF strip/tile row and column calulations corrected to compute
+     the correct row and column count
+   - Several compiler warnings removed (false positive warnings in
+     third-party headers disabled, and additional warnings fixed)
+   - It is now possible to build with Boost 1.59 and compile with a
+     C++14 compiler
+* The source release is now provided in both tar.xz and zip formats
 * Documentation updates, including:
    - substantial updates to the format pages
        - improved linking of reader/writer classes to each format page


### PR DESCRIPTION
Follow-up of https://github.com/openmicroscopy/bioformats/pull/2019