### PR TITLE
XML reading

### DIFF
--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -705,40 +705,40 @@ public final class MetadataConverter {
     }
     catch (NullPointerException e) { }
     for (int i = 0; i < instrumentCount; i++) {
-        int lightSourceCount = 0;
-        try {
-          lightSourceCount = src.getLightSourceCount(i);
+      int lightSourceCount = 0;
+      try {
+        lightSourceCount = src.getLightSourceCount(i);
+      }
+      catch (NullPointerException e) { }
+      for (int j = 0; j < lightSourceCount; j++) {
+        String type = src.getLightSourceType(i, j);
+        if (type.equals("Arc")) {
+          String id = src.getArcID(i, j);
+          if (id != null && id.trim().length() > 0) {
+            lightSourceIds.add(id);
+          }
+        } else if (type.equals("Filament")) {
+          String id = src.getFilamentID(i, j);
+          if (id != null && id.trim().length() > 0) {
+            lightSourceIds.add(id);
+          }
+        } else if (type.equals("GenericExcitationSource")) {
+          String id = src.getGenericExcitationSourceID(i, j);
+          if (id != null && id.trim().length() > 0) {
+            lightSourceIds.add(id);
+          }
+        } else if (type.equals("Laser")) {
+          String id = src.getLaserID(i, j);
+          if (id != null && id.trim().length() > 0) {
+            lightSourceIds.add(id);
+          }
+        } else if (type.equals("LightEmittingDiode")) {
+          String id = src.getLightEmittingDiodeID(i, j);
+          if (id != null && id.trim().length() > 0) {
+            lightSourceIds.add(id);
+          }
         }
-        catch (NullPointerException e) { }
-        for (int j = 0; j < lightSourceCount; j++) {
-            String type = src.getLightSourceType(i, j);
-            if (type.equals("Arc")) {
-                String id = src.getArcID(i, j);
-                if (id != null && id.trim().length() > 0) {
-                    lightSourceIds.add(id);
-                }
-            } else if (type.equals("Filament")) {
-                String id = src.getFilamentID(i, j);
-                if (id != null && id.trim().length() > 0) {
-                    lightSourceIds.add(id);
-                }
-            } else if (type.equals("GenericExcitationSource")) {
-                String id = src.getGenericExcitationSourceID(i, j);
-                if (id != null && id.trim().length() > 0) {
-                    lightSourceIds.add(id);
-                }
-            } else if (type.equals("Laser")) {
-                String id = src.getLaserID(i, j);
-                if (id != null && id.trim().length() > 0) {
-                    lightSourceIds.add(id);
-                }
-            } else if (type.equals("LightEmittingDiode")) {
-                String id = src.getLightEmittingDiodeID(i, j);
-                if (id != null && id.trim().length() > 0) {
-                    lightSourceIds.add(id);
-                }
-            }
-        }
+      }
     }
     int imageCount = 0;
     try {

--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -32,13 +32,13 @@
 
 package loci.formats.meta;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import ome.xml.model.*;
 import ome.xml.model.enums.*;
 import ome.xml.model.primitives.*;
-
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Frequency;
 import ome.units.quantity.Length;
@@ -698,6 +698,48 @@ public final class MetadataConverter {
    * @param dest the MetadataStore to which to copy
    */
   private static void convertImages(MetadataRetrieve src, MetadataStore dest) {
+    List<String> lightSourceIds = new ArrayList<String>();
+    int instrumentCount = 0;
+    try {
+      instrumentCount = src.getInstrumentCount();
+    }
+    catch (NullPointerException e) { }
+    for (int i = 0; i < instrumentCount; i++) {
+        int lightSourceCount = 0;
+        try {
+          lightSourceCount = src.getLightSourceCount(i);
+        }
+        catch (NullPointerException e) { }
+        for (int j = 0; j < lightSourceCount; j++) {
+            String type = src.getLightSourceType(i, j);
+            if (type.equals("Arc")) {
+                String id = src.getArcID(i, j);
+                if (id != null && id.trim().length() > 0) {
+                    lightSourceIds.add(id);
+                }
+            } else if (type.equals("Filament")) {
+                String id = src.getFilamentID(i, j);
+                if (id != null && id.trim().length() > 0) {
+                    lightSourceIds.add(id);
+                }
+            } else if (type.equals("GenericExcitationSource")) {
+                String id = src.getGenericExcitationSourceID(i, j);
+                if (id != null && id.trim().length() > 0) {
+                    lightSourceIds.add(id);
+                }
+            } else if (type.equals("Laser")) {
+                String id = src.getLaserID(i, j);
+                if (id != null && id.trim().length() > 0) {
+                    lightSourceIds.add(id);
+                }
+            } else if (type.equals("LightEmittingDiode")) {
+                String id = src.getLightEmittingDiodeID(i, j);
+                if (id != null && id.trim().length() > 0) {
+                    lightSourceIds.add(id);
+                }
+            }
+        }
+    }
     int imageCount = 0;
     try {
       imageCount = src.getImageCount();
@@ -1104,7 +1146,7 @@ public final class MetadataConverter {
 
         try {
           String lightSourceID = src.getChannelLightSourceSettingsID(i, c);
-          if (lightSourceID != null) {
+          if (lightSourceID != null && lightSourceIds.contains(lightSourceID)) {
             dest.setChannelLightSourceSettingsID(lightSourceID, i, c);
 
             try {


### PR DESCRIPTION
In this PR, we do not record the light settings if the light source is not present in the file
This can be the case with 3rd party generated ome-tiff see https://trac.openmicroscopy.org/ome/ticket/13038
To test this PR:

test 1
 * Open the image from ​https://www.openmicroscopy.org/qa2/qa/feedback/11402/, using BF importer
 * Check the "Display OME-XML metadata" option
 * Check that there is no ligthsettings under channel and no light source under instrument. W/o this PR, light settings were present under channels

test 2:
 * Follow the same steps but this time opened the sample image https://github.com/openmicroscopy/bioformats/blob/develop/components/specification/samples/2015-01/6x4y1z1t1c8b-swatch-instrument.ome. Check that light settings are present under channel.

The image should now import in OMERO.