### PR TITLE
docs: Update tutorial doxygen links

### DIFF
--- a/docs/sphinx/developers/cpp/tutorial.txt
+++ b/docs/sphinx/developers/cpp/tutorial.txt
@@ -472,8 +472,8 @@ Full example source: :download:`pixeldata.cpp <examples/pixeldata.cpp>`
   - :doxygen:`PixelType <classome_1_1xml_1_1model_1_1enums_1_1PixelType.html>`
   - :doxygen:`PixelBuffer <classome_1_1bioformats_1_1PixelBuffer.html>`
   - :doxygen:`VariantPixelBuffer <classome_1_1bioformats_1_1VariantPixelBuffer.html>`
-  - :doxygen:`FormatReader::getLookupTable <classome_1_1bioformats_1_1FormatReader.html#a75ad99e400c31ccb9e52da8aeb991b73>`
-  - :doxygen:`FormatReader::openBytes <classome_1_1bioformats_1_1FormatReader.html#aae4d2b9475b078f7ba2378ed505e864c>`
+  - :doxygen:`FormatReader::getLookupTable <classome_1_1bioformats_1_1FormatReader.html#a9b69e3612f0ad4c945d1c0f111242cc2>`
+  - :doxygen:`FormatReader::openBytes <classome_1_1bioformats_1_1FormatReader.html#a5bfa86b4b68b03b63d76bb050cbe7101>`
   - :doxygen:`FormatWriter::setLookupTable <classome_1_1bioformats_1_1FormatWriter.html#a00ae3dc46c205e64f782c7b6f47bd5ab>`
   - :doxygen:`FormatWriter::saveBytes <classome_1_1bioformats_1_1FormatWriter.html#ad1e8b427214f7cfd19ce2251d38e24f5>`
 


### PR DESCRIPTION
Correct two broken links for 5.1.5.

/cc @hflynn 