### PR TITLE
release: xz compress tar archives

### DIFF
--- a/tools/source-archive.py
+++ b/tools/source-archive.py
@@ -9,6 +9,7 @@ import sys
 import zipfile
 import tarfile
 import StringIO
+import platform
 
 # This script archives the base tree and repacks it into a single zip which is
 # the source release, taking care to preserve timestamps and exectute
@@ -219,4 +220,10 @@ if __name__ == "__main__":
     cmakeversion.size = cmakeversionbuf.len
     basetar.addfile(cmakeversion, cmakeversionbuf)
     basetar.close()
-    call(['xz', "%s/%s.tar" % (options.target, prefix)])
+    try:
+        call(['xz', "%s/%s.tar" % (options.target, prefix)])
+    except:
+        # This is expected to fail on Windows when xz is unavailable,
+        # but is always an error on all other platforms.
+        if platform.system() != 'Windows':
+            sys.exit(1)

--- a/tools/source-archive.py
+++ b/tools/source-archive.py
@@ -218,3 +218,5 @@ if __name__ == "__main__":
     cmakeversion = tarfile.TarInfo("%s/cpp/cmake/GitVersion.cmake" % (prefix))
     cmakeversion.size = cmakeversionbuf.len
     basetar.addfile(cmakeversion, cmakeversionbuf)
+    basetar.close()
+    call(['xz', "%s/%s.tar" % (options.target, prefix)])


### PR DESCRIPTION
Previously the tar archives were uncompressed.  This was done for portability--xz isn't available by default on Windows.  This is the most appropriate place for it though; if anyone cares to run it on Windows, they can put xz in their PATH e.g. with cygwin or standalone xz.  The other alternative is Python3, which has this stuff built in, but probably not useful to use that right now.

Testing: run `ant release`; check the two .tar.xz files under `artifacts`.  Unpack them with e.g. `tar -xvf` and check unpacking works and that the content looks OK.  (The actual content is unchanged, just added compression.)

Followup tasks: update merge/latest/release builds to archive these artifacts; update download page to add them (button already exists).