### PR TITLE
Fix for tiling issue

### DIFF
--- a/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JPEGTurboServiceImpl.java
@@ -249,7 +249,7 @@ public class JPEGTurboServiceImpl implements JPEGTurboService {
           for (int trow=0; trow<intersection.height; trow++) {
             int realRow = trow + intersection.y - tileBoundary.y;
             int inputOffset =
-              3 * (realRow * tileBoundary.width + intersectionX);
+              3 * (realRow * tileDim + intersectionX);
             System.arraycopy(tile, inputOffset, buf, outputOffset, rowLen);
             outputOffset += outputRowLen;
           }


### PR DESCRIPTION
User reported issue: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-October/005678.html
Sample file: https://drive.switch.ch/public.php?service=files&t=f006627509d481a9af386e1b90efb1eb

For unregular sized tiles (ie tiles at the end of the row), we were
using the width of the tile to increase the input to be copied from the
tile array to the image array. However the tile array which we use still
maintains the regular tile dimensions but with sensible data only being
found in the first section of each row.

Steps to reproduce: 
- Import the user submitted file using bioformats
- Open series 1 (note series 0 is extremely large and will require a lot of RAM, series 2 does not have the reported issue)
- Verify that the image displays the unusual pattern as shown in 
https://drive.switch.ch/public.php?service=files&t=f0bd77f7c4a96898c339b3cd5b408515

Testing Steps: 
- Import the user submitted file using bioformats
- Open series 1 
- Verify that the image displays correctly
- Open series 2
- Verify that it also displays correctly