### PR TITLE
OME-TIFF: override reopenFile

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -280,6 +280,19 @@ public class OMETiffReader extends FormatReader {
     return info[series][lastPlane].reader.get16BitLookupTable();
   }
 
+  /* @see loci.formats.IFormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    super.reopenFile();
+    for (int s=0; s<info.length; s++) {
+      for (int q=0; q<info[s].length; q++) {
+        if (info[s][q] != null && info[s][q].reader != null) {
+          info[s][q].reader.reopenFile();
+        }
+      }
+    }
+  }
+
   /*
    * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
    */

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -286,7 +286,10 @@ public class OMETiffReader extends FormatReader {
     super.reopenFile();
     for (int s=0; s<info.length; s++) {
       for (int q=0; q<info[s].length; q++) {
-        if (info[s][q] != null && info[s][q].reader != null) {
+        // only reopen readers that had previously been initialized
+        if (info[s][q] != null && info[s][q].reader != null &&
+          info[s][q].reader.getCurrentFile() != null)
+        {
           info[s][q].reader.reopenFile();
         }
       }


### PR DESCRIPTION
This allows reopenFile to reopen the helper readers, which prevents
exceptions when calling get*LookupTable() and other state methods after
reopening.

See https://trello.com/c/kjQdHktu/7-ome-tiff-memoization-issues

To test, use ```showinf -cache -crop 0,0,512,512``` with the file from QA 16852 twice in succession.  Without this change, the second run of the command will throw an exception as mentioned in the thread referenced from the above card.  With this change (and after removing the ```.*.bfmemo``` file from the previous test), both commands should display an image without an exception.