### PR TITLE
Jpeg physical dims

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -54,7 +54,11 @@ import java.util.HashMap;
 import org.joda.time.DateTime;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
 import ome.xml.model.primitives.Timestamp;
+
+import com.drew.metadata.exif.ExifSubIFDDirectory;
 
 /**
  * JPEGReader is the file format reader for JPEG images.
@@ -207,8 +211,38 @@ public class JPEGReader extends DelegateReader {
         }
 
         HashMap<String, String> tags = exif.getTags();
-        for (String tagName : tags.keySet()) {
-          addGlobalMeta(tagName, tags.get(tagName));
+        for (String tagName : tags.keySet()) {  
+          if (tagName.equals(ExifSubIFDDirectory.TAG_FOCAL_PLANE_X_RES)) {
+            Length sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)));
+            String units = tags.get(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT);
+            if (units != null)
+            {
+              if (Integer.parseInt(units) == 2) { 
+                sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)), UNITS.INCH);
+              }
+              else if (Integer.parseInt(units) == 3) { 
+                sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)), UNITS.CM);
+              }
+            }
+            store.setPixelsPhysicalSizeX(sizeX, 0);
+          }
+          else if (tagName.equals(ExifSubIFDDirectory.TAG_FOCAL_PLANE_Y_RES)) {
+            Length sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)));
+            String units = tags.get(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT);
+            if (units != null)
+            {
+              if (Integer.parseInt(units) == 2) { 
+                sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)), UNITS.INCH);
+              }
+              else if (Integer.parseInt(units) == 3) { 
+                sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)), UNITS.CM);
+              }
+            }
+            store.setPixelsPhysicalSizeX(sizeY, 0);
+          }
+          else {
+            addGlobalMeta(tagName, tags.get(tagName));
+          }
         }
       }
       catch (ServiceException e) {

--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -213,32 +213,42 @@ public class JPEGReader extends DelegateReader {
         HashMap<String, String> tags = exif.getTags();
         for (String tagName : tags.keySet()) {  
           if (tagName.equals(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_X_RES))) {
-            Length sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)));
-            String units = tags.get(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT));
-            if (units != null)
-            {
-              if (Integer.parseInt(units) == 2) { 
-                sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)), UNITS.INCH);
+            try {
+              Length sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)));
+              String units = tags.get(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT));
+              if (units != null)
+              {
+                if (Integer.parseInt(units) == 2) { 
+                  sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)), UNITS.INCH);
+                }
+                else if (Integer.parseInt(units) == 3) { 
+                  sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)), UNITS.CM);
+                }
               }
-              else if (Integer.parseInt(units) == 3) { 
-                sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)), UNITS.CM);
-              }
+              store.setPixelsPhysicalSizeX(sizeX, 0);
             }
-            store.setPixelsPhysicalSizeX(sizeX, 0);
+            catch(NumberFormatException e) {
+              LOGGER.debug("EXIF Tag - Focal Plane Resolution X not in correct format, expected double, found : " + tags.get(tagName));
+            }
           }
           else if (tagName.equals(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_Y_RES))) {
-            Length sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)));
-            String units = tags.get(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT));
-            if (units != null)
-            {
-              if (Integer.parseInt(units) == 2) { 
-                sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)), UNITS.INCH);
+            try {
+              Length sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)));
+              String units = tags.get(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT));
+              if (units != null)
+              {
+                if (Integer.parseInt(units) == 2) { 
+                  sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)), UNITS.INCH);
+                }
+                else if (Integer.parseInt(units) == 3) { 
+                  sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)), UNITS.CM);
+                }
               }
-              else if (Integer.parseInt(units) == 3) { 
-                sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)), UNITS.CM);
-              }
+              store.setPixelsPhysicalSizeX(sizeY, 0);
             }
-            store.setPixelsPhysicalSizeX(sizeY, 0);
+            catch(NumberFormatException e) {
+              LOGGER.debug("EXIF Tag - Focal Plane Resolution Y not in correct format, expected double, found : " + tags.get(tagName));
+            }
           }
           else {
             addGlobalMeta(tagName, tags.get(tagName));

--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -212,9 +212,9 @@ public class JPEGReader extends DelegateReader {
 
         HashMap<String, String> tags = exif.getTags();
         for (String tagName : tags.keySet()) {  
-          if (tagName.equals(ExifSubIFDDirectory.TAG_FOCAL_PLANE_X_RES)) {
+          if (tagName.equals(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_X_RES))) {
             Length sizeX = FormatTools.getPhysicalSizeX(Double.parseDouble(tags.get(tagName)));
-            String units = tags.get(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT);
+            String units = tags.get(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT));
             if (units != null)
             {
               if (Integer.parseInt(units) == 2) { 
@@ -226,9 +226,9 @@ public class JPEGReader extends DelegateReader {
             }
             store.setPixelsPhysicalSizeX(sizeX, 0);
           }
-          else if (tagName.equals(ExifSubIFDDirectory.TAG_FOCAL_PLANE_Y_RES)) {
+          else if (tagName.equals(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_Y_RES))) {
             Length sizeY = FormatTools.getPhysicalSizeY(Double.parseDouble(tags.get(tagName)));
-            String units = tags.get(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT);
+            String units = tags.get(exif.getTagName(ExifSubIFDDirectory.TAG_FOCAL_PLANE_UNIT));
             if (units != null)
             {
               if (Integer.parseInt(units) == 2) { 

--- a/components/formats-bsd/src/loci/formats/services/EXIFService.java
+++ b/components/formats-bsd/src/loci/formats/services/EXIFService.java
@@ -52,4 +52,5 @@ public interface EXIFService extends Service {
 
   void close() throws IOException;
 
+  String getTagName(int tagType);
 }

--- a/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/EXIFServiceImpl.java
@@ -87,7 +87,6 @@ public class EXIFServiceImpl extends AbstractService implements EXIFService {
         tagMap.put(tag.getTagName(), tag.getDescription());
       }
     }
-
     return tagMap;
   }
 
@@ -104,4 +103,12 @@ public class EXIFServiceImpl extends AbstractService implements EXIFService {
     directory = null;
   }
 
+  public String getTagName(int tagType)
+  {
+    String tagName = null;
+    if (directory != null) {
+      tagName = directory.getTagName(tagType);
+    }
+    return tagName;
+  }
 }


### PR DESCRIPTION
Reading Physical Size X and Y from Exif Tags along with units.

Note the alternative Exif tags Exif.Image.YResolution and
 Exif.Image.ResolutionUnit are not supported by the Exif library we are
 using.

Alternative tags Exif.Image.FocalPlaneXResolution,
 Exif.Image.FocalPlaneYResolution and Exif.Image.FocalPlaneResolutionUnit
 are used instead.

https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7877&p=16128#p16128
