### PR TITLE
IMODReader: add support for native length units

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/IMODReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IMODReader.java
@@ -457,7 +457,7 @@ public class IMODReader extends FormatReader {
         }
       }
       if (physicalZ > 0) {
-        Length z = FormatTools.getPhysicalSizeX(physicalZ, physicalSizeUnit);
+        Length z = FormatTools.getPhysicalSizeZ(physicalZ, physicalSizeUnit);
         if (z != null) {
           store.setPixelsPhysicalSizeZ(z, 0);
         }

--- a/components/formats-gpl/src/loci/formats/in/IMODReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IMODReader.java
@@ -36,7 +36,9 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
+
 import ome.units.UNITS;
+import ome.units.unit.Unit;
 import ome.units.quantity.Length;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.NonNegativeInteger;
@@ -441,45 +443,52 @@ public class IMODReader extends FormatReader {
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
+      Unit<Length> physicalSizeUnit = convertUnits(pixSizeUnits);
       if (physicalX > 0) {
-        store.setPixelsPhysicalSizeX(
-          FormatTools.createLength(adjustForUnits(pixSizeUnits, physicalX), UNITS.MICROM), 0);
+        Length x = FormatTools.getPhysicalSizeX(physicalX, physicalSizeUnit);
+        if (x != null) {
+          store.setPixelsPhysicalSizeX(x, 0);
+        }
       }
       if (physicalY > 0) {
-        store.setPixelsPhysicalSizeY(
-          FormatTools.createLength(adjustForUnits(pixSizeUnits, physicalY), UNITS.MICROM), 0);
+        Length y = FormatTools.getPhysicalSizeY(physicalY, physicalSizeUnit);
+        if (y != null) {
+          store.setPixelsPhysicalSizeY(y, 0);
+        }
       }
       if (physicalZ > 0) {
-        store.setPixelsPhysicalSizeZ(
-          FormatTools.createLength(adjustForUnits(pixSizeUnits, physicalZ), UNITS.MICROM), 0);
+        Length z = FormatTools.getPhysicalSizeX(physicalZ, physicalSizeUnit);
+        if (z != null) {
+          store.setPixelsPhysicalSizeZ(z, 0);
+        }
       }
     }
   }
 
   // -- Helper methods --
 
-  private double adjustForUnits(int units, double value) {
+  private Unit<Length> convertUnits(int units) {
     switch (units) {
-      case 0:   // pixels
-        return value;
-      case 1:   // m
-        return value * 100000000.0;
-      case 3:   // km
-        return value * 100000000000.0;
-      case -2:  // cm
-        return value * 1000000.0;
-      case -3:  // mm
-        return value * 1000.0;
-      case -6:  // µm
-        return value;
-      case -9:  // nm
-        return value / 1000.0;
-      case -10: // Å
-        return value / 10000.0;
-      case -12: // pm
-        return value / 1000000.0;
+      case 0:
+        return UNITS.REFERENCEFRAME;
+      case 1:
+        return UNITS.M;
+      case 3:
+        return UNITS.KM;
+      case -2:
+        return UNITS.CM;
+      case -3:
+        return UNITS.MM;
+      case -6:
+        return UNITS.MICROM;
+      case -9:
+        return UNITS.NM;
+      case -10:
+        return UNITS.ANGSTROM;
+      case -12:
+        return UNITS.PM;
     }
-    return value;
+    return UNITS.MICROM;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/IMODReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IMODReader.java
@@ -470,7 +470,7 @@ public class IMODReader extends FormatReader {
   private Unit<Length> convertUnits(int units) {
     switch (units) {
       case 0:
-        return UNITS.REFERENCEFRAME;
+        return UNITS.PIXEL;
       case 1:
         return UNITS.M;
       case 3:


### PR DESCRIPTION
See https://trello.com/c/nO35TKXK/3-units-and-readers

This PR adjusts the IMODReader to store the physical pixel size read from `imod` files using the native units. The specification for the units can be found at http://bio3d.colorado.edu/imod/doc/binspec.html.

Since one of the samples IMOD file uses the pixel unit (`0`) which that cannot be converted to micrometers, the format reader automated tests are also adjusted to handle this case (using `isConvertible` similarly to what is done in https://github.com/openmicroscopy/bioformats/pull/2030). The size comparison logic used across all physical size tests is also refactored into a single helper method to simplify future maintenance.

For automated tests, this means we do not differentiate the case where the physical size is 1 micron or 1 pixel. In the future we may want to introduce a `physicalSize{X,Y,Z}Unit` optional configuration to store non-convertible length unit.

To test this PR, check `imod` files are read correctly and automated tests are passing.