### PR TITLE
Test suite refactor native units

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1398,7 +1398,7 @@ public final class FormatTools {
    * given unit.
    *
    * @param value  the value of the wavelength
-   * @param unit   the unit of the wavelength
+   * @param unit   the unit of the wavelength. If null will default to Nanometre
    *
    * @return       the wavelength formatted as a {@link Length}
 
@@ -1419,7 +1419,7 @@ public final class FormatTools {
    * given unit.
    *
    * @param value  the value of the time
-   * @param unit   the unit of the time
+   * @param unit   the unit of the time. If null will default to Seconds
    *
    * @return       the wavelength formatted as a {@link Length}
 

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -54,6 +54,7 @@ import loci.formats.services.OMEXMLServiceImpl;
 
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.UnitsLength;
+import ome.xml.model.enums.UnitsTime;
 import ome.xml.model.primitives.PrimitiveNumber;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
@@ -1392,6 +1393,48 @@ public final class FormatTools {
       value < Double.POSITIVE_INFINITY);
   }
 
+  /**
+   * Formats the input value for the wavelength into a length of the
+   * given unit.
+   *
+   * @param value  the value of the wavelength
+   * @param unit   the unit of the wavelength
+   *
+   * @return       the wavelength formatted as a {@link Length}
+
+   */
+  public static Length getWavelength(Double value, String unit) {
+    if (unit != null) {
+      try {
+        UnitsLength ul = UnitsLength.fromString(unit);
+        return UnitsLength.create(value, ul);
+      } catch (EnumerationException e) {
+      }
+    }
+    return new Length(value, UNITS.NM);
+  }
+  
+  /**
+   * Formats the input value for the time into a length of the
+   * given unit.
+   *
+   * @param value  the value of the time
+   * @param unit   the unit of the time
+   *
+   * @return       the wavelength formatted as a {@link Length}
+
+   */
+  public static Time getTime(Double value, String unit) {
+    if (unit != null) {
+      try {
+        UnitsTime ut = UnitsTime.fromString(unit);
+        return UnitsTime.create(value, ut);
+      } catch (EnumerationException e) {
+      }
+    }
+    return new Time(value, UNITS.S);
+  }
+  
   public static Length getPhysicalSize(Double value, String unit) {
     if (unit != null) {
       try {

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -104,13 +104,13 @@ public class Configuration {
   private static final String X_POSITION = "PositionX_";
   private static final String Y_POSITION = "PositionY_";
   private static final String Z_POSITION = "PositionZ_";
-  private static final String TIME_INCREMENT_UNITS = "TimeIncrementUnits";
-  private static final String EXPOSURE_TIME_UNITS = "ExposureTimeUnits";
-  private static final String PHYSICAL_SIZE_Z_UNITS = "PhysicalSizeZUnits";
-  private static final String PHYSICAL_SIZE_Y_UNITS = "PhysicalSizeYUnits";
-  private static final String PHYSICAL_SIZE_X_UNITS = "PhysicalSizeXUnits";
-  private static final String EMISSION_WAVELENGTH_UNITS = "EmissionWavelengthUnits";
-  private static final String EXCITATION_WAVELENGTH_UNITS = "ExcitationWavelengthUnits";
+  private static final String TIME_INCREMENT_UNIT = "TimeIncrementUnit";
+  private static final String EXPOSURE_TIME_UNIT = "ExposureTimeUnit";
+  private static final String PHYSICAL_SIZE_Z_UNIT = "PhysicalSizeZUnit";
+  private static final String PHYSICAL_SIZE_Y_UNIT = "PhysicalSizeYUnit";
+  private static final String PHYSICAL_SIZE_X_UNIT = "PhysicalSizeXUnit";
+  private static final String EMISSION_WAVELENGTH_UNIT = "EmissionWavelengthUnit";
+  private static final String EXCITATION_WAVELENGTH_UNIT = "ExcitationWavelengthUnit";
   
   // -- Fields --
 
@@ -250,7 +250,7 @@ public class Configuration {
   public Length getPhysicalSizeX() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_X);
     if (physicalSize == null) return null;
-    String sizeXUnits = currentTable.get(PHYSICAL_SIZE_X_UNITS);
+    String sizeXUnits = currentTable.get(PHYSICAL_SIZE_X_UNIT);
     try {
       return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeXUnits);
     }
@@ -261,7 +261,7 @@ public class Configuration {
 
   public Length getPhysicalSizeY() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Y);
-    String sizeYUnits = currentTable.get(PHYSICAL_SIZE_Y_UNITS);
+    String sizeYUnits = currentTable.get(PHYSICAL_SIZE_Y_UNIT);
     try {
       return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeYUnits);
     }
@@ -271,7 +271,7 @@ public class Configuration {
 
   public Length getPhysicalSizeZ() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Z);
-    String sizeZUnits = currentTable.get(PHYSICAL_SIZE_Z_UNITS);
+    String sizeZUnits = currentTable.get(PHYSICAL_SIZE_Z_UNIT);
     try {
       return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeZUnits);
     }
@@ -282,7 +282,7 @@ public class Configuration {
 
   public Time getTimeIncrement() {
     String timeIncrement = currentTable.get(TIME_INCREMENT);
-    String timeIncrementUnits = currentTable.get(TIME_INCREMENT_UNITS);
+    String timeIncrementUnits = currentTable.get(TIME_INCREMENT_UNIT);
     try {
       return timeIncrement == null ? null : FormatTools.getTime(new Double(timeIncrement), timeIncrementUnits);
     }
@@ -309,7 +309,7 @@ public class Configuration {
 
   public Time getExposureTime(int channel) {
     String exposure = currentTable.get(EXPOSURE_TIME + channel);
-    String exposureUnits = currentTable.get(EXPOSURE_TIME_UNITS);
+    String exposureUnits = currentTable.get(EXPOSURE_TIME_UNIT);
     try {
       return exposure == null ? null : FormatTools.getTime(new Double(exposure), exposureUnits);
     }
@@ -340,7 +340,7 @@ public class Configuration {
 
   public Length getEmissionWavelength(int channel) {
     String wavelength = currentTable.get(EMISSION_WAVELENGTH + channel);
-    String emissionUnits = currentTable.get(EMISSION_WAVELENGTH_UNITS);
+    String emissionUnits = currentTable.get(EMISSION_WAVELENGTH_UNIT);
     try {
       return wavelength == null ? null : FormatTools.getWavelength(new Double(wavelength), emissionUnits);
     }
@@ -351,7 +351,7 @@ public class Configuration {
 
   public Length getExcitationWavelength(int channel) {
     String wavelength = currentTable.get(EXCITATION_WAVELENGTH + channel);
-    String excitationUnits = currentTable.get(EXCITATION_WAVELENGTH_UNITS);
+    String excitationUnits = currentTable.get(EXCITATION_WAVELENGTH_UNIT);
     try {
       return wavelength == null ? null : FormatTools.getWavelength(new Double(wavelength), excitationUnits);
     }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -104,7 +104,14 @@ public class Configuration {
   private static final String X_POSITION = "PositionX_";
   private static final String Y_POSITION = "PositionY_";
   private static final String Z_POSITION = "PositionZ_";
-
+  private static final String TIME_INCREMENT_UNITS = "TimeIncrementUnits";
+  private static final String EXPOSURE_TIME_UNITS = "ExposureTimeUnits";
+  private static final String PHYSICAL_SIZE_Z_UNITS = "PhysicalSizeZUnits";
+  private static final String PHYSICAL_SIZE_Y_UNITS = "PhysicalSizeYUnits";
+  private static final String PHYSICAL_SIZE_X_UNITS = "PhysicalSizeXUnits";
+  private static final String EMISSION_WAVELENGTH_UNITS = "EmissionWavelengthUnits";
+  private static final String EXCITATION_WAVELENGTH_UNITS = "ExcitationWavelengthUnits";
+  
   // -- Fields --
 
   private String dataFile;
@@ -240,39 +247,48 @@ public class Configuration {
     return currentTable.get(TILE_ALTERNATE_MD5);
   }
 
-  public Double getPhysicalSizeX() {
+  public Length getPhysicalSizeX() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_X);
     if (physicalSize == null) return null;
+    String sizeXUnits = currentTable.get(PHYSICAL_SIZE_X_UNITS);
     try {
-      return new Double(physicalSize);
+      return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeXUnits);
     }
-    catch (NumberFormatException e) { }
-    return null;
+    catch (NumberFormatException e) {
+      return null;
+    }
   }
 
-  public Double getPhysicalSizeY() {
+  public Length getPhysicalSizeY() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Y);
-    if (physicalSize == null) return null;
+    String sizeYUnits = currentTable.get(PHYSICAL_SIZE_Y_UNITS);
     try {
-      return new Double(physicalSize);
+      return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeYUnits);
     }
     catch (NumberFormatException e) { }
     return null;
   }
 
-  public Double getPhysicalSizeZ() {
+  public Length getPhysicalSizeZ() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Z);
-    if (physicalSize == null) return null;
+    String sizeZUnits = currentTable.get(PHYSICAL_SIZE_Z_UNITS);
     try {
-      return new Double(physicalSize);
+      return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeZUnits);
     }
-    catch (NumberFormatException e) { }
-    return null;
+    catch (NumberFormatException e) { 
+      return null;
+    } 
   }
 
   public Time getTimeIncrement() {
-    String physicalSize = currentTable.get(TIME_INCREMENT);
-    return physicalSize == null ? null : new Time(new Double(physicalSize), UNITS.S);
+    String timeIncrement = currentTable.get(TIME_INCREMENT);
+    String timeIncrementUnits = currentTable.get(TIME_INCREMENT_UNITS);
+    try {
+      return timeIncrement == null ? null : FormatTools.getTime(new Double(timeIncrement), timeIncrementUnits);
+    }
+    catch (NumberFormatException e) { 
+      return null; 
+    }
   }
 
   public int getChannelCount() {
@@ -293,7 +309,13 @@ public class Configuration {
 
   public Time getExposureTime(int channel) {
     String exposure = currentTable.get(EXPOSURE_TIME + channel);
-    return exposure == null ? null : new Time(new Double(exposure), UNITS.S);
+    String exposureUnits = currentTable.get(EXPOSURE_TIME_UNITS);
+    try {
+      return exposure == null ? null : FormatTools.getTime(new Double(exposure), exposureUnits);
+    }
+    catch (NumberFormatException e) { 
+      return null; 
+    }
   }
 
   public Double getDeltaT(int plane) {
@@ -316,14 +338,26 @@ public class Configuration {
     return pos == null ? null : new Double(pos);
   }
 
-  public Double getEmissionWavelength(int channel) {
+  public Length getEmissionWavelength(int channel) {
     String wavelength = currentTable.get(EMISSION_WAVELENGTH + channel);
-    return wavelength == null ? null : new Double(wavelength);
+    String emissionUnits = currentTable.get(EMISSION_WAVELENGTH_UNITS);
+    try {
+      return wavelength == null ? null : FormatTools.getWavelength(new Double(wavelength), emissionUnits);
+    }
+    catch (NumberFormatException e) { 
+      return null;
+    } 
   }
 
-  public Double getExcitationWavelength(int channel) {
+  public Length getExcitationWavelength(int channel) {
     String wavelength = currentTable.get(EXCITATION_WAVELENGTH + channel);
-    return wavelength == null ? null : new Double(wavelength);
+    String excitationUnits = currentTable.get(EXCITATION_WAVELENGTH_UNITS);
+    try {
+      return wavelength == null ? null : FormatTools.getWavelength(new Double(wavelength), excitationUnits);
+    }
+    catch (NumberFormatException e) { 
+      return null;
+    } 
   }
 
   public String getDetector(int channel) {
@@ -491,15 +525,15 @@ public class Configuration {
 
       Length physicalX = retrieve.getPixelsPhysicalSizeX(series);
       if (physicalX != null) {
-        seriesTable.put(PHYSICAL_SIZE_X, physicalX.value(UNITS.MICROM).toString());
+        seriesTable.put(PHYSICAL_SIZE_X, physicalX.value().toString());
       }
       Length physicalY = retrieve.getPixelsPhysicalSizeY(series);
       if (physicalY != null) {
-        seriesTable.put(PHYSICAL_SIZE_Y, physicalY.value(UNITS.MICROM).toString());
+        seriesTable.put(PHYSICAL_SIZE_Y, physicalY.value().toString());
       }
       Length physicalZ = retrieve.getPixelsPhysicalSizeZ(series);
       if (physicalZ != null) {
-        seriesTable.put(PHYSICAL_SIZE_Z, physicalZ.value(UNITS.MICROM).toString());
+        seriesTable.put(PHYSICAL_SIZE_Z, physicalZ.value().toString());
       }
       Time timeIncrement = retrieve.getPixelsTimeIncrement(series);
       if (timeIncrement != null) {
@@ -533,12 +567,12 @@ public class Configuration {
 
         Length emWavelength = retrieve.getChannelEmissionWavelength(series, c);
         if (emWavelength != null) {
-          seriesTable.put(EMISSION_WAVELENGTH + c, emWavelength.value(UNITS.NM).toString());
+          seriesTable.put(EMISSION_WAVELENGTH + c, emWavelength.value().toString());
         }
         Length exWavelength =
           retrieve.getChannelExcitationWavelength(series, c);
         if (exWavelength != null) {
-          seriesTable.put(EXCITATION_WAVELENGTH + c, exWavelength.value(UNITS.NM).toString());
+          seriesTable.put(EXCITATION_WAVELENGTH + c, exWavelength.value().toString());
         }
         try {
           seriesTable.put(DETECTOR + c,
@@ -597,5 +631,4 @@ public class Configuration {
     }
     ini = newIni;
   }
-
 }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -249,7 +249,6 @@ public class Configuration {
 
   public Length getPhysicalSizeX() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_X);
-    if (physicalSize == null) return null;
     String sizeXUnits = currentTable.get(PHYSICAL_SIZE_X_UNIT);
     try {
       return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeXUnits);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -897,6 +897,31 @@ public class FormatReaderTest {
     result(testName, true);
   }
 
+  public void compareSizes(Double expected, Length real, String testName, int i) {
+      if (expectedSize == null || expectedSize == 0d) {
+        expectedSize = null;
+      }
+
+      Double doubleSize;
+      if (realSize != null) {
+        if (realSize.unit().isConvertible(UNITS.MICROM)) {
+          Number size = realSize.value(UNITS.MICROM);
+          doubleSize = size == null ? null : size.doubleValue();
+        } else {
+          doubleSize = realSize.value().doubleValue();
+        }
+      } else {
+        doubleSize = null;
+      }
+
+      if (!(expectedSize == null && doubleSize == null) &&
+        (expectedSize == null || doubleSize == null || (
+          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)))
+      {
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
+      }
+  }
+
   @Test(groups = {"all", "fast", "automated"})
   public void testPhysicalSizeX() {
     if (config == null) throw new SkipException("No config tree");
@@ -908,19 +933,8 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       Double expectedSize = config.getPhysicalSizeX();
-      if (expectedSize == null || expectedSize == 0d) {
-        expectedSize = null;
-      }
       Length realSize = retrieve.getPixelsPhysicalSizeX(i);
-      Number size = realSize == null ? null : realSize.value(UNITS.MICROM);
-      Double doubleSize = size == null ? null : size.doubleValue();
-
-      if (!(expectedSize == null && doubleSize == null) &&
-        (expectedSize == null || doubleSize == null || (
-          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)))
-      {
-        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
-      }
+      compareSizes(expectedSize, realSize, testName, i);
     }
     result(testName, true);
   }
@@ -935,19 +949,8 @@ public class FormatReaderTest {
     for (int i=0; i<reader.getSeriesCount(); i++) {
       config.setSeries(i);
       Double expectedSize = config.getPhysicalSizeY();
-      if (expectedSize == null || expectedSize == 0d) {
-        expectedSize = null;
-      }
       Length realSize = retrieve.getPixelsPhysicalSizeY(i);
-      Number size = realSize == null ? null : realSize.value(UNITS.MICROM);
-      Double doubleSize = size == null ? null : size.doubleValue();
-
-      if (!(expectedSize == null && doubleSize == null) &&
-        (expectedSize == null || doubleSize == null || (
-          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)))
-      {
-        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
-      }
+      compareSizes(expectedSize, realSize, testName, i);
     }
     result(testName, true);
   }
@@ -963,19 +966,8 @@ public class FormatReaderTest {
       config.setSeries(i);
 
       Double expectedSize = config.getPhysicalSizeZ();
-      if (expectedSize == null || expectedSize == 0d) {
-        expectedSize = null;
-      }
       Length realSize = retrieve.getPixelsPhysicalSizeZ(i);
-      Number size = realSize == null ? null : realSize.value(UNITS.MICROM);
-      Double doubleSize = size == null ? null : size.doubleValue();
-
-      if (!(expectedSize == null && doubleSize == null) &&
-        (expectedSize == null || doubleSize == null || (
-          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)))
-      {
-        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
-      }
+      compareSizes(expectedSize, realSize, testName, i);
     }
     result(testName, true);
   }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -897,34 +897,6 @@ public class FormatReaderTest {
     result(testName, true);
   }
 
-  public void compareSizes(Double expectedSize, Length realSize, String testName, int i) {
-    if (expectedSize == 0d) {
-      expectedSize = null;
-    }
-
-    Double doubleSize;
-    if (realSize != null) {
-      if (realSize.unit().isConvertible(UNITS.MICROM)) {
-        Number size = realSize.value(UNITS.MICROM);
-        doubleSize = size == null ? null : size.doubleValue();
-      } else {
-        // Handle non-convertible units like reference frame
-        doubleSize = realSize.value().doubleValue();
-      }
-    } else {
-      doubleSize = null;
-    }
-
-    if (expectedSize == null && doubleSize == null) {
-      return;
-    } else {
-      if (expectedSize == null || doubleSize == null || (
-          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)) {
-        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
-      }
-    }
-  }
-
   @Test(groups = {"all", "fast", "automated"})
   public void testPhysicalSizeX() {
     if (config == null) throw new SkipException("No config tree");
@@ -935,9 +907,14 @@ public class FormatReaderTest {
     for (int i=0; i<reader.getSeriesCount(); i++) {
       config.setSeries(i);
 
-      Double expectedSize = config.getPhysicalSizeX();
+      Length expectedSize = config.getPhysicalSizeX();
       Length realSize = retrieve.getPixelsPhysicalSizeX(i);
-      compareSizes(expectedSize, realSize, testName, i);
+      
+      if (!(expectedSize == null && realSize == null) &&
+          (expectedSize == null || !expectedSize.equals(realSize)))
+        {
+          result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
+        }
     }
     result(testName, true);
   }
@@ -951,9 +928,14 @@ public class FormatReaderTest {
 
     for (int i=0; i<reader.getSeriesCount(); i++) {
       config.setSeries(i);
-      Double expectedSize = config.getPhysicalSizeY();
+      Length expectedSize = config.getPhysicalSizeY();
       Length realSize = retrieve.getPixelsPhysicalSizeY(i);
-      compareSizes(expectedSize, realSize, testName, i);
+      
+      if (!(expectedSize == null && realSize == null) &&
+          (expectedSize == null || !expectedSize.equals(realSize)))
+        {
+          result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
+        }
     }
     result(testName, true);
   }
@@ -968,9 +950,14 @@ public class FormatReaderTest {
     for (int i=0; i<reader.getSeriesCount(); i++) {
       config.setSeries(i);
 
-      Double expectedSize = config.getPhysicalSizeZ();
+      Length expectedSize = config.getPhysicalSizeZ();
       Length realSize = retrieve.getPixelsPhysicalSizeZ(i);
-      compareSizes(expectedSize, realSize, testName, i);
+      
+      if (!(expectedSize == null && realSize == null) &&
+        (expectedSize == null || !expectedSize.equals(realSize)))
+      {
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
+      }
     }
     result(testName, true);
   }
@@ -1226,16 +1213,16 @@ public class FormatReaderTest {
 
       for (int c=0; c<config.getChannelCount(); c++) {
         Length realWavelength = retrieve.getChannelEmissionWavelength(i, c);
-        Double expectedWavelength = config.getEmissionWavelength(c);
+        Length expectedWavelength = config.getEmissionWavelength(c);
 
         if (realWavelength == null && expectedWavelength == null) {
           continue;
         }
 
-        if (realWavelength == null || expectedWavelength == null ||
-          Math.abs(expectedWavelength - realWavelength.value(UNITS.NM).doubleValue()) > Constants.EPSILON)
+        if (!(expectedWavelength == null && realWavelength == null) &&
+            (expectedWavelength == null || !expectedWavelength.equals(realWavelength)))
         {
-          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
+            result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
         }
       }
     }
@@ -1254,14 +1241,10 @@ public class FormatReaderTest {
 
       for (int c=0; c<config.getChannelCount(); c++) {
         Length realWavelength = retrieve.getChannelExcitationWavelength(i, c);
-        Double expectedWavelength = config.getExcitationWavelength(c);
+        Length expectedWavelength = config.getExcitationWavelength(c);
 
-        if (realWavelength == null && expectedWavelength == null) {
-          continue;
-        }
-
-        if (realWavelength == null || expectedWavelength == null ||
-          Math.abs(expectedWavelength - realWavelength.value(UNITS.NM).doubleValue()) > Constants.EPSILON)
+        if (!(expectedWavelength == null && realWavelength == null) &&
+            (expectedWavelength == null || !expectedWavelength.equals(realWavelength)))
         {
           result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
         }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -911,7 +911,8 @@ public class FormatReaderTest {
       Length realSize = retrieve.getPixelsPhysicalSizeX(i);
       
       if (!(expectedSize == null && realSize == null) &&
-          (expectedSize == null || !expectedSize.equals(realSize)))
+        (expectedSize == null || !expectedSize.equals(realSize)) &&  
+        !(realSize == null && expectedSize.value().doubleValue() == 0d))
       {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }
@@ -932,7 +933,8 @@ public class FormatReaderTest {
       Length realSize = retrieve.getPixelsPhysicalSizeY(i);
       
       if (!(expectedSize == null && realSize == null) &&
-          (expectedSize == null || !expectedSize.equals(realSize)))
+        (expectedSize == null || !expectedSize.equals(realSize)) &&  
+        !(realSize == null && expectedSize.value().doubleValue() == 0d))
       {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }
@@ -952,9 +954,9 @@ public class FormatReaderTest {
 
       Length expectedSize = config.getPhysicalSizeZ();
       Length realSize = retrieve.getPixelsPhysicalSizeZ(i);
-      
-      if (!(expectedSize == null && realSize == null) &&
-        (expectedSize == null || !expectedSize.equals(realSize)))
+      if ((!(expectedSize == null && realSize == null) &&
+        (expectedSize == null || !expectedSize.equals(realSize))) &&  
+        !(realSize == null && expectedSize.value().doubleValue() == 0d))
       {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -898,7 +898,7 @@ public class FormatReaderTest {
   }
 
   public void compareSizes(Double expectedSize, Length realSize, String testName, int i) {
-    if (expectedSize == null || expectedSize == 0d) {
+    if (expectedSize == 0d) {
       expectedSize = null;
     }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -912,9 +912,9 @@ public class FormatReaderTest {
       
       if (!(expectedSize == null && realSize == null) &&
           (expectedSize == null || !expectedSize.equals(realSize)))
-        {
-          result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
-        }
+      {
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
+      }
     }
     result(testName, true);
   }
@@ -933,9 +933,9 @@ public class FormatReaderTest {
       
       if (!(expectedSize == null && realSize == null) &&
           (expectedSize == null || !expectedSize.equals(realSize)))
-        {
-          result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
-        }
+      {
+        result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
+      }
     }
     result(testName, true);
   }
@@ -1222,7 +1222,7 @@ public class FormatReaderTest {
         if (!(expectedWavelength == null && realWavelength == null) &&
             (expectedWavelength == null || !expectedWavelength.equals(realWavelength)))
         {
-            result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
+          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
         }
       }
     }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -898,28 +898,31 @@ public class FormatReaderTest {
   }
 
   public void compareSizes(Double expectedSize, Length realSize, String testName, int i) {
-      if (expectedSize == null || expectedSize == 0d) {
-        expectedSize = null;
-      }
+    if (expectedSize == null || expectedSize == 0d) {
+      expectedSize = null;
+    }
 
-      Double doubleSize;
-      if (realSize != null) {
-        if (realSize.unit().isConvertible(UNITS.MICROM)) {
-          Number size = realSize.value(UNITS.MICROM);
-          doubleSize = size == null ? null : size.doubleValue();
-        } else {
-          doubleSize = realSize.value().doubleValue();
-        }
+    Double doubleSize;
+    if (realSize != null) {
+      if (realSize.unit().isConvertible(UNITS.MICROM)) {
+        Number size = realSize.value(UNITS.MICROM);
+        doubleSize = size == null ? null : size.doubleValue();
       } else {
-        doubleSize = null;
+        // Handle non-convertible units like reference frame
+        doubleSize = realSize.value().doubleValue();
       }
+    } else {
+      doubleSize = null;
+    }
 
-      if (!(expectedSize == null && doubleSize == null) &&
-        (expectedSize == null || doubleSize == null || (
-          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)))
-      {
+    if (expectedSize == null && doubleSize == null) {
+      return;
+    } else {
+      if (expectedSize == null || doubleSize == null || (
+          Math.abs(doubleSize - expectedSize) > Constants.EPSILON)) {
         result(testName, false, "Series " + i + " (expected " + expectedSize + ", actual " + realSize + ")");
       }
+    }
   }
 
   @Test(groups = {"all", "fast", "automated"})

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -897,7 +897,7 @@ public class FormatReaderTest {
     result(testName, true);
   }
 
-  public void compareSizes(Double expected, Length real, String testName, int i) {
+  public void compareSizes(Double expectedSize, Length realSize, String testName, int i) {
       if (expectedSize == null || expectedSize == 0d) {
         expectedSize = null;
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1224,7 +1224,7 @@ public class FormatReaderTest {
         if (!(expectedWavelength == null && realWavelength == null) &&
             (expectedWavelength == null || !expectedWavelength.equals(realWavelength)))
         {
-          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
+          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength + ")");
         }
       }
     }
@@ -1248,7 +1248,7 @@ public class FormatReaderTest {
         if (!(expectedWavelength == null && realWavelength == null) &&
             (expectedWavelength == null || !expectedWavelength.equals(realWavelength)))
         {
-          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength.value(UNITS.NM).doubleValue() + ")");
+          result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength + ")");
         }
       }
     }


### PR DESCRIPTION
Adding support for the following configuration options:
- TimeIncrementUnits
- ExposureTimeUnits
- PhysicalSizeZUnits
- PhysicalSizeYUnits
- PhysicalSizeXUnits
- EmissionWavelengthUnits
- ExcitationWavelengthUnits

When read the string units types will be converted into an appropriate
Length or Time object. If not present the default units will be used instead (mircometres for
sizes, nm for wavelengths and seconds for time).

FormatTestReader now compares Length objects rather than double values.

Extra utility methods added to FormatTools to easily convert from String to appropriate time and wavelength values.