### PR TITLE
C++: Path introspection on Windows, and support for relocatable installation

### DIFF
--- a/cpp/cmake/Options.cmake
+++ b/cpp/cmake/Options.cmake
@@ -73,16 +73,3 @@ if(SPHINX_DEFAULT AND XELATEX AND MAKEINDEX)
   set(SPHINX_PDF_DEFAULT ON)
 endif()
 option(sphinx-pdf "Enable sphinx PDF documentation" ${SPHINX_PDF_DEFAULT})
-
-set(SUPERBUILD_OPTIONS
-    "-Dbioformats-superbuild:BOOL=OFF"
-    "-Dcxxstd-autodetect:BOOL=${cxxstd-autodetect}"
-    "-Dextra-warnings:BOOL=${extra-warnings}"
-    "-Dfatal-warnings:BOOL=${fatal-warnings}"
-    "-Dtest:BOOL=${test}"
-    "-Dextended-tests:BOOL=${extended-tests}"
-    "-Dembedded-gtest:BOOL=${embedded-gtest}"
-    "-Dqtgui:BOOL=${qtgui}"
-    "-Ddoxygen:BOOL=${doxygen}"
-    "-Dsphinx:BOOL=${sphinx}"
-    "-Dsphinx-pdf:BOOL=${sphinx-pdf}")

--- a/cpp/cmake/Options.cmake
+++ b/cpp/cmake/Options.cmake
@@ -16,6 +16,14 @@ option(test "Enable unit tests (requires gtest)" ON)
 option(extended-tests "Enable extended tests (more comprehensive, longer run time)" ON)
 option(embedded-gtest "Use embedded gtest rather than an external build" OFF)
 
+# The installation is relocatable; this affects path lookups (if OFF,
+# paths are assumed to be their configured absolute install location;
+# paths will still be introspected as a fallback); if ON paths will be
+# introspected if possible.  In all cases the paths may be overridden
+# by the environment.
+option(relocatable-install OFF)
+set(OME_RELOCATABLE_INSTALL "Install tree will be relocatable" ${relocatable-install})
+
 # Doxygen documentation
 find_package(Doxygen)
 set(DOXYGEN_DEFAULT OFF)

--- a/cpp/lib/ome/common/module.cpp
+++ b/cpp/lib/ome/common/module.cpp
@@ -225,6 +225,7 @@ namespace ome
             }
         }
 
+#ifndef OME_RELOCATABLE_INSTALL
       // Full prefix is available only when configured explicitly.
       if (strlen(INSTALL_PREFIX) > 0)
         {
@@ -242,6 +243,7 @@ namespace ome
             }
         }
       else
+#endif // ! OME_RELOCATABLE_INSTALL
         {
 #ifdef OME_HAVE_DLADDR
           // Introspect root with dladdr(3) + relative component

--- a/cpp/lib/ome/common/module.cpp
+++ b/cpp/lib/ome/common/module.cpp
@@ -58,6 +58,10 @@ namespace fs = boost::filesystem;
 #include <stdio.h>
 #endif // OME_HAVE_DLADDR
 
+#ifdef _MSC_VER
+# include <windows.h>
+#endif
+
 namespace
 {
 
@@ -68,9 +72,59 @@ namespace
   void
   find_module(void)
   {
-    dladdr(reinterpret_cast<void *>(find_module), &this_module);
+    if(!dladdr(reinterpret_cast<void *>(find_module), &this_module))
+      {
+        this_module.dli_fname = 0;
+      }
   }
-#endif // OME_HAVE_DLADDR
+
+  fs::path
+  module_path()
+  {
+    if (this_module.dli_fname)
+      return canonical(fs::path(this_module.dli_fname));
+    return fs::path();
+  }
+#elif _MSC_VER
+  HMODULE
+  find_module(void)
+  {
+    static bool found_module = false;
+    static HMODULE this_module;
+
+    if (!found_module)
+      {
+        if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                reinterpret_cast<LPCWSTR>(&find_module),
+                                &this_module))
+          {
+            this_module = 0;
+          }
+        found_module = true;
+      }
+    return this_module;
+  }
+
+  fs::path
+  module_path()
+  {
+    HMODULE this_module = find_module();
+    if (this_module)
+      {
+        WCHAR win_wide_path[MAX_PATH];
+        GetModuleFileNameW(this_module, win_wide_path, sizeof(win_wide_path));
+        return fs::path(win_wide_path);
+      }
+    return fs::path();
+  }
+#else // No introspection available
+  fs::path
+  module_path()
+  {
+    return fs::path();
+  }
+#endif // _MSC_VER
 
   bool
   validate_root_path(const fs::path& path)
@@ -145,7 +199,6 @@ namespace
   }
 }
 
-
 namespace ome
 {
   namespace common
@@ -160,7 +213,7 @@ namespace ome
      *
      * CMAKE_INSTALL_PREFIX=$install_path
      * - will fail unless "make install" has run and the install tree
-     *   is present.
+     *   is present and relocatable-install is OFF.
      * - will work in the install tree and build tree if "make"
      *   install has run.
      * - BIOFORMATS_HOME can override the hardcoded install prefix,
@@ -170,12 +223,15 @@ namespace ome
      * - used for prepackaged zips
      * - will fail in the build tree since there is no valid install
      * - will work in the install tree since it will introspect the
-     *   correct path
-     * - BIOFORMATS_HOME can override the hardcoded install prefix,
+     *   correct path if relocatable-install is OFF or ON and dladdr
+     *   or GetModuleFileNameW are available (required to determine
+     *   the library path)
+     * - BIOFORMATS_HOME can override the autodetected install prefix,
      *   but only if the new path contains an install tree.
      *
      * Testing:
      * - With and without CMAKE_INSTALL_PREFIX set [default is /usr/local]
+     * - With relocatable-install set to OFF and ON
      * - In the install and build trees
      * - With and without BIOFORMATS_HOME
      * - With and without BIOFORMATS_HOME set to a valid path
@@ -245,34 +301,38 @@ namespace ome
       else
 #endif // ! OME_RELOCATABLE_INSTALL
         {
-#ifdef OME_HAVE_DLADDR
-          // Introspect root with dladdr(3) + relative component
-          fs::path module(canonical(fs::path(this_module.dli_fname)));
-          fs::path moduledir(module.parent_path());
-
-          bool match = true;
-          fs::path libdir(INSTALL_LIBDIR);
-
-          while(!libdir.empty())
+          fs::path module(module_path());
+          if (module.has_parent_path())
             {
-              if (libdir.filename() == moduledir.filename())
+              fs::path moduledir(module.parent_path());
+              bool match = true;
+
+#ifdef _MSC_VER
+              fs::path libdir(INSTALL_BINDIR);
+#else
+              fs::path libdir(INSTALL_LIBDIR);
+#endif
+
+              while(!libdir.empty())
                 {
-                  libdir = libdir.parent_path();
-                  moduledir = moduledir.parent_path();
+                  if (libdir.filename() == moduledir.filename())
+                    {
+                      libdir = libdir.parent_path();
+                      moduledir = moduledir.parent_path();
+                    }
+                  else
+                    {
+                      match = false;
+                      break;
+                    }
                 }
-              else
+              if (match && validate_path(moduledir))
                 {
-                  match = false;
-                  break;
+                  moduledir /= ipath->second.relpath;
+                  if (validate_path(moduledir))
+                    return ome::common::canonical(moduledir);
                 }
             }
-          if (match && validate_path(moduledir))
-            {
-              moduledir /= ipath->second.relpath;
-              if (validate_path(moduledir))
-                return ome::common::canonical(moduledir);
-            }
-#endif // OME_HAVE_DLADDR
         }
       boost::format fmt("Could not determine Bio-Formats runtime path for “%1%” directory");
       fmt % dtype;

--- a/cpp/lib/ome/internal/config.h.in
+++ b/cpp/lib/ome/internal/config.h.in
@@ -97,6 +97,8 @@
 
 #cmakedefine OME_HAVE_DLADDR 1
 
+#cmakedefine OME_RELOCATABLE_INSTALL 1
+
 #cmakedefine TIFF_HAVE_BIGTIFF 1
 #cmakedefine TIFF_HAVE_FIELD 1
 #cmakedefine TIFF_HAVE_FIELDINFO 1

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -756,6 +756,15 @@ extra-warnings=(ON|OFF)
 fatal-warnings=(ON|OFF)
   Make compiler warnings into fatal errors.  This is disabled by
   default.
+relocatable-install=(ON|OFF)
+  Make the installed libraries, programs and datafiles relocatable;
+  this means that they may be moved from their installation prefix to
+  another location without breaking them.  If OFF, the installation
+  prefix is assumed to contain the libraries and datafiles.  If ON, no
+  assumptions are made, and a slower fallback is used to introspect
+  the location.  In all cases the location may be set in the
+  environment to override the compiled-in defaults.  This is OFF by
+  default for a regular build, and ON by default for a superbuild.
 sphinx=(ON|OFF)
   Build manual pages and HTML documentation with Sphinx.  Enabled by
   default if Sphinx is autodetected.


### PR DESCRIPTION
- Add `relocatable-install` option (see https://github.com/ome/ome-cmake-superbuild/pull/10)
- Support path introspection on Windows, to match the existing Unix support
- Drop unused superbuild options (see again https://github.com/ome/ome-cmake-superbuild/pull/10)

----------

Testing: Covered by unit tests on Unix.  On Windows, apply this patch:

```
diff --git a/cpp/lib/ome/common/module.cpp b/cpp/lib/ome/common/module.cpp
index 0cc5580..42ae249 100644
--- a/cpp/lib/ome/common/module.cpp
+++ b/cpp/lib/ome/common/module.cpp
@@ -47,6 +47,7 @@
 #include <cstring>
 #include <map>
 #include <stdexcept>
+#include <iostream>
 
 namespace fs = boost::filesystem;
 
@@ -306,6 +307,7 @@ namespace ome
             {
               fs::path moduledir(module.parent_path());
               bool match = true;
+              std::cerr << "MODULEDIR: " << moduledir << '\n';
 
 #ifdef _MSC_VER
               fs::path libdir(INSTALL_BINDIR);
```

Then build and run:

```
<buildpath>>bf-test.bat cpp\libexec\info\Debug\info.exe --help
MODULEDIR: "<buildpath>\cpp\libexec\info\Debug"
E: Could not determine Bio-Formats runtime path for "doc" directory```

This is telling you that the runtime path was successfully introspected.  Since ome-common is static, it's giving you the path to the executable.  When made into a DLL, this will then work correctly.