### PR TITLE
C++: Path introspection on Windows, and support for relocatable installation (5.1)

### DIFF
--- a/components/autogen/src/FormatPageAutogen.java
+++ b/components/autogen/src/FormatPageAutogen.java
@@ -115,6 +115,7 @@ public class FormatPageAutogen {
       context.put("utilityRating", table.get("utilityRating"));
       context.put("reader", table.get("reader"));
       context.put("writer", table.get("writer"));
+      context.put("mif", table.get("mif"));
       context.put("notes", table.get("notes"));
       context.put("privateSpecification", table.get("privateSpecification"));
       context.put("readerextlink",

--- a/components/autogen/src/doc/FormatTable.vm
+++ b/components/autogen/src/doc/FormatTable.vm
@@ -7,12 +7,12 @@ Supported Formats
 
     You can sort this table by clicking on any of the headings.
 
-.. tabularcolumns:: |p{3cm}|p{2cm}|c|c|c|c|c|c|c|
+.. tabularcolumns:: |p{3cm}|p{2cm}|c|c|c|c|c|c|c|c|
 
 .. list-table::
    :class: sortable
    :header-rows: 1
-   :widths: 30, 20, 2, 2, 2, 2, 2, 2, 2
+   :widths: 30, 20, 2, 2, 2, 2, 2, 2, 2, 2
 
    *
      - Format
@@ -24,6 +24,7 @@ Supported Formats
      - .. image:: images/header-utility.png
      - .. image:: images/header-export.png
      - BSD
+     - Multiple Images
 
 #foreach ($format in $formats)
 #set ($pagename = $format.get("pagename"))
@@ -43,6 +44,11 @@ Supported Formats
   #set ($export = "no")
 #end
 #set ($bsd = $format.get("bsd"))
+#if ($format.get("mif"))
+  #set ($mif = "yes")
+#else
+  #set ($mif = "no")
+#end
    * - :doc:`$pagename`
      - $extensions
      - |$pixels|
@@ -52,6 +58,7 @@ Supported Formats
      - |$utility|
      - |$export|
      - |$bsd|
+     - |$mif|
 #end
 
 Bio-Formats currently supports **$count** formats
@@ -110,6 +117,10 @@ Bio-Formats currently supports **$count** formats
     BSD
         This indicates whether format is BSD-licensed.  By default,
         format readers and writers are GPL-licensed.
+
+    Multiple Images
+        This indicates whether the format can store multiple Images (in OME-XML terminology)
+        or series (in Bio-Formats API terminology).
 
 .. toctree::
     :maxdepth: 1

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -13,6 +13,7 @@ opennessRating = Fair
 presenceRating = Very good
 utilityRating = Fair
 reader = SlidebookReader, SlideBook6Reader
+mif = true
 notes = We strongly encourage users to export their .sld files to OME-TIFF \n
 using the SlideBook software.  Bio-Formats is not likely to support the full \n
 range of metadata that is included in .sld files, and so exporting to \n
@@ -92,6 +93,7 @@ opennessRating = Good
 presenceRating = Poor
 utilityRating = Fair
 reader = FlowSightReader
+mif = true
 
 [Amersham Biosciences Gel]
 extensions = .gel
@@ -151,6 +153,7 @@ presenceRating = Fair
 utilityRating = Good
 privateSpecification = true
 reader = FluoviewReader
+mif = true
 notes = With a few minor exceptions, the ABD-TIFF format is identical to the \n
 Fluoview TIFF format.
 
@@ -183,6 +186,7 @@ opennessRating = Very good
 presenceRating = Good
 utilityRating = Good
 reader = AFIReader
+mif = true
 notes = .. seealso:: \n
   `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
 
@@ -201,6 +205,7 @@ presenceRating = Good
 utilityRating = Good
 privateSpecification = true
 reader = SVSReader
+mif = true
 notes = .. seealso:: \n
   `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
 
@@ -217,6 +222,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Fair
 reader = CellWorxReader
+mif = true
 
 [AVI (Audio Video Interleave)]
 pagename = avi
@@ -276,6 +282,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Good
 reader = BDReader
+mif = true
 
 [Becker & Hickl SPCImage]
 extensions = .sdt
@@ -293,6 +300,7 @@ presenceRating = Poor
 utilityRating = Fair
 privateSpecification = true
 reader = SDTReader
+mif = true
 
 [Bio-Rad Gel]
 extensions = .1sc
@@ -363,6 +371,7 @@ opennessRating = Very good
 presenceRating = Fair
 utilityRating = Fair
 reader = ImarisHDFReader, ImarisTiffReader, ImarisReader
+mif = true
 notes = - There are three distinct Imaris formats: \n
     #. the old binary format (introduced in Imaris version 2.7) \n
     #. Imaris 3, a TIFF variant (introduced in Imaris version 3.0) \n
@@ -380,6 +389,7 @@ opennessRating = Fair
 presenceRating = Good
 utilityRating = Fair
 reader = BrukerReader
+mif = true
 
 [Burleigh]
 extensions = .img
@@ -422,6 +432,7 @@ opennessRating = Outstanding
 presenceRating = Fair
 utilityRating = Good
 reader = MicromanagerReader
+mif = true
 
 [CellH5]
 extensions = .ch5
@@ -436,6 +447,7 @@ presenceRating = Fair
 utilityRating = Very good
 reader = CellH5Reader
 writer = CellH5Writer
+mif = true
 
 [Cellomics]
 extensions = .c01
@@ -450,6 +462,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Poor
 reader = CellomicsReader
+mif = true
 
 [cellSens VSI]
 extensions = .vsi
@@ -463,6 +476,7 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = CellSensReader
+mif = true
 
 [CellVoyager]
 extensions = .xml, .tif
@@ -475,6 +489,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Good
 reader = CellVoyagerReader
+mif = true
 
 [DeltaVision]
 extensions = .dv, .r3d
@@ -489,6 +504,7 @@ opennessRating = Good
 presenceRating = Good
 utilityRating = Good
 reader = DeltavisionReader
+mif = true
 privateSpecification = true
 notes = - The Deltavision format is based on the Medical Research Council (MRC) file format. \n
 - Commercial applications that support DeltaVision include: \n
@@ -515,6 +531,7 @@ opennessRating = Very good
 presenceRating = Good
 utilityRating = Fair
 reader = DicomReader
+mif = true
 notes = * DICOM stands for "Digital Imaging and Communication in Medicine". \n
 * Bio-Formats supports both compressed and uncompressed DICOM files. \n
 \n
@@ -569,6 +586,7 @@ opennessRating = Poor
 presenceRating = Poor
 utilityRating = Poor
 reader = FlexReader
+mif = true
 notes = The LuraWave LWF decoder library (i.e. lwf\_jsdk2.6.jar) with \n
 license code is required to decode wavelet-compressed Flex files. \n
 \n
@@ -683,6 +701,7 @@ opennessRating = Poor
 presenceRating = Fair
 utilityRating = Fair
 reader = NAFReader
+mif = true
 
 [Hamamatsu HIS]
 extensions = .his
@@ -698,9 +717,10 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = HISReader
+mif = true
 
 [Hamamatsu ndpi]
-extensions = .ndpi
+extensions = .ndpi, .ndpis
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
 software = `NDP.view <http://www.olympusamerica.com/seg_section/seg_vm_downloads.asp>`_
@@ -712,7 +732,8 @@ metadataRating = Good
 opennessRating = Good
 presenceRating = Fair
 utilityRating = Fair
-reader = NDPIReader
+reader = NDPIReader, NDPISReader
+mif = true
 
 [Hamamatsu VMS]
 extensions = .vms
@@ -729,6 +750,7 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = HamamatsuVMSReader
+mif = true
 
 [Hitachi S-4800]
 extensions = .txt, .tif, .bmp, .jpg
@@ -796,6 +818,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Good
 reader = ImaconReader
+mif = true
 
 [ImagePro Sequence]
 extensions = .seq
@@ -882,6 +905,7 @@ presenceRating = Good
 utilityRating = Fair
 privateSpecification = true
 reader = OpenlabReader
+mif = true
 notes = .. seealso:: \n
   `Openlab software review <http://www.improvision.com/products/openlab/>`_
 
@@ -931,6 +955,7 @@ opennessRating = Very good
 presenceRating = Poor
 utilityRating = Fair
 reader = OBFReader
+mif = true
 
 [InCell 1000]
 extensions = .xdce, .tif
@@ -945,6 +970,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Good
 reader = InCellReader
+mif = true
 
 [InCell 3000]
 extensions = .frm
@@ -981,6 +1007,7 @@ opennessRating = Good
 presenceRating = Poor
 utilityRating = Fair
 reader = InveonReader
+mif = true
 
 [IVision]
 pagename = iplab-mac
@@ -1052,6 +1079,7 @@ presenceRating = Good
 utilityRating = Poor
 reader = JPEG2000Reader
 writer = JPEG2000Writer
+mif = true
 notes = Bio-Formats uses the `JAI Image I/O Tools <https://java.net/projects/jai-imageio>`_ library to read JP2 files. \n
 JPEG stands for "Joint Photographic Experts Group".
 
@@ -1090,6 +1118,7 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = JPKReader
+mif = true
 
 [JPX]
 extensions = .jpx
@@ -1102,6 +1131,7 @@ opennessRating = Outstanding
 presenceRating = Good
 utilityRating = Fair
 reader = JPXReader
+mif = true
 
 [Khoros VIFF (Visualization Image File Format) Bitmap]
 pagename = khoros-viff-bitmap
@@ -1146,6 +1176,7 @@ presenceRating = Fair
 utilityRating = Good
 privateSpecification = true
 reader = LiFlimReader
+mif = true
 
 [Leica LAS AF LIF (Leica Image File Format)]
 pagename = leica-lif
@@ -1165,6 +1196,7 @@ presenceRating = Good
 utilityRating = Very good
 privateSpecification = true
 reader = LIFReader
+mif = true
 notes = LAS stands for "Leica Application Suite". \n
 AF stands for "Advanced Fluorescence". \n
 \n
@@ -1185,6 +1217,7 @@ opennessRating = Poor
 presenceRating = Poor
 utilityRating = Fair
 reader = ImspectorReader
+mif = true
 
 [Leica LCS LEI]
 extensions = .lei, .tif
@@ -1201,6 +1234,7 @@ presenceRating = Very good
 utilityRating = Very good
 privateSpecification = true
 reader = LeicaReader
+mif = true
 notes = LCS stands for "Leica Confocal Software". \n
 LEI presumably stands for "Leica Experimental Information". \n
 \n
@@ -1224,6 +1258,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Good
 reader = LeicaSCNReader
+mif = true
 
 [LEO]
 extensions = .sxm
@@ -1253,6 +1288,7 @@ opennessRating = Good
 presenceRating = Good
 utilityRating = Good
 reader = L2DReader
+mif = true
 notes = L2D datasets cannot be imported into OME using server-side import. \n
 They can, however, be imported from ImageJ, or using the omeul utility.
 
@@ -1287,6 +1323,7 @@ opennessRating = Very good
 presenceRating = Fair
 utilityRating = Good
 reader = MetamorphTiffReader
+mif = true
 
 [MetaMorph Stack (STK)]
 extensions = .stk, .nd
@@ -1323,6 +1360,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Poor
 reader = MIASReader
+mif = true
 
 [MINC MRI]
 extensions = .mnc
@@ -1365,6 +1403,7 @@ opennessRating = Outstanding
 presenceRating = Fair
 utilityRating = Poor
 reader = MNGReader
+mif = true
 notes = .. seealso:: \n
   `MNG homepage <http://www.libpng.org/pub/mng/>`_  \n
   `MNG specification <http://www.libpng.org/pub/mng/spec>`_
@@ -1475,7 +1514,8 @@ metadataRating = Very good
 opennessRating = Fair
 presenceRating = Very good
 utilityRating = Very good
-reader = NativeND2Reader
+reader = NativeND2Reader, LegacyND2Reader
+mif = true
 notes = There are two distinct versions of ND2: an old version, which uses \n
 JPEG-2000 compression, and a new version which is either uncompressed or \n
 Zip-compressed.  We are not aware of the version number or release date \n
@@ -1520,6 +1560,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = APLReader
+mif = true
 
 [Olympus FluoView FV1000]
 extensions = .oib, .oif
@@ -1540,6 +1581,7 @@ presenceRating = Good
 utilityRating = Very good
 privateSpecification = true
 reader = FV1000Reader
+mif = true
 notes = Bio-Formats uses a modified version of the `Apache Jakarta POI \n
 <http://jakarta.apache.org/poi/>`_ library to read OIB files. \n
 OIF stands for "Original Imaging Format". \n
@@ -1571,6 +1613,7 @@ presenceRating = Good
 utilityRating = Good
 privateSpecification = true
 reader = FluoviewReader
+mif = true
 notes = Commercial applications that support this format include: \n
 \n
 * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
@@ -1588,6 +1631,7 @@ opennessRating = Good
 presenceRating = Poor
 utilityRating = Fair
 reader = ScanrReader
+mif = true
 
 [Olympus SIS TIFF]
 extensions = .tiff
@@ -1617,6 +1661,7 @@ presenceRating = Fair
 utilityRating = Outstanding
 reader = OMETiffReader
 writer = OMETiffWriter
+mif = true
 notes = Bio-Formats can save image stacks as OME-TIFF. \n
 \n
 Commercial applications that support OME-TIFF include: \n
@@ -1643,6 +1688,7 @@ presenceRating = Fair
 utilityRating = Outstanding
 reader = OMEXMLReader
 writer = OMEXMLWriter
+mif = true
 notes = Bio-Formats uses the :model_doc:`OME-XML Java library <ome-xml/java-library.html>` \n
 to read OME-XML files. \n
 \n
@@ -1730,6 +1776,7 @@ opennessRating = Poor
 presenceRating = Poor
 utilityRating = Fair
 reader = IM3Reader
+mif = true
 
 [PerkinElmer Operetta]
 extensions = .tiff, .xml
@@ -1744,6 +1791,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Good
 reader = OperettaReader
+mif = true
 
 [PerkinElmer UltraView]
 indexExtensions = .tif, .2, .3, .4
@@ -1795,6 +1843,7 @@ opennessRating = Good
 presenceRating = Good
 utilityRating = Good
 reader = PhotoshopTiffReader
+mif = true
 
 [PICT (Macintosh Picture)]
 extensions = .pict
@@ -1848,6 +1897,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Good
 reader = PrairieReader
+mif = true
 
 [Quesant]
 extensions = .afm
@@ -2054,6 +2104,7 @@ presenceRating = Outstanding
 utilityRating = Fair
 reader = TiffReader
 writer = TiffWriter
+mif = true
 notes = Bio-Formats can also read BigTIFF files (TIFF files larger than 4 GB). \n
 Bio-Formats can save image stacks as TIFF or BigTIFF. \n
 \n
@@ -2073,6 +2124,7 @@ opennessRating = Poor
 presenceRating = Poor
 utilityRating = Fair
 reader = TillVisionReader
+mif = true
 
 [Topometrix]
 extensions = .tfr, .ffr, .zfr, .zfp, .2fl
@@ -2101,6 +2153,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Fair
 reader = TrestleReader
+mif = true
 
 [UBM]
 extensions = .pr3
@@ -2182,6 +2235,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Good
 reader = VisitechReader
+mif = true
 
 [Volocity Library Clipping]
 extensions = .acff
@@ -2212,6 +2266,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = VolocityReader
+mif = true
 notes = .mvd2 files are `Metakit database files <http://equi4.com/metakit/>`_.
 
 [WA-TOP]
@@ -2291,6 +2346,7 @@ opennessRating = Good
 presenceRating = Fair
 utilityRating = Fair
 reader = ZeissTIFFReader
+mif = true
 
 [Zeiss AxioVision ZVI (Zeiss Vision Image)]
 pagename = zeiss-axiovision-zvi
@@ -2339,6 +2395,7 @@ presenceRating = Fair
 utilityRating = Good
 privateSpecification = true
 reader = ZeissCZIReader
+mif = true
 
 [Zeiss LSM (Laser Scanning Microscope) 510/710]
 pagename = zeiss-lsm
@@ -2360,6 +2417,7 @@ presenceRating = Very good
 utilityRating = Good
 privateSpecification = true
 reader = ZeissLSMReader
+mif = true
 notes = Bio-Formats uses the `MDB Tools Java port <http://mdbtools.sourceforge.net/>`_ \n
 \n
 Commercial applications that support this format include: \n

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -280,6 +280,22 @@ public class OMETiffReader extends FormatReader {
     return info[series][lastPlane].reader.get16BitLookupTable();
   }
 
+  /* @see loci.formats.IFormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    super.reopenFile();
+    for (int s=0; s<info.length; s++) {
+      for (int q=0; q<info[s].length; q++) {
+        // only reopen readers that had previously been initialized
+        if (info[s][q] != null && info[s][q].reader != null &&
+          info[s][q].reader.getCurrentFile() != null)
+        {
+          info[s][q].reader.reopenFile();
+        }
+      }
+    }
+  }
+
   /*
    * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
    */

--- a/cpp/cmake/Options.cmake
+++ b/cpp/cmake/Options.cmake
@@ -73,16 +73,3 @@ if(SPHINX_DEFAULT AND XELATEX AND MAKEINDEX)
   set(SPHINX_PDF_DEFAULT ON)
 endif()
 option(sphinx-pdf "Enable sphinx PDF documentation" ${SPHINX_PDF_DEFAULT})
-
-set(SUPERBUILD_OPTIONS
-    "-Dbioformats-superbuild:BOOL=OFF"
-    "-Dcxxstd-autodetect:BOOL=${cxxstd-autodetect}"
-    "-Dextra-warnings:BOOL=${extra-warnings}"
-    "-Dfatal-warnings:BOOL=${fatal-warnings}"
-    "-Dtest:BOOL=${test}"
-    "-Dextended-tests:BOOL=${extended-tests}"
-    "-Dembedded-gtest:BOOL=${embedded-gtest}"
-    "-Dqtgui:BOOL=${qtgui}"
-    "-Ddoxygen:BOOL=${doxygen}"
-    "-Dsphinx:BOOL=${sphinx}"
-    "-Dsphinx-pdf:BOOL=${sphinx-pdf}")

--- a/cpp/cmake/Options.cmake
+++ b/cpp/cmake/Options.cmake
@@ -16,6 +16,14 @@ option(test "Enable unit tests (requires gtest)" ON)
 option(extended-tests "Enable extended tests (more comprehensive, longer run time)" ON)
 option(embedded-gtest "Use embedded gtest rather than an external build" OFF)
 
+# The installation is relocatable; this affects path lookups (if OFF,
+# paths are assumed to be their configured absolute install location;
+# paths will still be introspected as a fallback); if ON paths will be
+# introspected if possible.  In all cases the paths may be overridden
+# by the environment.
+option(relocatable-install OFF)
+set(OME_RELOCATABLE_INSTALL "Install tree will be relocatable" ${relocatable-install})
+
 # Doxygen documentation
 find_package(Doxygen)
 set(DOXYGEN_DEFAULT OFF)

--- a/cpp/lib/ome/common/module.cpp
+++ b/cpp/lib/ome/common/module.cpp
@@ -225,6 +225,7 @@ namespace ome
             }
         }
 
+#ifndef OME_RELOCATABLE_INSTALL
       // Full prefix is available only when configured explicitly.
       if (strlen(INSTALL_PREFIX) > 0)
         {
@@ -242,6 +243,7 @@ namespace ome
             }
         }
       else
+#endif // ! OME_RELOCATABLE_INSTALL
         {
 #ifdef OME_HAVE_DLADDR
           // Introspect root with dladdr(3) + relative component

--- a/cpp/lib/ome/common/module.cpp
+++ b/cpp/lib/ome/common/module.cpp
@@ -58,6 +58,10 @@ namespace fs = boost::filesystem;
 #include <stdio.h>
 #endif // OME_HAVE_DLADDR
 
+#ifdef _MSC_VER
+# include <windows.h>
+#endif
+
 namespace
 {
 
@@ -68,9 +72,59 @@ namespace
   void
   find_module(void)
   {
-    dladdr(reinterpret_cast<void *>(find_module), &this_module);
+    if(!dladdr(reinterpret_cast<void *>(find_module), &this_module))
+      {
+        this_module.dli_fname = 0;
+      }
   }
-#endif // OME_HAVE_DLADDR
+
+  fs::path
+  module_path()
+  {
+    if (this_module.dli_fname)
+      return canonical(fs::path(this_module.dli_fname));
+    return fs::path();
+  }
+#elif _MSC_VER
+  HMODULE
+  find_module(void)
+  {
+    static bool found_module = false;
+    static HMODULE this_module;
+
+    if (!found_module)
+      {
+        if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                reinterpret_cast<LPCWSTR>(&find_module),
+                                &this_module))
+          {
+            this_module = 0;
+          }
+        found_module = true;
+      }
+    return this_module;
+  }
+
+  fs::path
+  module_path()
+  {
+    HMODULE this_module = find_module();
+    if (this_module)
+      {
+        WCHAR win_wide_path[MAX_PATH];
+        GetModuleFileNameW(this_module, win_wide_path, sizeof(win_wide_path));
+        return fs::path(win_wide_path);
+      }
+    return fs::path();
+  }
+#else // No introspection available
+  fs::path
+  module_path()
+  {
+    return fs::path();
+  }
+#endif // _MSC_VER
 
   bool
   validate_root_path(const fs::path& path)
@@ -145,7 +199,6 @@ namespace
   }
 }
 
-
 namespace ome
 {
   namespace common
@@ -160,7 +213,7 @@ namespace ome
      *
      * CMAKE_INSTALL_PREFIX=$install_path
      * - will fail unless "make install" has run and the install tree
-     *   is present.
+     *   is present and relocatable-install is OFF.
      * - will work in the install tree and build tree if "make"
      *   install has run.
      * - BIOFORMATS_HOME can override the hardcoded install prefix,
@@ -170,12 +223,15 @@ namespace ome
      * - used for prepackaged zips
      * - will fail in the build tree since there is no valid install
      * - will work in the install tree since it will introspect the
-     *   correct path
-     * - BIOFORMATS_HOME can override the hardcoded install prefix,
+     *   correct path if relocatable-install is OFF or ON and dladdr
+     *   or GetModuleFileNameW are available (required to determine
+     *   the library path)
+     * - BIOFORMATS_HOME can override the autodetected install prefix,
      *   but only if the new path contains an install tree.
      *
      * Testing:
      * - With and without CMAKE_INSTALL_PREFIX set [default is /usr/local]
+     * - With relocatable-install set to OFF and ON
      * - In the install and build trees
      * - With and without BIOFORMATS_HOME
      * - With and without BIOFORMATS_HOME set to a valid path
@@ -245,34 +301,38 @@ namespace ome
       else
 #endif // ! OME_RELOCATABLE_INSTALL
         {
-#ifdef OME_HAVE_DLADDR
-          // Introspect root with dladdr(3) + relative component
-          fs::path module(canonical(fs::path(this_module.dli_fname)));
-          fs::path moduledir(module.parent_path());
-
-          bool match = true;
-          fs::path libdir(INSTALL_LIBDIR);
-
-          while(!libdir.empty())
+          fs::path module(module_path());
+          if (module.has_parent_path())
             {
-              if (libdir.filename() == moduledir.filename())
+              fs::path moduledir(module.parent_path());
+              bool match = true;
+
+#ifdef _MSC_VER
+              fs::path libdir(INSTALL_BINDIR);
+#else
+              fs::path libdir(INSTALL_LIBDIR);
+#endif
+
+              while(!libdir.empty())
                 {
-                  libdir = libdir.parent_path();
-                  moduledir = moduledir.parent_path();
+                  if (libdir.filename() == moduledir.filename())
+                    {
+                      libdir = libdir.parent_path();
+                      moduledir = moduledir.parent_path();
+                    }
+                  else
+                    {
+                      match = false;
+                      break;
+                    }
                 }
-              else
+              if (match && validate_path(moduledir))
                 {
-                  match = false;
-                  break;
+                  moduledir /= ipath->second.relpath;
+                  if (validate_path(moduledir))
+                    return ome::common::canonical(moduledir);
                 }
             }
-          if (match && validate_path(moduledir))
-            {
-              moduledir /= ipath->second.relpath;
-              if (validate_path(moduledir))
-                return ome::common::canonical(moduledir);
-            }
-#endif // OME_HAVE_DLADDR
         }
       boost::format fmt("Could not determine Bio-Formats runtime path for “%1%” directory");
       fmt % dtype;

--- a/cpp/lib/ome/internal/config.h.in
+++ b/cpp/lib/ome/internal/config.h.in
@@ -97,6 +97,8 @@
 
 #cmakedefine OME_HAVE_DLADDR 1
 
+#cmakedefine OME_RELOCATABLE_INSTALL 1
+
 #cmakedefine TIFF_HAVE_BIGTIFF 1
 #cmakedefine TIFF_HAVE_FIELD 1
 #cmakedefine TIFF_HAVE_FIELDINFO 1

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -756,6 +756,15 @@ extra-warnings=(ON|OFF)
 fatal-warnings=(ON|OFF)
   Make compiler warnings into fatal errors.  This is disabled by
   default.
+relocatable-install=(ON|OFF)
+  Make the installed libraries, programs and datafiles relocatable;
+  this means that they may be moved from their installation prefix to
+  another location without breaking them.  If OFF, the installation
+  prefix is assumed to contain the libraries and datafiles.  If ON, no
+  assumptions are made, and a slower fallback is used to introspect
+  the location.  In all cases the location may be set in the
+  environment to override the compiled-in defaults.  This is OFF by
+  default for a regular build, and ON by default for a superbuild.
 sphinx=(ON|OFF)
   Build manual pages and HTML documentation with Sphinx.  Enabled by
   default if Sphinx is autodetected.

--- a/docs/sphinx/formats/hamamatsu-ndpi.txt
+++ b/docs/sphinx/formats/hamamatsu-ndpi.txt
@@ -1,10 +1,10 @@
 .. index:: Hamamatsu ndpi
-.. index:: .ndpi
+.. index:: .ndpi, .ndpis
 
 Hamamatsu ndpi
 ===============================================================================
 
-Extensions: .ndpi
+Extensions: .ndpi, .ndpis
 
 Developer: `Hamamatsu <http://www.hamamatsu.com>`_
 
@@ -18,7 +18,10 @@ Export: |no|
 
 Officially Supported Versions: 
 
-Reader: NDPIReader (:bfreader:`Source Code <NDPIReader.java>`, :doc:`Supported Metadata Fields </metadata/NDPIReader>`)
+Readers:
+
+- NDPIReader (:bfreader:`Source Code <NDPIReader.java>`, :doc:`Supported Metadata Fields </metadata/NDPIReader>`)
+- NDPISReader (:bfreader:`Source Code <NDPISReader.java>`, :doc:`Supported Metadata Fields </metadata/NDPISReader>`)
 
 
 Freely Available Software:

--- a/docs/sphinx/formats/nikon-nis-elements-nd2.txt
+++ b/docs/sphinx/formats/nikon-nis-elements-nd2.txt
@@ -18,7 +18,10 @@ Export: |no|
 
 Officially Supported Versions: 
 
-Reader: NativeND2Reader (:bfreader:`Source Code <NativeND2Reader.java>`, :doc:`Supported Metadata Fields </metadata/NativeND2Reader>`)
+Readers:
+
+- NativeND2Reader (:bfreader:`Source Code <NativeND2Reader.java>`, :doc:`Supported Metadata Fields </metadata/NativeND2Reader>`)
+- LegacyND2Reader (:bfreader:`Source Code <LegacyND2Reader.java>`, :doc:`Supported Metadata Fields </metadata/LegacyND2Reader>`)
 
 
 Freely Available Software:

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -7,12 +7,12 @@ Supported Formats
 
     You can sort this table by clicking on any of the headings.
 
-.. tabularcolumns:: |p{3cm}|p{2cm}|c|c|c|c|c|c|c|
+.. tabularcolumns:: |p{3cm}|p{2cm}|c|c|c|c|c|c|c|c|
 
 .. list-table::
    :class: sortable
    :header-rows: 1
-   :widths: 30, 20, 2, 2, 2, 2, 2, 2, 2
+   :widths: 30, 20, 2, 2, 2, 2, 2, 2, 2, 2
 
    *
      - Format
@@ -24,6 +24,7 @@ Supported Formats
      - .. image:: images/header-utility.png
      - .. image:: images/header-export.png
      - BSD
+     - Multiple Images
 
    * - :doc:`formats/3i-slidebook`
      - .sld
@@ -34,6 +35,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/abd-tiff`
      - .tif
      - |Very good|
@@ -43,6 +45,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/aim`
      - .aim
      - |Good|
@@ -50,6 +53,7 @@ Supported Formats
      - |Fair|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/alicona-3d`
@@ -61,6 +65,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/amersham-biosciences-gel`
      - .gel
      - |Very good|
@@ -68,6 +73,7 @@ Supported Formats
      - |Good|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/amira-mesh`
@@ -79,6 +85,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/amnis-flowsight`
      - .cif
      - |Good|
@@ -88,6 +95,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |yes|
+     - |yes|
    * - :doc:`formats/analyze-75`
      - .img, .hdr
      - |Very good|
@@ -95,6 +103,7 @@ Supported Formats
      - |Very good|
      - |Good|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/animated-png`
@@ -106,6 +115,7 @@ Supported Formats
      - |Poor|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/aperio-afi`
      - .afi, .svs
      - |Very good|
@@ -115,6 +125,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/aperio-svs-tiff`
      - .svs
      - |Very good|
@@ -124,6 +135,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/applied-precision-cellworx`
      - .htd, .pnl
      - |Very good|
@@ -133,6 +145,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/avi`
      - .avi
      - |Good|
@@ -142,6 +155,7 @@ Supported Formats
      - |Poor|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/axon-raw-format`
      - .arf
      - |Very good|
@@ -149,6 +163,7 @@ Supported Formats
      - |Very good|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/bd-pathway`
@@ -160,6 +175,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/becker-hickl-spcimage`
      - .sdt
      - |Very good|
@@ -169,6 +185,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/bio-rad-gel`
      - .1sc
      - |Good|
@@ -176,6 +193,7 @@ Supported Formats
      - |Fair|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/bio-rad-pic`
@@ -187,6 +205,7 @@ Supported Formats
      - |Very good|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/bio-rad-scn`
      - .scn
      - |Very good|
@@ -194,6 +213,7 @@ Supported Formats
      - |Fair|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/bitplane-imaris`
@@ -205,6 +225,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/bruker-mri`
      - 
      - |Good|
@@ -214,6 +235,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/burleigh`
      - .img
      - |Good|
@@ -221,6 +243,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/canon-dng`
@@ -232,6 +255,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/cellh5`
      - .ch5
      - |Very good|
@@ -241,6 +265,7 @@ Supported Formats
      - |Very good|
      - |yes|
      - |no|
+     - |yes|
    * - :doc:`formats/cellomics`
      - .c01
      - |Very good|
@@ -250,6 +275,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/cellsens-vsi`
      - .vsi
      - |Fair|
@@ -259,6 +285,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/cellvoyager`
      - .xml, .tif
      - |Very good|
@@ -268,6 +295,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/deltavision`
      - .dv, .r3d
      - |Outstanding|
@@ -277,6 +305,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/dicom`
      - .dcm, .dicom
      - |Very good|
@@ -286,6 +315,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |yes|
+     - |yes|
    * - :doc:`formats/ecat7`
      - .v
      - |Good|
@@ -293,6 +323,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/eps`
@@ -304,6 +335,7 @@ Supported Formats
      - |Poor|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/evotecperkinelmer-opera-flex`
      - .flex, .mea, .res
      - |Outstanding|
@@ -313,6 +345,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/fei`
      - .img
      - |Fair|
@@ -320,6 +353,7 @@ Supported Formats
      - |Poor|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/fei-tiff`
@@ -331,6 +365,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/fits`
      - .fits
      - |Very good|
@@ -340,6 +375,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/gatan-digital-micrograph`
      - .dm3, .dm4
      - |Very good|
@@ -347,6 +383,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/gatan-digital-micrograph-2`
@@ -358,6 +395,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/gif`
      - .gif
      - |Very good|
@@ -367,6 +405,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/hamamatsu-aquacosmos-naf`
      - .naf
      - |Good|
@@ -376,6 +415,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/hamamatsu-his`
      - .his
      - |Good|
@@ -385,8 +425,9 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/hamamatsu-ndpi`
-     - .ndpi
+     - .ndpi, .ndpis
      - |Fair|
      - |Good|
      - |Good|
@@ -394,6 +435,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/hamamatsu-vms`
      - .vms
      - |Good|
@@ -403,6 +445,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/hitachi-s-4800`
      - .txt, .tif, .bmp, .jpg
      - |Very good|
@@ -410,6 +453,7 @@ Supported Formats
      - |Very good|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/i2i`
@@ -421,6 +465,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/ics`
      - .ics, .ids
      - |Outstanding|
@@ -430,6 +475,7 @@ Supported Formats
      - |Very good|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/imacon`
      - .fff
      - |Poor|
@@ -439,6 +485,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/imagepro-sequence`
      - .seq
      - |Very good|
@@ -446,6 +493,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/imagepro-workspace`
@@ -457,6 +505,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/imagic`
      - .hed, .img
      - |Very good|
@@ -464,6 +513,7 @@ Supported Formats
      - |Very good|
      - |Good|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/imod`
@@ -475,6 +525,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/improvision-openlab-liff`
      - .liff
      - |Very good|
@@ -484,6 +535,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/improvision-openlab-raw`
      - .raw
      - |Outstanding|
@@ -491,6 +543,7 @@ Supported Formats
      - |Very good|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/improvision-tiff`
@@ -502,6 +555,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/imspector-obf`
      - .obf, .msr
      - |Very good|
@@ -510,6 +564,7 @@ Supported Formats
      - |Poor|
      - |Fair|
      - |no|
+     - |yes|
      - |yes|
    * - :doc:`formats/incell-1000`
      - .xdce, .tif
@@ -520,6 +575,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/incell-3000`
      - .frm
      - |Good|
@@ -527,6 +583,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Poor|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/inr`
@@ -538,6 +595,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/inveon`
      - .hdr
      - |Very good|
@@ -547,6 +605,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/iplab`
      - .ipl
      - |Outstanding|
@@ -554,6 +613,7 @@ Supported Formats
      - |Very good|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/iplab-mac`
@@ -565,6 +625,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/jeol`
      - .dat, .img, .par
      - |Good|
@@ -572,6 +633,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/jpeg`
@@ -583,6 +645,7 @@ Supported Formats
      - |Poor|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/jpeg-2000`
      - .jp2
      - |Very good|
@@ -590,6 +653,7 @@ Supported Formats
      - |Outstanding|
      - |Good|
      - |Poor|
+     - |yes|
      - |yes|
      - |yes|
    * - :doc:`formats/jpk`
@@ -601,6 +665,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/jpx`
      - .jpx
      - |Very good|
@@ -610,6 +675,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/khoros-viff-bitmap`
      - .xv
      - |Good|
@@ -617,6 +683,7 @@ Supported Formats
      - |Poor|
      - |Poor|
      - |Poor|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/kodak-bip`
@@ -628,6 +695,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/lambert-instruments-flim`
      - .fli
      - |Very good|
@@ -637,6 +705,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/lavision-imspector`
      - .msr
      - |Fair|
@@ -646,6 +715,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/leica-lcs-lei`
      - .lei, .tif
      - |Outstanding|
@@ -655,6 +725,7 @@ Supported Formats
      - |Very good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/leica-lif`
      - .lif
      - |Outstanding|
@@ -664,6 +735,7 @@ Supported Formats
      - |Very good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/leica-scn`
      - .scn
      - |Good|
@@ -673,6 +745,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/leo`
      - .sxm
      - |Good|
@@ -680,6 +753,7 @@ Supported Formats
      - |Good|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/li-cor-l2d`
@@ -691,6 +765,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/lim`
      - .lim
      - |Good|
@@ -698,6 +773,7 @@ Supported Formats
      - |Poor|
      - |Poor|
      - |Poor|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/metamorph-75-tiff`
@@ -709,6 +785,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/metamorph-stack-stk`
      - .stk, .nd
      - |Very good|
@@ -716,6 +793,7 @@ Supported Formats
      - |Very good|
      - |Very good|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/mias-maia-scientific`
@@ -727,6 +805,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/micro-manager`
      - .tif, .txt, .xml
      - |Outstanding|
@@ -736,6 +815,7 @@ Supported Formats
      - |Good|
      - |no|
      - |yes|
+     - |yes|
    * - :doc:`formats/minc-mri`
      - .mnc
      - |Very good|
@@ -743,6 +823,7 @@ Supported Formats
      - |Good|
      - |Good|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/minolta-mrw`
@@ -754,6 +835,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/mng`
      - .mng
      - |Good|
@@ -763,6 +845,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |yes|
+     - |yes|
    * - :doc:`formats/molecular-imaging`
      - .stp
      - |Good|
@@ -770,6 +853,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/mrc`
@@ -781,6 +865,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/nef`
      - .nef, .tif
      - |Very good|
@@ -788,6 +873,7 @@ Supported Formats
      - |Poor|
      - |Poor|
      - |Poor|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/nifti`
@@ -799,6 +885,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/nikon-elements-tiff`
      - .tiff
      - |Good|
@@ -806,6 +893,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/nikon-ez-c1-tiff`
@@ -817,6 +905,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/nikon-nis-elements-nd2`
      - .nd2
      - |Very good|
@@ -826,6 +915,7 @@ Supported Formats
      - |Very good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/nrrd`
      - .nrrd, .nhdr, .raw, .txt
      - |Very good|
@@ -835,6 +925,7 @@ Supported Formats
      - |Very good|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/olympus-cellrapl`
      - .apl, .mtb, .tnb, .tif, .obsep
      - |Very good|
@@ -844,6 +935,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/olympus-fluoview-fv1000`
      - .oib, .oif
      - |Very good|
@@ -853,6 +945,7 @@ Supported Formats
      - |Very good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/olympus-fluoview-tiff`
      - .tif
      - |Very good|
@@ -862,6 +955,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/olympus-scanr`
      - .xml, .dat, .tif
      - |Very good|
@@ -871,6 +965,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/olympus-sis-tiff`
      - .tiff
      - |Good|
@@ -878,6 +973,7 @@ Supported Formats
      - |Good|
      - |Fair|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/ome-tiff`
@@ -889,6 +985,7 @@ Supported Formats
      - |Outstanding|
      - |yes|
      - |yes|
+     - |yes|
    * - :doc:`formats/ome-xml`
      - `.ome <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
      - |Outstanding|
@@ -896,6 +993,7 @@ Supported Formats
      - |Outstanding|
      - |Fair|
      - |Outstanding|
+     - |yes|
      - |yes|
      - |yes|
    * - :doc:`formats/oxford-instruments`
@@ -907,6 +1005,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/pcoraw`
      - .pcoraw, .rec
      - |Very good|
@@ -914,6 +1013,7 @@ Supported Formats
      - |Very good|
      - |Fair|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/pcx-pc-paintbrush`
@@ -925,6 +1025,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/perkin-elmer-densitometer`
      - .pds
      - |Good|
@@ -932,6 +1033,7 @@ Supported Formats
      - |Good|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/perkinelmer-nuance`
@@ -943,6 +1045,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |yes|
+     - |yes|
    * - :doc:`formats/perkinelmer-operetta`
      - .tiff, .xml
      - |Very good|
@@ -952,6 +1055,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/perkinelmer-ultraview`
      - .tif, .2, .3, .4, etc.
      - |Very good|
@@ -959,6 +1063,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/pgm`
@@ -970,6 +1075,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/photoshop-psd`
      - .psd
      - |Good|
@@ -977,6 +1083,7 @@ Supported Formats
      - |Good|
      - |Good|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/photoshop-tiff`
@@ -988,6 +1095,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/picoquant-bin`
      - .bin
      - |Good|
@@ -995,6 +1103,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Poor|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/pict-macintosh-picture`
@@ -1006,6 +1115,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/png`
      - .png
      - |Very good|
@@ -1015,6 +1125,7 @@ Supported Formats
      - |Poor|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/prairie-tech-tiff`
      - .tif, .xml, .cfg
      - |Very good|
@@ -1024,6 +1135,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/quesant`
      - .afm
      - |Good|
@@ -1031,6 +1143,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/quicktime-movie`
@@ -1042,6 +1155,7 @@ Supported Formats
      - |Poor|
      - |yes|
      - |yes|
+     - |no|
    * - :doc:`formats/rhk`
      - .sm2, .sm3
      - |Good|
@@ -1049,6 +1163,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/sbig`
@@ -1060,6 +1175,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/seiko`
      - .xqd, .xqf
      - |Good|
@@ -1067,6 +1183,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/simplepci-hcimage`
@@ -1078,6 +1195,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/simplepci-hcimage-tiff`
      - .tiff
      - |Very good|
@@ -1085,6 +1203,7 @@ Supported Formats
      - |Very good|
      - |Fair|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/sm-camera`
@@ -1096,6 +1215,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/spider`
      - .spi, .stk
      - |Very good|
@@ -1103,6 +1223,7 @@ Supported Formats
      - |Outstanding|
      - |Good|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/targa`
@@ -1114,6 +1235,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/text`
      - .txt
      - |Good|
@@ -1123,6 +1245,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/tiff`
      - .tif
      - |Very good|
@@ -1130,6 +1253,7 @@ Supported Formats
      - |Outstanding|
      - |Outstanding|
      - |Fair|
+     - |yes|
      - |yes|
      - |yes|
    * - :doc:`formats/tillphotonics-tillvision`
@@ -1141,6 +1265,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/topometrix`
      - .tfr, .ffr, .zfr, .zfp, .2fl
      - |Good|
@@ -1148,6 +1273,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/trestle`
@@ -1159,6 +1285,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/ubm`
      - .pr3
      - |Good|
@@ -1166,6 +1293,7 @@ Supported Formats
      - |Fair|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/unisoku`
@@ -1177,6 +1305,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/varian-fdf`
      - .fdf
      - |Good|
@@ -1184,6 +1313,7 @@ Supported Formats
      - |Fair|
      - |Fair|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/veeco-afm`
@@ -1195,6 +1325,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/vg-sam`
      - .dti
      - |Good|
@@ -1202,6 +1333,7 @@ Supported Formats
      - |Fair|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/visitech-xys`
@@ -1213,6 +1345,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/volocity`
      - .mvd2
      - |Good|
@@ -1222,6 +1355,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/volocity-library-clipping`
      - .acff
      - |Good|
@@ -1229,6 +1363,7 @@ Supported Formats
      - |Fair|
      - |Poor|
      - |Poor|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/wa-top`
@@ -1240,6 +1375,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |no|
    * - :doc:`formats/windows-bitmap`
      - .bmp
      - |Very good|
@@ -1249,6 +1385,7 @@ Supported Formats
      - |Poor|
      - |no|
      - |yes|
+     - |no|
    * - :doc:`formats/woolz`
      - .wlz
      - |Very good|
@@ -1258,6 +1395,7 @@ Supported Formats
      - |Fair|
      - |yes|
      - |no|
+     - |no|
    * - :doc:`formats/zeiss-axio-csm`
      - .lms
      - |Good|
@@ -1265,6 +1403,7 @@ Supported Formats
      - |Poor|
      - |Poor|
      - |Fair|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/zeiss-axiovision-tiff`
@@ -1276,6 +1415,7 @@ Supported Formats
      - |Fair|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/zeiss-axiovision-zvi`
      - .zvi
      - |Outstanding|
@@ -1283,6 +1423,7 @@ Supported Formats
      - |Very good|
      - |Good|
      - |Good|
+     - |no|
      - |no|
      - |no|
    * - :doc:`formats/zeiss-czi`
@@ -1294,6 +1435,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
    * - :doc:`formats/zeiss-lsm`
      - .lsm, .mdb
      - |Outstanding|
@@ -1303,6 +1445,7 @@ Supported Formats
      - |Good|
      - |no|
      - |no|
+     - |yes|
 
 Bio-Formats currently supports **142** formats
 
@@ -1360,6 +1503,10 @@ Bio-Formats currently supports **142** formats
     BSD
         This indicates whether format is BSD-licensed.  By default,
         format readers and writers are GPL-licensed.
+
+    Multiple Images
+        This indicates whether the format can store multiple Images (in OME-XML terminology)
+        or series (in Bio-Formats API terminology).
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
- Add `relocatable-install` option (see https://github.com/ome/ome-cmake-superbuild/pull/11)
- Support path introspection on Windows, to match the existing Unix support
- Drop unused superbuild options (see again https://github.com/ome/ome-cmake-superbuild/pull/11)

----------

Testing: Covered by unit tests on Unix.  On Windows, apply this patch:

```
diff --git a/cpp/lib/ome/common/module.cpp b/cpp/lib/ome/common/module.cpp
index 0cc5580..42ae249 100644
--- a/cpp/lib/ome/common/module.cpp
+++ b/cpp/lib/ome/common/module.cpp
@@ -47,6 +47,7 @@
 #include <cstring>
 #include <map>
 #include <stdexcept>
+#include <iostream>
 
 namespace fs = boost::filesystem;
 
@@ -306,6 +307,7 @@ namespace ome
             {
               fs::path moduledir(module.parent_path());
               bool match = true;
+              std::cerr << "MODULEDIR: " << moduledir << '\n';
 
 #ifdef _MSC_VER
               fs::path libdir(INSTALL_BINDIR);
```

Then build and run:

```
<buildpath>>bf-test.bat cpp\libexec\info\Debug\info.exe --help
MODULEDIR: "<buildpath>\cpp\libexec\info\Debug"
E: Could not determine Bio-Formats runtime path for "doc" directory```

This is telling you that the runtime path was successfully introspected.  Since ome-common is static, it's giving you the path to the executable.  When made into a DLL, this will then work correctly.