### PR TITLE
loci.plugins.in.ImporterTest fails after 7a43d49

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -885,16 +885,21 @@ public class FileStitcher extends ReaderWrapper {
     LOGGER.debug("initFile: {}", id);
 
     FilePattern fp = new FilePattern(id);
+
+    LOGGER.info("fp.getFiles(): {}", Arrays.toString(fp.getFiles()));
+    LOGGER.info("patternIds: {}", patternIds);
+    LOGGER.info("canChangePattern(): {}", canChangePattern());
+
     if (!patternIds) {
       patternIds = fp.isValid() && fp.getFiles().length > 1;
     }
-    else if (canChangePattern()) {
+    else if (canChangePattern() || fp.getFiles().length == 0) {
       patternIds =
         !new Location(id).exists() && Location.getMappedId(id).equals(id);
     }
 
     boolean mustGroup = false;
-    if (patternIds) {
+    if (patternIds && fp.getFiles().length != 0) {
       mustGroup = fp.isValid() &&
         reader.fileGroupOption(fp.getFiles()[0]) == FormatTools.MUST_GROUP;
     }


### PR DESCRIPTION
This is still failing, but we moved from an `ArrayIndexOutOfBoundsException` in `FileStitcher` to a failed assertion in the test itself:

```
Running loci.plugins.in.ImporterTest
2015-10-30 12:07:34,189 [main] INFO  loci.formats.FileStitcher - fp.getFiles(): [test_C1_TP1&pixelType=uint8&sizeX=50&sizeY=50&sizeZ=7&sizeC=1&sizeT=1.fake]
2015-10-30 12:07:34,193 [main] INFO  loci.formats.FileStitcher - patternIds: true
2015-10-30 12:07:34,193 [main] INFO  loci.formats.FileStitcher - canChangePattern(): false
2015-10-30 12:07:34,194 [main] INFO  loci.formats.ImageReader - FakeReader initializing test_C1_TP1&pixelType=uint8&sizeX=50&sizeY=50&sizeZ=7&sizeC=1&sizeT=1.fake
2015-10-30 12:07:34,196 [main] INFO  loci.formats.ImageReader - FakeReader initializing test_C1_TP1&pixelType=uint8&sizeX=50&sizeY=50&sizeZ=7&sizeC=1&sizeT=1.fake
2015-10-30 12:07:34,230 [main] INFO  loci.formats.FileStitcher - fp.getFiles(): []
2015-10-30 12:07:34,231 [main] INFO  loci.formats.FileStitcher - patternIds: true
2015-10-30 12:07:34,231 [main] INFO  loci.formats.FileStitcher - canChangePattern(): false
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.794 sec <<< FAILURE! - in loci.plugins.in.ImporterTest
testDatasetGroupFiles(loci.plugins.in.ImporterTest)  Time elapsed: 0.753 sec  <<< FAILURE!
java.lang.AssertionError: /home/simleo/git/simleo/bioformats/components/bio-formats-plugins/iThinkI'mImportantButI'mNot (No such file or directory)
	at org.junit.Assert.fail(Assert.java:91)
	at loci.plugins.in.ImporterTest.datasetGroupFilesTester(ImporterTest.java:1039)
	at loci.plugins.in.ImporterTest.testDatasetGroupFiles(ImporterTest.java:2019)


Results :

Failed tests: 
  ImporterTest.testDatasetGroupFiles:2019->datasetGroupFilesTester:1039 /home/simleo/git/simleo/bioformats/components/bio-formats-plugins/iThinkI'mImportantButI'mNot (No such file or directory)

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.921s
[INFO] Finished at: Fri Oct 30 12:07:34 GMT 2015
[INFO] Final Memory: 25M/347M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.16:test (default-test) on project bio-formats_plugins: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/simleo/git/simleo/bioformats/components/bio-formats-plugins/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

```