### PR TITLE
Fiji preferences not persistent for macros

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Importer.java
@@ -29,6 +29,7 @@ package loci.plugins.in;
 
 import ij.ImageJ;
 import ij.ImagePlus;
+import ij.Macro;
 
 import java.io.IOException;
 
@@ -108,7 +109,9 @@ public class Importer {
   /** Parses core options. */
   public ImporterOptions parseOptions(String arg) throws IOException {
     ImporterOptions options = new ImporterOptions();
-    options.loadOptions();
+    if (Macro.getOptions() == null) {
+      options.loadOptions();
+    }
     options.parseArg(arg);
     options.checkObsoleteOptions();
     return options;


### PR DESCRIPTION
https://github.com/openmicroscopy/bioformats/issues/2057

When the importer has been run from an IJ macro, the options list should
not be loaded from preferences but instead read from the macro arguments
only.

In order to test the PR:
Open Fiji and record 2 macros (Plugins -> Macros -> Record)
Now import a multi channel image using bioformats
For the first macro select the split channels option during import, for the second make sure it is unselected

Now import an image again using bioformats and ensure the split channel option is selected. This will save the option to your Image J preferences.
Now rerun your 2 macros and ensure that the image channels are split in one and combined in the other

Now import an image again using bioformats and ensure the split channel option is not selected.
Now rerun your 2 macros and ensure that they still both run correctly.
