### PR TITLE
Slidebook: fix physical Z size calculation

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -274,9 +274,9 @@ public class SlideBook6Reader  extends FormatReader {
 					double stepSize = 0;
 					if (numZPlanes[capture] > 1) {
 						double plane0 = getZPosition(capture, 0, 0);
-						double plane1 = getZPosition(capture, 0, getNumChannels(capture));
+						double plane1 = getZPosition(capture, 0, 1);
 						// distance between plane 0 and 1 is step size, assume constant for all planes
-						stepSize = plane1 - plane0;
+						stepSize = Math.abs(plane1 - plane0);
 					}
 
 					Length physicalSizeZ = FormatTools.getPhysicalSizeZ(stepSize);


### PR DESCRIPTION
See lists.openmicroscopy.org.uk/pipermail/ome-users/2015-October/005703.html.

Tested with ```slidebook/emma/WT BY4742 Nem1 mcherry genome.sld``` on Windows (with appropriate .dlls).  Without this change, the physical Z size was not set at all; with this change, it is set to the absolute difference between two adjacent Z sections.