### PR TITLE
Fixing broken bruker link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -378,7 +378,7 @@ notes = - There are three distinct Imaris formats: \n
     #. Imaris 5.5, an HDF variant (introduced in Imaris version 5.5)
 
 [Bruker MRI]
-developer = `Bruker <http://www.bruker.com/>`_
+developer = `Bruker <https://www.bruker.com>`_
 bsd = no
 software = `Bruker plugin for ImageJ <http://rsbweb.nih.gov/ij/plugins/bruker.html>`_
 weHave = * a few Bruker MRI datasets

--- a/docs/sphinx/formats/bruker-mri.txt
+++ b/docs/sphinx/formats/bruker-mri.txt
@@ -4,7 +4,7 @@ Bruker MRI
 ===============================================================================
 
 
-Developer: `Bruker <http://www.bruker.com/>`_
+Developer: `Bruker <https://www.bruker.com>`_
 
 
 **Support**


### PR DESCRIPTION
The Jenkins builds are convinced this link is broken but actually it seems to be just redirecting to https so hopefully this will make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-5.1-merge-docs/ green.