### PR TITLE
Metamorph TIFF: fix parsing of multi-line freeform descriptions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -134,6 +134,8 @@ public class MetamorphHandler extends BaseHandler {
         if (metadata != null) metadata.remove("Comment");
 
         String k = null, v = null;
+        boolean freeform = true;
+        String freeformDescription = "";
 
         if (value.indexOf(delim) != -1) {
           int currentIndex = -delim.length();
@@ -150,12 +152,31 @@ public class MetamorphHandler extends BaseHandler {
             }
             currentIndex = nextIndex;
 
-            int colon = line.indexOf(":");
-            if (colon != -1) {
-              k = line.substring(0, colon).trim();
-              v = line.substring(colon + 1).trim();
-              if (metadata != null) metadata.put(k, v);
-              checkKey(k, v);
+            if (line.startsWith("Exposure: ")) {
+              freeform = false;
+              if (metadata != null) {
+                metadata.put("User Description", freeformDescription.trim());
+              }
+            }
+
+            if (freeform) {
+              freeformDescription += line;
+              freeformDescription += "\n";
+            }
+            else {
+              int colon = line.indexOf(":");
+              if (colon != -1) {
+                k = line.substring(0, colon).trim();
+                v = line.substring(colon + 1).trim();
+                if (metadata != null) metadata.put(k, v);
+                checkKey(k, v);
+              }
+              else {
+                // prevent non-key/value lines from being lost
+                if (metadata != null) {
+                  metadata.put(k, k);
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
See https://trello.com/c/efn0T64w/18-metaxpress-multi-line-descriptions

Based upon analysis of various Metamorph TIFF samples, the user-entered
freeform description appears to be stored contiguously, and always
before the "Exposure" key.  The "Exposure" key seems to consistently be
the first official standard Metamorph key, with "Binning", "Region",
etc. following in a predictable order.  This commit takes all lines from
the XML description field up to "Exposure" and assembles them into a
single "User Description" entry in the metadata table.

Non-freeform lines with no value are also now stored in the metadata table, with the key and value being the same.

This should match the behavior described in http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-March/005172.html, using the file linked from that thread.  This seems to be safer and less invasive than trying to maintain a whitelist of official vs. freeform keys, but feedback would be appreciated.

/cc @emmenlau