### PR TITLE
Zeiss LMS: fix stream variable in isThisType

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLMSReader.java
@@ -69,7 +69,7 @@ public class ZeissLMSReader extends FormatReader {
     if (!FormatTools.validStream(stream, checkLen, false)) {
       return false;
     }
-    return in.readString(checkLen).indexOf(CHECK) >= 0;
+    return stream.readString(checkLen).indexOf(CHECK) >= 0;
   }
 
   /* @see loci.formats.IFormatReader#get8BitLookupTable() */


### PR DESCRIPTION
See https://github.com/CellProfiler/CellProfiler/issues/1686

The ```in``` variable is only initialized during setId, so this changes isThisType to correctly use the ```stream``` that is passed in.

The easiest way to test is to pick any TIFF file (e.g. from test_images_good/tiff/) and compare the results of executing the following code (or something similar) with and without this change:

```
ZeissLMSReader reader = new ZeissLMSReader();
RandomAccessInputStream s = new RandomAccessInputStream("/path/to/tiff");
boolean isLMS = reader.isThisType(s);
s.close();
System.out.println("is LMS = " + isLMS);
```

Without this change, line 3 should throw an NPE; with this change, there should be no exception, and ```is LMS = false``` should be printed.  This is tricky to test with e.g. showinf, as the ZeissLMSReader by default will reject anything that does not have the ```.lms``` extension, and will not attempt to read from the file if it has an ```.lms``` extension (i.e. extended file type checking has to be forced).