### PR TITLE
Format tools units automatic conversion

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1439,7 +1439,17 @@ public final class FormatTools {
     if (unit != null) {
       try {
         UnitsLength ul = UnitsLength.fromString(unit);
-        return UnitsLength.create(value, ul);
+        int ordinal = ul.ordinal();
+        Length returnLength = UnitsLength.create(value, ul);
+
+        // If the requested unit produces a value less than Constants.EPSILON then we switch to the next smallest unit possible
+        // Using UnitsLength.values().length - 2 as a boundary so as not to include Pixel and Reference Frame as convertible units
+        while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 2)) { 
+          ordinal++;
+          ul = UnitsLength.values()[ordinal];
+          returnLength = UnitsLength.create(value, ul);
+        }
+        return returnLength;
       } catch (EnumerationException e) {
       }
     }
@@ -1490,7 +1500,7 @@ public final class FormatTools {
   public static Length getPhysicalSizeX(Double value, Unit<Length> unit) {
     if (isPositiveValue(value))
     {
-      return createLength(value, unit);
+      return getPhysicalSize(value, unit.getSymbol());
     } else {
       LOGGER.debug("Expected positive value for PhysicalSizeX; got {}", value);
       return null;
@@ -1541,7 +1551,7 @@ public final class FormatTools {
   public static Length getPhysicalSizeY(Double value, Unit<Length> unit) {
     if (isPositiveValue(value))
     {
-      return createLength(value, unit);
+      return getPhysicalSize(value, unit.getSymbol());
     } else {
       LOGGER.debug("Expected positive value for PhysicalSizeY; got {}", value);
       return null;

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1442,6 +1442,10 @@ public final class FormatTools {
         int ordinal = ul.ordinal();
         Length returnLength = UnitsLength.create(value, ul);
 
+        if (returnLength.value().doubleValue() > Constants.EPSILON) {
+          return returnLength;
+        }
+        
         // If the requested unit produces a value less than Constants.EPSILON then we switch to the next smallest unit possible
         // Using UnitsLength.values().length - 2 as a boundary so as not to include Pixel and Reference Frame as convertible units
         while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 2)) { 
@@ -1449,7 +1453,10 @@ public final class FormatTools {
           ul = UnitsLength.values()[ordinal];
           returnLength = UnitsLength.create(value, ul);
         }
-        return returnLength;
+        if (returnLength.value().doubleValue() > Constants.EPSILON) {
+          return returnLength;
+        }
+        else return null;
       } catch (EnumerationException e) {
       }
     }


### PR DESCRIPTION
For some readers we have native units that are not logical for the purpose resulting in very low values.
See https://github.com/openmicroscopy/bioformats/pull/2044 for an example.

This proposed change to FormatsTools getPhysicalSize would implement the following logic as suggested in the PR mentioned above:
1.check if the value is greater than  Constants.EPSILON  
2.if so, use whatever unit was supplied
3.if not, convert to the smallest order of magnitude unit such that (1) passes (or the default unit?)
4.if the value really is 0, or is less than  Constants.EPSILON  for even the smallest defined unit, return null

I have also updated getPhysicalSizeX and Y methods to use the same getPhysicalSize function as we had 2 separate workflows depending on if the units were provided as String or UNITS.MM for example.