### PR TITLE
cpp: PixelBuffer: Disable debug bounds checking

### DIFF
--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -44,6 +44,8 @@
 #include <stdexcept>
 #include <string>
 
+// Disable expensive bounds checking
+#define BOOST_DISABLE_ASSERTS 1
 #include <boost/multi_array.hpp>
 
 #include <ome/bioformats/PixelProperties.h>

--- a/cpp/test/ome-bioformats/pixelbuffer.h
+++ b/cpp/test/ome-bioformats/pixelbuffer.h
@@ -429,7 +429,7 @@ TYPED_TEST_P(PixelBufferType, SetIndex)
 
 TYPED_TEST_P(PixelBufferType, SetIndexDeathTest)
 {
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(BOOST_DISABLE_ASSERTS)
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   PixelBuffer<TypeParam> buf(boost::extents[10][10][1][1][1][1][1][1][1]);
@@ -442,7 +442,7 @@ TYPED_TEST_P(PixelBufferType, SetIndexDeathTest)
 
   ASSERT_DEATH_IF_SUPPORTED(buf.at(badidx) = 4U, "Assertion.*failed");
   ASSERT_DEATH_IF_SUPPORTED(cbuf.at(badidx), "Assertion.*failed");
-#endif // ! NDEBUG
+#endif // ! NDEBUG && ! BOOST_DISABLE_ASSERTS
 }
 
 TYPED_TEST_P(PixelBufferType, StreamInput)

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -985,7 +985,7 @@ TEST_P(VariantPixelBufferTest, SetIndex)
 
 TEST_P(VariantPixelBufferTest, SetIndexDeathTest)
 {
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(BOOST_DISABLE_ASSERTS)
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   const VariantPixelBufferTestParameters& params = GetParam();
@@ -995,7 +995,7 @@ TEST_P(VariantPixelBufferTest, SetIndexDeathTest)
 
   SetIndexDeathTestVisitor v(buf);
   boost::apply_visitor(v, buf.vbuffer());
-#endif // ! NDEBUG
+#endif // ! NDEBUG && ! BOOST_DISABLE_ASSERTS
 }
 
 TEST_P(VariantPixelBufferTest, StreamInput)


### PR DESCRIPTION
This is extremely expensive for some compilers, such as clang++, so disable unconditionally.  It was always disabled for Release builds; this ensures it's also disabled for Debug builds.

Possibly too late for the freeze, but note it's a trivial one-liner which should shave *several hours* off the build time of the slowest builds.

--------

Testing: check that the build times for Debug builds are reduced for both https://ci.openmicroscopy.org/job/BIOFORMATS-CPP-5.1-merge-superbuild/ and https://ci.openmicroscopy.org/job/BIOFORMATS-CPP-5.1-merge-win-superbuild/