### PR TITLE
Video spot tracker (rebased onto develop)

### DIFF
--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -21,12 +21,12 @@ Other projects using the JACE C++ bindings include:
 -  :doc:`/users/xuvtools/index` which uses an adapted version of the JACE C++
    bindings called
    `BlitzBioFormats <http://www.xuvtools.org/devel:libblitzbioformats>`_.
--  `Video Spot Tracker`_ which uses the Jace C++ bindings to add Bio-Formats
+-  `Video Spot Tracker`_ which uses the JACE C++ bindings to add Bio-Formats
    support since version 8.10.
 
 See the :doc:`build instructions <build>` (:doc:`Windows
 <build-windows>`, :doc:`Mac OS X <build-macosx>`, :doc:`Linux
-<build-linux>`) for details on compiling the Java C++ bindings from source.
+<build-linux>`) for details on compiling the JACE C++ bindings from source.
 Once this is done, simply include it in your project as you would any other
 external library.
 

--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -8,7 +8,7 @@ resulting proxies are then compiled into a library, which represents
 the actual interface from C++ to Bio-Formats. Using this library in
 your projects gives you access to the image support of Bio-Formats.
 
-The JACE C++ bindings comes with some standalone examples which you can use as
+The JACE C++ bindings come with some standalone examples which you can use as
 a starting point in your own project:
 
 -  :source:`showinf <components/formats-bsd/cppwrap/showinf.cpp>`

--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -17,14 +17,18 @@ starting point in your own project:
 
 Other projects using BF-CPP include:
 
--  `WiscScan <http://loci.wisc.edu/software/wiscscan>`_ which uses BF-CPP
-   to write :model_doc:`OME-TIFF <ome-tiff>` files.
+-  WiscScan_ which uses BF-CPP to write :model_doc:`OME-TIFF <ome-tiff>` files.
 -  :doc:`/users/xuvtools/index` which uses an adapted version of BF-CPP
    called
    `BlitzBioFormats <http://www.xuvtools.org/devel:libblitzbioformats>`_.
+-  `Video Spot Tracker`_ which uses the Jace C++ bindings to add Bio-Formats
+   support since version 8.10.
 
 See the :doc:`build instructions <build>` (:doc:`Windows
 <build-windows>`, :doc:`Mac OS X <build-macosx>`, :doc:`Linux
 <build-linux>`) for details on compiling BF-CPP from source. Once this
 is done, simply include it in your project as you would any other
 external library.
+
+.. _WiscScan: http://loci.wisc.edu/software/wiscscan
+.. _Video Spot Tracker: http://cismm.cs.unc.edu/resources/software-manuals/video-spot-tracker-manual

--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -2,33 +2,34 @@ JACE C++ bindings for the Java API
 ==================================
 
 To make Bio-Formats accessible to software written in C++, we have
-created a Bio-Formats C++ interface (BF-CPP for short). It uses LOCI's
-`jar2lib <http://loci.wisc.edu/software/jar2lib>`_ program to generate
-a C++ proxy class for each equivalent Bio-Formats Java class. The
+created a Bio-Formats C++ interface. It uses LOCI's jar2lib_ program to
+generate a C++ proxy class for each equivalent Bio-Formats Java class. The
 resulting proxies are then compiled into a library, which represents
 the actual interface from C++ to Bio-Formats. Using this library in
 your projects gives you access to the image support of Bio-Formats.
 
-BF-CPP comes with some standalone examples which you can use as a
-starting point in your own project:
+The JACE C++ bindings comes with some standalone examples which you can use as
+a starting point in your own project:
 
 -  :source:`showinf <components/formats-bsd/cppwrap/showinf.cpp>`
 -  :source:`minimum_writer <components/formats-bsd/cppwrap/minimum_writer.cpp>`
 
-Other projects using BF-CPP include:
+Other projects using the JACE C++ bindings include:
 
--  WiscScan_ which uses BF-CPP to write :model_doc:`OME-TIFF <ome-tiff>` files.
--  :doc:`/users/xuvtools/index` which uses an adapted version of BF-CPP
-   called
+-  WiscScan_ which uses the JACE C++ bindings to write
+   :model_doc:`OME-TIFF <ome-tiff>` files.
+-  :doc:`/users/xuvtools/index` which uses an adapted version of the JACE C++
+   bindings called
    `BlitzBioFormats <http://www.xuvtools.org/devel:libblitzbioformats>`_.
 -  `Video Spot Tracker`_ which uses the Jace C++ bindings to add Bio-Formats
    support since version 8.10.
 
 See the :doc:`build instructions <build>` (:doc:`Windows
 <build-windows>`, :doc:`Mac OS X <build-macosx>`, :doc:`Linux
-<build-linux>`) for details on compiling BF-CPP from source. Once this
-is done, simply include it in your project as you would any other
+<build-linux>`) for details on compiling the Java C++ bindings from source.
+Once this is done, simply include it in your project as you would any other
 external library.
 
+.. _jar2lib: http://loci.wisc.edu/software/jar2lib
 .. _WiscScan: http://loci.wisc.edu/software/wiscscan
 .. _Video Spot Tracker: http://cismm.cs.unc.edu/resources/software-manuals/video-spot-tracker-manual


### PR DESCRIPTION

This is the same as gh-2040 but rebased onto develop.

----

This PR:

- adds the Video Spot Tracker software to the list of projects using the Jace C++ bindings - see http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-October/005690.html
- removes the BF-CPP abbreviation and uses Jace C++ bindings in the documentation instead to prevent any confusion with Bio-Formats C++. /cc @rleigh-dundee



                