### PR TITLE
Bug fix - Convert values

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1436,7 +1436,7 @@ public final class FormatTools {
   }
   
   public static Length getPhysicalSize(Double value, String unit) {
-    if (value != null && value != 0) {
+    if (value != null && value != 0 && value < Double.POSITIVE_INFINITY) {
       if (unit != null) {
         try {
           UnitsLength ul = UnitsLength.fromString(unit);

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1449,7 +1449,7 @@ public final class FormatTools {
           
           // If the requested unit produces a value less than Constants.EPSILON then we switch to the next smallest unit possible
           // Using UnitsLength.values().length - 2 as a boundary so as not to include Pixel and Reference Frame as convertible units
-          while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 2)) { 
+          while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 3)) { 
             ordinal++;
             ul = UnitsLength.values()[ordinal];
             Length tempLength = UnitsLength.create(0, ul);

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1436,14 +1436,14 @@ public final class FormatTools {
   }
   
   public static Length getPhysicalSize(Double value, String unit) {
-    if (value != null) {
+    if (value != null && value != 0) {
       if (unit != null) {
         try {
           UnitsLength ul = UnitsLength.fromString(unit);
           int ordinal = ul.ordinal();
           Length returnLength = UnitsLength.create(value, ul);
   
-          if (returnLength.value().doubleValue() > Constants.EPSILON) {
+          if (returnLength.value().doubleValue() > Constants.EPSILON && returnLength.value().doubleValue() < Double.POSITIVE_INFINITY) {
             return returnLength;
           }
           
@@ -1829,5 +1829,4 @@ public final class FormatTools {
     }
     return new Time(value.getNumberValue(), valueUnit);
   }
-
 }

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1436,32 +1436,39 @@ public final class FormatTools {
   }
   
   public static Length getPhysicalSize(Double value, String unit) {
-    if (unit != null) {
-      try {
-        UnitsLength ul = UnitsLength.fromString(unit);
-        int ordinal = ul.ordinal();
-        Length returnLength = UnitsLength.create(value, ul);
-
-        if (returnLength.value().doubleValue() > Constants.EPSILON) {
-          return returnLength;
+    if (value != null) {
+      if (unit != null) {
+        try {
+          UnitsLength ul = UnitsLength.fromString(unit);
+          int ordinal = ul.ordinal();
+          Length returnLength = UnitsLength.create(value, ul);
+  
+          if (returnLength.value().doubleValue() > Constants.EPSILON) {
+            return returnLength;
+          }
+          
+          // If the requested unit produces a value less than Constants.EPSILON then we switch to the next smallest unit possible
+          // Using UnitsLength.values().length - 2 as a boundary so as not to include Pixel and Reference Frame as convertible units
+          while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 2)) { 
+            ordinal++;
+            ul = UnitsLength.values()[ordinal];
+            Length tempLength = UnitsLength.create(0, ul);
+            returnLength = UnitsLength.create(returnLength.value(tempLength.unit()), ul);
+          }
+          if (returnLength.value().doubleValue() > Constants.EPSILON && returnLength.value().doubleValue() < Double.POSITIVE_INFINITY) {
+            return returnLength;
+          }
+          else {
+            LOGGER.debug("Expected positive value for PhysicalSize; got {}", value);
+            return null;
+          }
+        } catch (EnumerationException e) {
         }
-        
-        // If the requested unit produces a value less than Constants.EPSILON then we switch to the next smallest unit possible
-        // Using UnitsLength.values().length - 2 as a boundary so as not to include Pixel and Reference Frame as convertible units
-        while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 2)) { 
-          ordinal++;
-          ul = UnitsLength.values()[ordinal];
-          Length tempLength = UnitsLength.create(0, ul);
-          returnLength = UnitsLength.create(returnLength.value(tempLength.unit()), ul);
-        }
-        if (returnLength.value().doubleValue() > Constants.EPSILON) {
-          return returnLength;
-        }
-        else return null;
-      } catch (EnumerationException e) {
       }
+      return new Length(value, UNITS.MICROM);
     }
-    return new Length(value, UNITS.MICROM);
+    LOGGER.debug("Expected positive value for PhysicalSize; got {}", value);
+    return null;
   }
 
   /**
@@ -1487,13 +1494,7 @@ public final class FormatTools {
    * @return       the physical size formatted as a {@link Length}
    */
   public static Length getPhysicalSizeX(Double value, String unit) {
-    if (isPositiveValue(value))
-    {
       return getPhysicalSize(value, unit);
-    } else {
-      LOGGER.debug("Expected positive value for PhysicalSizeX; got {}", value);
-      return null;
-    }
   }
 
   /**
@@ -1506,13 +1507,7 @@ public final class FormatTools {
    * @return       the physical size formatted as a {@link Length}
    */
   public static Length getPhysicalSizeX(Double value, Unit<Length> unit) {
-    if (isPositiveValue(value))
-    {
       return getPhysicalSize(value, unit.getSymbol());
-    } else {
-      LOGGER.debug("Expected positive value for PhysicalSizeX; got {}", value);
-      return null;
-    }
   }
 
   /**
@@ -1538,13 +1533,7 @@ public final class FormatTools {
    * @return       the physical size formatted as a {@link Length}
    */
   public static Length getPhysicalSizeY(Double value, String unit) {
-    if (isPositiveValue(value))
-    {
       return getPhysicalSize(value, unit);
-    } else {
-      LOGGER.debug("Expected positive value for PhysicalSizeY; got {}", value);
-      return null;
-    }
   }
 
   /**
@@ -1557,13 +1546,7 @@ public final class FormatTools {
    * @return       the physical size formatted as a {@link Length}
    */
   public static Length getPhysicalSizeY(Double value, Unit<Length> unit) {
-    if (isPositiveValue(value))
-    {
       return getPhysicalSize(value, unit.getSymbol());
-    } else {
-      LOGGER.debug("Expected positive value for PhysicalSizeY; got {}", value);
-      return null;
-    }
   }
 
   /**
@@ -1589,13 +1572,7 @@ public final class FormatTools {
    * @return       the physical size formatted as a {@link Length}
    */
   public static Length getPhysicalSizeZ(Double value, String unit) {
-    if (isPositiveValue(value))
-    {
       return getPhysicalSize(value, unit);
-    } else {
-      LOGGER.debug("Expected positive value for PhysicalSizeZ; got {}", value);
-      return null;
-    }
   }
 
   /**
@@ -1609,13 +1586,7 @@ public final class FormatTools {
 
    */
   public static Length getPhysicalSizeZ(Double value, Unit<Length> unit) {
-    if (isPositiveValue(value))
-    {
-      return createLength(value, unit);
-    } else {
-      LOGGER.debug("Expected positive value for PhysicalSizeZ; got {}", value);
-      return null;
-    }
+      return getPhysicalSize(value, unit.getSymbol());
   }
 
   public static Length getEmissionWavelength(Double value) {

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1451,7 +1451,8 @@ public final class FormatTools {
         while (returnLength.value().doubleValue() < Constants.EPSILON && ordinal < (UnitsLength.values().length - 2)) { 
           ordinal++;
           ul = UnitsLength.values()[ordinal];
-          returnLength = UnitsLength.create(value, ul);
+          Length tempLength = UnitsLength.create(0, ul);
+          returnLength = UnitsLength.create(returnLength.value(tempLength.unit()), ul);
         }
         if (returnLength.value().doubleValue() > Constants.EPSILON) {
           return returnLength;


### PR DESCRIPTION
When converting the units the value must also be converted.
Have to use a workaround of using a temporary created Length in order to
get the new Unit<Length> as opposed to the UnitsLength

This a a bug fix for the merged PR https://github.com/openmicroscopy/bioformats/pull/2071