### PR TITLE
Fake: warn on invalid physical sizes (rebased onto develop)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -47,6 +47,7 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import loci.common.Constants;
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.IniList;
@@ -998,9 +999,11 @@ public class FakeReader extends FormatReader {
       try {
         l = UnitsLengthEnumHandler.getBaseUnit(UnitsLength.fromString(unit));
       } catch (EnumerationException e) {
-        throw new RuntimeException(String.format(
-                "%s does not match a length unit!", unit));
+        LOGGER.warn("{} does not match a length unit!", unit);
       }
-      return new Length(d, l);
+      if (l != null && d > Constants.EPSILON) {
+        return new Length(d, l);
+      }
+      return null;
   }
 }


### PR DESCRIPTION


This is the same as gh-2073 but rebased onto develop.

----

This warns instead of throwing an exception, and ensures that physical
sizes of 0.0 are not allowed.

To test, compare the behavior of ```showinf -nopix -omexml fake/samples/emptySizes&physicalSizeX=0.0.fake```.  Without this change, XML validation should fail; with this change, PhysicalSizeX should not be populated at all.

                    