### PR TITLE
CZI: update line scan detection for airyscan data (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -306,7 +306,7 @@ public class ZeissCZIReader extends FormatReader {
     int outputRow = 0, outputCol = 0;
 
     boolean validScanDim =
-      scanDim == (getImageCount() / getSizeC()) && scanDim > 1;
+      scanDim == (getImageCount() / (getSizeC() * phases)) && scanDim > 1;
     if (planes.size() == getImageCount()) {
       validScanDim = false;
     }


### PR DESCRIPTION


This is the same as gh-2076 but rebased onto develop.

----

See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-October/005701.html

To test, use the .czi file from the thread (uploaded to ```team/community_images/```).  It's easiest to see the problem by using the ```Histo``` tab in Zen, and comparing the histogram table values for each plane against the output of something like:

```
ImageReader reader = new ImageReader();
    reader.setId(args[0]);

    for (int t=0; t<100; t++) {
      for (int c=0; c<reader.getSizeC(); c++) {
        byte[] b = reader.openBytes(reader.getIndex(0, c, t));
        int[] counter = new int[256];
        for (int pixel=0; pixel<b.length; pixel++) {
          int v = b[pixel] & 0xff;
          counter[v]++;
        }
        System.out.println("t = " + t + ", c = " + c);
        for (int pixel=0; pixel<counter.length; pixel++) {
          if (counter[pixel] != 0) {
            System.out.println("  * value = " + pixel + ", count = " + counter[pixel]);
          }
        }
      }
    }

    reader.close();
```

or any equivalent in ImageJ or MATLAB.  Without this change, the above code shows that all pixel values are 0 for t > 0.  With this change, the pixel value counts should match what is shown in Zen.

                    