### PR TITLE
Showinf: preload format improvements

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -377,6 +377,13 @@ public class ImageInfo {
     if (map != null) Location.mapId(id, map);
     else if (preload) {
       RandomAccessInputStream f = new RandomAccessInputStream(id);
+      if (!(reader instanceof ImageReader)) {
+        // verify format
+        LOGGER.info("Checking {} format [{}]", reader.getFormat(),
+                    reader.isThisType(f) ? "yes" : "no");
+        f.close();
+        f = new RandomAccessInputStream(id);
+      }
       int len = (int) f.length();
       LOGGER.info("Caching {} bytes:", len);
       byte[] b = new byte[len];

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -381,8 +381,7 @@ public class ImageInfo {
         // verify format
         LOGGER.info("Checking {} format [{}]", reader.getFormat(),
                     reader.isThisType(f) ? "yes" : "no");
-        f.close();
-        f = new RandomAccessInputStream(id);
+        f.seek(0);
       }
       int len = (int) f.length();
       LOGGER.info("Caching {} bytes:", len);


### PR DESCRIPTION
This PR has been used to test https://github.com/openmicroscopy/bioformats/pull/2089 using the command-line tools. It allows to call `FormatReader.isThisType(RandomAccessInputStream)` using `showinf`.

To test this PR, run

```
./showinf -preload -format FORMAT /path/to/file
```

and verify the format type is also checked before caching the bytes.