### PR TITLE
Turn off file stitching for OME-XML and OME-TIFF

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -361,17 +361,7 @@ public class OMETiffReader extends FormatReader {
   /* @see loci.formats.IFormatReader#fileGroupOption() */
   @Override
   public int fileGroupOption(String id) {
-    try {
-      boolean single = isSingleFile(id);
-      return single ? FormatTools.CAN_GROUP : FormatTools.MUST_GROUP;
-    }
-    catch (FormatException e) {
-      LOGGER.debug("", e);
-    }
-    catch (IOException e) {
-      LOGGER.debug("", e);
-    }
-    return FormatTools.CAN_GROUP;
+    return FormatTools.MUST_GROUP;
   }
 
   /* @see loci.formats.IFormatReader#close(boolean) */

--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -118,6 +118,12 @@ public class OMEXMLReader extends FormatReader {
       FormatTools.NON_SPECIAL_DOMAINS;
   }
 
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  @Override
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
+  }
+
   /**
    * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
    */

--- a/components/formats-bsd/src/loci/formats/in/ZipReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ZipReader.java
@@ -45,6 +45,7 @@ import loci.common.ZipHandle;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
+import loci.formats.FormatTools;
 import loci.formats.ImageReader;
 
 /**
@@ -84,6 +85,12 @@ public class ZipReader extends FormatReader {
   public void setGroupFiles(boolean groupFiles) {
     super.setGroupFiles(groupFiles);
     if (reader != null) reader.setGroupFiles(groupFiles);
+  }
+
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  @Override
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
   }
 
   /**


### PR DESCRIPTION
This should disable FileStitcher's file grouping for OME-XML and OME-TIFF files, as needed for testing  schema samples.