### PR TITLE
EM format type checking fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -56,7 +56,7 @@ public class MRCReader extends FormatReader {
   // there, according to: http://bio3d.colorado.edu/imod/doc/mrc_format.txt
 
   private static final String[] MRC_SUFFIXES =
-    {"mrc", "st", "ali", "map", "rec"};
+    {"mrc", "st", "ali", "map", "rec", "mrcs"};
 
   private static final int HEADER_SIZE = 1024;
   private static final int GRIDSIZE_OFFSET = 28;

--- a/components/formats-gpl/src/loci/formats/in/SpiderReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SpiderReader.java
@@ -73,6 +73,11 @@ public class SpiderReader extends FormatReader {
     final int blockLen = 104;
     if (!FormatTools.validStream(stream, blockLen, true)) return false;
     int size = (int) stream.readFloat() * 4;
+    if (size == 0) {
+      stream.seek(0);
+      stream.order(false);
+      size = (int) stream.readFloat() * 4;
+    }
     stream.skipBytes(4);
     size *= (int) stream.readFloat();
     stream.seek(44);
@@ -84,7 +89,7 @@ public class SpiderReader extends FormatReader {
     if (slices > 0) {
       size *= slices;
     }
-    return size + headerSize == stream.length();
+    return size + headerSize == stream.length() || size == stream.length();
   }
 
   /**
@@ -130,6 +135,13 @@ public class SpiderReader extends FormatReader {
     in.order(isLittleEndian());
 
     int nSlice = (int) in.readFloat();
+    m.littleEndian = nSlice > 0;
+    if (!isLittleEndian()) {
+      in.order(isLittleEndian());
+      in.seek(0);
+      nSlice = (int) in.readFloat();
+    }
+
     int nRow = (int) in.readFloat();
     int irec = (int) in.readFloat();
     in.skipBytes(4);


### PR DESCRIPTION
Resolves https://trac.openmicroscopy.org/ome/ticket/13058 and https://trac.openmicroscopy.org/ome/ticket/13059.

To test, use the files from QA 16850, ignoring ```cvim006036.0.img``` as it is raw data without the corresponding header file.  Without this change, ```showinf``` on the three remaining files should report ```UnknownFormatException```.  With this change, the same test should show ```15_movie_gc.mrcs``` being detected as MRC, and both .dat files being detected as Spider.  EMAN2 should be able to read all three (per http://blake.bcm.edu/emanwiki/EMAN2ImageFormats), so hopefully can be used to validate the images themselves.