### PR TITLE
Add version history for 5.1.6 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -7,9 +7,7 @@ Version history
 * Java bug fixes, including:
    - Updated to use native units for following formats:
        - IMOD
-       - Alicona AL3D
        - Analyze
-       - FEI TIFF
        - Unisoku
        - Olympus CellR (APL)
    - Metamorph TIFF

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,38 @@
 Version history
 ===============
 
+5.1.6 (2015 November 16)
+------------------------
+
+* Java bug fixes, including:
+   - Updated to use native units for following formats:
+       - IMOD
+       - Alicona AL3D
+       - Analyze
+       - FEI TIFF
+       - Unisoku
+       - Olympus CellR (APL)
+   - Metamorph TIFF
+       - fixed handling of multi-line descriptions
+       - added support for dual camera acquisitions
+   - Zeiss LMS
+       - fixed exception in type detection
+   - Zeiss CZI
+       - fixed detection of line scan Airyscan data
+   - Slidebook
+       - fixed calculation of physical Z size
+   - ImageJ plugins
+       - fixed handling of non-default units
+       - fixed setting of preferences via macros
+   - Automated testing
+       - fixed handling of non-default units for physical sizes and timings
+* C++ changes, including:
+   - allow relocatable installation on Windows
+   - reduce time required for debug builds
+* Documentation updates, including:
+   - addition of "Multiple Images" column to the supported formats table
+   - addition of a MapAnnotation example
+
 5.1.5 (2015 October 12)
 -----------------------
 


### PR DESCRIPTION


This is the same as gh-2085 but rebased onto develop.

----

A couple of yet-unmerged PRs are referenced here, so depending on how Friday goes this may need one more commit.

                    