### PR TITLE
Rebased/develop/analyze reader units

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
@@ -349,8 +349,8 @@ public class AnalyzeReader extends FormatReader {
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       store.setImageDescription(description, 0);
 
-      Length sizeX = FormatTools.getPhysicalSizeX(voxelWidth * 0.001);
-      Length sizeY = FormatTools.getPhysicalSizeY(voxelHeight * 0.001);
+      Length sizeX = FormatTools.getPhysicalSizeX(voxelWidth, UNITS.MM);
+      Length sizeY = FormatTools.getPhysicalSizeY(voxelHeight, UNITS.MM);
       Length sizeZ =
         FormatTools.getPhysicalSizeZ(sliceThickness * 0.001);
 
@@ -363,7 +363,7 @@ public class AnalyzeReader extends FormatReader {
       if (sizeZ != null) {
         store.setPixelsPhysicalSizeZ(sizeZ, 0);
       }
-      store.setPixelsTimeIncrement(new Time(new Double(deltaT * 1000), UNITS.S), 0);
+      store.setPixelsTimeIncrement(new Time(deltaT, UNITS.MS), 0);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AnalyzeReader.java
@@ -351,8 +351,7 @@ public class AnalyzeReader extends FormatReader {
 
       Length sizeX = FormatTools.getPhysicalSizeX(voxelWidth, UNITS.MM);
       Length sizeY = FormatTools.getPhysicalSizeY(voxelHeight, UNITS.MM);
-      Length sizeZ =
-        FormatTools.getPhysicalSizeZ(sliceThickness * 0.001);
+      Length sizeZ = FormatTools.getPhysicalSizeZ(sliceThickness, UNITS.MM);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);


### PR DESCRIPTION
Rebasing https://github.com/openmicroscopy/bioformats/pull/2045 onto develop

This PR adjusts the AnalyzeReader to store the physical pixel size read from analyze files using the native units.

To test this PR, check analyze files are read correctly and automated tests are passing.