### PR TITLE
Rebased: APLReader - Update to use native units

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -448,14 +448,8 @@ public class APLReader extends FormatReader {
         double px = realWidth / ms.sizeX;
         double py = realHeight / ms.sizeY;
 
-        if (units.equals("mm")) {
-          px *= 1000;
-          py *= 1000;
-        }
-        // TODO : add cases for other units
-
-        Length physicalSizeX = FormatTools.getPhysicalSizeX(px);
-        Length physicalSizeY = FormatTools.getPhysicalSizeY(py);
+        Length physicalSizeX = FormatTools.getPhysicalSizeX(px, units);
+        Length physicalSizeY = FormatTools.getPhysicalSizeY(py, units);
 
         if (physicalSizeX != null) {
           store.setPixelsPhysicalSizeX(physicalSizeX, i);


### PR DESCRIPTION
APLReader - Update to use native units - Rebased from https://github.com/openmicroscopy/bioformats/pull/2067 onto develop

This PR adjusts the APLReader to store the physical pixel size read from apl files using the native units.

To test this PR, check apl files (cellr) are read correctly and automated tests are passing.