### PR TITLE
Detect whether dual camera Metamorph image has been split, and

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -287,7 +287,26 @@ public class MetamorphHandler extends BaseHandler {
       lensNA = Double.parseDouble(value);
     }
     else if (key.startsWith("Dual Camera")) {
-      dualCamera = true;
+      // Determine if image has been already split by Metamorph.
+      // Metamorph seems to add the wavelength number to the end
+      // of the Description field when splitting. Example:
+      // Dual Camera Time Difference: 7 msec 561
+      int space = value.lastIndexOf(" ");
+      if(space == -1) {
+            // unknown value format, assume dual camera
+            dualCamera = true;
+      } else {
+          try {
+            Double.parseDouble(value.substring(space));
+            // last number is a wavelength and indicates this dual camera
+            // image has been split
+            dualCamera = false;
+          }
+          catch (NumberFormatException e) {
+            // last token is not a number, so image has not been split
+            dualCamera = true; 
+          }
+      }
     }
   }
 


### PR DESCRIPTION
Do not split further if dual camera Metamorph image has already been split.

This addresses QA 16915

Metamorph seems to add the wavelength number to the end of the Description field when splitting. Example:
Dual Camera Time Difference: 7 msec 561

[split_488_metadata.txt](https://github.com/openmicroscopy/bioformats/files/39324/split_488_metadata.txt)
[split_561_metadata.txt](https://github.com/openmicroscopy/bioformats/files/39323/split_561_metadata.txt)
[unsplit_metadata.txt](https://github.com/openmicroscopy/bioformats/files/39325/unsplit_metadata.txt)

