### PR TITLE
Flex fixes for new sysgro data

### DIFF
--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -130,12 +130,9 @@ public final class MetadataConverter {
     }
 
     convertInstruments(src, dest);
-    if (MetadataLevel.MINIMUM != level) {
-      convertExperimenters(src, dest);
-      convertExperimenterGroups(src, dest);
-      convertExperiments(src, dest);
-    }
-
+    convertExperimenters(src, dest);
+    convertExperimenterGroups(src, dest);
+    convertExperiments(src, dest);
     convertImages(src, dest, level);
     convertPlates(src, dest);
     convertScreens(src, dest);

--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -129,8 +129,8 @@ public final class MetadataConverter {
       convertROIs(src, dest);
     }
 
+    convertInstruments(src, dest);
     if (MetadataLevel.MINIMUM != level) {
-      convertInstruments(src, dest);
       convertExperimenters(src, dest);
       convertExperimenterGroups(src, dest);
       convertExperiments(src, dest);

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1053,6 +1053,9 @@ public class FlexReader extends FormatReader {
     if (fieldCount == 1) {
       fieldCount *= (nFiles / runCount);
     }
+    if (fieldCount == 0) {
+      fieldCount = 1;
+    }
 
     int seriesCount = runCount * plateCount * wellCount * fieldCount;
     if (seriesCount > 1) {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -204,13 +204,20 @@ public class FlexReader extends FormatReader {
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
 
-    FlexFile file = lookupFile(0);
-    IFD ifd = file.ifds.get(0);
-    try {
-      return (int) ifd.getTileWidth();
+    int index = 0;
+    FlexFile file = lookupFile(index);
+    while ((file == null || file.ifds == null) && index < getSeriesCount()) {
+      index++;
+      file = lookupFile(index);
     }
-    catch (FormatException e) {
-      LOGGER.debug("Could not retrieve tile width", e);
+    if (file != null && file.ifds != null && file.ifds.size() > 0) {
+      IFD ifd = file.ifds.get(0);
+      try {
+        return (int) ifd.getTileWidth();
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Could not retrieve tile width", e);
+      }
     }
     return super.getOptimalTileWidth();
   }
@@ -220,13 +227,20 @@ public class FlexReader extends FormatReader {
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
 
-    FlexFile file = lookupFile(0);
-    IFD ifd = file.ifds.get(0);
-    try {
-      return (int) ifd.getTileLength();
+    int index = 0;
+    FlexFile file = lookupFile(index);
+    while ((file == null || file.ifds == null) && index < getSeriesCount()) {
+      index++;
+      file = lookupFile(index);
     }
-    catch (FormatException e) {
-      LOGGER.debug("Could not retrieve tile height", e);
+    if (file != null && file.ifds != null && file.ifds.size() > 0) {
+      IFD ifd = file.ifds.get(0);
+      try {
+        return (int) ifd.getTileLength();
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Could not retrieve tile height", e);
+      }
     }
     return super.getOptimalTileHeight();
   }

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -829,7 +829,7 @@ public class FlexReader extends FormatReader {
    * If the 'firstFile' flag is set, then the core metadata is also
    * populated.
    */
-  private void parseFlexFile(int currentWell, int wellRow, int wellCol,
+  private boolean parseFlexFile(int currentWell, int wellRow, int wellCol,
     int field, boolean firstFile, MetadataStore store)
     throws FormatException, IOException
   {
@@ -838,7 +838,7 @@ public class FlexReader extends FormatReader {
     int fieldIndex = field < 0 || fieldCount == 0 ? 0 : field % fieldCount;
     int runIndex = field < 0 || fieldCount == 0 ? 0 : field / fieldCount;
     FlexFile file = lookupFile(wellRow, wellCol, fieldIndex, runIndex);
-    if (file == null) return;
+    if (file == null) return false;
 
     int originalFieldCount = fieldCount;
 
@@ -966,6 +966,7 @@ public class FlexReader extends FormatReader {
     if (oneFactors) {
       file.factors = null;
     }
+    return true;
   }
 
   /** Populate core metadata using the given list of image names. */
@@ -1406,9 +1407,9 @@ public class FlexReader extends FormatReader {
 
           // setting a negative field index indicates that the field count
           // should be taken from the XML
-          parseFlexFile(currentWell, row, col, nFiles == 1 ? -1 : field, firstFile, store);
+          boolean parsedXML = parseFlexFile(currentWell, row, col, nFiles == 1 ? -1 : field, firstFile, store);
           s.close();
-          if (firstFile) firstFile = false;
+	  if (firstFile && parsedXML) firstFile = false;
         }
         currentWell++;
       }
@@ -1555,9 +1556,8 @@ public class FlexReader extends FormatReader {
         plateBarcodes.add(value);
         if (plateBarcodes.size() > size) {
           nextPlate++;
-          plateCount++;
         }
-        if (populateCore) {
+        if (populateCore && value != null && nextPlate == 1) {
           store.setPlateExternalIdentifier(value, nextPlate - 1);
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -275,7 +275,7 @@ public class FlexReader extends FormatReader {
       ifd = file.ifds.get(imageNumber);
       factor = 1d;
     }
-    else {
+    else if (firstFile != null && firstFile.ifds != null) {
       // Only the first IFD was read. Hack the IFD to adjust the offset.
       final IFD firstIFD = firstFile.ifds.get(0);
       ifd = new IFD(firstIFD);
@@ -297,6 +297,9 @@ public class FlexReader extends FormatReader {
         offsets[i] += offset;
       }
       ifd.putIFDValue(tag, offsets);
+    }
+    else {
+      return buf;
     }
     int nBytes = ifd.getBitsPerSample()[0] / 8;
     int bpp = FormatTools.getBytesPerPixel(getPixelType());


### PR DESCRIPTION
See https://trello.com/c/ZZGjfe10/120-sysgro-continued.  This should resolve all three stack traces noted in the card.  I haven't tried full OMERO imports, so it's possible that there are still issues, but everything I could see from ```showinf -omexml``` works now.