### PR TITLE
Adding JPEG-XR note to CZI format page

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2396,6 +2396,7 @@ utilityRating = Good
 privateSpecification = true
 reader = ZeissCZIReader
 mif = true
+notes = Bio-Formats does not support CZI files generated using JPEG-XR compression.
 
 [Zeiss LSM (Laser Scanning Microscope) 510/710]
 pagename = zeiss-lsm

--- a/docs/sphinx/formats/zeiss-czi.txt
+++ b/docs/sphinx/formats/zeiss-czi.txt
@@ -52,3 +52,4 @@ Utility: |Good|
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**
 
+Bio-Formats does not support CZI files generated using JPEG-XR compression.


### PR DESCRIPTION
See https://trello.com/c/FAR5LQH2/4-czi-jpeg-xr-doc-limitation
Hopefully this wording is okay.

Will be staged at https://www.openmicroscopy.org/site/support/bio-formats5.1-staging/formats/zeiss-czi.html once built.