### PR TITLE
bfCheckJavaPath.m: Only check MATLAB static javaclasspath once

### DIFF
--- a/components/formats-gpl/matlab/bfCheckJavaPath.m
+++ b/components/formats-gpl/matlab/bfCheckJavaPath.m
@@ -42,6 +42,8 @@ function [status, version] = bfCheckJavaPath(varargin)
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+persistent hasBFJarStatic;
+
 % Input check
 ip = inputParser;
 ip.addOptional('autoloadBioFormats', true, @isscalar);
@@ -49,12 +51,27 @@ ip.parse(varargin{:});
 
 % Check if a Bio-Formats JAR file is in the Java class path
 % Can be in either static or dynamic Java class path
-jPath = javaclasspath('-all');
 bfJarFiles = {'bioformats_package.jar', 'loci_tools.jar'};
-hasBFJar =  false(numel(bfJarFiles), 1);
+
+if(isempty(hasBFJarStatic))
+    % The static javaclasspath should not change per matlab session
+    % Therefore, we only need to check it once and can use persistent to
+    % enforce that
+    jPathStatic = javaclasspath('-static');
+    hasBFJarStatic =  false(numel(bfJarFiles), 1);
+    for i = 1: numel(bfJarFiles);
+        isBFJar =  @(x) ~isempty(regexp(x, ['.*' bfJarFiles{i} '$'], 'once'));
+        hasBFJarStatic(i) = any(cellfun(isBFJar, jPathStatic));
+    end
+end
+
+jPath = javaclasspath('-dynamic');
+hasBFJar =  hasBFJarStatic;
 for i = 1: numel(bfJarFiles);
-    isBFJar =  @(x) ~isempty(regexp(x, ['.*' bfJarFiles{i} '$'], 'once'));
-    hasBFJar(i) = any(cellfun(isBFJar, jPath));
+    if(~hasBFJar(i))
+        isBFJar =  @(x) ~isempty(regexp(x, ['.*' bfJarFiles{i} '$'], 'once'));
+        hasBFJar(i) = any(cellfun(isBFJar, jPath)) ;
+    end
 end
 
 % Check conflicting JARs are not loaded


### PR DESCRIPTION
In bfCheckJavaPath.m, only check MATLAB static javaclasspath once by using a persistent variable. 

The static javaclasspath can only be changed at startup by adding a javaclasspath.txt file in either the MATLAB startup directory or in `prefdir`. Therefore, we only need to check the static classpath once for the jars. On subsequent calls to `bfCheckJavaPath.m`, just recheck the dynamic path and merge the results.

As the static classpath is quite long and the dynamic classpath is quite short in MATLAB the efficiency gains by not constantly rechecking the static classpath are substantial.

This change is against 5.1.x only and thus is against dev_5_1. It would need be reconciled with the version in develop ( 549b8673a619dce95e482234fad54367a8975b97 ) which does no analysis of the classpath directly. However, unlike the version in develop, it should retain the previous behavior and should not be breaking as in #2027. See also #2018.

