### PR TITLE
Add bio-formats-tools to bioformats_package

### DIFF
--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>bio-formats_plugins</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>bio-formats-tools</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
This PR modifies bioformats_package's pom to add `bio-formats-tools` as a dependency, so that the following classes are included in the bundle:
```
loci/formats/tools/ImageConverter.class
loci/formats/tools/ImageFaker.class
loci/formats/tools/ImageInfo.class
```

**To test:**
```
mvn install
cd tools
ln -s ~/.m2/repository/ome/bioformats_package/5.2.0-SNAPSHOT/bioformats_package-5.2.0-SNAPSHOT.jar bioformats_package.jar
./mkfake
./showinf 
./bfconvert 
```

Check that you get the expected usage help for all three tools. *Without* this patch, instead, you should get, respectively:
```
Error: Could not find or load main class loci.formats.tools.ImageFaker
Error: Could not find or load main class loci.formats.tools.ImageInfo
Error: Could not find or load main class loci.formats.tools.ImageConverter
```

**NOTE:**
*In addition* to the three classes mentioned above, this patch also causes the following to be added to the bundle (on my system, at least):
```
javax/xml/validation/SchemaFactoryLoader.class
META-INF/maven/ome/bio-formats-tools
org/w3c/css
```
While the second one is expected, I don't know if it's good or bad to have the other two.