### PR TITLE
Rebased: MINC2 - Endianess

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MINCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MINCReader.java
@@ -153,7 +153,8 @@ public class MINCReader extends FormatReader {
         pixels = netcdf.getVariableValue("/minc-2.0/image/0/image");
         isMINC2 = true;
       }
-
+      m.littleEndian = isMINC2;
+      
       if (pixels instanceof byte[][][]) {
         m.pixelType = FormatTools.UINT8;
         pixelData = (byte[][][]) pixels;
@@ -225,8 +226,6 @@ public class MINCReader extends FormatReader {
     catch (ServiceException e) {
       throw new FormatException(e);
     }
-
-    m.littleEndian = isMINC2;
 
     Double physicalX = null;
     Double physicalY = null;


### PR DESCRIPTION
--rebased-from #2114

For short, int, float and double data in MINC2 format, the endianess of
 the pixel format must be set before unpacking the data.

Issue was reported here: #2110

To reproduce:
•Using a sample 16bit minc2 image open with bioformats
•Verify that the outline of the data is visible but the pixel values appear to noise

To verify:
•Reopen the image with the PR
•Verify that the data is no longer appearing as noise and instead as sensible values
