### PR TITLE
Fix current year in POM file (rebased onto develop)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <release.version>5.2.0-SNAPSHOT</release.version>
     <vcs.shortrevision>${shortrevision}</vcs.shortrevision>
     <date>${maven.build.timestamp}</date>
-    <year>2013</year>
+    <year>2015</year>
     <project.rootdir>${basedir}</project.rootdir>
     <imagej1.version>1.48s</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>

--- a/tools/update_copyright
+++ b/tools/update_copyright
@@ -35,3 +35,6 @@ do
         fi
     done
 done
+
+echo "Updating pom.xml"
+inplace_sed "s/<year>${YEAR}/<year>${CURRENT_YEAR}/" pom.xml


### PR DESCRIPTION


This is the same as gh-2111 but rebased onto develop.

----

To test, build bioformats_package.jar using Maven and copy to your ImageJ plugins folder.  Without this change, ```Help > About Plugins > Bio-Formats Plugins``` in ImageJ should show the end copyright year as 2013.  With this change, the same test should show the end copyright year as 2015.

                    