### PR TITLE
LIF: use long offsets for tile acquisitions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -323,7 +323,8 @@ public class LIFReader extends FormatReader {
       tile -= tileCount[i];
     }
 
-    in.skipBytes((int) (tile * planeSize * getImageCount()));
+    // seek instead of skipBytes to prevent dangerous int cast
+    in.seek(in.getFilePointer() + tile * planeSize * getImageCount());
     in.skipBytes(bytesToSkip * getSizeY() * no);
 
     if (bytesToSkip == 0) {


### PR DESCRIPTION
This prevents large multi-tile files from having incorrect plane offsets after the 2GB mark.

See
https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=4710&p=16480#p16480

In the process of uploading the test file; test instructions and configuration PR forthcoming.