### PR TITLE
FilePattern: allow nonexistent single files

### DIFF
--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -984,23 +984,20 @@ public class ImporterTest {
 
   /** tests BF's options.setGroupFiles() */
   private void datasetGroupFilesTester(boolean virtual) {
-    String fake_pattern;
-    int fake_plane_count = 7;
-    int fake_channel_count = 3;
-    int fake_timepoint_count = 5;
-    int fake_size_x = 50;
-    int fake_size_y = 50;
+    int sizeZ = 7;
+    int sizeC = 3;
+    int sizeT = 5;
+    int sizeX = 50;
+    int sizeY = 50;
 
     String template = constructFakeFilename(
-        "test_C%s_TP%s", FormatTools.UINT8, fake_size_x, fake_size_y,
-        fake_plane_count, 1, 1, -1, false, -1, false, -1
+        "test_C%s_TP%s", FormatTools.UINT8, sizeX, sizeY, sizeZ,
+        1, 1, -1, false, -1, false, -1
     );
-
     String path = String.format(template, 1, 1);
     String file;
-
-    for (int c = 1; c <= fake_channel_count; c++) {
-      for (int t = 1; t <= fake_timepoint_count; t++) {
+    for (int c = 1; c <= sizeC; c++) {
+      for (int t = 1; t <= sizeT; t++) {
         file = String.format(template, c, t);
         try {
           (new Location(file)).createNewFile();
@@ -1009,16 +1006,14 @@ public class ImporterTest {
         }
       }
     }
-
-    String fake_pattern_base = String.format(
+    String pattern_base = String.format(
         template,
-        String.format("<1-%d>", fake_channel_count),
-        String.format("<1-%d>", fake_timepoint_count)
+        String.format("<1-%d>", sizeC),
+        String.format("<1-%d>", sizeT)
     );
-    fake_pattern = (new Location(fake_pattern_base).getAbsolutePath());
+    String pattern = (new Location(pattern_base).getAbsolutePath());
 
     ImagePlus[] imps = null;
-
     try {
       ImporterOptions options = new ImporterOptions();
       options.setAutoscale(false);
@@ -1026,7 +1021,7 @@ public class ImporterTest {
       options.setGroupFiles(true);
       options.setId(path);
       imps = BF.openImagePlus(options);
-      assertEquals(fake_pattern, options.getId());
+      assertEquals(pattern, options.getId());
     }
     catch (IOException e) {
       fail(e.getMessage());
@@ -1034,16 +1029,9 @@ public class ImporterTest {
     catch (FormatException e) {
       fail(e.getMessage());
     }
-
-    impsCountTest(imps,1);
-
-    xyzctTest(
-        imps[0], fake_size_x, fake_size_y, fake_plane_count,
-        fake_channel_count, fake_timepoint_count
-    );
-    groupedFilesTest(
-        imps[0], fake_plane_count, fake_channel_count, fake_timepoint_count
-    );
+    impsCountTest(imps, 1);
+    xyzctTest(imps[0], sizeX, sizeY, sizeZ, sizeC, sizeT);
+    groupedFilesTest(imps[0], sizeZ, sizeC, sizeT);
   }
 
   /** tests BF's options.setUngroupFiles() */

--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -151,49 +151,6 @@ public class ImporterTest {
 
   private static final int ONE_SERIES = 1;
 
-  private static final String[] FAKE_FILES;
-  private static final String FAKE_PATTERN;
-
-  private static final int FAKE_PLANE_COUNT = 7;
-  private static final int FAKE_CHANNEL_COUNT = 3;
-  private static final int FAKE_TIMEPOINT_COUNT = 5;
-  private static final int FAKE_SIZE_X = 50;
-  private static final int FAKE_SIZE_Y = 50;
-
-  static {
-    //String template = "test_C%s_TP%s&sizeX=50&sizeY=20&sizeZ=7.fake";
-    String template = constructFakeFilename("test_C%s_TP%s", FormatTools.UINT8, FAKE_SIZE_X, FAKE_SIZE_Y, FAKE_PLANE_COUNT, 1, 1,
-                        -1, false, -1, false, -1);
-
-    FAKE_FILES = new String[] {
-      String.format(template, "1", "1"),
-      String.format(template, "2", "1"),
-      String.format(template, "3", "1"),
-      String.format(template, "1", "2"),
-      String.format(template, "2", "2"),
-      String.format(template, "3", "2"),
-      String.format(template, "1", "3"),
-      String.format(template, "2", "3"),
-      String.format(template, "3", "3"),
-      String.format(template, "1", "4"),
-      String.format(template, "2", "4"),
-      String.format(template, "3", "4"),
-      String.format(template, "1", "5"),
-      String.format(template, "2", "5"),
-      String.format(template, "3", "5")
-    };
-
-    for (String file : FAKE_FILES) {
-      try {
-        (new Location(file)).createNewFile();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    String FAKE_PATTERN_BASE = String.format(template, "<1-3>", "<1-5>");
-    FAKE_PATTERN = (new Location(FAKE_PATTERN_BASE).getAbsolutePath());
-  }
 
   // ** Helper methods *******************************************************************
 
@@ -1026,9 +983,50 @@ public class ImporterTest {
   }
 
   /** tests BF's options.setGroupFiles() */
-  private void datasetGroupFilesTester(boolean virtual)
-  {
-    String path = FAKE_FILES[0];
+  private void datasetGroupFilesTester(boolean virtual) {
+    String[] fake_files;
+    String fake_pattern;
+    int fake_plane_count = 7;
+    int fake_channel_count = 3;
+    int fake_timepoint_count = 5;
+    int fake_size_x = 50;
+    int fake_size_y = 50;
+
+    String template = constructFakeFilename(
+        "test_C%s_TP%s", FormatTools.UINT8, fake_size_x, fake_size_y,
+        fake_plane_count, 1, 1, -1, false, -1, false, -1
+    );
+
+    fake_files = new String[] {
+      String.format(template, "1", "1"),
+      String.format(template, "2", "1"),
+      String.format(template, "3", "1"),
+      String.format(template, "1", "2"),
+      String.format(template, "2", "2"),
+      String.format(template, "3", "2"),
+      String.format(template, "1", "3"),
+      String.format(template, "2", "3"),
+      String.format(template, "3", "3"),
+      String.format(template, "1", "4"),
+      String.format(template, "2", "4"),
+      String.format(template, "3", "4"),
+      String.format(template, "1", "5"),
+      String.format(template, "2", "5"),
+      String.format(template, "3", "5")
+    };
+
+    for (String file : fake_files) {
+      try {
+        (new Location(file)).createNewFile();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    String fake_pattern_base = String.format(template, "<1-3>", "<1-5>");
+    fake_pattern = (new Location(fake_pattern_base).getAbsolutePath());
+
+    String path = fake_files[0];
 
     ImagePlus[] imps = null;
 
@@ -1039,7 +1037,7 @@ public class ImporterTest {
       options.setGroupFiles(true);
       options.setId(path);
       imps = BF.openImagePlus(options);
-      assertEquals(FAKE_PATTERN, options.getId());
+      assertEquals(fake_pattern, options.getId());
     }
     catch (IOException e) {
       fail(e.getMessage());
@@ -1050,9 +1048,13 @@ public class ImporterTest {
 
     impsCountTest(imps,1);
 
-    xyzctTest(imps[0], FAKE_SIZE_X, FAKE_SIZE_Y, FAKE_PLANE_COUNT, FAKE_CHANNEL_COUNT, FAKE_TIMEPOINT_COUNT);
-
-    groupedFilesTest(imps[0], FAKE_PLANE_COUNT, FAKE_CHANNEL_COUNT, FAKE_TIMEPOINT_COUNT);
+    xyzctTest(
+        imps[0], fake_size_x, fake_size_y, fake_plane_count,
+        fake_channel_count, fake_timepoint_count
+    );
+    groupedFilesTest(
+        imps[0], fake_plane_count, fake_channel_count, fake_timepoint_count
+    );
   }
 
   /** tests BF's options.setUngroupFiles() */

--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -41,6 +41,7 @@ import ij.process.LUT;
 import java.awt.Color;
 import java.awt.image.IndexColorModel;
 import java.io.IOException;
+import java.io.File;
 
 import loci.common.Location;
 import loci.common.Region;
@@ -998,26 +999,26 @@ public class ImporterTest {
         "test_C%s_TP%s", FormatTools.UINT8, sizeX, sizeY, sizeZ,
         1, 1, -1, false, -1, false, -1
     );
-    String file;
+    File file;
+    String path = "";
     for (int c = 1; c <= sizeC; c++) {
       for (int t = 1; t <= sizeT; t++) {
-        file = String.format(template, c, t);
         try {
-          wd.newFile(file);
+          file = wd.newFile(String.format(template, c, t));
+          if (1 == c && 1 == t) {
+            path = file.getAbsolutePath();
+          }
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
       }
     }
-    String path_base = String.format(template, 1, 1);
     String pattern_base = String.format(
         template,
         String.format("<1-%d>", sizeC),
         String.format("<1-%d>", sizeT)
     );
-    String abs_wd = wd.getRoot().getAbsolutePath();
-    String path = String.format("%s/%s", abs_wd, path_base);
-    String pattern = String.format("%s/%s", abs_wd, pattern_base);
+    String pattern = new File(wd.getRoot(), pattern_base).getAbsolutePath();
 
     ImagePlus[] imps = null;
     try {

--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -49,6 +49,8 @@ import loci.formats.FormatTools;
 import loci.plugins.BF;
 
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,6 +153,8 @@ public class ImporterTest {
 
   private static final int ONE_SERIES = 1;
 
+  @Rule
+  public TemporaryFolder wd = new TemporaryFolder();
 
   // ** Helper methods *******************************************************************
 
@@ -994,24 +998,26 @@ public class ImporterTest {
         "test_C%s_TP%s", FormatTools.UINT8, sizeX, sizeY, sizeZ,
         1, 1, -1, false, -1, false, -1
     );
-    String path = String.format(template, 1, 1);
     String file;
     for (int c = 1; c <= sizeC; c++) {
       for (int t = 1; t <= sizeT; t++) {
         file = String.format(template, c, t);
         try {
-          (new Location(file)).createNewFile();
+          wd.newFile(file);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
       }
     }
+    String path_base = String.format(template, 1, 1);
     String pattern_base = String.format(
         template,
         String.format("<1-%d>", sizeC),
         String.format("<1-%d>", sizeT)
     );
-    String pattern = (new Location(pattern_base).getAbsolutePath());
+    String abs_wd = wd.getRoot().getAbsolutePath();
+    String path = String.format("%s/%s", abs_wd, path_base);
+    String pattern = String.format("%s/%s", abs_wd, pattern_base);
 
     ImagePlus[] imps = null;
     try {

--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -984,7 +984,6 @@ public class ImporterTest {
 
   /** tests BF's options.setGroupFiles() */
   private void datasetGroupFilesTester(boolean virtual) {
-    String[] fake_files;
     String fake_pattern;
     int fake_plane_count = 7;
     int fake_channel_count = 3;
@@ -997,36 +996,26 @@ public class ImporterTest {
         fake_plane_count, 1, 1, -1, false, -1, false, -1
     );
 
-    fake_files = new String[] {
-      String.format(template, "1", "1"),
-      String.format(template, "2", "1"),
-      String.format(template, "3", "1"),
-      String.format(template, "1", "2"),
-      String.format(template, "2", "2"),
-      String.format(template, "3", "2"),
-      String.format(template, "1", "3"),
-      String.format(template, "2", "3"),
-      String.format(template, "3", "3"),
-      String.format(template, "1", "4"),
-      String.format(template, "2", "4"),
-      String.format(template, "3", "4"),
-      String.format(template, "1", "5"),
-      String.format(template, "2", "5"),
-      String.format(template, "3", "5")
-    };
+    String path = String.format(template, 1, 1);
+    String file;
 
-    for (String file : fake_files) {
-      try {
-        (new Location(file)).createNewFile();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
+    for (int c = 1; c <= fake_channel_count; c++) {
+      for (int t = 1; t <= fake_timepoint_count; t++) {
+        file = String.format(template, c, t);
+        try {
+          (new Location(file)).createNewFile();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
       }
     }
 
-    String fake_pattern_base = String.format(template, "<1-3>", "<1-5>");
+    String fake_pattern_base = String.format(
+        template,
+        String.format("<1-%d>", fake_channel_count),
+        String.format("<1-%d>", fake_timepoint_count)
+    );
     fake_pattern = (new Location(fake_pattern_base).getAbsolutePath());
-
-    String path = fake_files[0];
 
     ImagePlus[] imps = null;
 

--- a/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
+++ b/components/bio-formats-plugins/test/loci/plugins/in/ImporterTest.java
@@ -182,11 +182,17 @@ public class ImporterTest {
       String.format(template, "2", "5"),
       String.format(template, "3", "5")
     };
-    FAKE_PATTERN = String.format(template, "<1-3>", "<1-5>");
 
     for (String file : FAKE_FILES) {
-      Location.mapId(file, "iThinkI'mImportantButI'mNot");
+      try {
+        (new Location(file)).createNewFile();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
+
+    String FAKE_PATTERN_BASE = String.format(template, "<1-3>", "<1-5>");
+    FAKE_PATTERN = (new Location(FAKE_PATTERN_BASE).getAbsolutePath());
   }
 
   // ** Helper methods *******************************************************************

--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -169,7 +169,7 @@ public class FilePattern {
     buildFiles("", num, fileList);
     files = fileList.toArray(new String[0]);
 
-    if (files.length == 0 && new Location(pattern).exists()) {
+    if (files.length == 0) {
       files = new String[] {pattern};
     }
 


### PR DESCRIPTION
This PR addresses a problem that occurs when `FilePattern` is initialized with a string corresponding to a single but nonexistent file. In this case, `files` is left empty but the pattern is still marked as valid, leading to an `ArrayIndexOutOfBoundsException` in code that assumes that at least one element will be present. This [happens in FileStitcher](https://github.com/openmicroscopy/bioformats/blob/metadata/components/formats-bsd/src/loci/formats/FileStitcher.java#L275), and the error is currently being triggered by `loci.plugins.in.ImporterTest`.

Since not allowing nonexistent files breaks `.fake` support, the fix consists of removing the existence check. This PR also fixes a few problems in the aforementioned test. Note that the fixes proper are in the first commit, while subsequent ones make sure test files are not created in the current directory and perform some refactoring.

**To test:** run `mvn test` and check that all tests pass. *Without* this PR, you should get:
```
[...]
Running loci.plugins.in.ImporterTest
[...]
Tests run: 24, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 9.628 sec <<< FAILURE! - in loci.plugins.in.ImporterTest
testDatasetGroupFiles(loci.plugins.in.ImporterTest)  Time elapsed: 0.052 sec  <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: 0
	at loci.formats.FileStitcher.initFile(FileStitcher.java:911)
	at loci.formats.FileStitcher.setId(FileStitcher.java:891)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:651)
	at loci.formats.ChannelFiller.setId(ChannelFiller.java:223)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:651)
	at loci.formats.ChannelSeparator.setId(ChannelSeparator.java:289)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:651)
	at loci.formats.DimensionSwapper.setId(DimensionSwapper.java:293)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:651)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:651)
	at loci.plugins.in.ImportProcess.setId(ImportProcess.java:701)
	at loci.plugins.in.ImportProcess.initializeStack(ImportProcess.java:555)
	at loci.plugins.in.ImportProcess.execute(ImportProcess.java:147)
	at loci.plugins.BF.openImagePlus(BF.java:92)
	at loci.plugins.in.ImporterTest.datasetGroupFilesTester(ImporterTest.java:1035)
	at loci.plugins.in.ImporterTest.testDatasetGroupFiles(ImporterTest.java:2019)

```