### PR TITLE
Whitelist .ome.xml as an official extension of the OME-XML format

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -85,7 +85,7 @@ public class OMEXMLReader extends FormatReader {
 
   /** Constructs a new OME-XML reader. */
   public OMEXMLReader() {
-    super("OME-XML", "ome");
+    super("OME-XML", new String[] {"ome", "ome.xml"});
     domains = FormatTools.NON_GRAPHICS_DOMAINS;
     suffixNecessary = false;
   }

--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -74,7 +74,7 @@ public class OMEXMLWriter extends FormatWriter {
   // -- Constructor --
 
   public OMEXMLWriter() {
-    super("OME-XML", "ome");
+    super("OME-XML", new String[] {"ome", "ome.xml"});
     compressionTypes =
       new String[] {CompressionType.UNCOMPRESSED.getCompression(),
         CompressionType.ZLIB.getCompression()};


### PR DESCRIPTION
This extension is currently supported by the permissive nature of the reader but unsupported by the writer. There are a couple of reasons why we want to consider it as official including our own usage, the symmetry with the OME-TIFF format extension and the usability with other software.

To test this PR, try to convert an OME-XML into another one with the `.ome.xml` extension

```
./tools/bfconvert test.ome.xml test2.ome.xml
```

/cc @rleigh-dundee @mtbc @hflynn @joshmoore @melissalinkert 