### PR TITLE
Add version history for 5.1.7

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,28 @@
 Version history
 ===============
 
+5.1.7 (2015 December 7)
+-----------------------
+
+* Java bug fixes, including:
+   - Metamorph
+       - fixed calculation of Z step size
+       - fixed detection of post-processed dual camera acquisitions (thanks to Mark Kittisopikul)
+   - OME-XML
+       - fixed XML validation when an 'xmlns' value is not present (thanks to Bjoern Thiel)
+   - MINC
+       - fixed endianness of image data
+   - Andor/Fluoview TIFF
+       - fixed calculation of Z step size
+   - MATLAB
+       - improved performance by reducing static classpath checks (thanks to Mark Kittisopikul)
+   - Gatan
+       - fixed physical size parsing in non-English locales
+   - Automated testing
+       - fixed handling of non-default physical size and plane position units
+* Documentation updates, including:
+   - updated MapAnnotation example to show linkage of annotations to images
+
 5.1.6 (2015 November 16)
 ------------------------
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -5,6 +5,7 @@ Version history
 -----------------------
 
 * Java bug fixes, including:
+   - Prevent physical pixel sizes from being rounded to 0, for all formats
    - Metamorph
        - fixed calculation of Z step size
        - fixed detection of post-processed dual camera acquisitions (thanks to Mark Kittisopikul)


### PR DESCRIPTION
Just what it says on the tin.  I didn't add C++ changes since there don't seem to be any dev_5_1 C++ PRs not tagged for 5.1.6 - happy to add if I missed anything.