### PR TITLE
FEITiffReader - Using native units (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
@@ -50,6 +50,7 @@ import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
+import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 import org.xml.sax.Attributes;
@@ -319,8 +320,13 @@ public class FEITiffReader extends BaseTiffReader {
       store.setStageLabelZ(stageZ, 0);
       store.setStageLabelName("", 0);
 
-      Length physicalSizeX = FormatTools.getPhysicalSizeX(sizeX, UNITS.METRE);
-      Length physicalSizeY = FormatTools.getPhysicalSizeY(sizeY, UNITS.METRE);
+      boolean helios = ifds.get(0).containsKey(HELIOS_TAG);
+      Unit<Length> unit = UNITS.MICROM;
+      if (helios) {
+        unit = UNITS.METRE;
+      }
+      Length physicalSizeX = FormatTools.getPhysicalSizeX(sizeX, unit);
+      Length physicalSizeY = FormatTools.getPhysicalSizeY(sizeY, unit);
 
       if (physicalSizeX != null) {
         store.setPixelsPhysicalSizeX(physicalSizeX, 0);

--- a/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
@@ -225,9 +225,9 @@ public class FEITiffReader extends BaseTiffReader {
           }
 
           IniTable scanTable = ini.getTable("Scan");
-          // physical sizes are stored in meters
-          sizeX = new Double(scanTable.get("PixelWidth")) * 1000000;
-          sizeY = new Double(scanTable.get("PixelHeight")) * 1000000;
+ 
+          sizeX = new Double(scanTable.get("PixelWidth"));
+          sizeY = new Double(scanTable.get("PixelHeight"));
           timeIncrement = new Double(scanTable.get("FrameTime"));
         }
       }
@@ -319,8 +319,8 @@ public class FEITiffReader extends BaseTiffReader {
       store.setStageLabelZ(stageZ, 0);
       store.setStageLabelName("", 0);
 
-      Length physicalSizeX = FormatTools.getPhysicalSizeX(sizeX);
-      Length physicalSizeY = FormatTools.getPhysicalSizeY(sizeY);
+      Length physicalSizeX = FormatTools.getPhysicalSizeX(sizeX, UNITS.METRE);
+      Length physicalSizeY = FormatTools.getPhysicalSizeY(sizeY, UNITS.METRE);
 
       if (physicalSizeX != null) {
         store.setPixelsPhysicalSizeX(physicalSizeX, 0);
@@ -393,12 +393,12 @@ public class FEITiffReader extends BaseTiffReader {
         else if (key.equals("Magnification")) {
           magnification = new Double(value);
         }
-        // physical sizes stored in meters, but usually too small to be used without converting
+
         else if (key.endsWith("X") && "PixelSize".equals(parent)) {
-          sizeX = new Double(value) * 1000000;
+          sizeX = new Double(value);
         }
         else if (key.endsWith("Y") && "PixelSize".equals(parent)) {
-          sizeY = new Double(value) * 1000000;
+          sizeY = new Double(value);
         }
       }
     }


### PR DESCRIPTION
This is the same as #2046 but rebased onto develop.

---

Using metres for physical size rather than micrometres