### PR TITLE
AFI/SVS metadata fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -261,6 +261,11 @@ public class AFIReader extends FormatReader {
       reader[i] = new ChannelSeparator(new SVSReader());
       reader[i].setFlattenedResolutions(hasFlattenedResolutions());
       reader[i].setId(pixels.get(i));
+
+      ArrayList<String> dyeNames = ((SVSReader) reader[i].getReader()).getDyeNames();
+      if (dyeNames.size() > 0) {
+        channelNames[i] = dyeNames.get(0);
+      }
     }
 
     core = reader[0].getCoreMetadataList();
@@ -296,10 +301,17 @@ public class AFIReader extends FormatReader {
       getMetadataOptions().getMetadataLevel() == MetadataLevel.MINIMUM;
     MetadataTools.populatePixels(store, this, !minimalMetadata);
 
-    String fileID = currentId.substring(
-      currentId.lastIndexOf(File.separator) + 1, currentId.lastIndexOf("."));
-    for (int i=0; i<getSeriesCount(); i++) {
-      store.setImageName(fileID + " - image #" + (i + 1), i);
+    String fileID = currentId.substring(currentId.lastIndexOf(File.separator) + 1);
+
+    if (hasFlattenedResolutions()) {
+      for (int i=0; i<getSeriesCount(); i++) {
+        store.setImageName(fileID + " - image #" + (i + 1), i);
+      }
+    }
+    else {
+      store.setImageName(fileID, 0);
+      store.setImageName(fileID + " [label image]", 1);
+      store.setImageName(fileID + " [macro image]", 2);
     }
 
     if (!minimalMetadata) {

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Hashtable;
 
 import loci.common.Constants;
@@ -115,7 +116,7 @@ public class AFIReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader[0].setCoreIndex(getCoreIndex() + 1);
+      reader[0].setCoreIndex(getCoreIndex());
       return reader[0].openThumbBytes(no);
     }
 
@@ -137,7 +138,7 @@ public class AFIReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader[0].setCoreIndex(getCoreIndex() + 1);
+      reader[0].setCoreIndex(getCoreIndex());
       return reader[0].openBytes(no, buf, x, y, w, h);
     }
 
@@ -146,7 +147,33 @@ public class AFIReader extends FormatReader {
     int index = getIndex(coords[0], 0, coords[2]);
 
     reader[channel].setCoreIndex(getCoreIndex());
-    return reader[channel].openBytes(index, buf, x, y, w, h);
+
+    int srcBytes = FormatTools.getBytesPerPixel(reader[channel].getPixelType());
+    int destBytes = FormatTools.getBytesPerPixel(getPixelType());
+
+    int diff = destBytes - srcBytes;
+
+    if (diff == 0) {
+      return reader[channel].openBytes(index, buf, x, y, w, h);
+    }
+    else if (diff > 0) {
+      Arrays.fill(buf, (byte) 0);
+      byte[] tmp = reader[channel].openBytes(index, x, y, w, h);
+      for (int i=0, dest=0; i<tmp.length; i+=srcBytes, dest+=destBytes) {
+        if (isLittleEndian()) {
+          for (int j=0; j<srcBytes; j++) {
+            buf[dest + j] = tmp[i + j];
+          }
+        }
+        else {
+          for (int j=0; j<srcBytes; j++) {
+            buf[dest + destBytes - j - 1] = tmp[i + srcBytes - j - 1];
+          }
+        }
+      }
+      return buf;
+    }
+    throw new FormatException("Downsampling images is not supported");
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
@@ -228,7 +255,6 @@ public class AFIReader extends FormatReader {
     }
 
     core = reader[0].getCoreMetadataList();
-    core.remove(core.size() - EXTRA_IMAGES - 1);
 
     for (int i=0; i<core.size() - EXTRA_IMAGES; i++) {
       CoreMetadata c = core.get(i);
@@ -237,6 +263,9 @@ public class AFIReader extends FormatReader {
       c.rgb = false;
       if (i == 0) {
         c.resolutionCount = core.size() - EXTRA_IMAGES;
+      }
+      else {
+        c.pixelType = core.get(0).pixelType;
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Hashtable;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -235,6 +236,19 @@ public class AFIReader extends FormatReader {
         c.resolutionCount = core.size() - EXTRA_IMAGES;
       }
     }
+
+    for (int s=0; s<core.size(); s++) {
+      setCoreIndex(s);
+      core.get(s).seriesMetadata = new Hashtable<String, Object>();
+      for (int i=0; i<reader.length; i++) {
+        reader[i].setCoreIndex(s);
+        Hashtable<String, Object> m = reader[i].getSeriesMetadata();
+        for (String key : m.keySet()) {
+          addSeriesMetaList(key, m.get(key));
+        }
+      }
+    }
+    setCoreIndex(0);
 
     MetadataStore store = makeFilterMetadata();
     boolean minimalMetadata =

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -62,7 +62,7 @@ public class AFIReader extends FormatReader {
 
   // -- Constants --
 
-  private static final int EXTRA_IMAGES = 3;
+  private static final int EXTRA_IMAGES = 2;
 
   // -- Fields --
 
@@ -113,7 +113,7 @@ public class AFIReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader[0].setCoreIndex(getCoreIndex());
+      reader[0].setCoreIndex(getCoreIndex() + 1);
       return reader[0].openThumbBytes(no);
     }
 
@@ -135,7 +135,7 @@ public class AFIReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader[0].setCoreIndex(getCoreIndex());
+      reader[0].setCoreIndex(getCoreIndex() + 1);
       return reader[0].openBytes(no, buf, x, y, w, h);
     }
 
@@ -226,6 +226,7 @@ public class AFIReader extends FormatReader {
     }
 
     core = reader[0].getCoreMetadataList();
+    core.remove(core.size() - EXTRA_IMAGES - 1);
 
     for (int i=0; i<core.size() - EXTRA_IMAGES; i++) {
       CoreMetadata c = core.get(i);

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -98,12 +98,14 @@ public class AFIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
+    reader[0].setCoreIndex(getCoreIndex());
     return reader[0].getOptimalTileWidth();
   }
 
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
+    reader[0].setCoreIndex(getCoreIndex());
     return reader[0].getOptimalTileHeight();
   }
 

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -62,7 +62,7 @@ public class AFIReader extends FormatReader {
 
   // -- Constants --
 
-  private static final int EXTRA_IMAGES = 2;
+  private static final int EXTRA_IMAGES = 3;
 
   // -- Fields --
 

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -309,9 +309,9 @@ public class AFIReader extends FormatReader {
       }
     }
     else {
-      store.setImageName(fileID, 0);
-      store.setImageName(fileID + " [label image]", 1);
-      store.setImageName(fileID + " [macro image]", 2);
+      store.setImageName("", 0);
+      store.setImageName("label image", 1);
+      store.setImageName("macro image", 2);
     }
 
     if (!minimalMetadata) {

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Hashtable;
@@ -170,6 +171,14 @@ public class AFIReader extends FormatReader {
             buf[dest + destBytes - j - 1] = tmp[i + srcBytes - j - 1];
           }
         }
+      }
+      Object s = DataTools.makeDataArray(
+        buf, destBytes, FormatTools.isFloatingPoint(getPixelType()), isLittleEndian());
+      long max = (long) Math.pow(2, destBytes * 8) - 1;
+      for (int i=0; i<Array.getLength(s); i++) {
+        double scale = Array.getDouble(s, i) / 255;
+        DataTools.unpackBytes(
+          (long) (scale * max), buf, i * destBytes, destBytes, isLittleEndian());
       }
       return buf;
     }

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -62,7 +62,7 @@ public class AFIReader extends FormatReader {
 
   // -- Constants --
 
-  private static final int EXTRA_IMAGES = 3;
+  private static final int EXTRA_IMAGES = 2;
 
   // -- Fields --
 

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -404,6 +404,10 @@ public class SVSReader extends BaseTiffReader {
         if (getExcitation() != null) {
           store.setChannelExcitationWavelength(getExcitation(), i, c);
         }
+
+        if (c < dyeNames.size()) {
+          store.setChannelName(dyeNames.get(c), i, c);
+        }
       }
 
       if (i < pixelSize.length && pixelSize[i] != null && pixelSize[i].value(UNITS.MICROM).doubleValue() - Constants.EPSILON > 0) {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -80,6 +80,7 @@ public class SVSReader extends BaseTiffReader {
   private Double exposureTime, exposureScale;
   private Double magnification;
   private String date, time;
+  private ArrayList<String> dyeNames = new ArrayList<String>();
 
   // -- Constructor --
 
@@ -214,6 +215,7 @@ public class SVSReader extends BaseTiffReader {
       magnification = null;
       date = null;
       time = null;
+      dyeNames.clear();
     }
   }
 
@@ -311,6 +313,9 @@ public class SVSReader extends BaseTiffReader {
               }
               else if (key.equals("AppMag")) {
                 magnification = new Double(value);
+              }
+              else if (key.equals("Dye")) {
+                dyeNames.add(value);
               }
             }
           }
@@ -472,6 +477,10 @@ public class SVSReader extends BaseTiffReader {
 
   protected double getMagnification() {
     return magnification;
+  }
+
+  protected ArrayList<String> getDyeNames() {
+    return dyeNames;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -326,6 +326,26 @@ public class SVSReader extends BaseTiffReader {
 
     // repopulate core metadata
 
+    // remove any invalid pyramid resolutions
+    IFD firstIFD = ifds.get(getIFDIndex(0));
+    for (int s=1; s<getSeriesCount() - 2; s++) {
+      int index = getIFDIndex(s);
+      IFD ifd = ifds.get(index);
+      if (ifd.getPixelType() != firstIFD.getPixelType()) {
+        ifds.set(index, null);
+      }
+    }
+    for (int s=0; s<ifds.size(); ) {
+      if (ifds.get(s) != null) {
+        s++;
+      }
+      else {
+        ifds.remove(s);
+        core.remove(s);
+      }
+    }
+    seriesCount = ifds.size();
+
     for (int s=0; s<seriesCount; s++) {
       CoreMetadata ms = core.get(s);
       if (s == 0 && getSeriesCount() > 2) {
@@ -370,6 +390,7 @@ public class SVSReader extends BaseTiffReader {
     store.setObjectiveID(objective, 0, 0);
     store.setObjectiveNominalMagnification(magnification, 0, 0);
 
+    int lastImage = core.size() - 1;
     for (int i=0; i<getSeriesCount(); i++) {
       store.setImageInstrumentRef(instrument, i);
       store.setObjectiveSettingsID(objective, i);
@@ -383,7 +404,13 @@ public class SVSReader extends BaseTiffReader {
             store.setImageName("", i);
             break;
           case 1:
-            store.setImageName("label image", i);
+            // if there are only two images, assume that there is no label
+            if (lastImage == 1) {
+              store.setImageName("macro image", i);
+            }
+            else {
+              store.setImageName("label image", i);
+            }
             break;
           case 2:
             store.setImageName("macro image", i);

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -374,7 +374,22 @@ public class SVSReader extends BaseTiffReader {
       store.setImageInstrumentRef(instrument, i);
       store.setObjectiveSettingsID(objective, i);
 
-      store.setImageName("Series " + (i + 1), i);
+      if (hasFlattenedResolutions() || i > 2) {
+        store.setImageName("Series " + (i + 1), i);
+      }
+      else {
+        switch (i) {
+          case 0:
+            store.setImageName("", i);
+            break;
+          case 1:
+            store.setImageName("label image", i);
+            break;
+          case 2:
+            store.setImageName("macro image", i);
+            break;
+        }
+      }
       store.setImageDescription(comments[i], i);
 
       if (getDatestamp() != null) {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -450,7 +450,7 @@ public class SVSReader extends BaseTiffReader {
   }
 
   protected Double getExposureTime() {
-    return exposureTime;
+    return exposureTime * exposureScale * 1000;
   }
 
   protected Timestamp getDatestamp() {


### PR DESCRIPTION
Forward-ports 5.1.x-based fixes from private Glencoe repository to develop.  /cc @chris-allan, @emilroz 

I wouldn't expect major problems, but a configuration update PR may be necessary since image names have changed (waiting on confirmation from builds though).  To test, import a handful of .svs and .afi datasets (including some from Virtual Microscope), and verify that:

* pyramids all look correct
* thumbnails look correct with respect to the corresponding pyramid
* channel metadata is present in the original metadata table
* non-pyramid images are named ```macro image``` or ```label image```

Also /cc @aleksandra-tarkowska in case this impacts Virtual Microscope.