### PR TITLE
ScanR: read core metadata from first non-null TIFF file

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -545,7 +545,12 @@ public class ScanrReader extends FormatReader {
     }
 
     reader = new MinimalTiffReader();
-    reader.setId(tiffs[0]);
+    for (String tiff : tiffs) {
+      if (tiff != null) {
+        reader.setId(tiff);
+	break;
+      }
+    }
     int sizeX = reader.getSizeX();
     int sizeY = reader.getSizeY();
     int pixelType = reader.getPixelType();


### PR DESCRIPTION
This fixes the case where the files for the first recorded well were removed.

See https://trello.com/c/a3M5iBxQ/156-secretionb-failure