### PR TITLE
OBF: add fallback case for unparseable OME-XML (rebased onto develop)

### DIFF
--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -60,6 +60,8 @@ import loci.formats.meta.ModuloAnnotation;
 import loci.formats.meta.OriginalMetadataAnnotation;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.ome.OMEXMLMetadataImpl;
+
+import ome.units.quantity.Length;
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.BinData;
 import ome.xml.model.Channel;
@@ -807,7 +809,6 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
         throw new IllegalArgumentException(
             "Expecting OMEXMLMetadata instance.");
       }
-
       dest.setRoot(ome);
     }
     else {
@@ -815,6 +816,25 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
       // metadata object and copy it into the destination
       IMetadata src = createOMEXMLMetadata(xml);
       convertMetadata(src, dest);
+
+      // make sure that physical sizes are corrected
+      for (int image=0; image<src.getImageCount(); image++) {
+        Length physicalSizeX = src.getPixelsPhysicalSizeX(image);
+        if (physicalSizeX != null && physicalSizeX.value() != null) {
+          physicalSizeX = FormatTools.getPhysicalSize(physicalSizeX.value().doubleValue(), physicalSizeX.unit().getSymbol());
+          dest.setPixelsPhysicalSizeX(physicalSizeX, image);
+        }
+        Length physicalSizeY = src.getPixelsPhysicalSizeY(image);
+        if (physicalSizeY != null && physicalSizeY.value() != null) {
+          physicalSizeY = FormatTools.getPhysicalSize(physicalSizeY.value().doubleValue(), physicalSizeY.unit().getSymbol());
+          dest.setPixelsPhysicalSizeY(physicalSizeY, image);
+        }
+        Length physicalSizeZ = src.getPixelsPhysicalSizeZ(image);
+        if (physicalSizeZ != null && physicalSizeZ.value() != null) {
+          physicalSizeZ = FormatTools.getPhysicalSize(physicalSizeZ.value().doubleValue(), physicalSizeZ.unit().getSymbol());
+          dest.setPixelsPhysicalSizeZ(physicalSizeZ, image);
+        }
+      }
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -203,6 +203,7 @@ public class OBFReader extends FormatReader
         if (service.validateOMEXML(ome_xml)) {
           service.convertMetadata( ome_xml, ome ) ;
           parsedXML = true;
+          MetadataTools.populatePixels(ome, this, false, false);
         }
       }
       catch (DependencyException exception) 
@@ -221,7 +222,6 @@ public class OBFReader extends FormatReader
     if (fileVersion <= 1 || !parsedXML)
     {
       MetadataTools.populatePixels(ome, this);
-
       for (int series = 0; series != core.size(); ++ series)
       {
         CoreMetadata obf = core.get(series);

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -270,6 +270,10 @@ public class OBFReader extends FormatReader
       {
         throw new FormatException( exception ) ;
       }
+      catch (Exception e) {
+        LOGGER.warn("Could not parse OME-XML metadata", e);
+        MetadataTools.populatePixels(ome, this);
+      }
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -192,7 +192,33 @@ public class OBFReader extends FormatReader
     }
 
     MetadataStore ome = makeFilterMetadata();
-    if (fileVersion <= 1)
+
+    boolean parsedXML = false;
+    if (fileVersion > 1) {
+     try
+      {
+        ServiceFactory factory = new ServiceFactory() ;
+        OMEXMLService service = factory.getInstance( OMEXMLService.class ) ;
+
+        if (service.validateOMEXML(ome_xml)) {
+          service.convertMetadata( ome_xml, ome ) ;
+          parsedXML = true;
+        }
+      }
+      catch (DependencyException exception) 
+      {
+        throw new MissingLibraryException( OMEXMLServiceImpl.NO_OME_XML_MSG, exception ) ;
+      }
+      catch (ServiceException exception) 
+      {
+        throw new FormatException( exception ) ;
+      }
+      catch (Exception e) {
+        LOGGER.warn("Could not parse OME-XML metadata", e);
+      }
+    }
+
+    if (fileVersion <= 1 || !parsedXML)
     {
       MetadataTools.populatePixels(ome, this);
 
@@ -251,28 +277,6 @@ public class OBFReader extends FormatReader
             }
           }
         }
-      }
-    }
-    else
-    {
-      try
-      {
-        ServiceFactory factory = new ServiceFactory() ;
-        OMEXMLService service = factory.getInstance( OMEXMLService.class ) ;
-
-        service.convertMetadata( ome_xml, ome ) ;
-      }
-      catch (DependencyException exception) 
-      {
-        throw new MissingLibraryException( OMEXMLServiceImpl.NO_OME_XML_MSG, exception ) ;
-      }
-      catch (ServiceException exception) 
-      {
-        throw new FormatException( exception ) ;
-      }
-      catch (Exception e) {
-        LOGGER.warn("Could not parse OME-XML metadata", e);
-        MetadataTools.populatePixels(ome, this);
       }
     }
   }
@@ -407,10 +411,10 @@ public class OBFReader extends FormatReader
           xml = true;
         }
         catch (ParserConfigurationException e) {
-          LOGGER.warn("Could parse description as XML", e);
+          LOGGER.warn("Could not parse description as XML", e);
         }
         catch (SAXException e) {
-          LOGGER.warn("Could parse description as XML", e);
+          LOGGER.warn("Could not parse description as XML", e);
         }
 
         if (!xml) {


### PR DESCRIPTION


This is the same as gh-2068 but rebased onto develop.

----

See https://trello.com/c/ZNENhFMs/5-obf-reader-improvements

We don't have any example OBF files with OME-XML metadata, so code/job stability review is probably the best that can be done.  The idea is to allow image data to be read if the metadata is invalid or otherwise cannot be parsed.

                    