### PR TITLE
Gatan: explicitly set the locale used for parsing physical sizes (rebased onto develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -31,6 +31,7 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import loci.common.Constants;
 import loci.common.RandomAccessInputStream;
@@ -478,7 +479,7 @@ public class GatanReader extends FormatReader {
         LOGGER.debug("{}{}: unknown type: {}", new Object[] {indent, i, type});
       }
 
-      NumberFormat f = NumberFormat.getInstance();
+      NumberFormat f = NumberFormat.getInstance(Locale.ENGLISH);
       if (value != null) {
         addGlobalMeta(labelString, value);
 
@@ -617,7 +618,7 @@ public class GatanReader extends FormatReader {
 
   private Double correctForUnits(Double value, String units) {
     Double newValue = value;
-    Collator c = Collator.getInstance();
+    Collator c = Collator.getInstance(Locale.ENGLISH);
     if (units != null) {
       if (c.compare("nm", units) == 0) {
         newValue /= 1000;


### PR DESCRIPTION


This is the same as gh-2129 but rebased onto develop.

----

See https://trello.com/c/dx5t3btt/14-gatan-locale-issues

There is already a check for the "," separator not being present, so
using Locale.ENGLISH for parsing should be safe across the board.
This is thankfully the only place where we're using NumberFormat and Collator.

To test, pick any Gatan .dm3 file.  Verify that without this change, ```export BF_FLAGS="" && showinf -nopix -omexml``` shows valid values for PhysicalSizeX and PhysicalSizeY, and that ```export BF_FLAGS="-Duser.language=fr -Duser.country=FR" && showinf -nopix -omexml``` does not.  With this change, both tests should show the same valid values for PhysicalSizeX and PhysicalSizeY (and jobs running with fr_FR should pass).  

                    