### PR TITLE
Updates for Metamorph plates with one file per channel

### DIFF
--- a/components/formats-bsd/src/loci/formats/AxisGuesser.java
+++ b/components/formats-bsd/src/loci/formats/AxisGuesser.java
@@ -217,6 +217,16 @@ public class AxisGuesser {
           axisTypes[i] = C_AXIS;
           continue;
         }
+        else {
+          // look for specific channel names
+          for (String element : elements[i]) {
+            String channelName = element.toLowerCase();
+            if (channelName.equals("dapi") || channelName.equals("fitc")) {
+              axisTypes[i] = C_AXIS;
+              continue;
+            }
+          }
+        }
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -831,7 +831,7 @@ public class FileStitcher extends ReaderWrapper {
   /* @see IFormatReader#setMetadataStore(MetadataStore) */
   @Override
   public void setMetadataStore(MetadataStore store) {
-    FormatTools.assertId(getCurrentFile(), false, 2);
+    //FormatTools.assertId(getCurrentFile(), false, 2);
     reader.setMetadataStore(store);
     this.store = store;
   }

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -531,6 +531,12 @@ public class Memoizer extends ReaderWrapper {
     options.setMetadataOption(k + ".cacheDirectory", this.directory);
     options.setMetadataOption(k + ".inPlace", this.doInPlaceCaching);
     options.setMetadataOption(k + ".minimumElapsed", this.minimumElapsed);
+    reader.setMetadataOptions(options);
+  }
+
+  public void setMetadataOptions(MetadataOptions options) {
+    configure(options);
+    reader.setMetadataOptions(options);
   }
 
   /**
@@ -563,7 +569,7 @@ public class Memoizer extends ReaderWrapper {
     }
 
     if (((Boolean) inplace).booleanValue()) {
-      return new Memoizer(r, (Long) inplace);
+      return new Memoizer(r, (Long) elapsed);
     } else{
       return new Memoizer(r, (Long) elapsed, (File) cachedir);
     }

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -59,7 +59,9 @@ public class FilePatternReader extends FormatReader {
 
   // -- Fields --
 
-  private FileStitcher helper;
+  private transient FileStitcher helper;
+  private String pattern;
+  private ClassList<IFormatReader> newClasses;
 
   // -- Constructor --
 
@@ -69,8 +71,7 @@ public class FilePatternReader extends FormatReader {
 
     ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
     Class<? extends IFormatReader>[] classArray = classes.getClasses();
-    ClassList<IFormatReader> newClasses =
-      new ClassList<IFormatReader>(IFormatReader.class);
+    newClasses = new ClassList<IFormatReader>(IFormatReader.class);
     for (Class<? extends IFormatReader> c : classArray) {
       if (!c.equals(FilePatternReader.class)) {
         newClasses.addClass(c);
@@ -261,6 +262,9 @@ public class FilePatternReader extends FormatReader {
   @Override
   public void close(boolean fileOnly) throws IOException {
     helper.close(fileOnly);
+    if (!fileOnly) {
+      pattern = null;
+    }
   }
 
   @Override
@@ -490,6 +494,26 @@ public class FilePatternReader extends FormatReader {
     helper.setFlattenedResolutions(flattened);
   }
 
+  /* @see loci.formats.IFormatReader#reopenFile() */
+  @Override
+  public void reopenFile() throws IOException {
+    if (helper == null) {
+      helper = new FileStitcher(new ImageReader(newClasses));
+    }
+    else {
+      helper.close();
+    }
+    helper.setMetadataOptions(getMetadataOptions());
+    helper.setUsingPatternIds(true);
+    helper.setCanChangePattern(false);
+    try {
+      helper.setId(pattern);
+    }
+    catch (FormatException e) {
+      throw new IOException("Could not reopen file", e);
+    }
+  }
+
   // -- IFormatHandler API methods --
 
   @Override
@@ -514,15 +538,12 @@ public class FilePatternReader extends FormatReader {
     // absolute file pattern
 
     currentId = new Location(id).getAbsolutePath();
-    String pattern = DataTools.readFile(id).trim();
+    pattern = DataTools.readFile(id).trim();
     String dir = new Location(id).getAbsoluteFile().getParent();
     if (new Location(pattern).getParent() == null) {
       pattern = dir + File.separator + pattern;
     }
-
-    helper.setUsingPatternIds(true);
-    helper.setCanChangePattern(false);
-    helper.setId(pattern);
+    reopenFile();
     core = helper.getCoreMetadataList();
   }
 

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -47,6 +47,7 @@ import loci.formats.FileInfo;
 import loci.formats.FileStitcher;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
+import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.Memoizer;
@@ -64,6 +65,8 @@ public class FilePatternReader extends FormatReader {
   private transient IFormatReader helper;
   private String pattern;
   private ClassList<IFormatReader> newClasses;
+  private String[] files;
+  private int[][][] fileIndexes;
 
   // -- Constructor --
 
@@ -88,71 +91,6 @@ public class FilePatternReader extends FormatReader {
   // -- IFormatReader methods --
 
   @Override
-  public int getImageCount() {
-    return helper.getImageCount();
-  }
-
-  @Override
-  public boolean isRGB() {
-    return helper.isRGB();
-  }
-
-  @Override
-  public int getSizeX() {
-    return helper.getSizeX();
-  }
-
-  @Override
-  public int getSizeY() {
-    return helper.getSizeY();
-  }
-
-  @Override
-  public int getSizeZ() {
-    return helper.getSizeZ();
-  }
-
-  @Override
-  public int getSizeC() {
-    return helper.getSizeC();
-  }
-
-  @Override
-  public int getSizeT() {
-    return helper.getSizeT();
-  }
-
-  @Override
-  public int getPixelType() {
-    return helper.getPixelType();
-  }
-
-  @Override
-  public int getBitsPerPixel() {
-    return helper.getBitsPerPixel();
-  }
-
-  @Override
-  public int getEffectiveSizeC() {
-    return helper.getEffectiveSizeC();
-  }
-
-  @Override
-  public int getRGBChannelCount() {
-    return helper.getRGBChannelCount();
-  }
-
-  @Override
-  public boolean isIndexed() {
-    return helper.isIndexed();
-  }
-
-  @Override
-  public boolean isFalseColor() {
-    return helper.isFalseColor();
-  }
-
-  @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
     if (getCurrentFile() == null) {
       return null;
@@ -169,84 +107,33 @@ public class FilePatternReader extends FormatReader {
   }
 
   @Override
-  public Modulo getModuloZ() {
-    return helper.getModuloZ();
-  }
-
-  @Override
-  public Modulo getModuloC() {
-    return helper.getModuloC();
-  }
-
-  @Override
-  public Modulo getModuloT() {
-    return helper.getModuloT();
-  }
-
-  @Override
-  public int getThumbSizeX() {
-    return helper.getThumbSizeX();
-  }
-
-  @Override
-  public int getThumbSizeY() {
-    return helper.getThumbSizeY();
-  }
-
-  @Override
-  public boolean isLittleEndian() {
-    return helper.isLittleEndian();
-  }
-
-  @Override
-  public String getDimensionOrder() {
-    return helper.getDimensionOrder();
-  }
-
-  @Override
-  public boolean isOrderCertain() {
-    return helper.isOrderCertain();
-  }
-
-  @Override
-  public boolean isThumbnailSeries() {
-    return helper.isThumbnailSeries();
-  }
-
-  @Override
-  public boolean isInterleaved() {
-    return helper.isInterleaved();
-  }
-
-  @Override
-  public boolean isInterleaved(int subC) {
-    return helper.isInterleaved(subC);
-  }
-
-  @Override
   public byte[] openBytes(int no) throws FormatException, IOException {
-    return helper.openBytes(no);
+    return openBytes(no, 0, 0, getSizeX(), getSizeY());
   }
 
   @Override
   public byte[] openBytes(int no, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    return helper.openBytes(no, x, y, w, h);
+    byte[] buf = new byte[FormatTools.getPlaneSize(this, w, h)];
+    return openBytes(no, buf, x, y, w, h);
   }
 
   @Override
   public byte[] openBytes(int no, byte[] buf)
     throws FormatException, IOException
   {
-    return helper.openBytes(no, buf);
+    return openBytes(no, buf, 0, 0, getSizeX(), getSizeY());
   }
 
   @Override
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    return helper.openBytes(no, buf, x, y, w, h);
+    int fileIndex = fileIndexes[getSeries()][no][0];
+    int planeIndex = fileIndexes[getSeries()][no][1];
+    helper.setId(files[fileIndex]);
+    return helper.openBytes(planeIndex, buf, x, y, w, h);
   }
 
   @Override
@@ -266,22 +153,9 @@ public class FilePatternReader extends FormatReader {
     helper.close(fileOnly);
     if (!fileOnly) {
       pattern = null;
+      files = null;
+      fileIndexes = null;
     }
-  }
-
-  @Override
-  public int getSeriesCount() {
-    return helper.getSeriesCount();
-  }
-
-  @Override
-  public void setSeries(int no) {
-    helper.setSeries(no);
-  }
-
-  @Override
-  public int getSeries() {
-    return helper.getSeries();
   }
 
   @Override
@@ -292,11 +166,6 @@ public class FilePatternReader extends FormatReader {
   @Override
   public boolean isGroupFiles() {
     return helper.isGroupFiles();
-  }
-
-  @Override
-  public boolean isMetadataComplete() {
-    return helper.isMetadataComplete();
   }
 
   @Override
@@ -322,10 +191,9 @@ public class FilePatternReader extends FormatReader {
     if (noPixels) {
       return new String[] {currentId};
     }
-    String[] helperFiles = helper.getSeriesUsedFiles(noPixels);
-    String[] allFiles = new String[helperFiles.length + 1];
+    String[] allFiles = new String[files.length + 1];
     allFiles[0] = currentId;
-    System.arraycopy(helperFiles, 0, allFiles, 1, helperFiles.length);
+    System.arraycopy(files, 0, allFiles, 1, files.length);
     return allFiles;
   }
 
@@ -334,56 +202,10 @@ public class FilePatternReader extends FormatReader {
     if (noPixels) {
       return new String[] {currentId};
     }
-    String[] helperFiles = helper.getUsedFiles(noPixels);
-    String[] allFiles = new String[helperFiles.length + 1];
+    String[] allFiles = new String[files.length + 1];
     allFiles[0] = currentId;
-    System.arraycopy(helperFiles, 0, allFiles, 1, helperFiles.length);
+    System.arraycopy(files, 0, allFiles, 1, files.length);
     return allFiles;
-  }
-
-  @Override
-  public int getIndex(int z, int c, int t) {
-    return helper.getIndex(z, c, t);
-  }
-
-  @Override
-  public int[] getZCTCoords(int index) {
-    return helper.getZCTCoords(index);
-  }
-
-  @Override
-  public Object getMetadataValue(String field) {
-    return helper.getMetadataValue(field);
-  }
-
-  @Override
-  public Object getSeriesMetadataValue(String field) {
-    return helper.getSeriesMetadataValue(field);
-  }
-
-  @Override
-  public Hashtable<String, Object> getGlobalMetadata() {
-    return helper.getGlobalMetadata();
-  }
-
-  @Override
-  public Hashtable<String, Object> getSeriesMetadata() {
-    return helper.getSeriesMetadata();
-  }
-
-  @Override
-  public List<CoreMetadata> getCoreMetadataList() {
-    // Only used for determining the object type.
-    List<CoreMetadata> oldcore = helper.getCoreMetadataList();
-    List<CoreMetadata> newcore = new ArrayList<CoreMetadata>();
-
-    for (int s=0; s<oldcore.size(); s++) {
-      CoreMetadata newMeta = oldcore.get(s).clone(this, s);
-      newMeta.resolutionCount = oldcore.get(s).resolutionCount;
-      newcore.add(newMeta);
-    }
-
-    return newcore;
   }
 
   @Override
@@ -396,17 +218,8 @@ public class FilePatternReader extends FormatReader {
 
   @Override
   public void setMetadataStore(MetadataStore store) {
+    super.setMetadataStore(store);
     helper.setMetadataStore(store);
-  }
-
-  @Override
-  public MetadataStore getMetadataStore() {
-    return helper.getMetadataStore();
-  }
-
-  @Override
-  public Object getMetadataStoreRoot() {
-    return helper.getMetadataStoreRoot();
   }
 
   @Override
@@ -442,51 +255,6 @@ public class FilePatternReader extends FormatReader {
   }
 
   @Override
-  public int getOptimalTileWidth() {
-    return helper.getOptimalTileWidth();
-  }
-
-  @Override
-  public int getOptimalTileHeight() {
-    return helper.getOptimalTileHeight();
-  }
-
-  @Override
-  public int getCoreIndex() {
-    return helper.getCoreIndex();
-  }
-
-  @Override
-  public void setCoreIndex(int no) {
-    helper.setCoreIndex(no);
-  }
-
-  @Override
-  public int seriesToCoreIndex(int series) {
-    return helper.seriesToCoreIndex(series);
-  }
-
-  @Override
-  public int coreIndexToSeries(int index) {
-    return helper.coreIndexToSeries(index);
-  }
-
-  @Override
-  public int getResolutionCount() {
-    return helper.getResolutionCount();
-  }
-
-  @Override
-  public void setResolution(int no) {
-    helper.setResolution(no);
-  }
-
-  @Override
-  public int getResolution() {
-    return helper.getResolution();
-  }
-
-  @Override
   public boolean hasFlattenedResolutions() {
     return helper.hasFlattenedResolutions();
   }
@@ -499,20 +267,36 @@ public class FilePatternReader extends FormatReader {
   /* @see loci.formats.IFormatReader#reopenFile() */
   @Override
   public void reopenFile() throws IOException {
-    if (helper == null) {
+    if (files != null) {
+      IFormatReader r = new ImageReader(newClasses);
+      helper = Memoizer.wrap(getMetadataOptions(), r);
+      stitcher = null;
+    }
+    else if (helper == null) {
       stitcher = new FileStitcher(new ImageReader(newClasses));
-      helper = Memoizer.wrap(getMetadataOptions(), stitcher);
+      IFormatReader r = new ImageReader(newClasses);
+      helper = Memoizer.wrap(getMetadataOptions(), r);
     }
     else {
       helper.close();
     }
-    stitcher.setUsingPatternIds(true);
-    stitcher.setCanChangePattern(false);
-    try {
-      helper.setId(pattern);
+    if (stitcher != null) {
+      stitcher.setUsingPatternIds(true);
+      stitcher.setCanChangePattern(false);
+      try {
+        helper.setId(pattern);
+      }
+      catch (FormatException e) {
+        throw new IOException("Could not reopen file", e);
+      }
     }
-    catch (FormatException e) {
-      throw new IOException("Could not reopen file", e);
+    else {
+      try {
+        helper.setId(files[0]);
+      }
+      catch (FormatException e) {
+        throw new IOException("Could not reopen " + files[0], e);
+      }
     }
   }
 
@@ -535,6 +319,7 @@ public class FilePatternReader extends FormatReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    super.initFile(id);
     // read the pattern from the file
     // the file should just contain a single line with the relative or
     // absolute file pattern
@@ -546,7 +331,21 @@ public class FilePatternReader extends FormatReader {
       pattern = dir + File.separator + pattern;
     }
     reopenFile();
-    core = helper.getCoreMetadataList();
+    core.clear();
+    for (CoreMetadata m : helper.getCoreMetadataList()) {
+      core.add(new CoreMetadata(m));
+    }
+
+    files = stitcher.getUsedFiles();
+    fileIndexes = new int[getSeriesCount()][][];
+    for (int s=0; s<getSeriesCount(); s++) {
+      setSeries(s);
+      fileIndexes[s] = new int[core.get(s).imageCount][];
+      for (int p=0; p<fileIndexes[s].length; p++) {
+        fileIndexes[s][p] = stitcher.computeIndices(p);
+      }
+    }
+    setSeries(0);
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -49,6 +49,7 @@ import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.Memoizer;
 import loci.formats.Modulo;
 import loci.formats.meta.MetadataStore;
 
@@ -59,7 +60,8 @@ public class FilePatternReader extends FormatReader {
 
   // -- Fields --
 
-  private transient FileStitcher helper;
+  private transient FileStitcher stitcher;
+  private transient IFormatReader helper;
   private String pattern;
   private ClassList<IFormatReader> newClasses;
 
@@ -77,8 +79,8 @@ public class FilePatternReader extends FormatReader {
         newClasses.addClass(c);
       }
     }
-    helper = new FileStitcher(new ImageReader(newClasses));
-    helper.setMetadataOptions(getMetadataOptions());
+    stitcher = new FileStitcher(new ImageReader(newClasses));
+    helper = Memoizer.wrap(getMetadataOptions(), stitcher);
 
     suffixSufficient = true;
   }
@@ -498,14 +500,14 @@ public class FilePatternReader extends FormatReader {
   @Override
   public void reopenFile() throws IOException {
     if (helper == null) {
-      helper = new FileStitcher(new ImageReader(newClasses));
+      stitcher = new FileStitcher(new ImageReader(newClasses));
+      helper = Memoizer.wrap(getMetadataOptions(), stitcher);
     }
     else {
       helper.close();
     }
-    helper.setMetadataOptions(getMetadataOptions());
-    helper.setUsingPatternIds(true);
-    helper.setCanChangePattern(false);
+    stitcher.setUsingPatternIds(true);
+    stitcher.setCanChangePattern(false);
     try {
       helper.setId(pattern);
     }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -726,24 +726,26 @@ public class MetamorphReader extends BaseTiffReader {
     ArrayList<String> uniqueWells = new ArrayList<String>();
     int rows = 0;
     int cols = 0;
-    for (String label : stageLabels) {
-      if (label != null && label.startsWith("Scan ") &&
-        !uniqueWells.contains(label))
-      {
-        uniqueWells.add(label);
-        int row = getWellRow(label);
-        if (row >= rows) {
-          rows = row + 1;
-        }
-        int col = getWellColumn(label);
-        if (col >= cols) {
-          cols = col + 1;
+    if (stageLabels != null) {
+      for (String label : stageLabels) {
+        if (label != null && label.startsWith("Scan ") &&
+          !uniqueWells.contains(label))
+        {
+          uniqueWells.add(label);
+          int row = getWellRow(label);
+          if (row >= rows) {
+            rows = row + 1;
+          }
+          int col = getWellColumn(label);
+          if (col >= cols) {
+            cols = col + 1;
+          }
         }
       }
     }
 
     // each plane corresponds to a unique well
-    boolean isHCS = uniqueWells.size() == stageLabels.length;
+    boolean isHCS = stageLabels != null && uniqueWells.size() == stageLabels.length;
     if (isHCS) {
       CoreMetadata c = core.get(0);
       core.clear();
@@ -1472,7 +1474,7 @@ public class MetamorphReader extends BaseTiffReader {
         name = name.substring(0, name.length() - 1);
       }
     }
-    if (name.length() == 0) {
+    if (name.length() == 0 && stageLabels != null) {
       name = stageLabels[i];
     }
     return name;


### PR DESCRIPTION
See https://trello.com/c/vpc8NKAC/163-idr-metamorph-stk-per-channel.

The Metamorph changes use stage labels starting with ```Scan ``` to detect when a whole plate is saved in a single .stk file.  That doesn't allow for Z stacks/time series as well as a plate being stored, but I imagine we could extend it if/when we have an example.

The AxisGuesser changes allow a pattern block such as ```<53bp1,dapi>``` to be automatically detected as 2 channels, instead of 2 Z sections