### PR TITLE
Update README.md to current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ following before submitting a pull request:
  * verify that the branch merges cleanly into ```develop```
  * verify that the branch compiles with the ```clean jars tools``` Ant targets
  * verify that the branch compiles using Maven
- * verify that the branch does not use syntax or API specific to Java 1.7+
+ * verify that the branch does not use syntax or API specific to Java 1.8+
  * run the unit tests (```ant test```) and correct any failures
  * test at least one file in each affected format, using the ```showinf```
    command
  * internal developers only: [run the data
-   tests](http://www.openmicroscopy.org/site/support/bio-formats/developers/commit-testing.html).
-   against directories corresponding to the affected format(s), as well as the
-   test_per_commit directory
+   tests](http://www.openmicroscopy.org/site/support/bio-formats/developers/commit-testing.html)
+   against directories corresponding to the affected format(s)
  * make sure that your commits contain the correct authorship information and,
    if necessary, a signed-off-by line
  * make sure that the commit messages or pull request comment contains


### PR DESCRIPTION
Java 1.7+ code can now be added to the repo since Java 6 support has been dropped. Also removing the reference to "test_per_commit" as suggested by @sbesson 