### PR TITLE
cmake: Add model-source-only option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,17 @@ include(XsdFu)
 include(GTest)
 include(Doxygen)
 include(HeaderTest)
-find_package(OME 5.2.0 REQUIRED Compat Common)
+
+# This is a hack to generate the model sources without having to have
+# ome-common available.  It will be removed or moved once the model
+# has been split out.
+option(model-source-only "Generate model source only" OFF)
+if(NOT model-source-only)
+  find_package(OME 5.2.0 REQUIRED Compat Common)
+else()
+  add_library(OME::Compat INTERFACE IMPORTED)
+  add_library(OME::Common INTERFACE IMPORTED)
+endif()
 
 if(MSVC)
   # Debug library suffix.


### PR DESCRIPTION
This is a temporary change to permit the model source to be generated without a dependency upon ome-common, which isn't needed for source generation.  The source will not build with this option enabled, but the code generator will run.

When the model code is split into a separate repository, this option can be moved there, or redone in a better way.

--------

Testing: Add `-Dmodel-source-only=ON` to source generation job, and it should work again.  Done in https://ci.openmicroscopy.org/view/DEV/job/BIOFORMATS-DEV-merge-generated-sources/ and https://ci.openmicroscopy.org/view/DEV/job/BIOFORMATS-DEV-latest-generated-sources/ -- the latter will require the PR merging before it will go green.