### PR TITLE
cpp: Set default log level by hand

### DIFF
--- a/cpp/lib/ome/test/main.cpp
+++ b/cpp/lib/ome/test/main.cpp
@@ -36,6 +36,8 @@
  * #L%
  */
 
+#include <ome/common/log.h>
+
 #include <ome/test/test.h>
 
 int
@@ -43,6 +45,10 @@ main (int   argc,
       char *argv[])
 {
   testing::InitGoogleTest(&argc, argv);
+
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   return RUN_ALL_TESTS();
 }
 

--- a/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
@@ -185,6 +185,9 @@ namespace
 int
 main(int argc, char *argv[])
 {
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   try
     {
       if (argc > 1)

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
@@ -169,6 +169,9 @@ namespace
 int
 main(int argc, char *argv[])
 {
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   try
     {
       if (argc > 1)

--- a/docs/sphinx/developers/cpp/examples/metadata-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-io.cpp
@@ -230,6 +230,9 @@ namespace
 int
 main(int argc, char *argv[])
 {
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   try
     {
       if (argc > 1)

--- a/docs/sphinx/developers/cpp/examples/model-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/model-io.cpp
@@ -97,6 +97,9 @@ namespace
 int
 main(int argc, char *argv[])
 {
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   try
     {
       if (argc > 1)

--- a/docs/sphinx/developers/cpp/examples/pixeldata.cpp
+++ b/docs/sphinx/developers/cpp/examples/pixeldata.cpp
@@ -232,6 +232,9 @@ namespace
 int
 main()
 {
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   try
     {
       createPixelBuffer();


### PR DESCRIPTION
It's set automatically at startup, but for some reason this isn't happening on Windows.  Likely related to being built as a static library.

--------

Testing: Check the size of the build log.  It should be vastly reduced, since it will no longer be logging everything at TRACE level (it's WARNING only).