### PR TITLE
Zeiss ZVI: rework image ordering calculation to allow for tiles

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -187,27 +187,51 @@ public class ZeissZVIReader extends BaseZeissReader {
     }
 
     boolean equalZ = true, equalC = true, equalT = true;
+    int minZ = Integer.MAX_VALUE, minC = Integer.MAX_VALUE, minT = Integer.MAX_VALUE;
+    int minTile = Integer.MAX_VALUE;
     for (int[] coord : coordinates) {
       if (coord[0] != coordinates[0][0]) {
         equalZ = false;
       }
+      if (coord[0] < minZ) {
+        minZ = coord[0];
+      }
       if (coord[1] != coordinates[0][1]) {
         equalC = false;
       }
+      if (coord[1] < minC) {
+        minC = coord[1];
+      }
       if (coord[2] != coordinates[0][2]) {
         equalT = false;
+      }
+      if (coord[2] < minT) {
+        minT = coord[2];
+      }
+      if (coord[3] < minTile) {
+        minTile = coord[3];
       }
     }
     for (int[] coord : coordinates) {
       if (equalZ) {
         coord[0] = 0;
       }
+      else {
+        coord[0] -= minZ;
+      }
       if (equalC) {
         coord[1] = 0;
+      }
+      else {
+        coord[1] -= minC;
       }
       if (equalT) {
         coord[2] = 0;
       }
+      else {
+        coord[2] -= minT;
+      }
+      coord[3] -= minTile;
     }
 
     for (int i=0; i<coordinates.length; i++) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -237,7 +237,7 @@ public class ZeissZVIReader extends BaseZeissReader {
     for (int i=0; i<coordinates.length; i++) {
       try {
         int index = FormatTools.positionToRaster(
-          new int[] {getSizeZ(), getSizeC(), getSizeT(), getSeriesCount()}, coordinates[i]);
+          new int[] {getSizeZ(), getEffectiveSizeC(), getSizeT(), getSeriesCount()}, coordinates[i]);
         valid.put(index, true);
       }
       catch (IllegalArgumentException e) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -105,7 +105,7 @@ public class ZeissZVIReader extends BaseZeissReader {
     options.littleEndian = isLittleEndian();
     options.interleaved = isInterleaved();
 
-    int index = -1;
+    int index = no;
 
     int[] coords = getZCTCoords(no);
     for (int q=0; q<coordinates.length; q++) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -116,6 +116,7 @@ public class ZeissZVIReader extends BaseZeissReader {
         break;
       }
     }
+    LOGGER.trace("no = " + no + ", index = " + index);
 
     if (index < 0 || index >= imageFiles.length) {
       return buf;
@@ -195,13 +196,7 @@ public class ZeissZVIReader extends BaseZeissReader {
       coordinates[i][1] = Arrays.binarySearch(cs, coordinates[i][1]);
       coordinates[i][2] = Arrays.binarySearch(ts, coordinates[i][2]);
       coordinates[i][3] = Arrays.binarySearch(tiles, coordinates[i][3]);
-      try {
-        int index = FormatTools.positionToRaster(
-          new int[] {getSizeZ(), getEffectiveSizeC(), getSizeT(), getSeriesCount()}, coordinates[i]);
-      }
-      catch (IllegalArgumentException e) {
-        LOGGER.trace("Found invalid coordinates", e);
-      }
+      LOGGER.trace("corrected coordinate #{} = {}", i, coordinates[i]);
     }
   }
 
@@ -321,6 +316,7 @@ public class ZeissZVIReader extends BaseZeissReader {
         coordinates[imageNum][1] = cidx;
         coordinates[imageNum][2] = tidx;
         coordinates[imageNum][3] = tileIndex;
+        LOGGER.trace("imageNum = {}, coordinate = {}", imageNum, coordinates[imageNum]);
         imageFiles[imageNum] = name;
         s.close();
       }


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-December/005759.html.

The corresponding test file is in ```data_repo/inbox/zeiss-zvi/pradeep```; note that it is smaller than the file mentioned on the mailing list (5 tiles, 2 timepoints).  Compare the file as displayed by Zeiss' ZEN software with what is shown by showinf or ImageJ.  Without this change, there should be small but noticeable differences between ZEN and Bio-Formats when changing timepoints.  With this change, there should be no noticeable differences.