### PR TITLE
TiffSaver: fix recorded offsets to non-interleaved RGB tiles

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -504,7 +504,7 @@ public class TiffSaver {
     int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
     for (int i=0; i<strips.length; i++) {
       out.seek(out.length());
-      int index = interleaved ? i : i / nChannels;
+      int index = interleaved ? i : (i / nChannels) * nChannels;
       int c = interleaved ? 0 : i % nChannels;
       int thisOffset = firstOffset + index + c * tileCount;
       offsets.set(thisOffset, out.getFilePointer());

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -353,14 +353,14 @@ public class TiffSaver {
                   }
                   else {
                     off = c * blockSize + ndx + n;
+                    int realStrip = c * (nStrips / nChannels) + strip;
                     if (row >= h || col >= w) {
-                      stripOut[strip].writeByte(0);
+                      stripOut[realStrip].writeByte(0);
                     } else if (off < buf.length) {
-                      stripOut[c * (nStrips / nChannels) + strip].writeByte(
-                          buf[off]);
+                      stripOut[realStrip].writeByte(buf[off]);
                     }
                     else {
-                      stripOut[strip].writeByte(0);
+                      stripOut[realStrip].writeByte(0);
                     }
                   }
                 }
@@ -504,7 +504,9 @@ public class TiffSaver {
     int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
     for (int i=0; i<strips.length; i++) {
       out.seek(out.length());
-      int thisOffset = firstOffset + i * tileCount;
+      int index = interleaved ? i : i / nChannels;
+      int c = interleaved ? 0 : i % nChannels;
+      int thisOffset = firstOffset + index + c * tileCount;
       offsets.set(thisOffset, out.getFilePointer());
       byteCounts.set(thisOffset, new Long(strips[i].length));
       if (LOGGER.isDebugEnabled()) {

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -501,9 +501,10 @@ public class TiffSaver {
     long fp = out.getFilePointer();
     writeIFD(ifd, 0);
 
+    int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
     for (int i=0; i<strips.length; i++) {
       out.seek(out.length());
-      int thisOffset = firstOffset + i;
+      int thisOffset = firstOffset + i * tileCount;
       offsets.set(thisOffset, out.getFilePointer());
       byteCounts.set(thisOffset, new Long(strips[i].length));
       if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION
This prevents earlier tiles from being overwritten by later tiles.
Strip-based data, single channels, and interleaved RGB tiles should be
unaffected.

See:

http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-October/005680.html
https://trello.com/c/nFq6AzGi/53-writing-tiff-in-tiles
http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2015-December/003531.html

I was able to reproduce the problem mentioned in the October 2015 thread using:

```bfconvert test_images_good/tiff-big-images/2kx2k.tif 2kx2k-tiled.ome.tiff -tilex 1000 -tiley 1000```

Without this change, ```2kx2k-tiled.ome.tiff``` should not match the original file (mixed up colors and tiles).  With this change, the two files should match when viewed in showinf/ImageJ/ImageMagick.

It would also be good to test the following to make sure that this change doesn't break anything else:

* ```bfconvert test_images_good/tiff-big-images/2kx2k.tif 2kx2k-copy.ome.tiff```
* bfconvert with and without ```-tilex```/```-tiley``` on a single-channel image
* bfconvert with and without ```-tilex```/```-tiley``` on a multi-channel interleaved image (e.g. anything in ```test_images_good/png/```)

As discussed earlier with @sbesson and @joshmoore, happy to exclude if this seems too distracting.