### PR TITLE
docs: Improve page on generating test images

### DIFF
--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -139,6 +139,10 @@ with their default values.
       * number of annotations of the given type to generate
       * 0
 
+To generate a valid plate the values of `plates`, `plateAcqs`, `plateRows`,
+`plateCols` and `fields` must all be greater than zero. If this condition is
+not met then an image will be generated instead of a plate.
+
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the
 file to something else. Make sure that you have Bio-Formats built and

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -12,7 +12,7 @@ Whatever is before the first ``&`` is the image name; the remaining key-value
 pairs, each preceded with ``&``, set the pixel type and image dimensions. Just
 replace the values with whatever you need for testing.
 
-Additionally, you can put such values in a separate .ini file:
+Additionally, you can put such values in a separate :file:`.ini` file:
 
 ::
 
@@ -21,7 +21,7 @@ Additionally, you can put such values in a separate .ini file:
     echo "sizeX=8192" >> my-special-test-file.fake.ini
     echo "sizeY=8192" >> my-special-test-file.fake.ini
 
-In fact, just the .fake.ini file alone suffices:
+In fact, just the :file:`.fake.ini` file alone suffices:
 
 ::
 
@@ -46,7 +46,8 @@ To generate a simple plate file:
 
 This will create a single plate which is, by default, within a containing
 screen. To create a plate with no containing screen add ``&screens=0`` to the
-key-value pairs in the file name. As above a .fake.ini file can be used.
+key-value pairs in the file name. As above a :file:`.fake.ini` file can be
+used.
 
 To generate a valid plate the values of ``plates``, ``plateAcqs``,
 ``plateRows``, ``plateCols`` and ``fields`` must **all** be greater than zero.

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -39,68 +39,105 @@ global metadata map:
     echo "my.key=some.value" >> my-special-test-file.fake.ini
 
 
-There are a few other keys that can be added as well:
+There are several other keys that can be added as well, these are listed below
+with their default values.
 
 .. tabularcolumns:: |p{3cm}|p{11cm}|
 
 .. list-table::
     :header-rows: 1
-    :widths: 30, 70
+    :widths: 30, 70, 10
 
     - * Key
       * Value
-    - * thumbSizeX
-      * number of pixels wide, for the thumbnail
-    - * thumbSizeY
-      * number of pixels tall, for the thumbnail
-    - * physicalSizeX
-      * real width of the pixels, supports units defaulting to microns
-    - * physicalSizeY
-      * real height of the pixels, supports units defaulting to microns
-    - * physicalSizeZ
-      * real depth of the pixels, supports units defaulting to microns
+      * Default
+    - * sizeX
+      * number of pixels wide
+      * 512
+    - * sizeY
+      * number of pixels tall
+      * 512
     - * sizeZ
       * number of Z sections
+      * 1
     - * sizeC
       * number of channels
+      * 1
     - * sizeT
       * number of timepoints
+      * 1
+    - * thumbSizeX
+      * number of pixels wide, for the thumbnail
+      * 0
+    - * thumbSizeY
+      * number of pixels tall, for the thumbnail
+      * 0
+    - * pixelType
+      * pixel type
+      * uint8
     - * bitsPerPixel
       * number of valid bits (<= number of bits implied by pixel type)
+      * 0
+    - * physicalSizeX
+      * real width of the pixels, supports units defaulting to microns
+      *
+    - * physicalSizeY
+      * real height of the pixels, supports units defaulting to microns
+      *
+    - * physicalSizeZ
+      * real depth of the pixels, supports units defaulting to microns
+      *
     - * acquisitionDate
       * timestamp formatted as "yyyy-MM-dd_HH-mm-ss"
+      *
     - * rgb
       * number of channels that are merged together
+      * 1
     - * dimOrder
       * dimension order (e.g. XYZCT)
+      * XYZCT
     - * little
       * whether or not the pixel data should be little-endian
+      * true
     - * interleaved
       * whether or not merged channels are interleaved
+      * false
     - * indexed
       * whether or not a color lookup table is present
+      * false
     - * falseColor
       * whether or not the color lookup table is just for making the image look pretty
+      * false
     - * series
       * number of series (Images)
+      * 1
     - * lutLength
       * number of entries in the color lookup table
+      * 3
     - * exposureTime
       * time of exposure, supports units defaulting to seconds
+      * 0
     - * screens
-      * number of screens, if omitted the default is 1
+      * number of screens
+      * 1
     - * plates
       * number of plates to generate
+      * 0
     - * plateAcqs
       * number of plate runs
+      * 0
     - * plateRows
       * number of rows per plate
+      * 0
     - * plateCols
       * number of rows per plate
+      * 0
     - * fields
       * number of fields per well
+      * 0
     - * annLong, annDouble, annMap, annComment, annBool, annTime, annTag, annTerm, annXml
       * number of annotations of the given type to generate
+      * 0
 
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -146,7 +146,8 @@ this condition is not met then an image will be generated instead of a plate.
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the
 file to something else. Make sure that you have Bio-Formats built and
-the JARs in your :envvar:`CLASSPATH` (individual JARs or just bioformats_package.jar):
+the JARs in your :envvar:`CLASSPATH` (individual JARs or just
+:file:`bioformats_package.jar`):
 
 ::
 
@@ -154,4 +155,4 @@ the JARs in your :envvar:`CLASSPATH` (individual JARs or just bioformats_package
 
 If you do not have the command line tools installed, substitute
 :source:`loci.formats.tools.ImageConverter <components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java>`
-for `bfconvert`.
+for :program:`bfconvert`.

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -42,11 +42,11 @@ global metadata map:
 There are several other keys that can be added as well, these are listed below
 with their default values.
 
-.. tabularcolumns:: |p{3cm}|p{11cm}|
+.. tabularcolumns:: |p{3cm}|p{9cm}|p{2cm}|
 
 .. list-table::
     :header-rows: 1
-    :widths: 30, 70, 10
+    :widths: 30, 60, 10
 
     - * Key
       * Value

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -2,15 +2,15 @@ Generating test images
 ======================
 
 Sometimes it is nice to have a file of a specific size or pixel type for
-testing. To generate a file (that contains gradient images):
+testing. To generate an image file (that contains a gradient image):
 
 ::
 
     touch "my-special-test-file&pixelType=uint8&sizeX=8192&sizeY=8192.fake"
 
-Whatever is before the ``&`` is the image name; remaining key value pairs
-should be pretty self-explanatory. Just replace the values with whatever
-you need for testing.
+Whatever is before the first ``&`` is the image name; the remaining key-value
+pairs, each preceded with ``&``, set the pixel type and image dimensions. Just
+replace the values with whatever you need for testing.
 
 Additionally, you can put such values in a separate .ini file:
 
@@ -38,6 +38,20 @@ global metadata map:
     echo "[GlobalMetadata]" >> my-special-test-file.fake.ini
     echo "my.key=some.value" >> my-special-test-file.fake.ini
 
+To generate a simple plate file:
+
+::
+
+    touch "plate-test-file&plates=1&plateAcqs=1&plateRows=1&plateCols=1&fields=1.fake"
+
+This will create a single plate which is, by default, within a containing
+screen. To create a plate with no containing screen add ``&screens=0`` to the
+key-value pairs in the file name. As above a .fake.ini file can be used.
+
+To generate a valid plate the values of ``plates``, ``plateAcqs``,
+``plateRows``, ``plateCols`` and ``fields`` must **all** be greater than zero.
+If this condition is not met then an image will be generated instead of a
+plate.
 
 There are several other keys that can be added as well, these are listed below
 with their default values.
@@ -138,10 +152,6 @@ with their default values.
     - * annLong, annDouble, annMap, annComment, annBool, annTime, annTag, annTerm, annXml
       * number of annotations of the given type to generate
       * 0
-
-To generate a valid plate the values of ``plates``, ``plateAcqs``,
-``plateRows``, ``plateCols`` and ``fields`` must all be greater than zero. If
-this condition is not met then an image will be generated instead of a plate.
 
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -25,9 +25,9 @@ In fact, just the .fake.ini file alone suffices:
 
 ::
 
-    echo "pixelType=uint8" >> my-special-test-file.fake
-    echo "sizeX=8192" >> my-special-test-file.fake
-    echo "sizeY=8192" >> my-special-test-file.fake
+    echo "pixelType=uint8" >> my-special-test-file.fake.ini
+    echo "sizeX=8192" >> my-special-test-file.fake.ini
+    echo "sizeY=8192" >> my-special-test-file.fake.ini
 
 If you include a "[GlobalMetadata]" section to the ini file,
 then all the included values will be accessible from the

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -54,8 +54,8 @@ To generate a valid plate the values of ``plates``, ``plateAcqs``,
 If this condition is not met then an image will be generated instead of a
 plate.
 
-There are several other keys that can be added as well, these are listed below
-with their default values.
+There are several other keys that can be added, a complete list of these,
+with their default values, is shown below.
 
 .. tabularcolumns:: |p{3cm}|p{11cm}|p{2cm}|
 
@@ -93,24 +93,15 @@ with their default values.
     - * bitsPerPixel
       * number of valid bits (<= number of bits implied by pixel type)
       * 0
-    - * physicalSizeX
-      * real width of the pixels, supports units defaulting to microns
-      *
-    - * physicalSizeY
-      * real height of the pixels, supports units defaulting to microns
-      *
-    - * physicalSizeZ
-      * real depth of the pixels, supports units defaulting to microns
-      *
-    - * acquisitionDate
-      * timestamp formatted as "yyyy-MM-dd_HH-mm-ss"
-      *
     - * rgb
       * number of channels that are merged together
       * 1
     - * dimOrder
       * dimension order (e.g. XYZCT)
       * XYZCT
+    - * orderCertain
+      *
+      * true
     - * little
       * whether or not the pixel data should be little-endian
       * true
@@ -123,15 +114,27 @@ with their default values.
     - * falseColor
       * whether or not the color lookup table is just for making the image look pretty
       * false
+    - * metadataComplete
+      *
+      * true
+    - * thumbnail
+      *
+      * false
     - * series
       * number of series (Images)
       * 1
     - * lutLength
       * number of entries in the color lookup table
       * 3
+    - * scaleFactor
+      *
+      * 1
     - * exposureTime
       * time of exposure, supports units defaulting to seconds
-      * 0
+      * null
+    - * acquisitionDate
+      * timestamp formatted as "yyyy-MM-dd_HH-mm-ss"
+      * null
     - * screens
       * number of screens
       * 1
@@ -153,6 +156,24 @@ with their default values.
     - * annLong, annDouble, annMap, annComment, annBool, annTime, annTag, annTerm, annXml
       * number of annotations of the given type to generate
       * 0
+    - * physicalSizeX
+      * real width of the pixels, supports units defaulting to microns
+      *
+    - * physicalSizeY
+      * real height of the pixels, supports units defaulting to microns
+      *
+    - * physicalSizeZ
+      * real depth of the pixels, supports units defaulting to microns
+      *
+    - * color
+      *
+      * null
+    - * color_*
+      *
+      *
+
+For full details of these keys, how unset and default values are handled and
+further examples see :source:`loci.formats.in.FakeReader <components/formats-bsd/src/loci/formats/in/FakeReader.java>`.
 
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -42,7 +42,7 @@ global metadata map:
 There are several other keys that can be added as well, these are listed below
 with their default values.
 
-.. tabularcolumns:: |p{3cm}|p{9cm}|p{2cm}|
+.. tabularcolumns:: |p{3cm}|p{11cm}|p{2cm}|
 
 .. list-table::
     :header-rows: 1
@@ -139,9 +139,9 @@ with their default values.
       * number of annotations of the given type to generate
       * 0
 
-To generate a valid plate the values of `plates`, `plateAcqs`, `plateRows`,
-`plateCols` and `fields` must all be greater than zero. If this condition is
-not met then an image will be generated instead of a plate.
+To generate a valid plate the values of ``plates``, ``plateAcqs``,
+``plateRows``, ``plateCols`` and ``fields`` must all be greater than zero. If
+this condition is not met then an image will be generated instead of a plate.
 
 You can often work with the .fake file directly, but in some cases
 support for those files is disabled and so you will need to convert the

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -87,6 +87,8 @@ There are a few other keys that can be added as well:
       * number of entries in the color lookup table
     - * exposureTime
       * time of exposure, supports units defaulting to seconds
+    - * screens
+      * number of screens, if omitted the default is 1
     - * plates
       * number of plates to generate
     - * plateAcqs


### PR DESCRIPTION
This PR brings the docs into line with the `screens` key added in https://github.com/openmicroscopy/bioformats/pull/1984

I'd be happy to add any further improvements to the docs from https://trello.com/c/f9tTxVFz/372-improve-fake-parameter-handling here is necessary. /cc @mtbc 

The later two commits attempt to address the documentation issues raised above.
