### PR TITLE
docs: Add note about missing C++ XSL transforms

### DIFF
--- a/docs/sphinx/developers/cpp/schema.txt
+++ b/docs/sphinx/developers/cpp/schema.txt
@@ -14,3 +14,8 @@ interfaces.
 
 The implementation will be updated to use a newer version of the OME-XML
 schema in a future release.
+
+XSL transforms to convert between different model versions are
+currently unimplemented.  This means that only OME-TIFF files using
+the 2013-06 schema may be reliably read and written at present.  This
+will be implemented in a future 5.2 release.


### PR DESCRIPTION
Guidance about missing XSLT transforms.  Should be possible to remove in the next few weeks, but adding to document the current state.  I'll remove it in the PR adding transform support.