### PR TITLE
Also set assumeEqualStrips during reading for PyramidTiffReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -86,6 +86,7 @@ public class PyramidTiffReader extends BaseTiffReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
     int index = getCoreIndex();
+    tiffParser.setAssumeEqualStrips(equalStrips);
     tiffParser.getSamples(ifds.get(index), buf, x, y, w, h);
     return buf;
   }


### PR DESCRIPTION
The assumeEqualStrips was only being set in isThisType().  It was causing the following error during import into OMERO:

```
2016-01-07 12:49:38,824 WARN  [        ome.services.util.ServiceHandler] (.Server-12) Unknown exception thrown.

java.lang.ArrayIndexOutOfBoundsException: 1
        at loci.formats.tiff.TiffParser.getTile(TiffParser.java:699) ~[formats-bsd.jar:na]
        at loci.formats.tiff.TiffParser.getSamples(TiffParser.java:995) ~[formats-bsd.jar:na]
        at loci.formats.tiff.TiffParser.getSamples(TiffParser.java:790) ~[formats-bsd.jar:na]
        at loci.formats.in.PyramidTiffReader.openBytes(PyramidTiffReader.java:90) ~[formats-gpl.jar:na]
        at loci.formats.ImageReader.openBytes(ImageReader.java:453) ~[formats-api.jar:5.1.4]
```

By also setting assumeEqualStrips for the parser in openBytes() this problem was resolved.