### PR TITLE
Flex: fix file indexing when multiple runs are present

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1369,7 +1369,7 @@ public class FlexReader extends FormatReader {
           FlexFile file = new FlexFile();
           file.row = row;
           file.column = col;
-          file.field = field % runCount;
+          file.field = field % (nFiles / (wellCount * runCount));
           file.file = files.get(field);
           file.acquisition = runDirs.size() == 0 ? 0:
             runDirs.indexOf(new Location(file.file).getParentFile());

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1356,6 +1356,9 @@ public class FlexReader extends FormatReader {
           continue;
         }
 
+        // 'files' represents all of the files for a specific well
+        // this can be a combination of runs and fields
+
         nFiles = files.size();
 
         String[] sortedFiles = files.toArray(new String[files.size()]);
@@ -1369,7 +1372,7 @@ public class FlexReader extends FormatReader {
           FlexFile file = new FlexFile();
           file.row = row;
           file.column = col;
-          file.field = field % (nFiles / (wellCount * runCount));
+          file.field = field % (nFiles / runCount);
           file.file = files.get(field);
           file.acquisition = runDirs.size() == 0 ? 0:
             runDirs.indexOf(new Location(file.file).getParentFile());


### PR DESCRIPTION
Fixes the bug introduced by 7aecd02.  See https://trello.com/c/OV5y9vcP/201-thumbnail-outage.

I was testing with a subset of one of the affected plates (see ```/ome/team/mlinkert/sysgro/```); without this change, ```showinf -minmax``` on series greater than 1 shows only blank planes.  With this change, every series has unique data.