### PR TITLE
Fix FEITiffReader metadata parser. Fix #2179

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FEITiffReader.java
@@ -343,15 +343,29 @@ public class FEITiffReader extends BaseTiffReader {
   // -- Helper class --
 
   class FEIHandler extends BaseHandler {
+    private StringBuilder sb;
     private String key, value;
-    private String qName;
     private Deque<String> parentNames = new ArrayDeque<String>();
 
     // -- DefaultHandler API methods --
 
     @Override
     public void characters(char[] data, int start, int len) {
-      String d = new String(data, start, len).trim();
+      sb.append(data, start, len);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      parentNames.push(qName);
+      sb = new StringBuilder();
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName)
+    {
+      String d = sb.toString().trim();
       if (d.isEmpty()) {
         return;
       }
@@ -407,19 +421,7 @@ public class FEITiffReader extends BaseTiffReader {
           sizeY = new Double(value);
         }
       }
-    }
 
-    @Override
-    public void startElement(String uri, String localName, String qName,
-      Attributes attributes)
-    {
-      this.qName = qName;
-      parentNames.push(qName);
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName)
-    {
       if (parentNames.size() > 0) {
         String name = parentNames.peek();
         if (qName.equals(name)) {


### PR DESCRIPTION
According to http://stackoverflow.com/questions/4567636/java-sax-parser-split-calls-to-characters , the processing should be done in endElement instead so that XML element value "1.943794245326921E-09" doesn't get split in two characters calls.