### PR TITLE
Allow for simpler fake plate definition

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -432,7 +432,7 @@ public class FakeReader extends FormatReader {
 
     String acquisitionDate = null;
 
-    int screens = 1;
+    int screens = 0;
     int plates = 0;
     int plateRows = 0;
     int plateCols = 0;
@@ -599,7 +599,7 @@ public class FakeReader extends FormatReader {
 
     // populate SPW metadata
     MetadataStore store = makeFilterMetadata();
-    boolean hasSPW = plates > 0 || plateRows > 0 ||
+    boolean hasSPW = screens > 0 || plates > 0 || plateRows > 0 ||
       plateCols > 0 || fields > 0 || plateAcqs > 0;
     if (hasSPW) {
       if (screens<0) screens = 0;

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -599,10 +599,15 @@ public class FakeReader extends FormatReader {
 
     // populate SPW metadata
     MetadataStore store = makeFilterMetadata();
-    boolean hasSPW = plates > 0 && plateRows > 0 &&
-      plateCols > 0 && fields > 0 && plateAcqs > 0;
+    boolean hasSPW = plates > 0 || plateRows > 0 ||
+      plateCols > 0 || fields > 0 || plateAcqs > 0;
     if (hasSPW) {
       if (screens<0) screens = 0;
+      if (plates<=0) plates = 1;
+      if (plateRows<=0) plateRows = 1;
+      if (plateCols<=0) plateCols = 1;
+      if (fields<=0) fields = 1;
+      if (plateAcqs<=0) plateAcqs = 1;
       // generate SPW metadata and override series count to match
       int imageCount =
         populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs);


### PR DESCRIPTION
This change allows for fake plates to be created by simply having one of the relevant keys in the name set to 1 or more. All non-set keys are then assumed to be equal to 1. See https://trello.com/c/f9tTxVFz/372-improve-fake-parameter-handling

Thus,
```
SPW&plates=1.fake
SPW&plates=1&plateRows=1&plateCols=1&plateAcqs=1&fields=1.fake
```
would both generate the same plate form.

I'm not sure how best to test this. I have done so locally using the breaking build of OMERO - and in fact the fake plate tests in https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_import.py in that build should pass with this PR included in Bio-Formats. The Bio-Formats unit tests can't easily be changed to test this as they don't appear to test filename-style fakes. Any other testing suggestions welcome.

If this is mergeable then the now merged docs PR, https://github.com/openmicroscopy/bioformats/pull/2170, will need an additional PR.
