### PR TITLE
Enable basic C++11 features

### DIFF
--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -455,7 +455,7 @@ class OMEModelProperty(OMEModelEntity):
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::vector<std::shared_ptr<%s> >&" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s>>&" % ns_sep
 
         return itype
     argType = property(_get_argType, doc="""The property's argument type.""")
@@ -508,10 +508,10 @@ class OMEModelProperty(OMEModelEntity):
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
                 itype = {' const':
-                         "const std::vector<std::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s>>"
                          % ns_sep,
                          '':
-                         "std::vector<std::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s>>"
                          % ns_sep}
 
         return itype
@@ -641,10 +641,10 @@ class OMEModelProperty(OMEModelEntity):
             elif (self.maxOccurs > 1 and
                     not self.parent.isAbstractProprietary):
                 itype = {' const':
-                         "const std::vector<std::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s>>"
                          % ns_sep,
                          '':
-                         "std::vector<std::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s>>"
                          % ns_sep}
 
         return itype
@@ -733,7 +733,7 @@ class OMEModelProperty(OMEModelEntity):
                 else:
                     itype = self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::vector<std::shared_ptr<%s> >" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s>>" % ns_sep
 
         return itype
     instanceVariableType = property(

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -439,11 +439,11 @@ class OMEModelProperty(OMEModelEntity):
                 itype = self.langTypeNS
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = "ome::compat::shared_ptr<%s>&" % ns_sep
+                    itype = "std::shared_ptr<%s>&" % ns_sep
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.isReference or self.isBackReference:
-                itype = "ome::compat::weak_ptr<%s>&" % ns_sep
+                itype = "std::weak_ptr<%s>&" % ns_sep
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -451,11 +451,11 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = "ome::compat::shared_ptr<%s>&" % ns_sep
+                    itype = "std::shared_ptr<%s>&" % ns_sep
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::vector<ome::compat::shared_ptr<%s> >&" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s> >&" % ns_sep
 
         return itype
     argType = property(_get_argType, doc="""The property's argument type.""")
@@ -481,16 +481,16 @@ class OMEModelProperty(OMEModelEntity):
                 itype = {' const': self.langTypeNS}
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = {' const': "const ome::compat::shared_ptr<%s>"
+                    itype = {' const': "const std::shared_ptr<%s>"
                              % ns_sep,
-                             '':       "ome::compat::shared_ptr<%s>"
+                             '':       "std::shared_ptr<%s>"
                              % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "const ome::compat::weak_ptr<%s>" % ns_sep,
-                         '':       "ome::compat::weak_ptr<%s>" % ns_sep}
+                itype = {' const': "const std::weak_ptr<%s>" % ns_sep,
+                         '':       "std::weak_ptr<%s>" % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -499,19 +499,19 @@ class OMEModelProperty(OMEModelEntity):
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
                     itype = {' const':
-                             "const ome::compat::shared_ptr<%s>"
+                             "const std::shared_ptr<%s>"
                              % ns_sep,
                              '':
-                             "ome::compat::shared_ptr<%s>"
+                             "std::shared_ptr<%s>"
                              % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
                 itype = {' const':
-                         "const std::vector<ome::compat::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s> >"
                          % ns_sep,
                          '':
-                         "std::vector<ome::compat::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -539,7 +539,7 @@ class OMEModelProperty(OMEModelEntity):
                     not self.isChoice):
                 itype = self.argType()
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "ome::compat::shared_ptr<%s>&" % ns_sep
+                itype = "std::shared_ptr<%s>&" % ns_sep
 
         return itype
     elementArgType = property(
@@ -576,9 +576,9 @@ class OMEModelProperty(OMEModelEntity):
                 itype = self.argType()
             elif (self.maxOccurs > 1 and
                   not self.parent.isAbstractProprietary):
-                itype = {' const': "const ome::compat::shared_ptr<%s>&"
+                itype = {' const': "const std::shared_ptr<%s>&"
                          % ns_sep,
-                         '':       "ome::compat::shared_ptr<%s>&"
+                         '':       "std::shared_ptr<%s>&"
                          % ns_sep}
 
         return itype
@@ -611,18 +611,18 @@ class OMEModelProperty(OMEModelEntity):
             elif self.isEnumeration:
                 if self.minOccurs == 0:
                     itype = {' const':
-                             "ome::compat::shared_ptr<const %s>" %
+                             "std::shared_ptr<const %s>" %
                              ns_sep,
                              '':
-                             "ome::compat::shared_ptr<%s>" %
+                             "std::shared_ptr<%s>" %
                              ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "ome::compat::shared_ptr<const %s>"
+                itype = {' const': "std::shared_ptr<const %s>"
                          % ns_sep,
-                         '':       "ome::compat::shared_ptr<%s>"
+                         '':       "std::shared_ptr<%s>"
                          % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
@@ -631,9 +631,9 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = {' const': "ome::compat::shared_ptr<const %s>"
+                    itype = {' const': "std::shared_ptr<const %s>"
                              % ns_sep,
-                             '': "ome::compat::shared_ptr<%s>"
+                             '': "std::shared_ptr<%s>"
                              % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
@@ -641,10 +641,10 @@ class OMEModelProperty(OMEModelEntity):
             elif (self.maxOccurs > 1 and
                     not self.parent.isAbstractProprietary):
                 itype = {' const':
-                         "const std::vector<ome::compat::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s> >"
                          % ns_sep,
                          '':
-                         "std::vector<ome::compat::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -714,14 +714,14 @@ class OMEModelProperty(OMEModelEntity):
                     self.unitsCompanion.instanceVariableType)
             elif self.isReference and self.maxOccurs > 1:
                 itype = ("OMEModelObject::indexed_container"
-                         "<%s, ome::compat::weak_ptr>::type") % ns_sep
+                         "<%s, std::weak_ptr>::type") % ns_sep
             elif self.isReference:
-                itype = "ome::compat::weak_ptr<%s>" % ns_sep
+                itype = "std::weak_ptr<%s>" % ns_sep
             elif self.isBackReference and self.maxOccurs > 1:
                 itype = ("OMEModelObject::indexed_container"
-                         "<%s, ome::compat::weak_ptr>::type") % ns_sep
+                         "<%s, std::weak_ptr>::type") % ns_sep
             elif self.isBackReference:
-                itype = "ome::compat::weak_ptr<%s>" % ns_sep
+                itype = "std::weak_ptr<%s>" % ns_sep
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstractProprietary or
                     self.isAttribute or not self.isComplex() or
@@ -729,11 +729,11 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = "ome::compat::shared_ptr<%s>" % ns_sep
+                    itype = "std::shared_ptr<%s>" % ns_sep
                 else:
                     itype = self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstractProprietary:
-                itype = "std::vector<ome::compat::shared_ptr<%s> >" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s> >" % ns_sep
 
         return itype
     instanceVariableType = property(
@@ -769,7 +769,7 @@ class OMEModelProperty(OMEModelEntity):
                 if self.isEnumeration:
                     if self.minOccurs == 0:
                         idefault = (
-                            "ome::compat::shared_ptr<%s>(new %s(%s::%s))"
+                            "std::shared_ptr<%s>(new %s(%s::%s))"
                             % (ns_sep, self.langTypeNS, self.langTypeNS,
                                self.defaultValue.upper()))
                     else:

--- a/components/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/components/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -25,7 +25,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             /// TODO: No handling of -1 as for Java.  Callee must throw.
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
@@ -52,7 +52,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -75,7 +75,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${indexes_name_string(indexes)});
           }
@@ -98,7 +98,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}();
           }
@@ -126,7 +126,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -149,7 +149,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)});
           }
@@ -172,7 +172,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName});
           }
@@ -302,7 +302,7 @@ namespace ome
       {
       public:
         /// A list of MetadataStore and MetadataRetrieve instances.
-        typedef std::vector<ome::compat::shared_ptr<BaseMetadata> > delegate_list_type;
+        typedef std::vector<std::shared_ptr<BaseMetadata> > delegate_list_type;
 
       private:
         /** The active metadata store delegates. */
@@ -348,7 +348,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->createRoot();
           }
@@ -362,11 +362,11 @@ namespace ome
          * exception if called.
          * @throws MetadataException always.
          */
-        ome::compat::shared_ptr<MetadataRoot>&
+        std::shared_ptr<MetadataRoot>&
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      std::shared_ptr<MetadataRoot>&
       AggregateMetadata::getRoot()
       {
         throw MetadataException("AggregateMetadata", "getRoot",
@@ -382,11 +382,11 @@ namespace ome
          * @throws MetadataException always.
          */
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(std::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      AggregateMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& /* root */)
+      AggregateMetadata::setRoot(std::shared_ptr<MetadataRoot>& /* root */)
       {
         throw MetadataException("AggregateMetadata", "setRoot",
                                 "unsupported");
@@ -410,7 +410,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getPixelsBinDataCount(imageIndex);
           }
@@ -432,7 +432,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getBooleanAnnotationAnnotationCount(booleanAnnotationIndex);
           }
@@ -454,7 +454,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getCommentAnnotationAnnotationCount(commentAnnotationIndex);
           }
@@ -476,7 +476,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getDoubleAnnotationAnnotationCount(doubleAnnotationIndex);
           }
@@ -498,7 +498,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getFileAnnotationAnnotationCount(fileAnnotationIndex);
           }
@@ -520,7 +520,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getListAnnotationAnnotationCount(listAnnotationIndex);
           }
@@ -542,7 +542,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getLongAnnotationAnnotationCount(longAnnotationIndex);
           }
@@ -564,7 +564,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTagAnnotationAnnotationCount(tagAnnotationIndex);
           }
@@ -586,7 +586,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTermAnnotationAnnotationCount(termAnnotationIndex);
           }
@@ -608,7 +608,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTimestampAnnotationAnnotationCount(timestampAnnotationIndex);
           }
@@ -630,7 +630,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getXMLAnnotationAnnotationCount(xmlAnnotationIndex);
           }
@@ -654,7 +654,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getLightSourceType(instrumentIndex,
                                                   lightSourceIndex);
@@ -679,7 +679,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getShapeType(roiIndex, shapeIndex);
           }
@@ -712,7 +712,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -733,7 +733,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -776,7 +776,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getPixelsBinDataBigEndian(imageIndex, binDataIndex);
           }
@@ -802,7 +802,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getUUID();
           }
@@ -908,7 +908,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setPixelsBinDataBigEndian(bigEndian, imageIndex, binDataIndex);
           }
@@ -934,7 +934,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setUUID(uuid);
           }

--- a/components/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/components/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -302,7 +302,7 @@ namespace ome
       {
       public:
         /// A list of MetadataStore and MetadataRetrieve instances.
-        typedef std::vector<std::shared_ptr<BaseMetadata> > delegate_list_type;
+        typedef std::vector<std::shared_ptr<BaseMetadata>> delegate_list_type;
 
       private:
         /** The active metadata store delegates. */

--- a/components/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/components/xsd-fu/templates-cpp/DummyMetadata.template
@@ -266,11 +266,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>&
+        std::shared_ptr<MetadataRoot>&
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      std::shared_ptr<MetadataRoot>&
       DummyMetadata::getRoot()
       {
         throw MetadataException("DummyMetadata", "getRoot",
@@ -281,11 +281,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(std::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      DummyMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& /* root */)
+      DummyMetadata::setRoot(std::shared_ptr<MetadataRoot>& /* root */)
       {
       }
 {% end source %}\

--- a/components/xsd-fu/templates-cpp/FilterMetadata.template
+++ b/components/xsd-fu/templates-cpp/FilterMetadata.template
@@ -187,7 +187,7 @@ namespace ome
       {
       private:
         /// The wrapped metadata store.
-	ome::compat::shared_ptr<MetadataStore> store;
+	std::shared_ptr<MetadataStore> store;
         /// Is filtering enabled?
 	bool filter;
 
@@ -199,11 +199,11 @@ namespace ome
          * @param filter @c true to enable filtering, @c false to
          * disable.
          */
-        FilterMetadata(ome::compat::shared_ptr<MetadataStore>& store,
+        FilterMetadata(std::shared_ptr<MetadataStore>& store,
                        bool filter);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      FilterMetadata::FilterMetadata(ome::compat::shared_ptr<MetadataStore>& store,
+      FilterMetadata::FilterMetadata(std::shared_ptr<MetadataStore>& store,
                                      bool filter):
         store(store),
         filter(filter)
@@ -237,11 +237,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>&
+        std::shared_ptr<MetadataRoot>&
 	getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      std::shared_ptr<MetadataRoot>&
       FilterMetadata::getRoot()
       {
         return store->getRoot();
@@ -251,11 +251,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
 	void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(std::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      FilterMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& root)
+      FilterMetadata::setRoot(std::shared_ptr<MetadataRoot>& root)
       {
         store->setRoot(root);
       }

--- a/components/xsd-fu/templates-cpp/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-cpp/MetadataRetrieve.template
@@ -117,9 +117,8 @@
 #ifndef ${fu.GUARD}
 #define ${fu.GUARD}
 
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/model/AffineTransform.h>

--- a/components/xsd-fu/templates-cpp/MetadataStore.template
+++ b/components/xsd-fu/templates-cpp/MetadataStore.template
@@ -109,9 +109,8 @@
 #ifndef ${fu.GUARD}
 #define ${fu.GUARD}
 
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/meta/MetadataRoot.h>
@@ -220,7 +219,7 @@ namespace ome
          *
          * @todo should this be a reference or shared_ptr?
          */
-        virtual ome::compat::shared_ptr<MetadataRoot>&
+        virtual std::shared_ptr<MetadataRoot>&
         getRoot() = 0;
 
         /**
@@ -234,7 +233,7 @@ namespace ome
          * @todo should this be a reference or shared_ptr?
          */
         virtual void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root) = 0;
+        setRoot(std::shared_ptr<MetadataRoot>& root) = 0;
 
 {% if debug %}\
         // -- Entity storage (manual definitions) --

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -81,7 +81,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
         // DUMMYLINE
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -90,7 +90,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract proprietary
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -99,7 +99,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract proprietary and not a reference
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -123,7 +123,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -132,7 +132,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -198,10 +198,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${prop.name} is abstract proprietary and is a reference
-        ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
+        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
         // ${parent} is abstract proprietary
@@ -212,42 +212,42 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when v['level'] == 2 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${obj.langTypeNS}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${obj.langTypeNS}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
-        ome::compat::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -256,7 +256,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(ome::compat::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -264,10 +264,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs more than once
-        ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
+        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
 {% end %}\
@@ -277,32 +277,32 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
-        ome::compat::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -311,7 +311,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(ome::compat::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -469,8 +469,8 @@ namespace
 
   // Throw an exception if a pointer is invalid.
   template<typename T>
-  ome::compat::shared_ptr<T>
-  safe_fetch(ome::compat::shared_ptr<T> ptr,
+  std::shared_ptr<T>
+  safe_fetch(std::shared_ptr<T> ptr,
              const char * const method)
   {
     if (!ptr)
@@ -481,11 +481,11 @@ namespace
 
   // Throw an exception if a pointer is invalid.
   template<typename T>
-  ome::compat::shared_ptr<T>
-  safe_fetch(ome::compat::weak_ptr<T>   ptr,
+  std::shared_ptr<T>
+  safe_fetch(std::weak_ptr<T>   ptr,
              const char * const method)
   {
-    ome::compat::shared_ptr<T> shared(ptr.lock());
+    std::shared_ptr<T> shared(ptr.lock());
     if (!shared)
       throw ome::xml::meta::MetadataException("OMEXMLMetadata", method,
                                               "Internal metadata store inconsistency: null weak reference");
@@ -522,11 +522,11 @@ namespace ome
       {
       private:
         /// OME-XML root node.
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> root; // OME
+        std::shared_ptr<OMEXMLMetadataRoot> root; // OME
         /// Generic root node.
-        ome::compat::shared_ptr<MetadataRoot> genericRoot; // OME
+        std::shared_ptr<MetadataRoot> genericRoot; // OME
         /// OME-XML model.
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModel> model;
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModel> model;
 
       public:
 {% end header %}\
@@ -563,18 +563,18 @@ namespace ome
       void
       OMEXMLMetadata::createRoot()
       {
-        ome::compat::shared_ptr<MetadataRoot> newroot(ome::compat::make_shared<OMEXMLMetadataRoot>());
+        std::shared_ptr<MetadataRoot> newroot(std::make_shared<OMEXMLMetadataRoot>());
         setRoot(newroot);
       }
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>&
+        std::shared_ptr<MetadataRoot>&
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      std::shared_ptr<MetadataRoot>&
       OMEXMLMetadata::getRoot()
       {
         return this->genericRoot;
@@ -590,22 +590,22 @@ namespace ome
          * @copydoc ::${lang.metadata_package}::MetadataStore::setRoot()
          */
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(std::shared_ptr<MetadataRoot>& root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      OMEXMLMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& root)
+      OMEXMLMetadata::setRoot(std::shared_ptr<MetadataRoot>& root)
       {
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> newroot =
-          ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
+        std::shared_ptr<OMEXMLMetadataRoot> newroot =
+          std::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
 
         if (!newroot)
           throw MetadataException("OMEXMLMetadata", "setRoot",
                                   "root must be of type OMEXMLMetadataRoot");
 
         this->root = newroot;
-        this->genericRoot = ome::compat::static_pointer_cast<MetadataRoot>(this->root);
-        model = ome::compat::make_shared< ::${lang.omexml_model_package}::detail::OMEModel>();
+        this->genericRoot = std::static_pointer_cast<MetadataRoot>(this->root);
+        model = std::make_shared< ::${lang.omexml_model_package}::detail::OMEModel>();
       }
 {% end source %}\
 
@@ -849,7 +849,7 @@ namespace ome
                                          index_type lightSourceIndex) const
       {
         const char * const instrument_method("getLightSourceType [getInstrument]");
-        ome::compat::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex), instrument_method)->getLightSource(lightSourceIndex);
+        std::shared_ptr<const ::${lang.omexml_model_package}::LightSource> o = safe_fetch(root->getInstrument(instrumentIndex), instrument_method)->getLightSource(lightSourceIndex);
         return o->getLightSourceType();
       }
 {% end source %}\
@@ -896,28 +896,28 @@ namespace ome
       {
         if (root->sizeOfImageList() == imageIndex)
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
+            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         if (o2->sizeOfTiffDataList() == tiffDataIndex)
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(ome::compat::make_shared< ::${lang.omexml_model_package}::TiffData>());
+            std::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared< ::${lang.omexml_model_package}::TiffData>());
             o2->addTiffData(newTiffData);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
+        std::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
         if (!o3->getUUID()) // null
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(ome::compat::make_shared< ::${lang.omexml_model_package}::UUID>());
+            std::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(std::make_shared< ::${lang.omexml_model_package}::UUID>());
             o3->setUUID(newUUID);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
+        std::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
         o4->setValue(value);
       }
 {% end source %}\
@@ -969,7 +969,7 @@ ${counter(k, o, v)}\
         const char * const pixels_method("getPixelsBinDataBigEndian [getPixels]");
         const char * const bindata_method("getPixelsBinDataBigEndian [getBinData]");
 
-        ome::compat::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getBigEndian();
+        std::shared_ptr<bool> bigEndian = safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getBigEndian();
 
         if (bigEndian) { // not null
           return *bigEndian;
@@ -993,7 +993,7 @@ ${counter(k, o, v)}\
       const std::string&
       OMEXMLMetadata::getUUID() const
       {
-        ome::compat::shared_ptr<const std::string> uuid = root->getUUID();
+        std::shared_ptr<const std::string> uuid = root->getUUID();
         if (uuid)
           return *root->getUUID();
         else
@@ -1104,17 +1104,17 @@ ${getter(k, o, prop, v)}\
         // Type is not a reference
         if (root->sizeOfImageList() == imageIndex)
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
+            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
-        ome::compat::shared_ptr<bool> newBool(ome::compat::make_shared<bool>(bigEndian));
+        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        std::shared_ptr<bool> newBool(std::make_shared<bool>(bigEndian));
         o2->setBigEndian(newBool);
       }
 {% end source %}\
@@ -1132,7 +1132,7 @@ ${getter(k, o, prop, v)}\
       void
       OMEXMLMetadata::setUUID(const std::string& uuid)
       {
-        ome::compat::shared_ptr<std::string> newString(ome::compat::make_shared<std::string>(uuid));
+        std::shared_ptr<std::string> newString(std::make_shared<std::string>(uuid));
         root->setUUID(newString);
       }
 {% end source %}\

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -81,7 +81,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
         // DUMMYLINE
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        std::shared_ptr<${obj.langTypeNS}> o = std::dynamic_pointer_cast<${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -90,7 +90,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract proprietary
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        std::shared_ptr<${obj.langTypeNS}> o = std::dynamic_pointer_cast<${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -99,7 +99,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract proprietary and not a reference
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
+        std::shared_ptr<${obj.langTypeNS}> o = std::dynamic_pointer_cast<${obj.langTypeNS}>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -123,7 +123,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        std::shared_ptr<${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -132,7 +132,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
+        std::shared_ptr<${prop.langTypeNS}> annotation(${safe_accessor(['root']+accessor(obj.name, parent, prop), getPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -198,7 +198,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${prop.name} is abstract proprietary and is a reference
-        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr<${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared<${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
         std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
@@ -216,7 +216,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${obj.langTypeNS}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${obj.langTypeNS}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
@@ -226,7 +226,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${v['type']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
@@ -236,18 +236,18 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${v['type']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
-        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr<${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr<${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast<${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -256,7 +256,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared<${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -264,7 +264,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr<${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
         std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));

--- a/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -200,8 +200,8 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         // ${prop.name} is abstract proprietary and is a reference
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
-        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
+        std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
         // ${parent} is abstract proprietary
@@ -244,7 +244,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
         std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
@@ -266,8 +266,8 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         // ${prop.name} is reference and occurs more than once
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
-        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor(['root']+accessor(obj.name, parent, prop), setPropMethod(is_multi_path[o.name], parent, obj.name, prop.name))}));
+        std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
 {% end %}\
@@ -299,7 +299,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop.na
         std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         model->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
         std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
@@ -526,7 +526,7 @@ namespace ome
         /// Generic root node.
         std::shared_ptr<MetadataRoot> genericRoot; // OME
         /// OME-XML model.
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModel> model;
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModel> model;
 
       public:
 {% end header %}\
@@ -605,7 +605,7 @@ namespace ome
 
         this->root = newroot;
         this->genericRoot = std::static_pointer_cast<MetadataRoot>(this->root);
-        model = std::make_shared< ::${lang.omexml_model_package}::detail::OMEModel>();
+        model = std::make_shared<::${lang.omexml_model_package}::detail::OMEModel>();
       }
 {% end source %}\
 
@@ -896,28 +896,28 @@ namespace ome
       {
         if (root->sizeOfImageList() == imageIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
+            std::shared_ptr<::${lang.omexml_model_package}::Image> newImage(std::make_shared<::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        std::shared_ptr<::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            std::shared_ptr<::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared<::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        std::shared_ptr<::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         if (o2->sizeOfTiffDataList() == tiffDataIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared< ::${lang.omexml_model_package}::TiffData>());
+            std::shared_ptr<::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared<::${lang.omexml_model_package}::TiffData>());
             o2->addTiffData(newTiffData);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
+        std::shared_ptr<::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
         if (!o3->getUUID()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(std::make_shared< ::${lang.omexml_model_package}::UUID>());
+            std::shared_ptr<::${lang.omexml_model_package}::UUID> newUUID(std::make_shared<::${lang.omexml_model_package}::UUID>());
             o3->setUUID(newUUID);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
+        std::shared_ptr<::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
         o4->setValue(value);
       }
 {% end source %}\
@@ -1104,16 +1104,16 @@ ${getter(k, o, prop, v)}\
         // Type is not a reference
         if (root->sizeOfImageList() == imageIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
+            std::shared_ptr<::${lang.omexml_model_package}::Image> newImage(std::make_shared<::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        std::shared_ptr<::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            std::shared_ptr<::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared<::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        std::shared_ptr<::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         std::shared_ptr<bool> newBool(std::make_shared<bool>(bigEndian));
         o2->setBigEndian(newBool);
       }

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -297,16 +297,16 @@ namespace ome
          *
          * @returns a new model object.
          */
-        static std::shared_ptr< ${klass.name}>
+        static std::shared_ptr<${klass.name}>
         create(const common::xml::dom::Element& element,
                ${lang.omexml_model_package}::OMEModel& model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr< ${klass.name}>
+      std::shared_ptr<${klass.name}>
       ${klass.name}::create(const common::xml::dom::Element& element,
                               ${lang.omexml_model_package}::OMEModel& model)
       {
-        std::shared_ptr< ${klass.name}> newinstance(std::make_shared< ${klass.name}>());
+        std::shared_ptr<${klass.name}> newinstance(std::make_shared<${klass.name}>());
         newinstance->update(element, model);
         return newinstance;
       }
@@ -413,10 +413,10 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            std::shared_ptr<${prop.name}> rcptr(std::make_shared< ${prop.name}>());
+            std::shared_ptr<${prop.name}> rcptr(std::make_shared<${prop.name}>());
             rcptr->setID(elem->getAttribute("ID"));
             std::shared_ptr<Reference> rptr(std::static_pointer_cast<Reference>(rcptr));
-            std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+            std::shared_ptr<${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
             model.addReference(optr, rptr);
           }
 {% end %}\
@@ -442,7 +442,7 @@ ${customUpdatePropertyContent[prop.name]}
              set${prop.methodName}(element.getAttribute("${prop.name}"));
 {% end %}\
              // Adding this model object to the model handler
-             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+             std::shared_ptr<${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
              model.addModelObject(getID(), thisptr);
            }
 {% end %}\
@@ -453,7 +453,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Attribute property which is an enumeration ${prop.name}
 {% if prop.minOccurs == 0 %}\
             std::string text(element.getAttribute("${prop.name}"));
-            ${prop.instanceVariableType} nattr(std::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} nattr(std::make_shared<${prop.langTypeNS}>(text));
             set${prop.methodName}(nattr);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -503,7 +503,7 @@ ${customUpdatePropertyContent[prop.name]}
             // sub-elements)
             std::string text(${prop.name}_nodeList.at(0).getTextContent());
 {% if prop.minOccurs == 0 %}\
-            ${prop.instanceVariableType} ns(std::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} ns(std::make_shared<${prop.langTypeNS}>(text));
             set${prop.methodName}(ns);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -593,12 +593,12 @@ ${customUpdatePropertyContent[prop.name]}
         /// @copydoc ${lang.omexml_model_package}::OMEModelObject::link
         bool
         link (std::shared_ptr<Reference>& reference,
-              std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
+              std::shared_ptr<${lang.omexml_model_package}::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
       ${klass.name}::link (std::shared_ptr<Reference>& reference,
-                           std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
+                           std::shared_ptr<${lang.omexml_model_package}::OMEModelObject>& object)
       {
         if (${klass.parentName}::link(reference, object))
           {
@@ -1273,7 +1273,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 // shared_ptr, but keep compatible with the rest of
                 // the API to allow consistency for future
                 // refactoring.
-                std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+                std::shared_ptr<${prop.name}> o(std::make_shared<${prop.name}>());
                 std::shared_ptr<${prop.langTypeNS}> is(i->lock());
                 if (is)
                   {
@@ -1290,7 +1290,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
             // Note that this doesn't strictly need to be a
             // shared_ptr, but keep compatible with the rest of the
             // API to allow consistency for future refactoring.
-            std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+            std::shared_ptr<${prop.name}> o(std::make_shared<${prop.name}>());
             std::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
             if (sv)
               {

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -228,7 +228,7 @@ namespace ome
       private:
         class Impl;
         /// Private implementation details.
-        ome::compat::shared_ptr<Impl> impl;
+        std::shared_ptr<Impl> impl;
 
       public:
         /// Default constructor.
@@ -241,7 +241,7 @@ namespace ome
 {% if klass.parentName is not None %}\
         ${klass.parentName}(),
 {% end has parent %}\
-        impl(ome::compat::make_shared<Impl>())
+        impl(std::make_shared<Impl>())
       {
 #ifdef OME_HAVE_BOOST_LOG
         logger.add_attribute("ClassName", logging::attributes::constant<std::string>("${klass.name}"));
@@ -265,7 +265,7 @@ namespace ome
 {% if klass.parentName is not None %}\
         ${klass.parentName}(copy),
 {% end has parent %}\
-        impl(ome::compat::make_shared<Impl>(*copy.impl))
+        impl(std::make_shared<Impl>(*copy.impl))
       {
       }
 {% end source %}\
@@ -297,16 +297,16 @@ namespace ome
          *
          * @returns a new model object.
          */
-        static ome::compat::shared_ptr< ${klass.name}>
+        static std::shared_ptr< ${klass.name}>
         create(const common::xml::dom::Element& element,
                ${lang.omexml_model_package}::OMEModel& model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr< ${klass.name}>
+      std::shared_ptr< ${klass.name}>
       ${klass.name}::create(const common::xml::dom::Element& element,
                               ${lang.omexml_model_package}::OMEModel& model)
       {
-        ome::compat::shared_ptr< ${klass.name}> newinstance(ome::compat::make_shared< ${klass.name}>());
+        std::shared_ptr< ${klass.name}> newinstance(std::make_shared< ${klass.name}>());
         newinstance->update(element, model);
         return newinstance;
       }
@@ -413,10 +413,10 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            ome::compat::shared_ptr<${prop.name}> rcptr(ome::compat::make_shared< ${prop.name}>());
+            std::shared_ptr<${prop.name}> rcptr(std::make_shared< ${prop.name}>());
             rcptr->setID(elem->getAttribute("ID"));
-            ome::compat::shared_ptr<Reference> rptr(ome::compat::static_pointer_cast<Reference>(rcptr));
-            ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(ome::compat::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+            std::shared_ptr<Reference> rptr(std::static_pointer_cast<Reference>(rcptr));
+            std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
             model.addReference(optr, rptr);
           }
 {% end %}\
@@ -442,7 +442,7 @@ ${customUpdatePropertyContent[prop.name]}
              set${prop.methodName}(element.getAttribute("${prop.name}"));
 {% end %}\
              // Adding this model object to the model handler
-             ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(ome::compat::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
              model.addModelObject(getID(), thisptr);
            }
 {% end %}\
@@ -453,7 +453,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Attribute property which is an enumeration ${prop.name}
 {% if prop.minOccurs == 0 %}\
             std::string text(element.getAttribute("${prop.name}"));
-            ${prop.instanceVariableType} nattr(ome::compat::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} nattr(std::make_shared< ${prop.langTypeNS}>(text));
             set${prop.methodName}(nattr);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -489,7 +489,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Element property ${prop.name} which is complex (has sub-elements)
 {% if prop.minOccurs == 0 or (not lang.hasPrimitiveType(prop.langType) and not prop.isEnumeration) %}\
             common::xml::dom::Element elem(${prop.name}_nodeList.at(0));
-            // While ome::compat::make_shared<> works, here,
+            // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
             ${prop.instanceVariableType} p(${prop.langTypeNS}::create(elem, model));
 {% end %}\
@@ -503,7 +503,7 @@ ${customUpdatePropertyContent[prop.name]}
             // sub-elements)
             std::string text(${prop.name}_nodeList.at(0).getTextContent());
 {% if prop.minOccurs == 0 %}\
-            ${prop.instanceVariableType} ns(ome::compat::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} ns(std::make_shared< ${prop.langTypeNS}>(text));
             set${prop.methodName}(ns);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -537,10 +537,10 @@ ${customUpdatePropertyContent[prop.name]}
                  inner_elem != ${inner_prop.name}_nodeList.end();
                  ++inner_elem)
                    {
-                     // While ome::compat::make_shared<> works, here,
+                     // While std::make_shared<> works, here,
                      // boost::make_shared<> does not, so use new
                      // directly.
-                     ome::compat::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
+                     std::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
                      object->update(*inner_elem, model);
                      add${prop.methodName}(object);
                    }
@@ -556,9 +556,9 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            // While ome::compat::make_shared<> works, here,
+            // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
-            ome::compat::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -572,7 +572,7 @@ ${customUpdatePropertyContent[prop.name]}
              ++elem)
           {
             std::string text(element.getTextContent());
-            ome::compat::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -592,13 +592,13 @@ ${customUpdatePropertyContent[prop.name]}
 
         /// @copydoc ${lang.omexml_model_package}::OMEModelObject::link
         bool
-        link (ome::compat::shared_ptr<Reference>& reference,
-              ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
+        link (std::shared_ptr<Reference>& reference,
+              std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::link (ome::compat::shared_ptr<Reference>& reference,
-                           ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
+      ${klass.name}::link (std::shared_ptr<Reference>& reference,
+                           std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
       {
         if (${klass.parentName}::link(reference, object))
           {
@@ -606,18 +606,18 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
-        if (ome::compat::dynamic_pointer_cast<${prop.name}>(reference))
+        if (std::dynamic_pointer_cast<${prop.name}>(reference))
           {
             /// @todo This bit is silly; why do we have two dynamic_casts here.
-            ome::compat::shared_ptr<${prop.langTypeNS}> o_casted = ome::compat::dynamic_pointer_cast<${prop.langTypeNS}>(object);
+            std::shared_ptr<${prop.langTypeNS}> o_casted = std::dynamic_pointer_cast<${prop.langTypeNS}>(object);
             if (o_casted)
               {
 {% if not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-                o_casted->link${klass.type}(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+                o_casted->link${klass.type}(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-                o_casted->link${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+                o_casted->link${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
 {% end %}\
 {% end %}\
 {% if prop.maxOccurs > 1 %}\
@@ -628,7 +628,7 @@ ${customUpdatePropertyContent[prop.name]}
                   }
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
-                typedef OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::nth_index<1>::type container_set_type;
+                typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
                 container_set_type::iterator it(this->impl->${prop.instanceVariableName}.get<1>().find(o_casted));
                 if (it != this->impl->${prop.instanceVariableName}.get<1>().end())
                   {
@@ -733,11 +733,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a weak pointer to the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        const ome::compat::weak_ptr<${prop.langTypeNS}>&
+        const std::weak_ptr<${prop.langTypeNS}>&
         getLinked${prop.methodName} (${prop.instanceVariableType}::size_type index) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const ome::compat::weak_ptr<${prop.langTypeNS}>&
+      const std::weak_ptr<${prop.langTypeNS}>&
       ${klass.name}::getLinked${prop.methodName} (${prop.instanceVariableType}::size_type index) const
       {
         return this->impl->${prop.instanceVariableName}.at(index);
@@ -755,21 +755,21 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a weak pointer to the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        const ome::compat::weak_ptr<${prop.langTypeNS}>&
+        const std::weak_ptr<${prop.langTypeNS}>&
         setLinked${prop.methodName} (${prop.instanceVariableType}::size_type index,
-                                     const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+                                     const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const ome::compat::weak_ptr<${prop.langTypeNS}>&
+      const std::weak_ptr<${prop.langTypeNS}>&
       ${klass.name}::setLinked${prop.methodName}(${prop.instanceVariableType}::size_type index,
-                                                 const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+                                                 const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isReference and not prop.isBackReference %}\
         return this->impl->${prop.instanceVariableName}.at(index) = ${prop.argumentName};
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
         ${prop.instanceVariableType}::iterator it(this->impl->${prop.instanceVariableName}.iterator_to(this->impl->${prop.instanceVariableName}.at(index)));
-        const ome::compat::weak_ptr<${prop.langTypeNS}> wp(${prop.argumentName});
+        const std::weak_ptr<${prop.langTypeNS}> wp(${prop.argumentName});
         this->impl->${prop.instanceVariableName}.replace(it, wp);
         return *it;
 {% end %}\
@@ -788,18 +788,18 @@ ${customUpdatePropertyContent[prop.name]}
          * Is this an artifact of the Java API?
          */
         bool
-        link${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        link${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::link${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::link${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->link${klass.type}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->link${klass.type}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->link${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->link${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% end %}\
 {% if not prop.isReference and not prop.isBackReference %}\
@@ -810,11 +810,11 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
-        typedef OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::nth_index<1>::type container_set_type;
+        typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
         container_set_type::iterator it(this->impl->${prop.instanceVariableName}.get<1>().find(${prop.argumentName}));
         if (it == this->impl->${prop.instanceVariableName}.get<1>().end())
           {
-            std::pair<OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::iterator, bool> res(this->impl->${prop.instanceVariableName}.push_back(ome::compat::weak_ptr<${prop.langTypeNS}>(${prop.argumentName})));
+            std::pair<OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::iterator, bool> res(this->impl->${prop.instanceVariableName}.push_back(std::weak_ptr<${prop.langTypeNS}>(${prop.argumentName})));
             return res.second;
           }
 {% end %}\
@@ -839,18 +839,18 @@ ${customUpdatePropertyContent[prop.name]}
          * aren't preventing duplicates on insertion.
          */
         bool
-        unlink${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        unlink${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::unlink${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::unlink${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->unlink${klass.type}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->unlink${klass.type}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->unlink${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->unlink${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% end %}\
         bool found = false;
@@ -896,11 +896,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @param ${prop.argumentName} the ${prop.methodName} to link.
          */
         void
-        link${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        link${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::link${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::link${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
         this->impl->${prop.instanceVariableName} = ${prop.argumentName};
       }
@@ -917,15 +917,15 @@ ${customUpdatePropertyContent[prop.name]}
          * internally.
          */
         void
-        unlink${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        unlink${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::unlink${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::unlink${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
-        if (ome::compat::shared_ptr<${prop.langTypeNS}>(this->impl->${prop.instanceVariableName}) == ${prop.argumentName})
+        if (std::shared_ptr<${prop.langTypeNS}>(this->impl->${prop.instanceVariableName}) == ${prop.argumentName})
           {
-            this->impl->${prop.instanceVariableName} = ome::compat::shared_ptr<${prop.langTypeNS}>();
+            this->impl->${prop.instanceVariableName} = std::shared_ptr<${prop.langTypeNS}>();
           }
       }
 {% end source %}\
@@ -1047,7 +1047,7 @@ ${customUpdatePropertyContent[prop.name]}
                                             ${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
-        ome::compat::weak_ptr<${klass.type}> self(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+        std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
         ${prop.argumentName}->set${klass.type}(self);
 {% end %}\
 {% if not prop.isReference and not prop.isBackReference %}\
@@ -1077,7 +1077,7 @@ ${customUpdatePropertyContent[prop.name]}
       ${klass.name}::add${prop.methodName} (${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
-        ome::compat::weak_ptr<${klass.type}> self(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+        std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
         ${prop.argumentName}->set${klass.type}(self);
 {% end %}\
         this->impl->${prop.instanceVariableName}.push_back(${prop.argumentName});
@@ -1273,8 +1273,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 // shared_ptr, but keep compatible with the rest of
                 // the API to allow consistency for future
                 // refactoring.
-                ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
-                ome::compat::shared_ptr<${prop.langTypeNS}> is(i->lock());
+                std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+                std::shared_ptr<${prop.langTypeNS}> is(i->lock());
                 if (is)
                   {
                     o->setID(is->getID());
@@ -1290,8 +1290,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
             // Note that this doesn't strictly need to be a
             // shared_ptr, but keep compatible with the rest of the
             // API to allow consistency for future refactoring.
-            ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
-            ome::compat::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
+            std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+            std::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
             if (sv)
               {
                 o->setID(sv->getID());

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_MapAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_MapAnnotation_update_Value.template
@@ -20,6 +20,6 @@ if (Value_nodeList.size() > 1)
            map.insert(::${lang.omexml_model_package}::MapPairs::map_type::value_type(e.getAttribute("K"),
                                                                       e.getTextContent()));
        }
-     ome::compat::shared_ptr< ::${lang.omexml_model_package}::MapPairs> mapPairs(ome::compat::make_shared< ::${lang.omexml_model_package}::MapPairs>(map));
+     std::shared_ptr< ::${lang.omexml_model_package}::MapPairs> mapPairs(std::make_shared< ::${lang.omexml_model_package}::MapPairs>(map));
      setValue(mapPairs);
    }

--- a/components/xsd-fu/templates-cpp/OMEXMLModelObject_MapAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelObject_MapAnnotation_update_Value.template
@@ -20,6 +20,6 @@ if (Value_nodeList.size() > 1)
            map.insert(::${lang.omexml_model_package}::MapPairs::map_type::value_type(e.getAttribute("K"),
                                                                       e.getTextContent()));
        }
-     std::shared_ptr< ::${lang.omexml_model_package}::MapPairs> mapPairs(std::make_shared< ::${lang.omexml_model_package}::MapPairs>(map));
+     std::shared_ptr<::${lang.omexml_model_package}::MapPairs> mapPairs(std::make_shared<::${lang.omexml_model_package}::MapPairs>(map));
      setValue(mapPairs);
    }

--- a/cpp/cmake/BoostChecks.cmake
+++ b/cpp/cmake/BoostChecks.cmake
@@ -71,7 +71,6 @@ check_include_file_cxx(boost/format.hpp OME_HAVE_BOOST_FORMAT)
 check_include_file_cxx(boost/log/core.hpp OME_HAVE_BOOST_LOG)
 check_include_file_cxx(boost/shared_ptr.hpp OME_HAVE_BOOST_SHARED_PTR)
 check_include_file_cxx(boost/smart_ptr/owner_less.hpp OME_HAVE_BOOST_OWNER_LESS)
-check_include_file_cxx(boost/tuple/tuple.hpp OME_HAVE_BOOST_TUPLE)
 check_include_file_cxx(boost/type_traits.hpp OME_HAVE_BOOST_TYPE_TRAITS_HPP)
 check_include_file_cxx(boost/geometry/index/rtree.hpp OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP)
 

--- a/cpp/cmake/BoostChecks.cmake
+++ b/cpp/cmake/BoostChecks.cmake
@@ -67,7 +67,6 @@ set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} -DBOOST_ALL_DYN_LIN
 set(CMAKE_REQUIRED_INCLUDES_SAVE ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${Boost_INCLUDE_DIRS})
 
-check_include_file_cxx(boost/array.hpp OME_HAVE_BOOST_ARRAY)
 check_include_file_cxx(boost/format.hpp OME_HAVE_BOOST_FORMAT)
 check_include_file_cxx(boost/log/core.hpp OME_HAVE_BOOST_LOG)
 check_include_file_cxx(boost/shared_ptr.hpp OME_HAVE_BOOST_SHARED_PTR)

--- a/cpp/cmake/BoostChecks.cmake
+++ b/cpp/cmake/BoostChecks.cmake
@@ -69,8 +69,6 @@ set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${Boost_INCLUDE_DIRS})
 
 check_include_file_cxx(boost/format.hpp OME_HAVE_BOOST_FORMAT)
 check_include_file_cxx(boost/log/core.hpp OME_HAVE_BOOST_LOG)
-check_include_file_cxx(boost/shared_ptr.hpp OME_HAVE_BOOST_SHARED_PTR)
-check_include_file_cxx(boost/smart_ptr/owner_less.hpp OME_HAVE_BOOST_OWNER_LESS)
 check_include_file_cxx(boost/type_traits.hpp OME_HAVE_BOOST_TYPE_TRAITS_HPP)
 check_include_file_cxx(boost/geometry/index/rtree.hpp OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP)
 

--- a/cpp/cmake/BoostChecks.cmake
+++ b/cpp/cmake/BoostChecks.cmake
@@ -80,11 +80,6 @@ if(NOT OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP)
   message(WARNING "Spatial indexes not available with this version of Boost.Geometry; tile coverage lookups will have reduced performance (linear scan replacing quadratic R*Tree)")
 endif()
 
-check_cxx_source_compiles("
-#include <boost/cstdint.hpp>
-int main() { uint16_t test(134); }
-" OME_HAVE_BOOST_CSTDINT)
-
 # Boost library checks could be dropped?
 # boost::program_options::variables_map in -lboost_program_options
 # + BOOST_PROGRAM_OPTIONS_DESCRIPTION_OLD (drop?)

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -244,11 +244,6 @@ int main() { std::tr1::tuple<int,double> t; }
 " OME_HAVE_TR1_TUPLE)
 
 check_cxx_source_compiles("
-#include <cstdint>
-int main() { uint16_t test(134); }
-" OME_HAVE_CSTDINT)
-
-check_cxx_source_compiles("
 #include <memory>
 struct foo : public std::enable_shared_from_this<foo>
 {

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -114,7 +114,9 @@ int main()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_SAVE}")
 endfunction(cxx_std_check)
 
-if (cxxstd-autodetect)
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER "3.0")
+  set(CMAKE_CXX_STANDARD 11)
+else()
   if (NOT MSVC)
     cxx_std_check(-std=c++14 CXX_FLAG_CXX14)
     if (CXX_FLAG_CXX14)
@@ -141,7 +143,7 @@ if (cxxstd-autodetect)
       endif(CXX_FLAG_CXX11)
     endif(CXX_FLAG_CXX14)
   endif (NOT MSVC)
-endif (cxxstd-autodetect)
+endif()
 
 # Try to enable the -pedantic flag.  This one needs special casing
 # since it may break building with older compilers where int64_t (long
@@ -248,11 +250,11 @@ int main() { uint16_t test(134); }
 
 check_cxx_source_compiles("
 #include <memory>
-struct foo : public ome::compat::enable_shared_from_this<foo>
+struct foo : public std::enable_shared_from_this<foo>
 {
         foo() {}
 };
-int main() { ome::compat::shared_ptr<foo> f(new foo()); }
+int main() { std::shared_ptr<foo> f(new foo()); }
 " OME_HAVE_MEMORY)
 
 check_cxx_source_compiles("

--- a/cpp/cmake/CompilerChecks.cmake
+++ b/cpp/cmake/CompilerChecks.cmake
@@ -114,36 +114,7 @@ int main()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_SAVE}")
 endfunction(cxx_std_check)
 
-if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER "3.0")
-  set(CMAKE_CXX_STANDARD 11)
-else()
-  if (NOT MSVC)
-    cxx_std_check(-std=c++14 CXX_FLAG_CXX14)
-    if (CXX_FLAG_CXX14)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    else()
-      cxx_std_check(-std=c++11 CXX_FLAG_CXX11)
-      if (CXX_FLAG_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-      else()
-        cxx_std_check(-std=c++03 CXX_FLAG_CXX03)
-        if (CXX_FLAG_CXX03)
-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
-        else()
-          cxx_std_check(-std=c++98 CXX_FLAG_CXX98)
-          if (CXX_FLAG_CXX98)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
-          else()
-            cxx_std_check("" CXX_FLAG_NONE)
-            if (NOT CXX_FLAG_NONE)
-              message(WARNING "Could not determine compiler options for enabling the most recent C++ standard; this might be expected for your compiler")
-            endif (NOT CXX_FLAG_NONE)
-          endif(CXX_FLAG_CXX98)
-        endif(CXX_FLAG_CXX03)
-      endif(CXX_FLAG_CXX11)
-    endif(CXX_FLAG_CXX14)
-  endif (NOT MSVC)
-endif()
+set(CMAKE_CXX_STANDARD 11)
 
 # Try to enable the -pedantic flag.  This one needs special casing
 # since it may break building with older compilers where int64_t (long
@@ -232,35 +203,6 @@ foreach(flag ${test_flags})
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
   endif (${test_cxx_flag})
 endforeach(flag ${test_flags})
-
-check_cxx_source_compiles("
-#include <tuple>
-int main() { std::tuple<int,double> t; }
-" OME_HAVE_TUPLE)
-
-check_cxx_source_compiles("
-#include <tr1/tuple>
-int main() { std::tr1::tuple<int,double> t; }
-" OME_HAVE_TR1_TUPLE)
-
-check_cxx_source_compiles("
-#include <memory>
-struct foo : public std::enable_shared_from_this<foo>
-{
-        foo() {}
-};
-int main() { std::shared_ptr<foo> f(new foo()); }
-" OME_HAVE_MEMORY)
-
-check_cxx_source_compiles("
-void foo() noexcept{}
-int main() { foo(); }
-" OME_HAVE_NOEXCEPT)
-
-check_cxx_source_compiles("
-#include <array>
-int main() { std::array<int,3> a; a[0] = 5; }
-" OME_HAVE_ARRAY)
 
 check_cxx_source_compiles("
 #include <cstdarg>

--- a/cpp/cmake/Options.cmake
+++ b/cpp/cmake/Options.cmake
@@ -1,8 +1,3 @@
-# Try to put the compiler into the most recent standard mode.  This
-# will generally have the most features, and will remove the need for
-# Boost fallbacks if native implementations are available.
-option(cxxstd-autodetect "Enable C++14 features if possible, otherwise fall back to C++11, C++03 or C++98" OFF)
-
 # These are annoyingly verbose, produce false positives or don't work
 # nicely with all supported compiler versions, so are disabled unless
 # explicitly enabled.

--- a/cpp/lib/ome/bioformats/CoreMetadata.h
+++ b/cpp/lib/ome/bioformats/CoreMetadata.h
@@ -38,12 +38,11 @@
 #ifndef OME_BIOFORMATS_COREMETADATA_H
 #define OME_BIOFORMATS_COREMETADATA_H
 
+#include <cstdint>
 #include <map>
 #include <numeric>
 #include <string>
 #include <vector>
-
-#include <ome/compat/cstdint.h>
 
 #include <ome/bioformats/MetadataMap.h>
 #include <ome/bioformats/Modulo.h>

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -946,7 +946,7 @@ namespace ome
        * @returns a const reference to the core metadata.
        */
       virtual
-      const std::vector<std::shared_ptr<CoreMetadata> >&
+      const std::vector<std::shared_ptr<CoreMetadata>>&
       getCoreMetadataList() const = 0;
 
       /**
@@ -1009,7 +1009,7 @@ namespace ome
        * @returns a list of readers.
        */
       virtual
-      std::vector<std::shared_ptr<FormatReader> >
+      std::vector<std::shared_ptr<FormatReader>>
       getUnderlyingReaders() const = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -980,7 +980,7 @@ namespace ome
        */
       virtual
       void
-      setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store) = 0;
+      setMetadataStore(std::shared_ptr<::ome::xml::meta::MetadataStore>& store) = 0;
 
       /**
        * Get the current metadata store for this reader.
@@ -988,7 +988,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      const std::shared_ptr<::ome::xml::meta::MetadataStore>&
       getMetadataStore() const = 0;
 
       /**
@@ -997,7 +997,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      std::shared_ptr<::ome::xml::meta::MetadataStore>&
       getMetadataStore() = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -946,7 +946,7 @@ namespace ome
        * @returns a const reference to the core metadata.
        */
       virtual
-      const std::vector<ome::compat::shared_ptr<CoreMetadata> >&
+      const std::vector<std::shared_ptr<CoreMetadata> >&
       getCoreMetadataList() const = 0;
 
       /**
@@ -980,7 +980,7 @@ namespace ome
        */
       virtual
       void
-      setMetadataStore(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>& store) = 0;
+      setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store) = 0;
 
       /**
        * Get the current metadata store for this reader.
@@ -988,7 +988,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
       getMetadataStore() const = 0;
 
       /**
@@ -997,7 +997,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      std::shared_ptr< ::ome::xml::meta::MetadataStore>&
       getMetadataStore() = 0;
 
       /**
@@ -1009,7 +1009,7 @@ namespace ome
        * @returns a list of readers.
        */
       virtual
-      std::vector<ome::compat::shared_ptr<FormatReader> >
+      std::vector<std::shared_ptr<FormatReader> >
       getUnderlyingReaders() const = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatReader.h
+++ b/cpp/lib/ome/bioformats/FormatReader.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_FORMATREADER_H
 #define OME_BIOFORMATS_FORMATREADER_H
 
+#include <array>
 #include <string>
 #include <vector>
 #include <map>
@@ -50,8 +51,6 @@
 #include <ome/bioformats/MetadataConfigurable.h>
 #include <ome/bioformats/MetadataMap.h>
 #include <ome/bioformats/Types.h>
-
-#include <ome/compat/array.h>
 
 #include <ome/xml/meta/MetadataStore.h>
 
@@ -860,7 +859,7 @@ namespace ome
        * @todo unify with the pixel buffer dimension indexes.
        */
       virtual
-      ome::compat::array<dimension_size_type, 3>
+      std::array<dimension_size_type, 3>
       getZCTCoords(dimension_size_type index) const = 0;
 
       /**
@@ -880,7 +879,7 @@ namespace ome
        * @todo unify with the pixel buffer dimension indexes.
        */
       virtual
-      ome::compat::array<dimension_size_type, 6>
+      std::array<dimension_size_type, 6>
       getZCTModuloCoords(dimension_size_type index) const = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatTools.cpp
+++ b/cpp/lib/ome/bioformats/FormatTools.cpp
@@ -35,6 +35,7 @@
  * #L%
  */
 
+#include <array>
 #include <stdexcept>
 
 #include <boost/format.hpp>
@@ -418,7 +419,7 @@ namespace ome
 
     }
 
-    ome::compat::array<dimension_size_type, 3>
+    std::array<dimension_size_type, 3>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,
@@ -436,7 +437,7 @@ namespace ome
       dimension_size_type v1 = index / len0 % len1;
       dimension_size_type v2 = index / len0 / len1;
 
-      ome::compat::array<dimension_size_type, 3> ret;
+      std::array<dimension_size_type, 3> ret;
       ret[0] = iz == 0 ? v0 : (iz == 1 ? v1 : v2); // z
       ret[1] = ic == 0 ? v0 : (ic == 1 ? v1 : v2); // c
       ret[2] = it == 0 ? v0 : (it == 1 ? v1 : v2); // t
@@ -444,7 +445,7 @@ namespace ome
       return ret;
     }
 
-    ome::compat::array<dimension_size_type, 6>
+    std::array<dimension_size_type, 6>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,
@@ -455,7 +456,7 @@ namespace ome
                  dimension_size_type num,
                  dimension_size_type index)
     {
-      ome::compat::array<dimension_size_type, 3> coords
+      std::array<dimension_size_type, 3> coords
         (getZCTCoords(order,
                       zSize,
                       cSize,
@@ -463,7 +464,7 @@ namespace ome
                       num,
                       index));
 
-      ome::compat::array<dimension_size_type, 6> ret;
+      std::array<dimension_size_type, 6> ret;
       ret[0] = coords[0] / moduloZSize;
       ret[1] = coords[1] / moduloCSize;
       ret[2] = coords[2] / moduloTSize;

--- a/cpp/lib/ome/bioformats/FormatTools.h
+++ b/cpp/lib/ome/bioformats/FormatTools.h
@@ -38,9 +38,8 @@
 #ifndef OME_BIOFORMATS_FORMATTOOLS_H
 #define OME_BIOFORMATS_FORMATTOOLS_H
 
+#include <array>
 #include <string>
-
-#include <ome/compat/array.h>
 
 #include <ome/bioformats/Types.h>
 
@@ -179,7 +178,7 @@ namespace ome
      * @param index 1D (rasterized) index to convert to ZCT coordinates.
      * @returns an array containing the ZCT coordinates (real sizes, in that order).
      */
-    ome::compat::array<dimension_size_type, 3>
+    std::array<dimension_size_type, 3>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,
@@ -215,7 +214,7 @@ namespace ome
      * @returns an array containing the ZCTmZmCmT coordinates (effective sizes, in that
      * order).
      */
-    ome::compat::array<dimension_size_type, 6>
+    std::array<dimension_size_type, 6>
     getZCTCoords(const std::string& order,
                  dimension_size_type zSize,
                  dimension_size_type cSize,

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -52,8 +52,6 @@
 #include <ome/bioformats/MetadataMap.h>
 #include <ome/bioformats/Types.h>
 
-#include <ome/compat/array.h>
-
 #include <ome/xml/meta/MetadataRetrieve.h>
 
 namespace ome

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -227,7 +227,7 @@ namespace ome
        */
       virtual
       void
-      setMetadataRetrieve(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve) = 0;
+      setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve) = 0;
 
       /**
        * Get the current metadata store for this writer.
@@ -235,7 +235,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       getMetadataRetrieve() const = 0;
 
       /**
@@ -244,7 +244,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       getMetadataRetrieve() = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/FormatWriter.h
@@ -227,7 +227,7 @@ namespace ome
        */
       virtual
       void
-      setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve) = 0;
+      setMetadataRetrieve(std::shared_ptr<::ome::xml::meta::MetadataRetrieve>& retrieve) = 0;
 
       /**
        * Get the current metadata store for this writer.
@@ -235,7 +235,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      const std::shared_ptr<::ome::xml::meta::MetadataRetrieve>&
       getMetadataRetrieve() const = 0;
 
       /**
@@ -244,7 +244,7 @@ namespace ome
        * @returns the metadata store, which will never be @c null.
        */
       virtual
-      std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      std::shared_ptr<::ome::xml::meta::MetadataRetrieve>&
       getMetadataRetrieve() = 0;
 
       /**

--- a/cpp/lib/ome/bioformats/MetadataMap.h
+++ b/cpp/lib/ome/bioformats/MetadataMap.h
@@ -131,13 +131,13 @@ namespace ome
       };
 
       /// Aggregate view of all storable list types.
-      typedef boost::mpl::transform_view<basic_types_view, make_vector<boost::mpl::_1> >::type list_types_view;
+      typedef boost::mpl::transform_view<basic_types_view, make_vector<boost::mpl::_1>>::type list_types_view;
 
       /// Aggregate view of all storable types.
       typedef boost::mpl::joint_view<basic_types_view, list_types_view> all_types_view;
 
       /// List of discriminated types used by boost::variant.
-      typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<> >::type, all_types_view>::type discriminated_types;
+      typedef boost::mpl::insert_range<boost::mpl::vector0<>, boost::mpl::end<boost::mpl::vector0<>>::type, all_types_view>::type discriminated_types;
 
     public:
       /// Key type.

--- a/cpp/lib/ome/bioformats/MetadataMap.h
+++ b/cpp/lib/ome/bioformats/MetadataMap.h
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <iomanip>
 #include <map>
 #include <ostream>
@@ -47,7 +48,6 @@
 #include <string>
 #include <vector>
 
-#include <ome/compat/cstdint.h>
 #include <ome/common/variant.h>
 
 namespace ome

--- a/cpp/lib/ome/bioformats/MetadataOptions.h
+++ b/cpp/lib/ome/bioformats/MetadataOptions.h
@@ -38,11 +38,10 @@
 #ifndef OME_BIOFORMATS_METADATAOPTIONS_H
 #define OME_BIOFORMATS_METADATAOPTIONS_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <sstream>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -219,20 +219,20 @@ namespace ome
       return fmt.str();
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::common::xml::dom::Document& document)
     {
       ome::common::xml::dom::Element docroot(document.getDocumentElement());
 
-      ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+      std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
       ome::xml::model::detail::OMEModel model;
-      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
       root->update(docroot, model);
 
       return meta;
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file)
     {
       // Parse OME-XML into DOM Document.
@@ -252,7 +252,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text)
     {
       // Parse OME-XML into DOM Document.
@@ -273,7 +273,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream)
     {
       // Parse OME-XML into DOM Document.
@@ -294,41 +294,41 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane,
                          bool                doImageName)
     {
-      ome::compat::shared_ptr<OMEXMLMetadata> metadata(ome::compat::make_shared<OMEXMLMetadata>());
-      ome::compat::shared_ptr<MetadataStore> store(ome::compat::static_pointer_cast<MetadataStore>(metadata));
+      std::shared_ptr<OMEXMLMetadata> metadata(std::make_shared<OMEXMLMetadata>());
+      std::shared_ptr<MetadataStore> store(std::static_pointer_cast<MetadataStore>(metadata));
       fillMetadata(*store, reader, doPlane, doImageName);
       return metadata;
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::MetadataRoot>
+    std::shared_ptr< ::ome::xml::meta::MetadataRoot>
     createOMEXMLRoot(const std::string& document)
     {
       /// @todo Implement model transforms.
 
-      ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(createOMEXMLMetadata(document)));
-      return meta ? meta->getRoot() : ome::compat::shared_ptr< ::ome::xml::meta::MetadataRoot>();
+      std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(createOMEXMLMetadata(document)));
+      return meta ? meta->getRoot() : std::shared_ptr< ::ome::xml::meta::MetadataRoot>();
     }
 
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-    getOMEXMLMetadata(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
     {
-      ome::compat::shared_ptr<OMEXMLMetadata> ret;
+      std::shared_ptr<OMEXMLMetadata> ret;
 
       if (retrieve)
         {
-          ome::compat::shared_ptr<OMEXMLMetadata> omexml(ome::compat::dynamic_pointer_cast<OMEXMLMetadata>(retrieve));
+          std::shared_ptr<OMEXMLMetadata> omexml(std::dynamic_pointer_cast<OMEXMLMetadata>(retrieve));
           if (omexml)
             {
               ret = omexml;
             }
           else
             {
-              ret = ome::compat::shared_ptr<OMEXMLMetadata>(ome::compat::make_shared<OMEXMLMetadata>());
+              ret = std::shared_ptr<OMEXMLMetadata>(std::make_shared<OMEXMLMetadata>());
               ome::xml::meta::convert(*retrieve, *ret);
             }
         }
@@ -536,11 +536,11 @@ namespace ome
 
     void
     fillMetadata(::ome::xml::meta::MetadataStore&                          store,
-                 const std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList,
+                 const std::vector<std::shared_ptr<CoreMetadata> > seriesList,
                  bool                                                      doPlane)
     {
       dimension_size_type s = 0U;
-      for (std::vector<ome::compat::shared_ptr<CoreMetadata> >::const_iterator i = seriesList.begin();
+      for (std::vector<std::shared_ptr<CoreMetadata> >::const_iterator i = seriesList.begin();
            i != seriesList.end();
            ++i, ++s)
         {
@@ -669,17 +669,17 @@ namespace ome
     {
       if (resolve)
         omexml.resolveReferences();
-      ome::compat::shared_ptr<MetadataRoot> root(omexml.getRoot());
-      ome::compat::shared_ptr<OMEXMLMetadataRoot> omexmlroot(ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root));
+      std::shared_ptr<MetadataRoot> root(omexml.getRoot());
+      std::shared_ptr<OMEXMLMetadataRoot> omexmlroot(std::dynamic_pointer_cast<OMEXMLMetadataRoot>(root));
       if (omexmlroot)
         {
-          ome::compat::shared_ptr<Image> image = omexmlroot->getImage(series);
+          std::shared_ptr<Image> image = omexmlroot->getImage(series);
           if (image)
             {
-              ome::compat::shared_ptr<Pixels> pixels = image->getPixels();
+              std::shared_ptr<Pixels> pixels = image->getPixels();
               if (pixels)
                 {
-                  ome::compat::shared_ptr<MetadataOnly> meta(ome::compat::make_shared<MetadataOnly>());
+                  std::shared_ptr<MetadataOnly> meta(std::make_shared<MetadataOnly>());
                   pixels->setMetadataOnly(meta);
                 }
             }
@@ -715,12 +715,12 @@ namespace ome
       // @todo Implement Modulo retrieval.
       ::ome::xml::meta::OMEXMLMetadata& momexml(const_cast< ::ome::xml::meta::OMEXMLMetadata&>(omexml));
 
-      ome::compat::shared_ptr<OMEXMLMetadataRoot> root =
-        ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(momexml.getRoot());
+      std::shared_ptr<OMEXMLMetadataRoot> root =
+        std::dynamic_pointer_cast<OMEXMLMetadataRoot>(momexml.getRoot());
       if (!root) // Should never occur
         throw std::logic_error("OMEXMLMetadata does not have an OMEXMLMetadataRoot");
 
-      ome::compat::shared_ptr< ::ome::xml::model::Image> mimage(root->getImage(image));
+      std::shared_ptr< ::ome::xml::model::Image> mimage(root->getImage(image));
       if (!mimage)
         throw std::runtime_error("Image does not exist in OMEXMLMetadata");
 
@@ -728,8 +728,8 @@ namespace ome
            i < mimage->sizeOfLinkedAnnotationList();
            ++i)
         {
-          ome::compat::shared_ptr< ::ome::xml::model::Annotation> annotation(mimage->getLinkedAnnotation(i));
-          ome::compat::shared_ptr< ::ome::xml::model::XMLAnnotation> xmlannotation(ome::compat::dynamic_pointer_cast< ::ome::xml::model::XMLAnnotation>(annotation));
+          std::shared_ptr< ::ome::xml::model::Annotation> annotation(mimage->getLinkedAnnotation(i));
+          std::shared_ptr< ::ome::xml::model::XMLAnnotation> xmlannotation(std::dynamic_pointer_cast< ::ome::xml::model::XMLAnnotation>(annotation));
           if (xmlannotation)
             {
               try
@@ -834,27 +834,27 @@ namespace ome
     removeBinData(::ome::xml::meta::OMEXMLMetadata& omexml)
     {
       omexml.resolveReferences();
-      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          std::vector<ome::compat::shared_ptr<ome::xml::model::Image> >& images(root->getImageList());
-          for(std::vector<ome::compat::shared_ptr<ome::xml::model::Image> >::const_iterator image = images.begin();
+          std::vector<std::shared_ptr<ome::xml::model::Image> >& images(root->getImageList());
+          for(std::vector<std::shared_ptr<ome::xml::model::Image> >::const_iterator image = images.begin();
               image != images.end();
               ++image)
             {
-              ome::compat::shared_ptr<ome::xml::model::Pixels> pixels((*image)->getPixels());
+              std::shared_ptr<ome::xml::model::Pixels> pixels((*image)->getPixels());
               if (pixels)
                 {
                   // Note a copy not a reference to avoid iterator
                   // invalidation during removal.
-                  std::vector<ome::compat::shared_ptr<ome::xml::model::BinData> > binData(pixels->getBinDataList());
-                  for (std::vector<ome::compat::shared_ptr<ome::xml::model::BinData> >::iterator bin = binData.begin();
+                  std::vector<std::shared_ptr<ome::xml::model::BinData> > binData(pixels->getBinDataList());
+                  for (std::vector<std::shared_ptr<ome::xml::model::BinData> >::iterator bin = binData.begin();
                    bin != binData.end();
                        ++bin)
                     {
                       pixels->removeBinData(*bin);
                     }
-                  ome::compat::shared_ptr<ome::xml::model::MetadataOnly> metadataOnly;
+                  std::shared_ptr<ome::xml::model::MetadataOnly> metadataOnly;
                   pixels->setMetadataOnly(metadataOnly);
                 }
             }
@@ -867,19 +867,19 @@ namespace ome
                    dimension_size_type               sizeC)
     {
       omexml.resolveReferences();
-      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          ome::compat::shared_ptr<ome::xml::model::Image>& imageref(root->getImage(image));
+          std::shared_ptr<ome::xml::model::Image>& imageref(root->getImage(image));
           if (image)
             {
-              ome::compat::shared_ptr<ome::xml::model::Pixels> pixels(imageref->getPixels());
+              std::shared_ptr<ome::xml::model::Pixels> pixels(imageref->getPixels());
               if (pixels)
                 {
-                  std::vector<ome::compat::shared_ptr<ome::xml::model::Channel> > channels(pixels->getChannelList());
+                  std::vector<std::shared_ptr<ome::xml::model::Channel> > channels(pixels->getChannelList());
                   for (Metadata::index_type c = 0U; c < channels.size(); ++c)
                     {
-                      ome::compat::shared_ptr<ome::xml::model::Channel> channel(channels.at(c));
+                      std::shared_ptr<ome::xml::model::Channel> channel(channels.at(c));
                       if (channel->getID().empty() || c >= sizeC)
                         pixels->removeChannel(channel);
                     }
@@ -893,17 +893,17 @@ namespace ome
     {
       MetadataMap map;
 
-      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          ome::compat::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
+          std::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
           if (sa)
             {
               for (OMEXMLMetadata::index_type i = 0; i < sa->sizeOfXMLAnnotationList(); ++i)
                 {
                   // Check if this is an OriginalMetadataAnnotation object.
-                  ome::compat::shared_ptr<XMLAnnotation> annotation(sa->getXMLAnnotation(i));
-                  ome::compat::shared_ptr<OriginalMetadataAnnotation> original(ome::compat::dynamic_pointer_cast<OriginalMetadataAnnotation>(annotation));
+                  std::shared_ptr<XMLAnnotation> annotation(sa->getXMLAnnotation(i));
+                  std::shared_ptr<OriginalMetadataAnnotation> original(std::dynamic_pointer_cast<OriginalMetadataAnnotation>(annotation));
                   if (original)
                     {
                       const OriginalMetadataAnnotation::metadata_type kv(original->getMetadata());
@@ -981,12 +981,12 @@ namespace ome
 
       MetadataMap flat(metadata.flatten());
 
-      ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
+      std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          ome::compat::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
+          std::shared_ptr<StructuredAnnotations> sa(root->getStructuredAnnotations());
           if (!sa)
-            sa = ome::compat::make_shared<StructuredAnnotations>();
+            sa = std::make_shared<StructuredAnnotations>();
           OMEXMLMetadata::index_type annotationIndex = sa->sizeOfXMLAnnotationList();
           OMEXMLMetadata::index_type idIndex = sa->sizeOfXMLAnnotationList();
 
@@ -1012,10 +1012,10 @@ namespace ome
               std::ostringstream value;
               boost::apply_visitor(::ome::bioformats::detail::MetadataMapValueTypeOStreamVisitor(value), i->second);
 
-              ome::compat::shared_ptr<OriginalMetadataAnnotation> orig(ome::compat::make_shared<OriginalMetadataAnnotation>());
+              std::shared_ptr<OriginalMetadataAnnotation> orig(std::make_shared<OriginalMetadataAnnotation>());
               orig->setID(id);
               orig->setMetadata(OriginalMetadataAnnotation::metadata_type(i->first, value.str()));
-              ome::compat::shared_ptr<XMLAnnotation> xmlorig(ome::compat::static_pointer_cast<XMLAnnotation>(orig));
+              std::shared_ptr<XMLAnnotation> xmlorig(std::static_pointer_cast<XMLAnnotation>(orig));
               sa->addXMLAnnotation(xmlorig);
             }
 
@@ -1052,7 +1052,7 @@ namespace ome
     {
       ome::common::xml::Platform xmlplat;
 
-      ome::compat::shared_ptr<xercesc::SAX2XMLReader> parser(xercesc::XMLReaderFactory::createXMLReader());
+      std::shared_ptr<xercesc::SAX2XMLReader> parser(xercesc::XMLReaderFactory::createXMLReader());
       // We only want to get the schema version, so disable checking
       // of schema etc.  If there are problems with the XML, they'll
       // be picked up when we parse it for real.  Here, we'll only

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -35,6 +35,7 @@
  * #L%
  */
 
+#include <array>
 #include <string>
 
 #include <boost/format.hpp>
@@ -520,7 +521,7 @@ namespace ome
             {
               for (dimension_size_type p = 0; p < reader.getImageCount(); ++p)
                 {
-                  ome::compat::array<dimension_size_type, 3> coords = reader.getZCTCoords(p);
+                  std::array<dimension_size_type, 3> coords = reader.getZCTCoords(p);
                   // The cast to int here is nasty, but the data model
                   // isn't using unsigned types…
                   store.setPlaneTheZ(static_cast<int>(coords[0]), s, p);
@@ -568,7 +569,7 @@ namespace ome
                   if (sizeZT)
                     effSizeC = (*i)->imageCount / sizeZT;
 
-                  ome::compat::array<dimension_size_type, 3> coords =
+                  std::array<dimension_size_type, 3> coords =
                     getZCTCoords((*i)->dimensionOrder,
                                  (*i)->sizeZ,
                                  effSizeC,

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -535,9 +535,9 @@ namespace ome
     }
 
     void
-    fillMetadata(::ome::xml::meta::MetadataStore&                          store,
+    fillMetadata(::ome::xml::meta::MetadataStore&                 store,
                  const std::vector<std::shared_ptr<CoreMetadata>> seriesList,
-                 bool                                                      doPlane)
+                 bool                                             doPlane)
     {
       dimension_size_type s = 0U;
       for (std::vector<std::shared_ptr<CoreMetadata>>::const_iterator i = seriesList.begin();

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -219,12 +219,12 @@ namespace ome
       return fmt.str();
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::common::xml::dom::Document& document)
     {
       ome::common::xml::dom::Element docroot(document.getDocumentElement());
 
-      std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+      std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared<::ome::xml::meta::OMEXMLMetadata>());
       ome::xml::model::detail::OMEModel model;
       std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
       root->update(docroot, model);
@@ -232,7 +232,7 @@ namespace ome
       return meta;
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file)
     {
       // Parse OME-XML into DOM Document.
@@ -252,7 +252,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text)
     {
       // Parse OME-XML into DOM Document.
@@ -273,7 +273,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream)
     {
       // Parse OME-XML into DOM Document.
@@ -294,7 +294,7 @@ namespace ome
       return createOMEXMLMetadata(doc);
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane,
                          bool                doImageName)
@@ -305,17 +305,17 @@ namespace ome
       return metadata;
     }
 
-    std::shared_ptr< ::ome::xml::meta::MetadataRoot>
+    std::shared_ptr<::ome::xml::meta::MetadataRoot>
     createOMEXMLRoot(const std::string& document)
     {
       /// @todo Implement model transforms.
 
-      std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(createOMEXMLMetadata(document)));
-      return meta ? meta->getRoot() : std::shared_ptr< ::ome::xml::meta::MetadataRoot>();
+      std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(std::dynamic_pointer_cast<::ome::xml::meta::OMEXMLMetadata>(createOMEXMLMetadata(document)));
+      return meta ? meta->getRoot() : std::shared_ptr<::ome::xml::meta::MetadataRoot>();
     }
 
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-    getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
+    getOMEXMLMetadata(std::shared_ptr<::ome::xml::meta::MetadataRetrieve>& retrieve)
     {
       std::shared_ptr<OMEXMLMetadata> ret;
 
@@ -713,14 +713,14 @@ namespace ome
               dimension_size_type                     image)
     {
       // @todo Implement Modulo retrieval.
-      ::ome::xml::meta::OMEXMLMetadata& momexml(const_cast< ::ome::xml::meta::OMEXMLMetadata&>(omexml));
+      ::ome::xml::meta::OMEXMLMetadata& momexml(const_cast<::ome::xml::meta::OMEXMLMetadata&>(omexml));
 
       std::shared_ptr<OMEXMLMetadataRoot> root =
         std::dynamic_pointer_cast<OMEXMLMetadataRoot>(momexml.getRoot());
       if (!root) // Should never occur
         throw std::logic_error("OMEXMLMetadata does not have an OMEXMLMetadataRoot");
 
-      std::shared_ptr< ::ome::xml::model::Image> mimage(root->getImage(image));
+      std::shared_ptr<::ome::xml::model::Image> mimage(root->getImage(image));
       if (!mimage)
         throw std::runtime_error("Image does not exist in OMEXMLMetadata");
 
@@ -728,8 +728,8 @@ namespace ome
            i < mimage->sizeOfLinkedAnnotationList();
            ++i)
         {
-          std::shared_ptr< ::ome::xml::model::Annotation> annotation(mimage->getLinkedAnnotation(i));
-          std::shared_ptr< ::ome::xml::model::XMLAnnotation> xmlannotation(std::dynamic_pointer_cast< ::ome::xml::model::XMLAnnotation>(annotation));
+          std::shared_ptr<::ome::xml::model::Annotation> annotation(mimage->getLinkedAnnotation(i));
+          std::shared_ptr<::ome::xml::model::XMLAnnotation> xmlannotation(std::dynamic_pointer_cast<::ome::xml::model::XMLAnnotation>(annotation));
           if (xmlannotation)
             {
               try

--- a/cpp/lib/ome/bioformats/MetadataTools.cpp
+++ b/cpp/lib/ome/bioformats/MetadataTools.cpp
@@ -536,11 +536,11 @@ namespace ome
 
     void
     fillMetadata(::ome::xml::meta::MetadataStore&                          store,
-                 const std::vector<std::shared_ptr<CoreMetadata> > seriesList,
+                 const std::vector<std::shared_ptr<CoreMetadata>> seriesList,
                  bool                                                      doPlane)
     {
       dimension_size_type s = 0U;
-      for (std::vector<std::shared_ptr<CoreMetadata> >::const_iterator i = seriesList.begin();
+      for (std::vector<std::shared_ptr<CoreMetadata>>::const_iterator i = seriesList.begin();
            i != seriesList.end();
            ++i, ++s)
         {
@@ -837,8 +837,8 @@ namespace ome
       std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(omexml.getRoot()));
       if (root)
         {
-          std::vector<std::shared_ptr<ome::xml::model::Image> >& images(root->getImageList());
-          for(std::vector<std::shared_ptr<ome::xml::model::Image> >::const_iterator image = images.begin();
+          std::vector<std::shared_ptr<ome::xml::model::Image>>& images(root->getImageList());
+          for(std::vector<std::shared_ptr<ome::xml::model::Image>>::const_iterator image = images.begin();
               image != images.end();
               ++image)
             {
@@ -847,8 +847,8 @@ namespace ome
                 {
                   // Note a copy not a reference to avoid iterator
                   // invalidation during removal.
-                  std::vector<std::shared_ptr<ome::xml::model::BinData> > binData(pixels->getBinDataList());
-                  for (std::vector<std::shared_ptr<ome::xml::model::BinData> >::iterator bin = binData.begin();
+                  std::vector<std::shared_ptr<ome::xml::model::BinData>> binData(pixels->getBinDataList());
+                  for (std::vector<std::shared_ptr<ome::xml::model::BinData>>::iterator bin = binData.begin();
                    bin != binData.end();
                        ++bin)
                     {
@@ -876,7 +876,7 @@ namespace ome
               std::shared_ptr<ome::xml::model::Pixels> pixels(imageref->getPixels());
               if (pixels)
                 {
-                  std::vector<std::shared_ptr<ome::xml::model::Channel> > channels(pixels->getChannelList());
+                  std::vector<std::shared_ptr<ome::xml::model::Channel>> channels(pixels->getChannelList());
                   for (Metadata::index_type c = 0U; c < channels.size(); ++c)
                     {
                       std::shared_ptr<ome::xml::model::Channel> channel(channels.at(c));

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -254,9 +254,9 @@ namespace ome
      * @param doPlane create Plane elements if @c true.
      */
     void
-    fillMetadata(::ome::xml::meta::MetadataStore&                          store,
+    fillMetadata(::ome::xml::meta::MetadataStore&                 store,
                  const std::vector<std::shared_ptr<CoreMetadata>> seriesList,
-                 bool                                                      doPlane = false);
+                 bool                                             doPlane = false);
 
     /**
      * Fill all OME-XML metadata store Pixels elements from reader core metadata.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -122,7 +122,7 @@ namespace ome
      * @param document the XML document.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::common::xml::dom::Document& document);
 
     /**
@@ -131,7 +131,7 @@ namespace ome
      * @param file the XML file.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file);
 
     /**
@@ -140,7 +140,7 @@ namespace ome
      * @param text the XML string.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text);
 
     /**
@@ -149,7 +149,7 @@ namespace ome
      * @param stream the XML input stream.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream);
 
     /**
@@ -160,7 +160,7 @@ namespace ome
      * @param doImageName set image name if @c true.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane = false,
                          bool                doImageName = true);
@@ -172,7 +172,7 @@ namespace ome
      * @param document the XML document source.
      * @returns the OME-XML metadata root.
      */
-    std::shared_ptr< ::ome::xml::meta::MetadataRoot>
+    std::shared_ptr<::ome::xml::meta::MetadataRoot>
     createOMEXMLRoot(const std::string& document);
 
     /**
@@ -183,8 +183,8 @@ namespace ome
      * @param retrieve the metadata to use.
      * @returns the OME-XML metadata.
      */
-    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-    getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
+    std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>
+    getOMEXMLMetadata(std::shared_ptr<::ome::xml::meta::MetadataRetrieve>& retrieve);
 
     /**
      * Get OME-XML document from OME-XML metadata.

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -122,7 +122,7 @@ namespace ome
      * @param document the XML document.
      * @returns the OME-XML metadata.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(ome::common::xml::dom::Document& document);
 
     /**
@@ -131,7 +131,7 @@ namespace ome
      * @param file the XML file.
      * @returns the OME-XML metadata.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const boost::filesystem::path& file);
 
     /**
@@ -140,7 +140,7 @@ namespace ome
      * @param text the XML string.
      * @returns the OME-XML metadata.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const std::string& text);
 
     /**
@@ -149,7 +149,7 @@ namespace ome
      * @param stream the XML input stream.
      * @returns the OME-XML metadata.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(std::istream& stream);
 
     /**
@@ -160,7 +160,7 @@ namespace ome
      * @param doImageName set image name if @c true.
      * @returns the OME-XML metadata.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
     createOMEXMLMetadata(const FormatReader& reader,
                          bool                doPlane = false,
                          bool                doImageName = true);
@@ -172,7 +172,7 @@ namespace ome
      * @param document the XML document source.
      * @returns the OME-XML metadata root.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::MetadataRoot>
+    std::shared_ptr< ::ome::xml::meta::MetadataRoot>
     createOMEXMLRoot(const std::string& document);
 
     /**
@@ -183,8 +183,8 @@ namespace ome
      * @param retrieve the metadata to use.
      * @returns the OME-XML metadata.
      */
-    ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-    getOMEXMLMetadata(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
+    std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+    getOMEXMLMetadata(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
 
     /**
      * Get OME-XML document from OME-XML metadata.
@@ -255,7 +255,7 @@ namespace ome
      */
     void
     fillMetadata(::ome::xml::meta::MetadataStore&                          store,
-                 const std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList,
+                 const std::vector<std::shared_ptr<CoreMetadata> > seriesList,
                  bool                                                      doPlane = false);
 
     /**

--- a/cpp/lib/ome/bioformats/MetadataTools.h
+++ b/cpp/lib/ome/bioformats/MetadataTools.h
@@ -255,7 +255,7 @@ namespace ome
      */
     void
     fillMetadata(::ome::xml::meta::MetadataStore&                          store,
-                 const std::vector<std::shared_ptr<CoreMetadata> > seriesList,
+                 const std::vector<std::shared_ptr<CoreMetadata>> seriesList,
                  bool                                                      doPlane = false);
 
     /**

--- a/cpp/lib/ome/bioformats/Modulo.h
+++ b/cpp/lib/ome/bioformats/Modulo.h
@@ -38,11 +38,10 @@
 #ifndef OME_BIOFORMATS_MODULO_H
 #define OME_BIOFORMATS_MODULO_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <sstream>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -455,7 +455,7 @@ namespace ome
       bool
       managed() const
       {
-        return (boost::get<std::shared_ptr<array_type> >(&multiarray) != 0);
+        return (boost::get<std::shared_ptr<array_type>>(&multiarray) != 0);
       }
 
       /**
@@ -822,7 +822,7 @@ namespace ome
        * C++11 move constructor for @c MultiArray types.
        */
       boost::variant<std::shared_ptr<array_type>,
-                     std::shared_ptr<array_ref_type> > multiarray;
+                     std::shared_ptr<array_ref_type>> multiarray;
     };
 
     namespace detail

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -40,6 +40,7 @@
 
 #include <istream>
 #include <limits>
+#include <memory>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -54,7 +55,6 @@
 
 #include <ome/compat/array.h>
 #include <ome/compat/cstdint.h>
-#include <ome/compat/memory.h>
 
 #include <ome/xml/model/enums/DimensionOrder.h>
 
@@ -260,7 +260,7 @@ namespace ome
        */
       explicit PixelBuffer():
         PixelBufferBase(::ome::xml::model::enums::PixelType::UINT8, ENDIAN_NATIVE),
-        multiarray(ome::compat::shared_ptr<array_type>(new array_type(boost::extents[1][1][1][1][1][1][1][1][1],
+        multiarray(std::shared_ptr<array_type>(new array_type(boost::extents[1][1][1][1][1][1][1][1][1],
                                                                       PixelBufferBase::default_storage_order())))
       {}
 
@@ -282,7 +282,7 @@ namespace ome
                   EndianType                          endiantype = ENDIAN_NATIVE,
                   const storage_order_type&           storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(ome::compat::shared_ptr<array_type>(new array_type(extents, storage)))
+        multiarray(std::shared_ptr<array_type>(new array_type(extents, storage)))
       {}
 
       /**
@@ -307,7 +307,7 @@ namespace ome
                   EndianType                           endiantype = ENDIAN_NATIVE,
                   const storage_order_type&            storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(ome::compat::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, extents, storage)))
+        multiarray(std::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, extents, storage)))
       {}
 
       /**
@@ -327,7 +327,7 @@ namespace ome
                   EndianType                          endiantype = ENDIAN_NATIVE,
                   const storage_order_type&           storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(ome::compat::shared_ptr<array_type>(new array_type(range, storage)))
+        multiarray(std::shared_ptr<array_type>(new array_type(range, storage)))
       {}
 
       /**
@@ -351,7 +351,7 @@ namespace ome
                   EndianType                           endiantype = ENDIAN_NATIVE,
                   const storage_order_type&            storage = PixelBufferBase::default_storage_order()):
         PixelBufferBase(pixeltype, endiantype),
-        multiarray(ome::compat::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, range, storage)))
+        multiarray(std::shared_ptr<array_ref_type>(new array_ref_type(pixeldata, range, storage)))
       {}
 
       /**
@@ -455,7 +455,7 @@ namespace ome
       bool
       managed() const
       {
-        return (boost::get<ome::compat::shared_ptr<array_type> >(&multiarray) != 0);
+        return (boost::get<std::shared_ptr<array_type> >(&multiarray) != 0);
       }
 
       /**
@@ -821,8 +821,8 @@ namespace ome
        * also permits efficient shallow copying in the absence of a
        * C++11 move constructor for @c MultiArray types.
        */
-      boost::variant<ome::compat::shared_ptr<array_type>,
-                     ome::compat::shared_ptr<array_ref_type> > multiarray;
+      boost::variant<std::shared_ptr<array_type>,
+                     std::shared_ptr<array_ref_type> > multiarray;
     };
 
     namespace detail

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_PIXELBUFFER_H
 #define OME_BIOFORMATS_PIXELBUFFER_H
 
+#include <array>
 #include <cstdint>
 #include <istream>
 #include <limits>
@@ -53,8 +54,6 @@
 #include <ome/bioformats/PixelProperties.h>
 
 #include <ome/common/variant.h>
-
-#include <ome/compat/array.h>
 
 #include <ome/xml/model/enums/DimensionOrder.h>
 
@@ -114,8 +113,8 @@ namespace ome
       typedef boost::multi_array_types::index index;
 
       /// Type used to index all dimensions in public interfaces.
-      typedef ome::compat::array<boost::multi_array_types::index,
-                                 PixelBufferBase::dimensions> indices_type;
+      typedef std::array<boost::multi_array_types::index,
+                         PixelBufferBase::dimensions> indices_type;
 
       /// Storage ordering type for controlling pixel memory layout.
       typedef boost::general_storage_order<dimensions> storage_order_type;

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_PIXELBUFFER_H
 #define OME_BIOFORMATS_PIXELBUFFER_H
 
+#include <cstdint>
 #include <istream>
 #include <limits>
 #include <memory>
@@ -54,7 +55,6 @@
 #include <ome/common/variant.h>
 
 #include <ome/compat/array.h>
-#include <ome/compat/cstdint.h>
 
 #include <ome/xml/model/enums/DimensionOrder.h>
 

--- a/cpp/lib/ome/bioformats/PixelBuffer.h
+++ b/cpp/lib/ome/bioformats/PixelBuffer.h
@@ -261,7 +261,7 @@ namespace ome
       explicit PixelBuffer():
         PixelBufferBase(::ome::xml::model::enums::PixelType::UINT8, ENDIAN_NATIVE),
         multiarray(std::shared_ptr<array_type>(new array_type(boost::extents[1][1][1][1][1][1][1][1][1],
-                                                                      PixelBufferBase::default_storage_order())))
+                                                              PixelBufferBase::default_storage_order())))
       {}
 
       /**

--- a/cpp/lib/ome/bioformats/PixelProperties.cpp
+++ b/cpp/lib/ome/bioformats/PixelProperties.cpp
@@ -60,37 +60,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT8>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT16>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT32>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::BIT>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::pixel_byte_size();
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_byte_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_byte_size();
           break;
         }
 
@@ -105,37 +105,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT8>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT16>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT32>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::BIT>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::pixel_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_bit_size();
           break;
         }
 
@@ -150,37 +150,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT8>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT16>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::INT32>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::BIT>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::pixel_significant_bit_size();
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_significant_bit_size();
+          size = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_significant_bit_size();
           break;
         }
 
@@ -195,37 +195,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::INT8>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::INT16>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::INT32>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::BIT>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::is_signed;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_signed;
+          is_signed = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_signed;
           break;
         }
 
@@ -240,37 +240,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::INT8>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::INT16>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::INT32>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::BIT>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::is_integer;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_integer;
+          is_integer = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_integer;
           break;
         }
 
@@ -291,37 +291,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::INT8>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::INT16>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::INT32>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::BIT>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::is_complex;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_complex;
+          is_complex = PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_complex;
           break;
         }
 

--- a/cpp/lib/ome/bioformats/PixelProperties.h
+++ b/cpp/lib/ome/bioformats/PixelProperties.h
@@ -113,8 +113,8 @@ namespace ome
 
     /// Properties of INT8 pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::INT8> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::INT8> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::INT8>>
     {
       /// Pixel type (standard language type).
       typedef int8_t std_type;
@@ -136,8 +136,8 @@ namespace ome
 
     /// Properties of INT16 pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::INT16> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT16>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::INT16> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::INT16>>
     {
       /// Pixel type (standard language type).
       typedef int16_t std_type;
@@ -159,8 +159,8 @@ namespace ome
 
     /// Properties of INT32 pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::INT32> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT32>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::INT32> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::INT32>>
     {
       /// Pixel type (standard language type).
       typedef int32_t std_type;
@@ -182,8 +182,8 @@ namespace ome
 
     /// Properties of UINT8 pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT8> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::UINT8> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::UINT8>>
     {
       /// Pixel type (standard language type).
       typedef uint8_t std_type;
@@ -205,8 +205,8 @@ namespace ome
 
     /// Properties of UINT16 pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT16> :
-      public PixelPropertiesBase<struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::UINT16> :
+      public PixelPropertiesBase<struct PixelProperties<::ome::xml::model::enums::PixelType::UINT16>>
     {
       /// Pixel type (standard language type).
       typedef uint16_t std_type;
@@ -228,8 +228,8 @@ namespace ome
 
     /// Properties of UINT32 pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT32> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::UINT32> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::UINT32>>
     {
       /// Pixel type (standard language type).
       typedef uint32_t std_type;
@@ -251,8 +251,8 @@ namespace ome
 
     /// Properties of FLOAT pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::FLOAT> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>>
     {
       /// Pixel type (standard language type).
       typedef float std_type;
@@ -274,8 +274,8 @@ namespace ome
 
     /// Properties of DOUBLE pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>>
     {
       /// Pixel type (standard language type).
       typedef double std_type;
@@ -297,8 +297,8 @@ namespace ome
 
     /// Properties of BIT pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::BIT> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::BIT>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::BIT> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::BIT>>
     {
       /// Pixel type (standard language type).
       typedef bool std_type;
@@ -332,8 +332,8 @@ namespace ome
 
     /// Properties of COMPLEX pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>>
     {
       /// Pixel type (standard language type).
       typedef std::complex<float> std_type;
@@ -355,8 +355,8 @@ namespace ome
 
     /// Properties of DOUBLECOMPLEX pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>>
+    struct PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> :
+      public PixelPropertiesBase<PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>>
     {
       /// Pixel type (standard language type).
       typedef std::complex<double> std_type;

--- a/cpp/lib/ome/bioformats/PixelProperties.h
+++ b/cpp/lib/ome/bioformats/PixelProperties.h
@@ -114,7 +114,7 @@ namespace ome
     /// Properties of INT8 pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::INT8> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT8> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>>
     {
       /// Pixel type (standard language type).
       typedef int8_t std_type;
@@ -137,7 +137,7 @@ namespace ome
     /// Properties of INT16 pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::INT16> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT16> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT16>>
     {
       /// Pixel type (standard language type).
       typedef int16_t std_type;
@@ -160,7 +160,7 @@ namespace ome
     /// Properties of INT32 pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::INT32> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT32> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::INT32>>
     {
       /// Pixel type (standard language type).
       typedef int32_t std_type;
@@ -183,7 +183,7 @@ namespace ome
     /// Properties of UINT8 pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT8> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>>
     {
       /// Pixel type (standard language type).
       typedef uint8_t std_type;
@@ -206,7 +206,7 @@ namespace ome
     /// Properties of UINT16 pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT16> :
-      public PixelPropertiesBase<struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT16> >
+      public PixelPropertiesBase<struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>>
     {
       /// Pixel type (standard language type).
       typedef uint16_t std_type;
@@ -229,7 +229,7 @@ namespace ome
     /// Properties of UINT32 pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::UINT32> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>>
     {
       /// Pixel type (standard language type).
       typedef uint32_t std_type;
@@ -252,7 +252,7 @@ namespace ome
     /// Properties of FLOAT pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>>
     {
       /// Pixel type (standard language type).
       typedef float std_type;
@@ -275,7 +275,7 @@ namespace ome
     /// Properties of DOUBLE pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>>
     {
       /// Pixel type (standard language type).
       typedef double std_type;
@@ -298,7 +298,7 @@ namespace ome
     /// Properties of BIT pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::BIT> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::BIT> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::BIT>>
     {
       /// Pixel type (standard language type).
       typedef bool std_type;
@@ -333,7 +333,7 @@ namespace ome
     /// Properties of COMPLEX pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>>
     {
       /// Pixel type (standard language type).
       typedef std::complex<float> std_type;
@@ -356,7 +356,7 @@ namespace ome
     /// Properties of DOUBLECOMPLEX pixels.
     template<>
     struct PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> >
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>>
     {
       /// Pixel type (standard language type).
       typedef std::complex<double> std_type;

--- a/cpp/lib/ome/bioformats/PixelProperties.h
+++ b/cpp/lib/ome/bioformats/PixelProperties.h
@@ -39,11 +39,10 @@
 #define OME_BIOFORMATS_PIXELPROPERTIES_H
 
 #include <complex>
+#include <cstdint>
 
 #include <ome/common/boolean.h>
 #include <ome/common/endian.h>
-
-#include <ome/compat/cstdint.h>
 
 #include <ome/bioformats/Types.h>
 

--- a/cpp/lib/ome/bioformats/TileCache.h
+++ b/cpp/lib/ome/bioformats/TileCache.h
@@ -38,12 +38,11 @@
 #ifndef OME_BIOFORMATS_TILECACHE_H
 #define OME_BIOFORMATS_TILECACHE_H
 
+#include <map>
+#include <memory>
+
 #include <ome/bioformats/Types.h>
 #include <ome/bioformats/TileBuffer.h>
-
-#include <ome/compat/memory.h>
-
-#include <map>
 
 namespace ome
 {
@@ -62,7 +61,7 @@ namespace ome
       /// Tile index type.
       typedef dimension_size_type key_type;
       /// Tile buffer type.
-      typedef ome::compat::shared_ptr<TileBuffer> value_type;
+      typedef std::shared_ptr<TileBuffer> value_type;
 
       /// Constructor.
       TileCache();

--- a/cpp/lib/ome/bioformats/TileCoverage.cpp
+++ b/cpp/lib/ome/bioformats/TileCoverage.cpp
@@ -194,7 +194,7 @@ namespace ome
     };
 
     TileCoverage::TileCoverage():
-      impl(ome::compat::shared_ptr<Impl>(new Impl()))
+      impl(std::shared_ptr<Impl>(new Impl()))
     {
     }
 

--- a/cpp/lib/ome/bioformats/TileCoverage.cpp
+++ b/cpp/lib/ome/bioformats/TileCoverage.cpp
@@ -120,7 +120,7 @@ namespace ome
     public:
       /// Region coverage stored as box ranges.
 #ifdef OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP
-      geomi::rtree<box, geomi::quadratic<16> > rtree;
+      geomi::rtree<box, geomi::quadratic<16>> rtree;
 #else // ! OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP
       std::list<box> rtree;
 #endif // OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP

--- a/cpp/lib/ome/bioformats/TileCoverage.h
+++ b/cpp/lib/ome/bioformats/TileCoverage.h
@@ -38,10 +38,10 @@
 #ifndef OME_BIOFORMATS_TILECOVERAGE_H
 #define OME_BIOFORMATS_TILECOVERAGE_H
 
+#include <memory>
+
 #include <ome/bioformats/Types.h>
 #include <ome/bioformats/PlaneRegion.h>
-
-#include <ome/compat/memory.h>
 
 namespace ome
 {
@@ -147,7 +147,7 @@ namespace ome
     protected:
       class Impl;
       /// Private implementation details.
-      ome::compat::shared_ptr<Impl> impl;
+      std::shared_ptr<Impl> impl;
     };
 
   }

--- a/cpp/lib/ome/bioformats/Types.h
+++ b/cpp/lib/ome/bioformats/Types.h
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <stdexcept>
 #include <string>
@@ -47,8 +48,6 @@
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
@@ -276,7 +276,7 @@ namespace
         >::value,
       void
       >::type
-    operator() (std::shared_ptr<PixelBuffer<typename PixelProperties<P>::std_type> >& lhs) const
+    operator() (std::shared_ptr<PixelBuffer<typename PixelProperties<P>::std_type>>& lhs) const
     {
       if (!lhs)
         throw std::runtime_error("Null pixel type");

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
@@ -235,7 +235,7 @@ namespace
     void
     operator() (T& lhs, const T& rhs) const
     {
-      ome::compat::array<VariantPixelBuffer::size_type, 9> source_shape, dest_shape;
+      std::array<VariantPixelBuffer::size_type, 9> source_shape, dest_shape;
 
       const VariantPixelBuffer::size_type *source_shape_ptr(rhs->shape());
       std::copy(source_shape_ptr, source_shape_ptr + T::element_type::dimensions,

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.cpp
@@ -276,7 +276,7 @@ namespace
         >::value,
       void
       >::type
-    operator() (ome::compat::shared_ptr<PixelBuffer<typename PixelProperties<P>::std_type> >& lhs) const
+    operator() (std::shared_ptr<PixelBuffer<typename PixelProperties<P>::std_type> >& lhs) const
     {
       if (!lhs)
         throw std::runtime_error("Null pixel type");

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_VARIANTPIXELBUFFER_H
 #define OME_BIOFORMATS_VARIANTPIXELBUFFER_H
 
+#include <array>
 #include <memory>
 
 #include <ome/bioformats/PixelBuffer.h>
@@ -138,7 +139,7 @@ namespace ome
       typedef boost::multi_array_types::size_type size_type;
 
       /// Type used to index all dimensions in public interfaces.
-      typedef ome::compat::array<boost::multi_array_types::index, PixelBufferBase::dimensions> indices_type;
+      typedef std::array<boost::multi_array_types::index, PixelBufferBase::dimensions> indices_type;
 
       /// Storage ordering type for controlling pixel memory layout.
       typedef PixelBufferBase::storage_order_type storage_order_type;
@@ -901,7 +902,7 @@ namespace ome
         operator()(const T& v)
         {
           // Shape is the same as the source buffer, but with one subchannel.
-          ome::compat::array<VariantPixelBuffer::size_type, 9> dest_shape;
+          std::array<VariantPixelBuffer::size_type, 9> dest_shape;
           const VariantPixelBuffer::size_type *shape_ptr(v->shape());
           std::copy(shape_ptr, shape_ptr + PixelBufferBase::dimensions,
                     dest_shape.begin());

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -38,12 +38,12 @@
 #ifndef OME_BIOFORMATS_VARIANTPIXELBUFFER_H
 #define OME_BIOFORMATS_VARIANTPIXELBUFFER_H
 
+#include <memory>
+
 #include <ome/bioformats/PixelBuffer.h>
 #include <ome/bioformats/PixelProperties.h>
 
 #include <ome/common/variant.h>
-
-#include <ome/compat/memory.h>
 
 namespace ome
 {
@@ -115,7 +115,7 @@ namespace ome
       struct make_buffer
       {
         /// Buffer type.
-        typedef ome::compat::shared_ptr<PixelBuffer<typename T::std_type> > type;
+        typedef std::shared_ptr<PixelBuffer<typename T::std_type> > type;
       };
 
       /// Aggregate view of all buffer types.
@@ -215,7 +215,7 @@ namespace ome
        */
       template<typename T>
       explicit
-      VariantPixelBuffer(ome::compat::shared_ptr<PixelBuffer<T> >& buffer):
+      VariantPixelBuffer(std::shared_ptr<PixelBuffer<T> >& buffer):
         buffer(buffer)
       {
       }
@@ -265,7 +265,7 @@ namespace ome
                  const storage_order_type&           storage,
                  ::ome::xml::model::enums::PixelType pixeltype)
       {
-        return variant_buffer_type(ome::compat::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(extents, pixeltype, ENDIAN_NATIVE, storage)));
+        return variant_buffer_type(std::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(extents, pixeltype, ENDIAN_NATIVE, storage)));
       }
 
       /**
@@ -285,7 +285,7 @@ namespace ome
                  const storage_order_type&           storage,
                  ::ome::xml::model::enums::PixelType pixeltype)
       {
-        return variant_buffer_type(ome::compat::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(range, pixeltype, ENDIAN_NATIVE, storage)));
+        return variant_buffer_type(std::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(range, pixeltype, ENDIAN_NATIVE, storage)));
       }
 
       // No switch default to avoid -Wunreachable-code errors.
@@ -709,7 +709,7 @@ namespace ome
          * @throws if the PixelBuffer is null.
          */
         PixelBuffer<T>&
-        operator() (ome::compat::shared_ptr<PixelBuffer<T> >& v) const
+        operator() (std::shared_ptr<PixelBuffer<T> >& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
@@ -742,7 +742,7 @@ namespace ome
          * @throws if the PixelBuffer is null.
          */
         const PixelBuffer<T>&
-        operator() (const ome::compat::shared_ptr<PixelBuffer<T> >& v) const
+        operator() (const std::shared_ptr<PixelBuffer<T> >& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
@@ -789,7 +789,7 @@ namespace ome
          * @throws if the PixelBuffer is null or the PixelBuffer's data array is null.
          */
         void
-        operator() (ome::compat::shared_ptr<PixelBuffer<typename std::iterator_traits<InputIterator>::value_type> >& v) const
+        operator() (std::shared_ptr<PixelBuffer<typename std::iterator_traits<InputIterator>::value_type> >& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -92,19 +92,19 @@ namespace ome
        */
 
       /// Integer pixel types.
-      typedef boost::mpl::vector<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::INT16>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::INT32>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::BIT>> integer_pixel_types;
+      typedef boost::mpl::vector<PixelProperties<::ome::xml::model::enums::PixelType::INT8>,
+                                 PixelProperties<::ome::xml::model::enums::PixelType::INT16>,
+                                 PixelProperties<::ome::xml::model::enums::PixelType::INT32>,
+                                 PixelProperties<::ome::xml::model::enums::PixelType::UINT8>,
+                                 PixelProperties<::ome::xml::model::enums::PixelType::UINT16>,
+                                 PixelProperties<::ome::xml::model::enums::PixelType::UINT32>,
+                                 PixelProperties<::ome::xml::model::enums::PixelType::BIT>> integer_pixel_types;
 
       /// Floating-point pixel types.
-      typedef boost::mpl::vector< PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>,
-                                  PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>,
-                                  PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>,
-                                  PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>> float_pixel_types;
+      typedef boost::mpl::vector< PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>,
+                                  PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>,
+                                  PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>,
+                                  PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>> float_pixel_types;
 
       /// Aggregate view of all numeric types.
       typedef boost::mpl::joint_view<integer_pixel_types,
@@ -132,7 +132,7 @@ namespace ome
       typedef boost::make_variant_over<pixel_buffer_types>::type variant_buffer_type;
 
       /// Raw pixel type used in public interfaces.
-      typedef PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::std_type raw_type;
+      typedef PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::std_type raw_type;
 
       /// Size type.
       typedef boost::multi_array_types::size_type size_type;
@@ -318,37 +318,37 @@ namespace ome
         switch(pixeltype)
           {
           case ::ome::xml::model::enums::PixelType::INT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::INT8>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::INT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::INT16>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::INT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::INT32>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::UINT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::UINT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::std_type>(extents, storage, pixeltype);
             break;
           case :: ome::xml::model::enums::PixelType::UINT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::FLOAT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::DOUBLE:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::BIT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::BIT>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::COMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::std_type>(extents, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::std_type>(extents, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::std_type>(extents, storage, pixeltype);
             break;
           }
 
@@ -376,37 +376,37 @@ namespace ome
         switch(pixeltype)
           {
           case ::ome::xml::model::enums::PixelType::INT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::INT8>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::INT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::INT16>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::INT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::INT32>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::UINT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::UINT8>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::UINT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::UINT16>::std_type>(range, storage, pixeltype);
             break;
           case :: ome::xml::model::enums::PixelType::UINT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::UINT32>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::FLOAT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::DOUBLE:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::BIT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::BIT>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::COMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::std_type>(range, storage, pixeltype);
             break;
           case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::std_type>(range, storage, pixeltype);
+            buf = makeBuffer<PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::std_type>(range, storage, pixeltype);
             break;
           }
 

--- a/cpp/lib/ome/bioformats/VariantPixelBuffer.h
+++ b/cpp/lib/ome/bioformats/VariantPixelBuffer.h
@@ -98,13 +98,13 @@ namespace ome
                                  PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>,
                                  PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>,
                                  PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>,
-                                 PixelProperties< ::ome::xml::model::enums::PixelType::BIT> > integer_pixel_types;
+                                 PixelProperties< ::ome::xml::model::enums::PixelType::BIT>> integer_pixel_types;
 
       /// Floating-point pixel types.
       typedef boost::mpl::vector< PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>,
                                   PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>,
                                   PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>,
-                                  PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> > float_pixel_types;
+                                  PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>> float_pixel_types;
 
       /// Aggregate view of all numeric types.
       typedef boost::mpl::joint_view<integer_pixel_types,
@@ -115,11 +115,11 @@ namespace ome
       struct make_buffer
       {
         /// Buffer type.
-        typedef std::shared_ptr<PixelBuffer<typename T::std_type> > type;
+        typedef std::shared_ptr<PixelBuffer<typename T::std_type>> type;
       };
 
       /// Aggregate view of all buffer types.
-      typedef boost::mpl::transform_view<basic_pixel_types_view, make_buffer<boost::mpl::_1> >::type pixel_buffer_types_view;
+      typedef boost::mpl::transform_view<basic_pixel_types_view, make_buffer<boost::mpl::_1>>::type pixel_buffer_types_view;
 
       /// Empty vector placeholder.
       typedef boost::mpl::vector<> empty_types;
@@ -215,7 +215,7 @@ namespace ome
        */
       template<typename T>
       explicit
-      VariantPixelBuffer(std::shared_ptr<PixelBuffer<T> >& buffer):
+      VariantPixelBuffer(std::shared_ptr<PixelBuffer<T>>& buffer):
         buffer(buffer)
       {
       }
@@ -265,7 +265,7 @@ namespace ome
                  const storage_order_type&           storage,
                  ::ome::xml::model::enums::PixelType pixeltype)
       {
-        return variant_buffer_type(std::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(extents, pixeltype, ENDIAN_NATIVE, storage)));
+        return variant_buffer_type(std::shared_ptr<PixelBuffer<T>>(new PixelBuffer<T>(extents, pixeltype, ENDIAN_NATIVE, storage)));
       }
 
       /**
@@ -285,7 +285,7 @@ namespace ome
                  const storage_order_type&           storage,
                  ::ome::xml::model::enums::PixelType pixeltype)
       {
-        return variant_buffer_type(std::shared_ptr<PixelBuffer<T> >(new PixelBuffer<T>(range, pixeltype, ENDIAN_NATIVE, storage)));
+        return variant_buffer_type(std::shared_ptr<PixelBuffer<T>>(new PixelBuffer<T>(range, pixeltype, ENDIAN_NATIVE, storage)));
       }
 
       // No switch default to avoid -Wunreachable-code errors.
@@ -709,7 +709,7 @@ namespace ome
          * @throws if the PixelBuffer is null.
          */
         PixelBuffer<T>&
-        operator() (std::shared_ptr<PixelBuffer<T> >& v) const
+        operator() (std::shared_ptr<PixelBuffer<T>>& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
@@ -742,7 +742,7 @@ namespace ome
          * @throws if the PixelBuffer is null.
          */
         const PixelBuffer<T>&
-        operator() (const std::shared_ptr<PixelBuffer<T> >& v) const
+        operator() (const std::shared_ptr<PixelBuffer<T>>& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
@@ -789,7 +789,7 @@ namespace ome
          * @throws if the PixelBuffer is null or the PixelBuffer's data array is null.
          */
         void
-        operator() (std::shared_ptr<PixelBuffer<typename std::iterator_traits<InputIterator>::value_type> >& v) const
+        operator() (std::shared_ptr<PixelBuffer<typename std::iterator_traits<InputIterator>::value_type>>& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");

--- a/cpp/lib/ome/bioformats/Version.h
+++ b/cpp/lib/ome/bioformats/Version.h
@@ -41,8 +41,6 @@
 #include <cstdint>
 #include <string>
 
-#include <ome/compat/tuple.h>
-
 #include <ome/xml/model/primitives/Timestamp.h>
 
 namespace ome

--- a/cpp/lib/ome/bioformats/Version.h
+++ b/cpp/lib/ome/bioformats/Version.h
@@ -38,9 +38,9 @@
 #ifndef OME_BIOFORMATS_VERSION_H
 #define OME_BIOFORMATS_VERSION_H
 
+#include <cstdint>
 #include <string>
 
-#include <ome/compat/cstdint.h>
 #include <ome/compat/tuple.h>
 
 #include <ome/xml/model/primitives/Timestamp.h>

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -98,7 +98,7 @@ namespace ome
         indexedAsRGB(false),
         group(true),
         domains(),
-        metadataStore(ome::compat::make_shared<DummyMetadata>()),
+        metadataStore(std::make_shared<DummyMetadata>()),
         metadataOptions()
       {
         assertId(currentId, false);
@@ -159,7 +159,7 @@ namespace ome
         metadata.clear();
 
         core.clear();
-        core.push_back(ome::compat::make_shared<CoreMetadata>());
+        core.push_back(std::make_shared<CoreMetadata>());
 
         // reinitialize the MetadataStore
         // NB: critical for metadata conversion to work properly!
@@ -389,12 +389,12 @@ namespace ome
         boost::apply_visitor(v, dest.vbuffer());
       }
 
-      ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>
+      std::shared_ptr< ::ome::xml::meta::MetadataStore>
       FormatReader::makeFilterMetadata()
       {
-        // While ome::compat::make_shared<> works, here, boost::make_shared<>
+        // While std::make_shared<> works, here, boost::make_shared<>
         // does not, so use new directly.
-        return ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>
+        return std::shared_ptr< ::ome::xml::meta::MetadataStore>
           (new FilterMetadata(getMetadataStore(), isMetadataFiltered()));
       }
 
@@ -760,7 +760,7 @@ namespace ome
       FormatReader::close(bool fileOnly)
       {
         if (in)
-          in = ome::compat::shared_ptr<std::istream>(); // set to null.
+          in = std::shared_ptr<std::istream>(); // set to null.
         if (!fileOnly)
           {
             currentId = boost::none;
@@ -1050,7 +1050,7 @@ namespace ome
         return getCoreMetadata(getCoreIndex()).seriesMetadata;
       }
 
-      const std::vector<ome::compat::shared_ptr< ::ome::bioformats::CoreMetadata> >&
+      const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&
       FormatReader::getCoreMetadataList() const
       {
         assertId(currentId, true);
@@ -1071,7 +1071,7 @@ namespace ome
       }
 
       void
-      FormatReader::setMetadataStore(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>& store)
+      FormatReader::setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store)
       {
         assertId(currentId, false);
 
@@ -1081,22 +1081,22 @@ namespace ome
         metadataStore = store;
       }
 
-      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
       FormatReader::getMetadataStore() const
       {
         return metadataStore;
       }
 
-      ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      std::shared_ptr< ::ome::xml::meta::MetadataStore>&
       FormatReader::getMetadataStore()
       {
         return metadataStore;
       }
 
-      std::vector<ome::compat::shared_ptr< ::ome::bioformats::FormatReader> >
+      std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >
       FormatReader::getUnderlyingReaders() const
       {
-        return std::vector<ome::compat::shared_ptr< ::ome::bioformats::FormatReader> >();
+        return std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >();
       }
 
       bool
@@ -1373,8 +1373,8 @@ namespace ome
           {
             initFile(canonicalpath);
 
-            const ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
-              ome::compat::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());
+            const std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
+              std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());
             if(store)
               {
                 if(saveOriginalMetadata)

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -1050,7 +1050,7 @@ namespace ome
         return getCoreMetadata(getCoreIndex()).seriesMetadata;
       }
 
-      const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&
+      const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata>>&
       FormatReader::getCoreMetadataList() const
       {
         assertId(currentId, true);
@@ -1093,10 +1093,10 @@ namespace ome
         return metadataStore;
       }
 
-      std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >
+      std::vector<std::shared_ptr< ::ome::bioformats::FormatReader>>
       FormatReader::getUnderlyingReaders() const
       {
-        return std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >();
+        return std::vector<std::shared_ptr< ::ome::bioformats::FormatReader>>();
       }
 
       bool

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -389,12 +389,12 @@ namespace ome
         boost::apply_visitor(v, dest.vbuffer());
       }
 
-      std::shared_ptr< ::ome::xml::meta::MetadataStore>
+      std::shared_ptr<::ome::xml::meta::MetadataStore>
       FormatReader::makeFilterMetadata()
       {
         // While std::make_shared<> works, here, boost::make_shared<>
         // does not, so use new directly.
-        return std::shared_ptr< ::ome::xml::meta::MetadataStore>
+        return std::shared_ptr<::ome::xml::meta::MetadataStore>
           (new FilterMetadata(getMetadataStore(), isMetadataFiltered()));
       }
 
@@ -1050,7 +1050,7 @@ namespace ome
         return getCoreMetadata(getCoreIndex()).seriesMetadata;
       }
 
-      const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata>>&
+      const std::vector<std::shared_ptr<::ome::bioformats::CoreMetadata>>&
       FormatReader::getCoreMetadataList() const
       {
         assertId(currentId, true);
@@ -1071,7 +1071,7 @@ namespace ome
       }
 
       void
-      FormatReader::setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store)
+      FormatReader::setMetadataStore(std::shared_ptr<::ome::xml::meta::MetadataStore>& store)
       {
         assertId(currentId, false);
 
@@ -1081,22 +1081,22 @@ namespace ome
         metadataStore = store;
       }
 
-      const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      const std::shared_ptr<::ome::xml::meta::MetadataStore>&
       FormatReader::getMetadataStore() const
       {
         return metadataStore;
       }
 
-      std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+      std::shared_ptr<::ome::xml::meta::MetadataStore>&
       FormatReader::getMetadataStore()
       {
         return metadataStore;
       }
 
-      std::vector<std::shared_ptr< ::ome::bioformats::FormatReader>>
+      std::vector<std::shared_ptr<::ome::bioformats::FormatReader>>
       FormatReader::getUnderlyingReaders() const
       {
-        return std::vector<std::shared_ptr< ::ome::bioformats::FormatReader>>();
+        return std::vector<std::shared_ptr<::ome::bioformats::FormatReader>>();
       }
 
       bool
@@ -1373,8 +1373,8 @@ namespace ome
           {
             initFile(canonicalpath);
 
-            const std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>& store =
-              std::dynamic_pointer_cast< ::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());
+            const std::shared_ptr<::ome::xml::meta::OMEXMLMetadata>& store =
+              std::dynamic_pointer_cast<::ome::xml::meta::OMEXMLMetadata>(getMetadataStore());
             if(store)
               {
                 if(saveOriginalMetadata)

--- a/cpp/lib/ome/bioformats/detail/FormatReader.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.cpp
@@ -359,7 +359,7 @@ namespace ome
                               dimension_size_type scanlinePad,
                               dimension_size_type samples)
       {
-        ome::compat::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
+        std::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
         shape[DIM_SPATIAL_X] = w;
         shape[DIM_SPATIAL_Y] = h;
         shape[DIM_SUBCHANNEL] = samples;
@@ -628,12 +628,12 @@ namespace ome
         return getCoreMetadata(getCoreIndex()).moduloC;
       }
 
-      ome::compat::array<dimension_size_type, 2>
+      std::array<dimension_size_type, 2>
       FormatReader::getThumbSize() const
       {
         assertId(currentId, true);
 
-        ome::compat::array<dimension_size_type, 2> ret;
+        std::array<dimension_size_type, 2> ret;
         ret[0] = getCoreMetadata(getCoreIndex()).thumbSizeX;
         ret[1] = getCoreMetadata(getCoreIndex()).thumbSizeY;
 
@@ -997,7 +997,7 @@ namespace ome
                                          moduloZ, moduloC, moduloT);
       }
 
-      ome::compat::array<dimension_size_type, 3>
+      std::array<dimension_size_type, 3>
       FormatReader::getZCTCoords(dimension_size_type index) const
       {
         assertId(currentId, true);
@@ -1009,7 +1009,7 @@ namespace ome
                                              index);
       }
 
-      ome::compat::array<dimension_size_type, 6>
+      std::array<dimension_size_type, 6>
       FormatReader::getZCTModuloCoords(dimension_size_type index) const
       {
         assertId(currentId, true);

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -521,7 +521,7 @@ namespace ome
          * @returns an array containing the X and Y dimension
          * thumbnail size (in that order).
          */
-        ome::compat::array<dimension_size_type, 2>
+        std::array<dimension_size_type, 2>
         getThumbSize() const;
 
       public:
@@ -682,11 +682,11 @@ namespace ome
                  dimension_size_type moduloT) const;
 
         // Documented in superclass.
-        ome::compat::array<dimension_size_type, 3>
+        std::array<dimension_size_type, 3>
         getZCTCoords(dimension_size_type index) const;
 
         // Documented in superclass.
-        ome::compat::array<dimension_size_type, 6>
+        std::array<dimension_size_type, 6>
         getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -109,7 +109,7 @@ namespace ome
       {
       protected:
         /// List type for storing CoreMetadata.
-        typedef std::vector<ome::compat::shared_ptr< ::ome::bioformats::CoreMetadata> > coremetadata_list_type;
+        typedef std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> > coremetadata_list_type;
 
         /// Reader properties specific to the derived file format.
         const ReaderProperties& readerProperties;
@@ -118,7 +118,7 @@ namespace ome
         boost::optional<boost::filesystem::path> currentId;
 
         /// Current input.
-        ome::compat::shared_ptr<std::istream> in;
+        std::shared_ptr<std::istream> in;
 
         /// Mapping of metadata key/value pairs.
         ::ome::bioformats::MetadataMap metadata;
@@ -202,7 +202,7 @@ namespace ome
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataStore() prevent "null" access.
          */
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore> metadataStore;
+        std::shared_ptr< ::ome::xml::meta::MetadataStore> metadataStore;
 
         /// Metadata parsing options.
         MetadataOptions metadataOptions;
@@ -311,7 +311,7 @@ namespace ome
          * @returns a FilterMetadata instance.
          */
         virtual
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>
+        std::shared_ptr< ::ome::xml::meta::MetadataStore>
         makeFilterMetadata();
 
         /**
@@ -690,7 +690,7 @@ namespace ome
         getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.
-        const std::vector<ome::compat::shared_ptr< ::ome::bioformats::CoreMetadata> >&
+        const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&
         getCoreMetadataList() const;
 
         // Documented in superclass.
@@ -703,18 +703,18 @@ namespace ome
 
         // Documented in superclass.
         void
-        setMetadataStore(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>& store);
+        setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store);
 
         // Documented in superclass.
-        const ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
+        const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
         getMetadataStore() const;
 
         // Documented in superclass.
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore>&
+        std::shared_ptr< ::ome::xml::meta::MetadataStore>&
         getMetadataStore();
 
         // Documented in superclass.
-        std::vector<ome::compat::shared_ptr< ::ome::bioformats::FormatReader> >
+        std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >
         getUnderlyingReaders() const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -109,7 +109,7 @@ namespace ome
       {
       protected:
         /// List type for storing CoreMetadata.
-        typedef std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> > coremetadata_list_type;
+        typedef std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata>> coremetadata_list_type;
 
         /// Reader properties specific to the derived file format.
         const ReaderProperties& readerProperties;
@@ -690,7 +690,7 @@ namespace ome
         getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.
-        const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata> >&
+        const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata>>&
         getCoreMetadataList() const;
 
         // Documented in superclass.
@@ -714,7 +714,7 @@ namespace ome
         getMetadataStore();
 
         // Documented in superclass.
-        std::vector<std::shared_ptr< ::ome::bioformats::FormatReader> >
+        std::vector<std::shared_ptr< ::ome::bioformats::FormatReader>>
         getUnderlyingReaders() const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/detail/FormatReader.h
+++ b/cpp/lib/ome/bioformats/detail/FormatReader.h
@@ -109,7 +109,7 @@ namespace ome
       {
       protected:
         /// List type for storing CoreMetadata.
-        typedef std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata>> coremetadata_list_type;
+        typedef std::vector<std::shared_ptr<::ome::bioformats::CoreMetadata>> coremetadata_list_type;
 
         /// Reader properties specific to the derived file format.
         const ReaderProperties& readerProperties;
@@ -202,7 +202,7 @@ namespace ome
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataStore() prevent "null" access.
          */
-        std::shared_ptr< ::ome::xml::meta::MetadataStore> metadataStore;
+        std::shared_ptr<::ome::xml::meta::MetadataStore> metadataStore;
 
         /// Metadata parsing options.
         MetadataOptions metadataOptions;
@@ -311,7 +311,7 @@ namespace ome
          * @returns a FilterMetadata instance.
          */
         virtual
-        std::shared_ptr< ::ome::xml::meta::MetadataStore>
+        std::shared_ptr<::ome::xml::meta::MetadataStore>
         makeFilterMetadata();
 
         /**
@@ -690,7 +690,7 @@ namespace ome
         getZCTModuloCoords(dimension_size_type index) const;
 
         // Documented in superclass.
-        const std::vector<std::shared_ptr< ::ome::bioformats::CoreMetadata>>&
+        const std::vector<std::shared_ptr<::ome::bioformats::CoreMetadata>>&
         getCoreMetadataList() const;
 
         // Documented in superclass.
@@ -703,18 +703,18 @@ namespace ome
 
         // Documented in superclass.
         void
-        setMetadataStore(std::shared_ptr< ::ome::xml::meta::MetadataStore>& store);
+        setMetadataStore(std::shared_ptr<::ome::xml::meta::MetadataStore>& store);
 
         // Documented in superclass.
-        const std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+        const std::shared_ptr<::ome::xml::meta::MetadataStore>&
         getMetadataStore() const;
 
         // Documented in superclass.
-        std::shared_ptr< ::ome::xml::meta::MetadataStore>&
+        std::shared_ptr<::ome::xml::meta::MetadataStore>&
         getMetadataStore();
 
         // Documented in superclass.
-        std::vector<std::shared_ptr< ::ome::bioformats::FormatReader>>
+        std::vector<std::shared_ptr<::ome::bioformats::FormatReader>>
         getUnderlyingReaders() const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -339,7 +339,7 @@ namespace ome
       }
 
       void
-      FormatWriter::setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
+      FormatWriter::setMetadataRetrieve(std::shared_ptr<::ome::xml::meta::MetadataRetrieve>& retrieve)
       {
         assertId(currentId, false);
 
@@ -349,13 +349,13 @@ namespace ome
         metadataRetrieve = retrieve;
       }
 
-      const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      const std::shared_ptr<::ome::xml::meta::MetadataRetrieve>&
       FormatWriter::getMetadataRetrieve() const
       {
         return metadataRetrieve;
       }
 
-      std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      std::shared_ptr<::ome::xml::meta::MetadataRetrieve>&
       FormatWriter::getMetadataRetrieve()
       {
         return metadataRetrieve;

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -484,7 +484,7 @@ namespace ome
                                          z, c, t);
       }
 
-      ome::compat::array<dimension_size_type, 3>
+      std::array<dimension_size_type, 3>
       FormatWriter::getZCTCoords(dimension_size_type index) const
       {
         assertId(currentId, true);

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -87,7 +87,7 @@ namespace ome
         interleaved(boost::none),
         sequential(false),
         framesPerSecond(0),
-        metadataRetrieve(ome::compat::make_shared<DummyMetadata>())
+        metadataRetrieve(std::make_shared<DummyMetadata>())
       {
         assertId(currentId, false);
       }
@@ -119,7 +119,7 @@ namespace ome
         if (!currentId || canonicalpath != currentId.get())
           {
             if (out)
-              out = ome::compat::shared_ptr<std::ostream>();
+              out = std::shared_ptr<std::ostream>();
 
             currentId = canonicalpath;
           }
@@ -339,7 +339,7 @@ namespace ome
       }
 
       void
-      FormatWriter::setMetadataRetrieve(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
+      FormatWriter::setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve)
       {
         assertId(currentId, false);
 
@@ -349,13 +349,13 @@ namespace ome
         metadataRetrieve = retrieve;
       }
 
-      const ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       FormatWriter::getMetadataRetrieve() const
       {
         return metadataRetrieve;
       }
 
-      ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+      std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
       FormatWriter::getMetadataRetrieve()
       {
         return metadataRetrieve;

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -116,7 +116,7 @@ namespace ome
         boost::optional<boost::filesystem::path> currentId;
 
         /// Current output.
-        ome::compat::shared_ptr<std::ostream> out;
+        std::shared_ptr<std::ostream> out;
 
         /// Current series.
         mutable dimension_size_type series;
@@ -140,7 +140,7 @@ namespace ome
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataRetrieve() prevent "null" access.
          */
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
+        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
 
       protected:
         /// Constructor.
@@ -210,14 +210,14 @@ namespace ome
 
         // Documented in superclass.
         void
-        setMetadataRetrieve(ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
+        setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
 
         // Documented in superclass.
-        const ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+        const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve() const;
 
         // Documented in superclass.
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve();
 
         /**

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -140,7 +140,7 @@ namespace ome
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataRetrieve() prevent "null" access.
          */
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
+        std::shared_ptr<::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
 
       protected:
         /// Constructor.
@@ -210,14 +210,14 @@ namespace ome
 
         // Documented in superclass.
         void
-        setMetadataRetrieve(std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>& retrieve);
+        setMetadataRetrieve(std::shared_ptr<::ome::xml::meta::MetadataRetrieve>& retrieve);
 
         // Documented in superclass.
-        const std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+        const std::shared_ptr<::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve() const;
 
         // Documented in superclass.
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve>&
+        std::shared_ptr<::ome::xml::meta::MetadataRetrieve>&
         getMetadataRetrieve();
 
         /**

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -57,7 +57,7 @@ namespace ome
       {
         /// Map of codec to pixel types.
         typedef std::map<std::string,
-                         std::set<ome::xml::model::enums::PixelType> > codec_pixel_type_map;
+                         std::set<ome::xml::model::enums::PixelType>> codec_pixel_type_map;
 
         /// Format name.
         std::string name;

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.h
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.h
@@ -360,7 +360,7 @@ namespace ome
          * @copydoc ome::bioformats::FormatReader::getZCTCoords(dimension_size_type) const
          */
         virtual
-        ome::compat::array<dimension_size_type, 3>
+        std::array<dimension_size_type, 3>
         getZCTCoords(dimension_size_type index) const;
 
         // Documented in superclass.

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.cpp
@@ -124,11 +124,11 @@ namespace ome
         return static_cast<bool>(TIFF::open(name, "r"));
       }
 
-      const ome::compat::shared_ptr<const tiff::IFD>
+      const std::shared_ptr<const tiff::IFD>
       MinimalTIFFReader::ifdAtIndex(dimension_size_type plane) const
       {
         dimension_size_type ifdidx = tiff::ifdIndex(seriesIFDRange, getSeries(), plane);
-        const ome::compat::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
+        const std::shared_ptr<const IFD>& ifd(tiff->getDirectoryByIndex(static_cast<tiff::directory_index_type>(ifdidx)));
 
         return ifd;
       }
@@ -185,8 +185,8 @@ namespace ome
       {
         core.clear();
 
-        ome::compat::shared_ptr<const tiff::IFD> prev_ifd;
-        ome::compat::shared_ptr<CoreMetadata> prev_core;
+        std::shared_ptr<const tiff::IFD> prev_ifd;
+        std::shared_ptr<CoreMetadata> prev_core;
 
         dimension_size_type current_ifd = 0U;
 
@@ -227,7 +227,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         try
           {
@@ -251,18 +251,18 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         ifd->readImage(buf, x, y, w, h);
       }
 
-      ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
+      std::shared_ptr<ome::bioformats::tiff::TIFF>
       MinimalTIFFReader::getTIFF()
       {
         return tiff;
       }
 
-      const ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
+      const std::shared_ptr<ome::bioformats::tiff::TIFF>
       MinimalTIFFReader::getTIFF() const
       {
         return tiff;

--- a/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/MinimalTIFFReader.h
@@ -70,7 +70,7 @@ namespace ome
       {
       protected:
         /// Underlying TIFF file.
-        ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
+        std::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
 
         /// Mapping between series index and start and end IFD as a half-open range.
         tiff::SeriesIFDRange seriesIFDRange;
@@ -109,7 +109,7 @@ namespace ome
          * @returns the IFD index.
          * @throws FormatException if out of range.
          */
-        const ome::compat::shared_ptr<const tiff::IFD>
+        const std::shared_ptr<const tiff::IFD>
         ifdAtIndex(dimension_size_type plane) const;
 
       public:
@@ -140,7 +140,7 @@ namespace ome
          *
          * @returns a reference to the TIFF file.
          */
-        ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
+        std::shared_ptr<ome::bioformats::tiff::TIFF>
         getTIFF();
 
         /**
@@ -150,7 +150,7 @@ namespace ome
          *
          * @returns a reference to the TIFF file.
          */
-        const ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>
+        const std::shared_ptr<ome::bioformats::tiff::TIFF>
         getTIFF() const;
       };
 

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -455,7 +455,7 @@ namespace ome
           throw FormatException("Could not parse OME-XML from TIFF ImageDescription");
 
         // Save image timestamps for later use.
-        std::vector<boost::optional<Timestamp> > acquiredDates(meta->getImageCount());
+        std::vector<boost::optional<Timestamp>> acquiredDates(meta->getImageCount());
         getAcquisitionDates(*meta, acquiredDates);
 
         // Get UUID for the first file.
@@ -938,11 +938,11 @@ namespace ome
 
         fillMetadata(*metadataStore, *this, false, false);
 
-        for (std::vector<boost::optional<Timestamp> >::const_iterator ts = acquiredDates.begin();
+        for (std::vector<boost::optional<Timestamp>>::const_iterator ts = acquiredDates.begin();
              ts != acquiredDates.end();
              ++ts)
           {
-            index_type series = std::distance<std::vector<boost::optional<Timestamp> >::const_iterator>(acquiredDates.begin(), ts);
+            index_type series = std::distance<std::vector<boost::optional<Timestamp>>::const_iterator>(acquiredDates.begin(), ts);
             if (*ts)
               {
                 try
@@ -1042,7 +1042,7 @@ namespace ome
 
       void
       OMETIFFReader::getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                  meta,
-                                         std::vector<boost::optional<ome::xml::model::primitives::Timestamp> >& timestamps)
+                                         std::vector<boost::optional<ome::xml::model::primitives::Timestamp>>& timestamps)
       {
         for (index_type i = 0; i < meta.getImageCount(); ++i)
           {

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -1041,7 +1041,7 @@ namespace ome
       }
 
       void
-      OMETIFFReader::getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                  meta,
+      OMETIFFReader::getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                 meta,
                                          std::vector<boost::optional<ome::xml::model::primitives::Timestamp>>& timestamps)
       {
         for (index_type i = 0; i < meta.getImageCount(); ++i)

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -121,7 +121,7 @@ namespace ome
         {
           try
             {
-              ome::compat::shared_ptr<tiff::IFD> ifd (tiff.getDirectoryByIndex(0));
+              std::shared_ptr<tiff::IFD> ifd (tiff.getDirectoryByIndex(0));
               if (ifd)
                 ifd->getField(ome::bioformats::tiff::IMAGEDESCRIPTION).get(omexml);
               else
@@ -216,7 +216,7 @@ namespace ome
         if (checkSuffix(id, companion_suffixes))
           return false;
 
-        ome::compat::shared_ptr<tiff::TIFF> tiff = TIFF::open(id, "r");
+        std::shared_ptr<tiff::TIFF> tiff = TIFF::open(id, "r");
 
         if (!tiff)
           {
@@ -228,7 +228,7 @@ namespace ome
         std::string omexml;
         getComment(*tiff, omexml);
 
-        ome::compat::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+        std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
 
         dimension_size_type nImages = 0U;
         for (dimension_size_type i = 0U;
@@ -262,7 +262,7 @@ namespace ome
       bool
       OMETIFFReader::isFilenameThisTypeImpl(const boost::filesystem::path& name) const
       {
-        ome::compat::shared_ptr<tiff::TIFF> tiff = TIFF::open(name, "r");
+        std::shared_ptr<tiff::TIFF> tiff = TIFF::open(name, "r");
 
         if (!tiff)
           {
@@ -280,7 +280,7 @@ namespace ome
 
         try
           {
-            ome::compat::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+            std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
 
             std::string metadataFile = meta->getBinaryOnlyMetadataFile();
             if (!metadataFile.empty())
@@ -300,19 +300,19 @@ namespace ome
           }
       }
 
-      const ome::compat::shared_ptr<const tiff::IFD>
+      const std::shared_ptr<const tiff::IFD>
       OMETIFFReader::ifdAtIndex(dimension_size_type plane) const
       {
-        ome::compat::shared_ptr<const IFD> ifd;
+        std::shared_ptr<const IFD> ifd;
 
         const OMETIFFMetadata& ometa(dynamic_cast<const OMETIFFMetadata&>(getCoreMetadata(getCoreIndex())));
 
         if (plane < ometa.tiffPlanes.size())
           {
             const OMETIFFPlane& tiffplane(ometa.tiffPlanes.at(plane));
-            const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(tiffplane.id));
+            const std::shared_ptr<const TIFF> tiff(getTIFF(tiffplane.id));
             if (tiff)
-              ifd = ome::compat::shared_ptr<const IFD>(tiff->getDirectoryByIndex(tiffplane.ifd));
+              ifd = std::shared_ptr<const IFD>(tiff->getDirectoryByIndex(tiffplane.ifd));
           }
 
         if (!ifd)
@@ -407,7 +407,7 @@ namespace ome
             // This is a companion file.  Read the metadata, get the
             // TIFF for the TiffData for the first image, and then
             // recurse with this file as the id.
-            ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(*currentId));
+            std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(*currentId));
             path firstTIFF(path(meta->getUUIDFileName(0, 0)));
             initFile(canonical(firstTIFF, dir));
             return;
@@ -415,13 +415,13 @@ namespace ome
 
         // Cache and use this TIFF.
         addTIFF(*currentId);
-        const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(*currentId));
+        const std::shared_ptr<const TIFF> tiff(getTIFF(*currentId));
 
         // Get the OME-XML from the first TIFF, and create OME-XML
         // metadata from it.
         std::string omexml;
         getComment(*tiff, omexml);
-        ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
+        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
 
         // Is there an associated binary-only metadata file?
         try
@@ -477,7 +477,7 @@ namespace ome
         core.clear();
         core.reserve(seriesCount);
         for (index_type i = 0; i < seriesCount; ++i)
-          core.push_back(ome::compat::make_shared<OMETIFFMetadata>());
+          core.push_back(std::make_shared<OMETIFFMetadata>());
 
         // UUID → file mapping and used files.
         findUsedFiles(*meta, *currentId, dir, currentUUID);
@@ -485,7 +485,7 @@ namespace ome
         // Process TiffData elements.
         for (index_type series = 0; series < seriesCount; ++series)
           {
-            ome::compat::shared_ptr<OMETIFFMetadata> coreMeta(ome::compat::dynamic_pointer_cast<OMETIFFMetadata>(core.at(series)));
+            std::shared_ptr<OMETIFFMetadata> coreMeta(std::dynamic_pointer_cast<OMETIFFMetadata>(core.at(series)));
             assert(coreMeta); // Should never be null.
 
             BOOST_LOG_SEV(logger, ome::logging::trivial::debug)
@@ -758,8 +758,8 @@ namespace ome
             try
               {
                 const OMETIFFPlane& plane(coreMeta->tiffPlanes.at(0));
-                const ome::compat::shared_ptr<const tiff::TIFF> ptiff(getTIFF(plane.id));
-                const ome::compat::shared_ptr<const tiff::IFD> pifd(ptiff->getDirectoryByIndex(plane.ifd));
+                const std::shared_ptr<const tiff::TIFF> ptiff(getTIFF(plane.id));
+                const std::shared_ptr<const tiff::IFD> pifd(ptiff->getDirectoryByIndex(plane.ifd));
 
                 uint32_t tiffWidth = pifd->getImageWidth();
                 uint32_t tiffHeight = pifd->getImageHeight();
@@ -831,8 +831,8 @@ namespace ome
                                                 0);
 
                     const OMETIFFPlane& plane(coreMeta->tiffPlanes.at(planeIndex));
-                    const ome::compat::shared_ptr<const tiff::TIFF> ctiff(getTIFF(plane.id));
-                    const ome::compat::shared_ptr<const tiff::IFD> cifd(ctiff->getDirectoryByIndex(plane.ifd));
+                    const std::shared_ptr<const tiff::TIFF> ctiff(getTIFF(plane.id));
+                    const std::shared_ptr<const tiff::IFD> cifd(ctiff->getDirectoryByIndex(plane.ifd));
                     const tiff::TileInfo tinfo(cifd->getTileInfo());
                     const dimension_size_type tiffSamples = cifd->getSamplesPerPixel();
 
@@ -923,11 +923,11 @@ namespace ome
           }
 
         // Remove null CoreMetadata entries.
-        std::remove(core.begin(), core.end(), ome::compat::shared_ptr<OMETIFFMetadata>());
+        std::remove(core.begin(), core.end(), std::shared_ptr<OMETIFFMetadata>());
 
         if (getImageCount() == 1U)
           {
-            ome::compat::shared_ptr<CoreMetadata>& ms0 = core.at(0);
+            std::shared_ptr<CoreMetadata>& ms0 = core.at(0);
             ms0->sizeZ = 1U;
             // Only one channel, but may contain subchannels.
             dimension_size_type subchannels = ms0->sizeC.at(0);
@@ -1154,7 +1154,7 @@ namespace ome
 
         if (numPlanes == 0)
           {
-            core.at(series) = ome::compat::shared_ptr<OMETIFFMetadata>();
+            core.at(series) = std::shared_ptr<OMETIFFMetadata>();
             valid = false;
           }
 
@@ -1210,7 +1210,7 @@ namespace ome
                 {
                   // Will throw if null.
                   std::string channelName(meta.getChannelName(series, 0));
-                  ome::compat::shared_ptr<CoreMetadata> coreMeta(core.at(series));
+                  std::shared_ptr<CoreMetadata> coreMeta(core.at(series));
                   if (meta.getTiffDataCount(series) > 0 &&
                       files.find("__omero_export") != files.end() &&
                       coreMeta)
@@ -1226,7 +1226,7 @@ namespace ome
       void
       OMETIFFReader::fixDimensions(ome::xml::meta::BaseMetadata::index_type series)
       {
-        ome::compat::shared_ptr<CoreMetadata> coreMeta(core.at(series));
+        std::shared_ptr<CoreMetadata> coreMeta(core.at(series));
         if (coreMeta)
           {
             dimension_size_type channelCount = std::accumulate(coreMeta->sizeC.begin(), coreMeta->sizeC.end(), dimension_size_type(0));
@@ -1269,7 +1269,7 @@ namespace ome
 
         setPlane(plane);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         try
           {
@@ -1293,7 +1293,7 @@ namespace ome
       {
         assertId(currentId, true);
 
-        const ome::compat::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
+        const std::shared_ptr<const IFD>& ifd(ifdAtIndex(plane));
 
         ifd->readImage(buf, x, y, w, h);
       }
@@ -1301,10 +1301,10 @@ namespace ome
       void
       OMETIFFReader::addTIFF(const boost::filesystem::path& tiff)
       {
-        tiffs.insert(std::make_pair(tiff, ome::compat::shared_ptr<tiff::TIFF>()));
+        tiffs.insert(std::make_pair(tiff, std::shared_ptr<tiff::TIFF>()));
       }
 
-      const ome::compat::shared_ptr<const ome::bioformats::tiff::TIFF>
+      const std::shared_ptr<const ome::bioformats::tiff::TIFF>
       OMETIFFReader::getTIFF(const boost::filesystem::path& tiff) const
       {
         tiff_map::iterator i = tiffs.find(tiff);
@@ -1328,16 +1328,16 @@ namespace ome
         if (i->second)
           {
             i->second->close();
-            i->second = ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>();
+            i->second = std::shared_ptr<ome::bioformats::tiff::TIFF>();
           }
       }
 
-      ome::compat::shared_ptr<ome::xml::meta::MetadataStore>
+      std::shared_ptr<ome::xml::meta::MetadataStore>
       OMETIFFReader::getMetadataStoreForConversion()
       {
         SaveSeries sentry(*this);
 
-        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
+        std::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
 
         if (store)
           {
@@ -1351,15 +1351,15 @@ namespace ome
         return store;
       }
 
-      ome::compat::shared_ptr<ome::xml::meta::MetadataStore>
+      std::shared_ptr<ome::xml::meta::MetadataStore>
       OMETIFFReader::getMetadataStoreForDisplay()
       {
-        ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> omexml;
-        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
+        std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omexml;
+        std::shared_ptr<ome::xml::meta::MetadataStore> store = getMetadataStore();
 
         if (store)
           {
-            omexml = ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(store);
+            omexml = std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(store);
             if (omexml)
               {
                 removeBinData(*omexml);

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -228,7 +228,7 @@ namespace ome
         std::string omexml;
         getComment(*tiff, omexml);
 
-        std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+        std::shared_ptr<::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
 
         dimension_size_type nImages = 0U;
         for (dimension_size_type i = 0U;
@@ -280,7 +280,7 @@ namespace ome
 
         try
           {
-            std::shared_ptr< ::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
+            std::shared_ptr<::ome::xml::meta::Metadata> meta(createOMEXMLMetadata(omexml));
 
             std::string metadataFile = meta->getBinaryOnlyMetadataFile();
             if (!metadataFile.empty())
@@ -407,7 +407,7 @@ namespace ome
             // This is a companion file.  Read the metadata, get the
             // TIFF for the TiffData for the first image, and then
             // recurse with this file as the id.
-            std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(*currentId));
+            std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(*currentId));
             path firstTIFF(path(meta->getUUIDFileName(0, 0)));
             initFile(canonical(firstTIFF, dir));
             return;
@@ -421,7 +421,7 @@ namespace ome
         // metadata from it.
         std::string omexml;
         getComment(*tiff, omexml);
-        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
+        std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(omexml));
 
         // Is there an associated binary-only metadata file?
         try

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.cpp
@@ -787,7 +787,7 @@ namespace ome
                   {
                     try
                       {
-                        ome::compat::array<std::vector<uint16_t>, 3> cmap;
+                        std::array<std::vector<uint16_t>, 3> cmap;
                         pifd->getField(ome::bioformats::tiff::COLORMAP).get(cmap);
                         coreMeta->indexed = true;
                       }

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -235,7 +235,7 @@ namespace ome
          * @param timestamps the acquisition dates, indexed by image.
          */
         void
-        getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                  meta,
+        getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                 meta,
                             std::vector<boost::optional<ome::xml::model::primitives::Timestamp>>& timestamps);
 
         /**

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -81,7 +81,7 @@ namespace ome
         typedef std::map<boost::filesystem::path, boost::filesystem::path> invalid_file_map;
 
         /// Map filename to open TIFF handle.
-        typedef std::map<boost::filesystem::path, ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
+        typedef std::map<boost::filesystem::path, std::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
 
         /// UUID to filename mapping.
         uuid_file_map files;
@@ -145,7 +145,7 @@ namespace ome
          * @returns the IFD index.
          * @throws FormatException if out of range.
          */
-        const ome::compat::shared_ptr<const tiff::IFD>
+        const std::shared_ptr<const tiff::IFD>
         ifdAtIndex(dimension_size_type plane) const;
 
         /**
@@ -167,7 +167,7 @@ namespace ome
          * @returns the open TIFF.
          * @throws FormatException if invalid.
          */
-        const ome::compat::shared_ptr<const ome::bioformats::tiff::TIFF>
+        const std::shared_ptr<const ome::bioformats::tiff::TIFF>
         getTIFF(const boost::filesystem::path& tiff) const;
 
         /**
@@ -340,7 +340,7 @@ namespace ome
          *
          * @returns the metadata store.
          */
-        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
+        std::shared_ptr< ome::xml::meta::MetadataStore>
         getMetadataStoreForConversion();
 
         /**
@@ -352,7 +352,7 @@ namespace ome
          *
          * @returns the metadata store.
          */
-        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
+        std::shared_ptr< ome::xml::meta::MetadataStore>
         getMetadataStoreForDisplay();
       };
 

--- a/cpp/lib/ome/bioformats/in/OMETIFFReader.h
+++ b/cpp/lib/ome/bioformats/in/OMETIFFReader.h
@@ -81,7 +81,7 @@ namespace ome
         typedef std::map<boost::filesystem::path, boost::filesystem::path> invalid_file_map;
 
         /// Map filename to open TIFF handle.
-        typedef std::map<boost::filesystem::path, std::shared_ptr<ome::bioformats::tiff::TIFF> > tiff_map;
+        typedef std::map<boost::filesystem::path, std::shared_ptr<ome::bioformats::tiff::TIFF>> tiff_map;
 
         /// UUID to filename mapping.
         uuid_file_map files;
@@ -236,7 +236,7 @@ namespace ome
          */
         void
         getAcquisitionDates(const ome::xml::meta::OMEXMLMetadata&                                  meta,
-                            std::vector<boost::optional<ome::xml::model::primitives::Timestamp> >& timestamps);
+                            std::vector<boost::optional<ome::xml::model::primitives::Timestamp>>& timestamps);
 
         /**
          * Clean up OME-XML metadata.

--- a/cpp/lib/ome/bioformats/in/TIFFReader.cpp
+++ b/cpp/lib/ome/bioformats/in/TIFFReader.cpp
@@ -109,7 +109,7 @@ namespace ome
       void
       TIFFReader::readIFDs()
       {
-        ome::compat::shared_ptr<IFD> ifd0 = *(tiff->begin());
+        std::shared_ptr<IFD> ifd0 = *(tiff->begin());
 
         if (ifd0)
           {
@@ -119,7 +119,7 @@ namespace ome
               {
                 tiff::ImageJMetadata ijmeta(*ifd0);
 
-                ome::compat::shared_ptr<CoreMetadata> ijm(tiff::makeCoreMetadata(*ifd0));
+                std::shared_ptr<CoreMetadata> ijm(tiff::makeCoreMetadata(*ifd0));
 
                 ijm->sizeZ = ijmeta.slices;
                 ijm->sizeT = ijmeta.frames;

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -140,7 +140,7 @@ namespace ome
         std::string flags("w");
 
         // Get expected size of pixel data.
-        ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
+        std::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
         storage_size_type pixelSize = significantPixelSize(*mr);
 
         if (enableBigTIFF(bigTIFF, pixelSize, *currentId, logger))

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -235,7 +235,7 @@ namespace ome
         ifd->setTileWidth(getSizeX());
         ifd->setTileHeight(1U);
 
-        ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
+        std::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
 
         dimension_size_type channel = coords[1];
 

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
@@ -73,10 +73,10 @@ namespace ome
         ome::common::Logger logger;
 
         /// Underlying TIFF file.
-        mutable ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
+        mutable std::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
 
         /// Current IFD.
-        mutable ome::compat::shared_ptr<ome::bioformats::tiff::IFD> ifd;
+        mutable std::shared_ptr<ome::bioformats::tiff::IFD> ifd;
 
         /// Current plane.
         mutable dimension_size_type ifdIndex;

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -634,7 +634,7 @@ namespace ome
         ifd->setTileWidth(getSizeX());
         ifd->setTileHeight(1U);
 
-        ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
+        std::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
 
         dimension_size_type channel = coords[1];
 
@@ -732,7 +732,7 @@ namespace ome
 
             for (dimension_size_type plane = 0U; plane < imageCount; ++plane)
               {
-                ome::compat::array<dimension_size_type, 3> coords =
+                std::array<dimension_size_type, 3> coords =
                   ome::bioformats::getZCTCoords(dimOrder, sizeZ, effC, sizeT, imageCount, plane);
                 const detail::OMETIFFPlane& planeState(seriesState.at(series).planes.at(plane));
 

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -408,7 +408,7 @@ namespace ome
 
       }
 
-      OMETIFFWriter::TIFFState::TIFFState(ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>& tiff):
+      OMETIFFWriter::TIFFState::TIFFState(std::shared_ptr<ome::bioformats::tiff::TIFF>& tiff):
         uuid(boost::uuids::to_string(boost::uuids::random_generator()())),
         tiff(tiff),
         ifdCount(0U)
@@ -466,7 +466,7 @@ namespace ome
 
             // Create OME-XML metadata.
             originalMetadataRetrieve = metadataRetrieve;
-            omeMeta = ome::compat::make_shared<OMEXMLMetadata>();
+            omeMeta = std::make_shared<OMEXMLMetadata>();
             convert(*metadataRetrieve, *omeMeta);
             omeMeta->resolveReferences();
             metadataRetrieve = omeMeta;
@@ -514,7 +514,7 @@ namespace ome
             flags += 'w';
 
             // Get expected size of pixel data.
-            ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
+            std::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr(getMetadataRetrieve());
             storage_size_type pixelSize = significantPixelSize(*mr);
 
             if (enableBigTIFF(bigTIFF, pixelSize, canonicalpath, logger))
@@ -525,7 +525,7 @@ namespace ome
         if (i == tiffs.end())
           {
             detail::FormatWriter::setId(canonicalpath);
-            ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff(ome::bioformats::tiff::TIFF::open(canonicalpath, flags));
+            std::shared_ptr<ome::bioformats::tiff::TIFF> tiff(ome::bioformats::tiff::TIFF::open(canonicalpath, flags));
             std::pair<tiff_map::iterator,bool> result =
               tiffs.insert(tiff_map::value_type(*currentId, TIFFState(tiff)));
             if (result.second) // should always be true
@@ -624,7 +624,7 @@ namespace ome
       OMETIFFWriter::setupIFD() const
       {
         // Get current IFD.
-        ome::compat::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
+        std::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
 
         // Default to single strips for now.
         ifd->setImageWidth(getSizeX());
@@ -673,7 +673,7 @@ namespace ome
         setPlane(plane);
 
         // Get current IFD.
-        ome::compat::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
+        std::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
 
         // Get plane metadata.
         detail::OMETIFFPlane& planeMeta(seriesState.at(getSeries()).planes.at(plane));

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
@@ -80,7 +80,7 @@ namespace ome
           /// UUID of file.
           std::string uuid;
           /// TIFF file handle.
-          ome::compat::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
+          std::shared_ptr<ome::bioformats::tiff::TIFF> tiff;
           /// Number of IFDs written.
           dimension_size_type ifdCount;
 
@@ -89,7 +89,7 @@ namespace ome
            *
            * @param tiff the TIFF file for which to cache state.
            */
-          TIFFState(ome::compat::shared_ptr<ome::bioformats::tiff::TIFF>& tiff);
+          TIFFState(std::shared_ptr<ome::bioformats::tiff::TIFF>& tiff);
 
           /// Destructor.
           ~TIFFState();
@@ -137,10 +137,10 @@ namespace ome
          * solution, but need to eliminate all direct use of
          * metadataRetrieve in all writers first.
          */
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> originalMetadataRetrieve;
+        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> originalMetadataRetrieve;
 
         /// OME-XML metadata for embedding in the TIFF.
-        ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> omeMeta;
+        std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omeMeta;
 
       private:
         /// Write a Big TIFF

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
@@ -137,7 +137,7 @@ namespace ome
          * solution, but need to eliminate all direct use of
          * metadataRetrieve in all writers first.
          */
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> originalMetadataRetrieve;
+        std::shared_ptr<::ome::xml::meta::MetadataRetrieve> originalMetadataRetrieve;
 
         /// OME-XML metadata for embedding in the TIFF.
         std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omeMeta;

--- a/cpp/lib/ome/bioformats/tiff/Codec.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Codec.cpp
@@ -35,9 +35,9 @@
  * #L%
  */
 
-#include <ome/bioformats/tiff/Codec.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/bioformats/tiff/Codec.h>
 
 #include <tiffio.h>
 
@@ -53,7 +53,7 @@ namespace ome
       {
         std::vector<Codec> ret;
 
-        ome::compat::shared_ptr<TIFFCodec> codecs(TIFFGetConfiguredCODECs(), _TIFFfree);
+        std::shared_ptr<TIFFCodec> codecs(TIFFGetConfiguredCODECs(), _TIFFfree);
         if (codecs)
           {
             for (const TIFFCodec *c = &*codecs; c->name != 0; ++c)

--- a/cpp/lib/ome/bioformats/tiff/Codec.h
+++ b/cpp/lib/ome/bioformats/tiff/Codec.h
@@ -38,10 +38,9 @@
 #ifndef OME_BIOFORMATS_TIFF_CODEC_H
 #define OME_BIOFORMATS_TIFF_CODEC_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/tiff/Field.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Field.cpp
@@ -116,7 +116,7 @@ namespace ome
       {
       public:
         /// Weak reference to the parent IFD.
-        ome::compat::weak_ptr<IFD>  ifd;
+        std::weak_ptr<IFD>  ifd;
         /// The tag being wrapped.
         tag_type            tag;
         /// Field information for this tag.
@@ -128,7 +128,7 @@ namespace ome
          * @param ifd the directory the field belongs to.
          * @param tag the tag identifying this field.
          */
-        Impl(ome::compat::shared_ptr<IFD>& ifd,
+        Impl(std::shared_ptr<IFD>& ifd,
              tag_type                      tag):
           ifd(ifd),
           tag(tag),
@@ -146,10 +146,10 @@ namespace ome
          *
          * @returns the directory.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         getIFD() const
         {
-          ome::compat::shared_ptr<IFD> sifd = ome::compat::shared_ptr<IFD>(ifd);
+          std::shared_ptr<IFD> sifd = std::shared_ptr<IFD>(ifd);
           if (!sifd)
             throw Exception("Field reference to IFD no longer valid");
 
@@ -236,9 +236,9 @@ namespace ome
         }
       };
 
-      FieldBase::FieldBase(ome::compat::shared_ptr<IFD> ifd,
+      FieldBase::FieldBase(std::shared_ptr<IFD> ifd,
                            tag_type                     tag):
-        impl(ome::compat::shared_ptr<Impl>(new Impl(ifd, tag)))
+        impl(std::shared_ptr<Impl>(new Impl(ifd, tag)))
       {
       }
 
@@ -340,7 +340,7 @@ namespace ome
         return impl->tag;
       }
 
-      ome::compat::shared_ptr<IFD>
+      std::shared_ptr<IFD>
       FieldBase::getIFD() const
       {
         return impl->getIFD();
@@ -351,7 +351,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_get1(ome::compat::shared_ptr<IFD> ifd,
+        generic_get1(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* readcount */,
@@ -362,7 +362,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_set1(ome::compat::shared_ptr<IFD> ifd,
+        generic_set1(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* writecount */,
@@ -373,7 +373,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_get2(ome::compat::shared_ptr<IFD> ifd,
+        generic_get2(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* readcount */,
@@ -384,7 +384,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_set2(ome::compat::shared_ptr<IFD> ifd,
+        generic_set2(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* writecount */,
@@ -395,7 +395,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_get3(ome::compat::shared_ptr<IFD> ifd,
+        generic_get3(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* readcount */,
@@ -406,7 +406,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_set3(ome::compat::shared_ptr<IFD> ifd,
+        generic_set3(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* writecount */,
@@ -417,7 +417,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_get6(ome::compat::shared_ptr<IFD> ifd,
+        generic_get6(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* readcount */,
@@ -428,7 +428,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_set6(ome::compat::shared_ptr<IFD> ifd,
+        generic_set6(std::shared_ptr<IFD> ifd,
                      tag_type                     tag,
                      bool                         /* passcount */,
                      int                          /* writecount */,
@@ -439,7 +439,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_get1(ome::compat::shared_ptr<IFD> ifd,
+        generic_enum16_get1(std::shared_ptr<IFD> ifd,
                             tag_type                     tag,
                             Type                         type,
                             bool                         passcount,
@@ -460,7 +460,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_set1(ome::compat::shared_ptr<IFD> ifd,
+        generic_enum16_set1(std::shared_ptr<IFD> ifd,
                             tag_type                     tag,
                             Type                         type,
                             bool                         passcount,
@@ -480,7 +480,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_get1(ome::compat::shared_ptr<IFD> ifd,
+        generic_array_get1(std::shared_ptr<IFD> ifd,
                            tag_type                     tag,
                            int                          readcount,
                            T&                           value)
@@ -560,7 +560,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_set1(ome::compat::shared_ptr<IFD> ifd,
+        generic_array_set1(std::shared_ptr<IFD> ifd,
                            tag_type                     tag,
                            int                          writecount,
                            const T&                     value)
@@ -594,7 +594,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_get3(ome::compat::shared_ptr<IFD> ifd,
+        generic_array_get3(std::shared_ptr<IFD> ifd,
                            tag_type                     tag,
                            int                          readcount,
                            T&                           value)
@@ -657,7 +657,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_array_set3(ome::compat::shared_ptr<IFD> ifd,
+        generic_array_set3(std::shared_ptr<IFD> ifd,
                            tag_type                     tag,
                            int                          writecount,
                            const T&                     value)
@@ -710,7 +710,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_array_get1(ome::compat::shared_ptr<IFD> ifd,
+        generic_enum16_array_get1(std::shared_ptr<IFD> ifd,
                                   tag_type                     tag,
                                   int                          readcount,
                                   T&                           value)
@@ -726,7 +726,7 @@ namespace ome
 
         template<typename T>
         void
-        generic_enum16_array_set1(ome::compat::shared_ptr<IFD> ifd,
+        generic_enum16_array_set1(std::shared_ptr<IFD> ifd,
                                   tag_type                     tag,
                                   int                          writecount,
                                   const T&                     value)

--- a/cpp/lib/ome/bioformats/tiff/Field.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Field.cpp
@@ -167,7 +167,7 @@ namespace ome
         getTIFF()
         {
           getIFD()->makeCurrent();
-          ::TIFF *tiff = reinterpret_cast< ::TIFF *>(getIFD()->getTIFF()->getWrapped());
+          ::TIFF *tiff = reinterpret_cast<::TIFF *>(getIFD()->getTIFF()->getWrapped());
           return tiff;
         }
 

--- a/cpp/lib/ome/bioformats/tiff/Field.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Field.cpp
@@ -129,7 +129,7 @@ namespace ome
          * @param tag the tag identifying this field.
          */
         Impl(std::shared_ptr<IFD>& ifd,
-             tag_type                      tag):
+             tag_type              tag):
           ifd(ifd),
           tag(tag),
           fieldinfo()
@@ -237,7 +237,7 @@ namespace ome
       };
 
       FieldBase::FieldBase(std::shared_ptr<IFD> ifd,
-                           tag_type                     tag):
+                           tag_type             tag):
         impl(std::shared_ptr<Impl>(new Impl(ifd, tag)))
       {
       }
@@ -352,10 +352,10 @@ namespace ome
         template<typename T>
         void
         generic_get1(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* readcount */,
-                     T&                           value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* readcount */,
+                     T&                   value)
         {
           ifd->getRawField(tag, &value);
         }
@@ -363,10 +363,10 @@ namespace ome
         template<typename T>
         void
         generic_set1(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* writecount */,
-                     const T&                     value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* writecount */,
+                     const T&             value)
         {
           ifd->setRawField(tag, value);
         }
@@ -374,10 +374,10 @@ namespace ome
         template<typename T>
         void
         generic_get2(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* readcount */,
-                     T&                           value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* readcount */,
+                     T&                   value)
         {
           ifd->getRawField(tag, &value[0], &value[1]);
         }
@@ -385,10 +385,10 @@ namespace ome
         template<typename T>
         void
         generic_set2(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* writecount */,
-                     const T&                     value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* writecount */,
+                     const T&             value)
         {
           ifd->setRawField(tag, value[0], value[1]);
         }
@@ -396,10 +396,10 @@ namespace ome
         template<typename T>
         void
         generic_get3(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* readcount */,
-                     T&                           value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* readcount */,
+                     T&                   value)
         {
           ifd->getRawField(tag, &value[0], &value[1], &value[2]);
         }
@@ -407,10 +407,10 @@ namespace ome
         template<typename T>
         void
         generic_set3(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* writecount */,
-                     const T&                     value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* writecount */,
+                     const T&             value)
         {
           ifd->setRawField(tag, value[0], value[1], value[2]);
         }
@@ -418,10 +418,10 @@ namespace ome
         template<typename T>
         void
         generic_get6(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* readcount */,
-                     T&                           value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* readcount */,
+                     T&                   value)
         {
           ifd->getRawField(tag, &value[0], &value[1], &value[2], &value[3], &value[4], &value[5]);
         }
@@ -429,10 +429,10 @@ namespace ome
         template<typename T>
         void
         generic_set6(std::shared_ptr<IFD> ifd,
-                     tag_type                     tag,
-                     bool                         /* passcount */,
-                     int                          /* writecount */,
-                     const T&                     value)
+                     tag_type             tag,
+                     bool                 /* passcount */,
+                     int                  /* writecount */,
+                     const T&             value)
         {
           ifd->setRawField(tag, value[0], value[1], value[2], value[3], value[4], value[5]);
         }
@@ -440,11 +440,11 @@ namespace ome
         template<typename T>
         void
         generic_enum16_get1(std::shared_ptr<IFD> ifd,
-                            tag_type                     tag,
-                            Type                         type,
-                            bool                         passcount,
-                            int                          readcount,
-                            T&                           value)
+                            tag_type             tag,
+                            Type                 type,
+                            bool                 passcount,
+                            int                  readcount,
+                            T&                   value)
         {
 #if defined(TIFF_HAVE_FIELD) || defined(TIFF_HAVE_FIELDINFO)
           if (type != TYPE_SHORT &&
@@ -461,11 +461,11 @@ namespace ome
         template<typename T>
         void
         generic_enum16_set1(std::shared_ptr<IFD> ifd,
-                            tag_type                     tag,
-                            Type                         type,
-                            bool                         passcount,
-                            int                          writecount,
-                            const T&                     value)
+                            tag_type             tag,
+                            Type                 type,
+                            bool                 passcount,
+                            int                  writecount,
+                            const T&             value)
         {
 #if defined(TIFF_HAVE_FIELD) || defined(TIFF_HAVE_FIELDINFO)
           if (type != TYPE_SHORT &&
@@ -481,9 +481,9 @@ namespace ome
         template<typename T>
         void
         generic_array_get1(std::shared_ptr<IFD> ifd,
-                           tag_type                     tag,
-                           int                          readcount,
-                           T&                           value)
+                           tag_type             tag,
+                           int                  readcount,
+                           T&                   value)
         {
           // Special case:
           if (tag == TIFFTAG_IMAGEJ_META_DATA_BYTE_COUNTS ||
@@ -561,9 +561,9 @@ namespace ome
         template<typename T>
         void
         generic_array_set1(std::shared_ptr<IFD> ifd,
-                           tag_type                     tag,
-                           int                          writecount,
-                           const T&                     value)
+                           tag_type             tag,
+                           int                  writecount,
+                           const T&             value)
         {
           if (writecount == TIFF_SPP)
             {
@@ -595,9 +595,9 @@ namespace ome
         template<typename T>
         void
         generic_array_get3(std::shared_ptr<IFD> ifd,
-                           tag_type                     tag,
-                           int                          readcount,
-                           T&                           value)
+                           tag_type             tag,
+                           int                  readcount,
+                           T&                   value)
         {
           bool limit = false; // Special case for TIFFTAG_TRANSFERFUNCTION which can used 1 or 3 vectors.
           typename T::value_type::value_type *valueptr0, *valueptr1, *valueptr2;
@@ -658,9 +658,9 @@ namespace ome
         template<typename T>
         void
         generic_array_set3(std::shared_ptr<IFD> ifd,
-                           tag_type                     tag,
-                           int                          writecount,
-                           const T&                     value)
+                           tag_type             tag,
+                           int                  writecount,
+                           const T&             value)
         {
           if (value[0].size() != value[1].size() ||
               value[0].size() != value[2].size())
@@ -711,9 +711,9 @@ namespace ome
         template<typename T>
         void
         generic_enum16_array_get1(std::shared_ptr<IFD> ifd,
-                                  tag_type                     tag,
-                                  int                          readcount,
-                                  T&                           value)
+                                  tag_type             tag,
+                                  int                  readcount,
+                                  T&                   value)
         {
           std::vector<uint16_t> v;
           generic_array_get1(ifd, tag, readcount, v);
@@ -727,9 +727,9 @@ namespace ome
         template<typename T>
         void
         generic_enum16_array_set1(std::shared_ptr<IFD> ifd,
-                                  tag_type                     tag,
-                                  int                          writecount,
-                                  const T&                     value)
+                                  tag_type             tag,
+                                  int                  writecount,
+                                  const T&             value)
         {
           std::vector<uint16_t> v;
           for(typename T::const_iterator i = value.begin();

--- a/cpp/lib/ome/bioformats/tiff/Field.h
+++ b/cpp/lib/ome/bioformats/tiff/Field.h
@@ -66,7 +66,7 @@ namespace ome
          * @param tag the tag identifying this field.
          */
         FieldBase(std::shared_ptr<IFD> ifd,
-                  tag_type                     tag);
+                  tag_type             tag);
 
       public:
         /// Destructor.
@@ -171,7 +171,7 @@ namespace ome
          * @param tag the tag identifying this field.
          */
         Field(std::shared_ptr<IFD> ifd,
-              tag_category                 tag):
+              tag_category         tag):
           FieldBase(ifd, getWrappedTag(tag)),
           tag(tag)
         {}

--- a/cpp/lib/ome/bioformats/tiff/Field.h
+++ b/cpp/lib/ome/bioformats/tiff/Field.h
@@ -38,8 +38,7 @@
 #ifndef OME_BIOFORMATS_TIFF_FIELD_H
 #define OME_BIOFORMATS_TIFF_FIELD_H
 
-#include <ome/compat/memory.h>
-
+#include <memory>
 #include <string>
 
 #include <ome/bioformats/tiff/Tags.h>
@@ -66,7 +65,7 @@ namespace ome
          * @param ifd the directory the field belongs to.
          * @param tag the tag identifying this field.
          */
-        FieldBase(ome::compat::shared_ptr<IFD> ifd,
+        FieldBase(std::shared_ptr<IFD> ifd,
                   tag_type                     tag);
 
       public:
@@ -141,13 +140,13 @@ namespace ome
          *
          * @returns the directory.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         getIFD() const;
 
       protected:
         class Impl;
         /// Private implementation details.
-        ome::compat::shared_ptr<Impl> impl;
+        std::shared_ptr<Impl> impl;
       };
 
       /**
@@ -171,7 +170,7 @@ namespace ome
          * @param ifd the directory the field belongs to.
          * @param tag the tag identifying this field.
          */
-        Field(ome::compat::shared_ptr<IFD> ifd,
+        Field(std::shared_ptr<IFD> ifd,
               tag_category                 tag):
           FieldBase(ifd, getWrappedTag(tag)),
           tag(tag)

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -146,12 +146,12 @@ namespace
 
     template<typename T>
     void
-    transfer(std::shared_ptr<T>& buffer,
-             typename T::indices_type&   destidx,
-             const TileBuffer&           tilebuf,
-             PlaneRegion&                rfull,
-             PlaneRegion&                rclip,
-             uint16_t                    copysamples)
+    transfer(std::shared_ptr<T>&       buffer,
+             typename T::indices_type& destidx,
+             const TileBuffer&         tilebuf,
+             PlaneRegion&              rfull,
+             PlaneRegion&              rclip,
+             uint16_t                  copysamples)
     {
       if (rclip.w == rfull.w &&
           rclip.x == region.x &&
@@ -197,11 +197,11 @@ namespace
     // Special case for BIT
     void
     transfer(std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type>>& buffer,
-             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&             destidx,
-             const TileBuffer&                                                                 tilebuf,
-             PlaneRegion&                                                                      rfull,
-             PlaneRegion&                                                                      rclip,
-             uint16_t                                                                          copysamples)
+             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&    destidx,
+             const TileBuffer&                                                        tilebuf,
+             PlaneRegion&                                                             rfull,
+             PlaneRegion&                                                             rclip,
+             uint16_t                                                                 copysamples)
     {
       // Unpack bits from buffer.
 
@@ -241,8 +241,8 @@ namespace
     template<typename T>
     dimension_size_type
     expected_read(const std::shared_ptr<T>& /* buffer */,
-                  const PlaneRegion&                rclip,
-                  uint16_t                          copysamples) const
+                  const PlaneRegion&        rclip,
+                  uint16_t                  copysamples) const
     {
       return rclip.w * rclip.h * copysamples * sizeof(typename T::value_type);
     }
@@ -250,8 +250,8 @@ namespace
     // Special case for BIT
     dimension_size_type
     expected_read(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type>>& /* buffer */,
-                  const PlaneRegion&                                                                      rclip,
-                  uint16_t                                                                                copysamples) const
+                  const PlaneRegion&                                                             rclip,
+                  uint16_t                                                                       copysamples) const
     {
       dimension_size_type expectedread = rclip.w;
 
@@ -395,11 +395,11 @@ namespace
     template<typename T>
     void
     transfer(const std::shared_ptr<T>& buffer,
-             typename T::indices_type&         srcidx,
-             TileBuffer&                       tilebuf,
-             PlaneRegion&                      rfull,
-             PlaneRegion&                      rclip,
-             uint16_t                          copysamples)
+             typename T::indices_type& srcidx,
+             TileBuffer&               tilebuf,
+             PlaneRegion&              rfull,
+             PlaneRegion&              rclip,
+             uint16_t                  copysamples)
     {
       if (rclip.w == rfull.w &&
           rclip.x == region.x &&
@@ -449,11 +449,11 @@ namespace
     // Special case for BIT
     void
     transfer(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type>>& buffer,
-             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&                   srcidx,
-             TileBuffer&                                                                             tilebuf,
-             PlaneRegion&                                                                            rfull,
-             PlaneRegion&                                                                            rclip,
-             uint16_t                                                                                copysamples)
+             PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&          srcidx,
+             TileBuffer&                                                                    tilebuf,
+             PlaneRegion&                                                                   rfull,
+             PlaneRegion&                                                                   rclip,
+             uint16_t                                                                       copysamples)
     {
       // Pack bits into buffer.
 
@@ -621,7 +621,7 @@ namespace ome
          * @param offset the IFD offset.
          */
         Impl(std::shared_ptr<TIFF>& tiff,
-             offset_type                    offset):
+             offset_type            offset):
           tiff(tiff),
           offset(offset),
           coverage(),
@@ -652,7 +652,7 @@ namespace ome
       };
 
       IFD::IFD(std::shared_ptr<TIFF>& tiff,
-               offset_type                    offset):
+               offset_type            offset):
         // Note boost::make_shared makes arguments const, so can't use
         // here.
         impl(std::shared_ptr<Impl>(new Impl(tiff, offset)))
@@ -672,7 +672,7 @@ namespace ome
 
       std::shared_ptr<IFD>
       IFD::openIndex(std::shared_ptr<TIFF>& tiff,
-                     directory_index_type           index)
+                     directory_index_type   index)
       {
         ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
@@ -688,7 +688,7 @@ namespace ome
 
       std::shared_ptr<IFD>
       IFD::openOffset(std::shared_ptr<TIFF>& tiff,
-                      offset_type                    offset)
+                      offset_type            offset)
       {
         // Note boost::make_shared makes arguments const, so can't use
         // here.

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -267,8 +267,8 @@ namespace
     void
     operator()(std::shared_ptr<T>& buffer)
     {
-      std::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
-      ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+      std::shared_ptr<::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
+      ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
 
       uint16_t samples = ifd.getSamplesPerPixel();
@@ -351,8 +351,8 @@ namespace
     void
     flush()
     {
-      std::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
-      ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+      std::shared_ptr<::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
+      ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
       PlaneRegion rimage(0, 0, ifd.getImageWidth(), ifd.getImageHeight());
       tstrile_t tile = static_cast<tstrile_t>(ifd.getCurrentTile());
@@ -674,7 +674,7 @@ namespace ome
       IFD::openIndex(std::shared_ptr<TIFF>& tiff,
                      directory_index_type           index)
       {
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
 
@@ -707,7 +707,7 @@ namespace ome
       IFD::makeCurrent() const
       {
         std::shared_ptr<TIFF>& tiff = getTIFF();
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
 
@@ -740,7 +740,7 @@ namespace ome
                        ...) const
       {
         std::shared_ptr<TIFF>& tiff = getTIFF();
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
 
@@ -769,7 +769,7 @@ namespace ome
                        ...)
       {
         std::shared_ptr<TIFF>& tiff = getTIFF();
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
 
@@ -1394,7 +1394,7 @@ namespace ome
         std::shared_ptr<IFD> ret;
 
         std::shared_ptr<TIFF>& tiff = getTIFF();
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
 
@@ -1413,7 +1413,7 @@ namespace ome
       IFD::last() const
       {
         std::shared_ptr<TIFF>& tiff = getTIFF();
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
 

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -146,7 +146,7 @@ namespace
 
     template<typename T>
     void
-    transfer(ome::compat::shared_ptr<T>& buffer,
+    transfer(std::shared_ptr<T>& buffer,
              typename T::indices_type&   destidx,
              const TileBuffer&           tilebuf,
              PlaneRegion&                rfull,
@@ -196,7 +196,7 @@ namespace
 
     // Special case for BIT
     void
-    transfer(ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
+    transfer(std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
              PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&             destidx,
              const TileBuffer&                                                                 tilebuf,
              PlaneRegion&                                                                      rfull,
@@ -240,7 +240,7 @@ namespace
 
     template<typename T>
     dimension_size_type
-    expected_read(const ome::compat::shared_ptr<T>& /* buffer */,
+    expected_read(const std::shared_ptr<T>& /* buffer */,
                   const PlaneRegion&                rclip,
                   uint16_t                          copysamples) const
     {
@@ -249,7 +249,7 @@ namespace
 
     // Special case for BIT
     dimension_size_type
-    expected_read(const ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& /* buffer */,
+    expected_read(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& /* buffer */,
                   const PlaneRegion&                                                                      rclip,
                   uint16_t                                                                                copysamples) const
     {
@@ -265,9 +265,9 @@ namespace
 
     template<typename T>
     void
-    operator()(ome::compat::shared_ptr<T>& buffer)
+    operator()(std::shared_ptr<T>& buffer)
     {
-      ome::compat::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
+      std::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
       ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
 
@@ -351,7 +351,7 @@ namespace
     void
     flush()
     {
-      ome::compat::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
+      std::shared_ptr< ::ome::bioformats::tiff::TIFF>& tiff(ifd.getTIFF());
       ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
       PlaneRegion rimage(0, 0, ifd.getImageWidth(), ifd.getImageHeight());
@@ -394,7 +394,7 @@ namespace
 
     template<typename T>
     void
-    transfer(const ome::compat::shared_ptr<T>& buffer,
+    transfer(const std::shared_ptr<T>& buffer,
              typename T::indices_type&         srcidx,
              TileBuffer&                       tilebuf,
              PlaneRegion&                      rfull,
@@ -448,7 +448,7 @@ namespace
 
     // Special case for BIT
     void
-    transfer(const ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
+    transfer(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
              PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&                   srcidx,
              TileBuffer&                                                                             tilebuf,
              PlaneRegion&                                                                            rfull,
@@ -494,7 +494,7 @@ namespace
 
     template<typename T>
     void
-    operator()(const ome::compat::shared_ptr<T>& buffer)
+    operator()(const std::shared_ptr<T>& buffer)
     {
       uint16_t samples = ifd.getSamplesPerPixel();
       PlanarConfiguration planarconfig = ifd.getPlanarConfiguration();
@@ -522,7 +522,7 @@ namespace
           // Note boost::make_shared makes arguments const, so can't use
           // here.
           if (!tilecache.find(tile))
-            tilecache.insert(tile, ome::compat::shared_ptr<TileBuffer>(new TileBuffer(tileinfo.bufferSize())));
+            tilecache.insert(tile, std::shared_ptr<TileBuffer>(new TileBuffer(tileinfo.bufferSize())));
           assert(tilecache.find(tile));
           TileBuffer& tilebuf = *tilecache.find(tile);
 
@@ -558,13 +558,13 @@ namespace ome
         class IFDConcrete : public IFD
         {
         public:
-          IFDConcrete(ome::compat::shared_ptr<TIFF>& tiff,
+          IFDConcrete(std::shared_ptr<TIFF>& tiff,
                       offset_type            offset):
             IFD(tiff, offset)
           {
           }
 
-          IFDConcrete(ome::compat::shared_ptr<TIFF>& tiff):
+          IFDConcrete(std::shared_ptr<TIFF>& tiff):
             IFD(tiff, 0)
           {
           }
@@ -584,7 +584,7 @@ namespace ome
       {
       public:
         /// Reference to the parent TIFF.
-        ome::compat::shared_ptr<TIFF> tiff;
+        std::shared_ptr<TIFF> tiff;
         /// Offset of this IFD.
         offset_type offset;
         /// Tile coverage cache (used when writing).
@@ -620,7 +620,7 @@ namespace ome
          * @param tiff the parent TIFF.
          * @param offset the IFD offset.
          */
-        Impl(ome::compat::shared_ptr<TIFF>& tiff,
+        Impl(std::shared_ptr<TIFF>& tiff,
              offset_type                    offset):
           tiff(tiff),
           offset(offset),
@@ -651,18 +651,18 @@ namespace ome
         operator= (const Impl&);
       };
 
-      IFD::IFD(ome::compat::shared_ptr<TIFF>& tiff,
+      IFD::IFD(std::shared_ptr<TIFF>& tiff,
                offset_type                    offset):
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        impl(ome::compat::shared_ptr<Impl>(new Impl(tiff, offset)))
+        impl(std::shared_ptr<Impl>(new Impl(tiff, offset)))
       {
       }
 
-      IFD::IFD(ome::compat::shared_ptr<TIFF>& tiff):
+      IFD::IFD(std::shared_ptr<TIFF>& tiff):
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        impl(ome::compat::shared_ptr<Impl>(new Impl(tiff, 0)))
+        impl(std::shared_ptr<Impl>(new Impl(tiff, 0)))
       {
       }
 
@@ -670,8 +670,8 @@ namespace ome
       {
       }
 
-      ome::compat::shared_ptr<IFD>
-      IFD::openIndex(ome::compat::shared_ptr<TIFF>& tiff,
+      std::shared_ptr<IFD>
+      IFD::openIndex(std::shared_ptr<TIFF>& tiff,
                      directory_index_type           index)
       {
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
@@ -686,27 +686,27 @@ namespace ome
         return openOffset(tiff, static_cast<uint64_t>(TIFFCurrentDirOffset(tiffraw)));
       }
 
-      ome::compat::shared_ptr<IFD>
-      IFD::openOffset(ome::compat::shared_ptr<TIFF>& tiff,
+      std::shared_ptr<IFD>
+      IFD::openOffset(std::shared_ptr<TIFF>& tiff,
                       offset_type                    offset)
       {
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        return ome::compat::shared_ptr<IFD>(new IFDConcrete(tiff, offset));
+        return std::shared_ptr<IFD>(new IFDConcrete(tiff, offset));
       }
 
-      ome::compat::shared_ptr<IFD>
-      IFD::current(ome::compat::shared_ptr<TIFF>& tiff)
+      std::shared_ptr<IFD>
+      IFD::current(std::shared_ptr<TIFF>& tiff)
       {
         // Note boost::make_shared makes arguments const, so can't use
         // here.
-        return ome::compat::shared_ptr<IFD>(new IFDConcrete(tiff));
+        return std::shared_ptr<IFD>(new IFDConcrete(tiff));
       }
 
       void
       IFD::makeCurrent() const
       {
-        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
+        std::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -723,7 +723,7 @@ namespace ome
           }
       }
 
-      ome::compat::shared_ptr<TIFF>&
+      std::shared_ptr<TIFF>&
       IFD::getTIFF() const
       {
         return impl->tiff;
@@ -739,7 +739,7 @@ namespace ome
       IFD::getRawField(tag_type tag,
                        ...) const
       {
-        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
+        std::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -768,7 +768,7 @@ namespace ome
       IFD::setRawField(tag_type tag,
                        ...)
       {
-        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
+        std::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -1266,8 +1266,8 @@ namespace ome
 
         buf.setBuffer(shape, PixelType::UINT16, order_planar);
 
-        ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > uint16_buffer
-          (boost::get<ome::compat::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > >(buf.vbuffer()));
+        std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > uint16_buffer
+          (boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > >(buf.vbuffer()));
         assert(uint16_buffer);
 
         for (VariantPixelBuffer::size_type s = 0U; s < shape[DIM_SUBCHANNEL]; ++s)
@@ -1388,12 +1388,12 @@ namespace ome
         throw Exception("Writing subchannels separately is not yet implemented (requires TileCache and WriteVisitor to handle writing and caching of interleaved and non-interleaved subchannels; currently it handles writing all subchannels in one call only and can not combine separate subchannels from separate calls");
       }
 
-      ome::compat::shared_ptr<IFD>
+      std::shared_ptr<IFD>
       IFD::next() const
       {
-        ome::compat::shared_ptr<IFD> ret;
+        std::shared_ptr<IFD> ret;
 
-        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
+        std::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;
@@ -1412,7 +1412,7 @@ namespace ome
       bool
       IFD::last() const
       {
-        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
+        std::shared_ptr<TIFF>& tiff = getTIFF();
         ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
 
         Sentry sentry;

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -1206,7 +1206,7 @@ namespace ome
         PlanarConfiguration planarconfig = getPlanarConfiguration();
         uint16_t subC = getSamplesPerPixel();
 
-        ome::compat::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
+        std::array<VariantPixelBuffer::size_type, 9> shape, dest_shape;
         shape[DIM_SPATIAL_X] = w;
         shape[DIM_SPATIAL_Y] = h;
         shape[DIM_SUBCHANNEL] = subC;
@@ -1252,10 +1252,10 @@ namespace ome
       void
       IFD::readLookupTable(VariantPixelBuffer& buf) const
       {
-        ome::compat::array<std::vector<uint16_t>, 3> cmap;
+        std::array<std::vector<uint16_t>, 3> cmap;
         getField(tiff::COLORMAP).get(cmap);
 
-        ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+        std::array<VariantPixelBuffer::size_type, 9> shape;
         shape[DIM_SPATIAL_X] = cmap.at(0).size();
         shape[DIM_SPATIAL_Y] = 1;
         shape[DIM_SUBCHANNEL] = cmap.size();
@@ -1312,7 +1312,7 @@ namespace ome
         PlanarConfiguration planarconfig = getPlanarConfiguration();
         uint16_t subC = getSamplesPerPixel();
 
-        ome::compat::array<VariantPixelBuffer::size_type, 9> shape, source_shape;
+        std::array<VariantPixelBuffer::size_type, 9> shape, source_shape;
         shape[DIM_SPATIAL_X] = w;
         shape[DIM_SPATIAL_Y] = h;
         shape[DIM_SUBCHANNEL] = subC;

--- a/cpp/lib/ome/bioformats/tiff/IFD.cpp
+++ b/cpp/lib/ome/bioformats/tiff/IFD.cpp
@@ -196,7 +196,7 @@ namespace
 
     // Special case for BIT
     void
-    transfer(std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
+    transfer(std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type>>& buffer,
              PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&             destidx,
              const TileBuffer&                                                                 tilebuf,
              PlaneRegion&                                                                      rfull,
@@ -249,7 +249,7 @@ namespace
 
     // Special case for BIT
     dimension_size_type
-    expected_read(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& /* buffer */,
+    expected_read(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type>>& /* buffer */,
                   const PlaneRegion&                                                                      rclip,
                   uint16_t                                                                                copysamples) const
     {
@@ -448,7 +448,7 @@ namespace
 
     // Special case for BIT
     void
-    transfer(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type> >& buffer,
+    transfer(const std::shared_ptr<PixelBuffer<PixelProperties<PixelType::BIT>::std_type>>& buffer,
              PixelBuffer<PixelProperties<PixelType::BIT>::std_type>::indices_type&                   srcidx,
              TileBuffer&                                                                             tilebuf,
              PlaneRegion&                                                                            rfull,
@@ -1266,8 +1266,8 @@ namespace ome
 
         buf.setBuffer(shape, PixelType::UINT16, order_planar);
 
-        std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > uint16_buffer
-          (boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> > >(buf.vbuffer()));
+        std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type>> uint16_buffer
+          (boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type>>>(buf.vbuffer()));
         assert(uint16_buffer);
 
         for (VariantPixelBuffer::size_type s = 0U; s < shape[DIM_SUBCHANNEL]; ++s)

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -38,9 +38,8 @@
 #ifndef OME_BIOFORMATS_TIFF_IFD_H
 #define OME_BIOFORMATS_TIFF_IFD_H
 
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/bioformats/CoreMetadata.h>
 #include <ome/bioformats/TileCoverage.h>
@@ -68,20 +67,20 @@ namespace ome
        *
        * An IFD represents a subfile within a TIFF.
        */
-      class IFD : public ome::compat::enable_shared_from_this<IFD>
+      class IFD : public std::enable_shared_from_this<IFD>
       {
       private:
         class Impl;
         /// Private implementation details.
-        ome::compat::shared_ptr<Impl> impl;
+        std::shared_ptr<Impl> impl;
 
       protected:
         /// Constructor (not public).
-        IFD(ome::compat::shared_ptr<TIFF>& tiff,
+        IFD(std::shared_ptr<TIFF>& tiff,
             offset_type                    offset);
 
         /// Constructor (not public).
-        IFD(ome::compat::shared_ptr<TIFF>& tiff);
+        IFD(std::shared_ptr<TIFF>& tiff);
 
       private:
         /// Copy constructor (deleted).
@@ -102,8 +101,8 @@ namespace ome
          * @param index the directory index.
          * @returns the open IFD.
          */
-        static ome::compat::shared_ptr<IFD>
-        openIndex(ome::compat::shared_ptr<TIFF>& tiff,
+        static std::shared_ptr<IFD>
+        openIndex(std::shared_ptr<TIFF>& tiff,
                   directory_index_type           index);
 
         /**
@@ -113,8 +112,8 @@ namespace ome
          * @param offset the directory offset.
          * @returns the open IFD.
          */
-        static ome::compat::shared_ptr<IFD>
-        openOffset(ome::compat::shared_ptr<TIFF>& tiff,
+        static std::shared_ptr<IFD>
+        openOffset(std::shared_ptr<TIFF>& tiff,
                    offset_type                    offset);
 
         /**
@@ -123,15 +122,15 @@ namespace ome
          * @param tiff the source TIFF.
          * @returns the open IFD.
          */
-        static ome::compat::shared_ptr<IFD>
-        current(ome::compat::shared_ptr<TIFF>& tiff);
+        static std::shared_ptr<IFD>
+        current(std::shared_ptr<TIFF>& tiff);
 
         /**
          * Get the source TIFF this descriptor belongs to.
          *
          * @returns the source TIFF.
          */
-        ome::compat::shared_ptr<TIFF>&
+        std::shared_ptr<TIFF>&
         getTIFF() const;
 
         /**
@@ -543,7 +542,7 @@ namespace ome
          *
          * @returns the next directory, or null if this is the last directory.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         next() const;
 
         /**

--- a/cpp/lib/ome/bioformats/tiff/IFD.h
+++ b/cpp/lib/ome/bioformats/tiff/IFD.h
@@ -77,7 +77,7 @@ namespace ome
       protected:
         /// Constructor (not public).
         IFD(std::shared_ptr<TIFF>& tiff,
-            offset_type                    offset);
+            offset_type           offset);
 
         /// Constructor (not public).
         IFD(std::shared_ptr<TIFF>& tiff);
@@ -103,7 +103,7 @@ namespace ome
          */
         static std::shared_ptr<IFD>
         openIndex(std::shared_ptr<TIFF>& tiff,
-                  directory_index_type           index);
+                  directory_index_type   index);
 
         /**
          * Open an IFD.
@@ -114,7 +114,7 @@ namespace ome
          */
         static std::shared_ptr<IFD>
         openOffset(std::shared_ptr<TIFF>& tiff,
-                   offset_type                    offset);
+                   offset_type            offset);
 
         /**
          * Get the current IFD.

--- a/cpp/lib/ome/bioformats/tiff/Sentry.h
+++ b/cpp/lib/ome/bioformats/tiff/Sentry.h
@@ -39,12 +39,11 @@
 #define OME_BIOFORMATS_TIFF_SENTRY_H
 
 #include <cstdarg>
+#include <cstdint>
 #include <memory>
 #include <string>
 
 #include <boost/thread.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/tiff/Sentry.h
+++ b/cpp/lib/ome/bioformats/tiff/Sentry.h
@@ -39,12 +39,12 @@
 #define OME_BIOFORMATS_TIFF_SENTRY_H
 
 #include <cstdarg>
+#include <memory>
 #include <string>
 
 #include <boost/thread.hpp>
 
 #include <ome/compat/cstdint.h>
-#include <ome/compat/memory.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -352,7 +352,7 @@ namespace ome
             }
           };
 
-        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(getWrapped());
+        ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(getWrapped());
 
         Sentry sentry;
 

--- a/cpp/lib/ome/bioformats/tiff/TIFF.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.cpp
@@ -191,7 +191,7 @@ namespace ome
       // Note boost::make_shared can't be used here.
       TIFF::TIFF(const boost::filesystem::path& filename,
                  const std::string&             mode):
-        impl(ome::compat::shared_ptr<Impl>(new Impl(filename, mode)))
+        impl(std::shared_ptr<Impl>(new Impl(filename, mode)))
       {
         registerImageJTags();
       }
@@ -206,15 +206,15 @@ namespace ome
         return reinterpret_cast<wrapped_type *>(impl->tiff);
       }
 
-      ome::compat::shared_ptr<TIFF>
+      std::shared_ptr<TIFF>
       TIFF::open(const boost::filesystem::path& filename,
                  const std::string& mode)
       {
-        ome::compat::shared_ptr<TIFF> ret;
+        std::shared_ptr<TIFF> ret;
         try
           {
             // Note boost::make_shared can't be used here.
-            ret = ome::compat::shared_ptr<TIFF>(new TIFFConcrete(filename, mode));
+            ret = std::shared_ptr<TIFF>(new TIFFConcrete(filename, mode));
           }
         catch (const std::exception& e)
           {
@@ -249,7 +249,7 @@ namespace ome
         return impl->directoryCount;
       }
 
-      ome::compat::shared_ptr<IFD>
+      std::shared_ptr<IFD>
       TIFF::getDirectoryByIndex(directory_index_type index) const
       {
         Sentry sentry;
@@ -257,11 +257,11 @@ namespace ome
         if (!TIFFSetDirectory(impl->tiff, index))
           sentry.error();
 
-        ome::compat::shared_ptr<TIFF> t(ome::compat::const_pointer_cast<TIFF>(shared_from_this()));
+        std::shared_ptr<TIFF> t(std::const_pointer_cast<TIFF>(shared_from_this()));
         return IFD::openIndex(t, index);
       }
 
-      ome::compat::shared_ptr<IFD>
+      std::shared_ptr<IFD>
       TIFF::getDirectoryByOffset(offset_type offset) const
       {
         Sentry sentry;
@@ -274,14 +274,14 @@ namespace ome
           sentry.error();
 #endif // TIFF_HAVE_BIGTIFF
 
-        ome::compat::shared_ptr<TIFF> t(ome::compat::const_pointer_cast<TIFF>(shared_from_this()));
+        std::shared_ptr<TIFF> t(std::const_pointer_cast<TIFF>(shared_from_this()));
         return IFD::openOffset(t, offset);
       }
 
-      ome::compat::shared_ptr<IFD>
+      std::shared_ptr<IFD>
       TIFF::getCurrentDirectory() const
       {
-        ome::compat::shared_ptr<TIFF> t(ome::compat::const_pointer_cast<TIFF>(shared_from_this()));
+        std::shared_ptr<TIFF> t(std::const_pointer_cast<TIFF>(shared_from_this()));
         return IFD::current(t);
       }
 
@@ -300,14 +300,14 @@ namespace ome
       TIFF::iterator
       TIFF::begin()
       {
-        ome::compat::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
+        std::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
         return iterator(ifd);
       }
 
       TIFF::const_iterator
       TIFF::begin() const
       {
-        ome::compat::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
+        std::shared_ptr<IFD> ifd(getDirectoryByIndex(0U));
         return const_iterator(ifd);
       }
 

--- a/cpp/lib/ome/bioformats/tiff/TIFF.h
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_TIFF_TIFF_H
 #define OME_BIOFORMATS_TIFF_TIFF_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -46,8 +47,6 @@
 #include <ome/bioformats/tiff/Types.h>
 
 #include <ome/common/filesystem.h>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/tiff/TIFF.h
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.h
@@ -275,7 +275,7 @@ namespace ome
          * correct type:
          *
          * @verbatim
-         * ::TIFF *tiff = reinterpret_cast< ::TIFF *>(myfile.getWrapped());
+         * ::TIFF *tiff = reinterpret_cast<::TIFF *>(myfile.getWrapped());
          * @endverbatim
          *
          * @returns an opaque pointer to the wrapped @c \::TIFF

--- a/cpp/lib/ome/bioformats/tiff/TIFF.h
+++ b/cpp/lib/ome/bioformats/tiff/TIFF.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_TIFF_TIFF_H
 #define OME_BIOFORMATS_TIFF_TIFF_H
 
+#include <memory>
 #include <string>
 
 #include <boost/iterator/iterator_facade.hpp>
@@ -47,7 +48,6 @@
 #include <ome/common/filesystem.h>
 
 #include <ome/compat/cstdint.h>
-#include <ome/compat/memory.h>
 
 namespace ome
 {
@@ -66,7 +66,7 @@ namespace ome
        */
       template<typename Value>
       class IFDIterator : public boost::iterator_facade<IFDIterator<Value>,
-                                                        ome::compat::shared_ptr<Value>,
+                                                        std::shared_ptr<Value>,
                                                         boost::forward_traversal_tag>
       {
       public:
@@ -86,7 +86,7 @@ namespace ome
          *
          * @param ifd the descriptor to point to.
          */
-        IFDIterator(ome::compat::shared_ptr<IFD>& ifd):
+        IFDIterator(std::shared_ptr<IFD>& ifd):
           pos(ifd)
         {}
 
@@ -106,7 +106,7 @@ namespace ome
          * It's mutable to allow const and non-const access to the
          * underlying descriptor via const and non-const iterators.
          */
-        mutable ome::compat::shared_ptr<Value> pos;
+        mutable std::shared_ptr<Value> pos;
 
         friend class boost::iterator_core_access;
         template <class> friend class IFDIterator;
@@ -138,7 +138,7 @@ namespace ome
          *
          * @returns a reference to currently referenced descriptor.
          */
-        ome::compat::shared_ptr<Value>&
+        std::shared_ptr<Value>&
         dereference() const
         {
           return pos;
@@ -153,13 +153,13 @@ namespace ome
        * instance.  This instance may be used to get IFD instances and
        * then access to image metadata and pixel data.
        */
-      class TIFF : public ome::compat::enable_shared_from_this<TIFF>
+      class TIFF : public std::enable_shared_from_this<TIFF>
       {
       private:
         class Impl;
         class wrapped_type;
         /// Private implementation details.
-        ome::compat::shared_ptr<Impl> impl;
+        std::shared_ptr<Impl> impl;
 
       protected:
         /// Constructor (non-public).
@@ -190,7 +190,7 @@ namespace ome
          * @returns the the open TIFF.
          * @throws an Exception on failure.
          */
-        static ome::compat::shared_ptr<TIFF>
+        static std::shared_ptr<TIFF>
         open(const boost::filesystem::path& filename,
              const std::string&             mode);
 
@@ -228,7 +228,7 @@ namespace ome
          * @throws an Exception if the index is invalid or could not
          * be accessed.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         getDirectoryByIndex(directory_index_type index) const;
 
         /**
@@ -239,7 +239,7 @@ namespace ome
          * @throws an Exception if the offset is invalid or could not
          * be accessed.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         getDirectoryByOffset(offset_type offset) const;
 
         /**
@@ -248,7 +248,7 @@ namespace ome
          * @returns the IFD.
          * @throws an Exception if the IFD could not be accessed.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         getCurrentDirectory() const;
 
         /**

--- a/cpp/lib/ome/bioformats/tiff/Tags.h
+++ b/cpp/lib/ome/bioformats/tiff/Tags.h
@@ -38,6 +38,7 @@
 #ifndef OME_BIOFORMATS_TIFF_TAGS_H
 #define OME_BIOFORMATS_TIFF_TAGS_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -45,7 +46,6 @@
 #include <ome/bioformats/tiff/Types.h>
 
 #include <ome/compat/array.h>
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/tiff/Tags.h
+++ b/cpp/lib/ome/bioformats/tiff/Tags.h
@@ -38,14 +38,13 @@
 #ifndef OME_BIOFORMATS_TIFF_TAGS_H
 #define OME_BIOFORMATS_TIFF_TAGS_H
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <ome/bioformats/tiff/Types.h>
-
-#include <ome/compat/array.h>
 
 namespace ome
 {
@@ -635,7 +634,7 @@ namespace ome
         struct TagProperties<::ome::bioformats::tiff::UInt16Tag2>
         {
           /// uint16_t array type.
-          typedef ome::compat::array<uint16_t, 2> value_type;
+          typedef std::array<uint16_t, 2> value_type;
         };
 
         /// Properties of UInt16Tag6 tags.
@@ -643,7 +642,7 @@ namespace ome
         struct TagProperties<::ome::bioformats::tiff::UInt16Tag6>
         {
           /// uint16 array type.
-          typedef ome::compat::array<uint16_t, 6> value_type;
+          typedef std::array<uint16_t, 6> value_type;
         };
 
         /// Properties of UInt16ExtraSamplesArray1 tags.
@@ -659,7 +658,7 @@ namespace ome
         struct TagProperties<::ome::bioformats::tiff::UInt16TagArray3>
         {
           /// uint16_t array type.
-          typedef ome::compat::array<std::vector<uint16_t>, 3> value_type;
+          typedef std::array<std::vector<uint16_t>, 3> value_type;
         };
 
         /// Properties of UInt32Tag1 tags.
@@ -707,7 +706,7 @@ namespace ome
         struct TagProperties<::ome::bioformats::tiff::FloatTag2>
         {
           /// float array type.
-          typedef ome::compat::array<float, 2> value_type;
+          typedef std::array<float, 2> value_type;
         };
 
         /// Properties of FloatTag3 tags.
@@ -715,7 +714,7 @@ namespace ome
         struct TagProperties<::ome::bioformats::tiff::FloatTag3>
         {
           /// float array type.
-          typedef ome::compat::array<float, 3> value_type;
+          typedef std::array<float, 3> value_type;
         };
 
         /// Properties of FloatTag6 tags.
@@ -723,7 +722,7 @@ namespace ome
         struct TagProperties<::ome::bioformats::tiff::FloatTag6>
         {
           /// float array type.
-          typedef ome::compat::array<float, 6> value_type;
+          typedef std::array<float, 6> value_type;
         };
 
       }

--- a/cpp/lib/ome/bioformats/tiff/Tags.h
+++ b/cpp/lib/ome/bioformats/tiff/Tags.h
@@ -38,12 +38,11 @@
 #ifndef OME_BIOFORMATS_TIFF_TAGS_H
 #define OME_BIOFORMATS_TIFF_TAGS_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <ome/bioformats/tiff/Types.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/compat/array.h>
 #include <ome/compat/cstdint.h>

--- a/cpp/lib/ome/bioformats/tiff/Tags.h
+++ b/cpp/lib/ome/bioformats/tiff/Tags.h
@@ -528,7 +528,7 @@ namespace ome
 
         /// Properties of StringTag1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::StringTag1>
+        struct TagProperties<::ome::bioformats::tiff::StringTag1>
         {
           /// string type.
           typedef std::string value_type;
@@ -536,7 +536,7 @@ namespace ome
 
         /// Properties of StringTagArray1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::StringTagArray1>
+        struct TagProperties<::ome::bioformats::tiff::StringTagArray1>
         {
           /// string type.
           typedef std::vector<std::string> value_type;
@@ -544,7 +544,7 @@ namespace ome
 
         /// Properties of UInt16Tag1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Tag1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Tag1>
         {
           /// uint16_t type.
           typedef uint16_t value_type;
@@ -552,7 +552,7 @@ namespace ome
 
         /// Properties of UInt16TagArray1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16TagArray1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16TagArray1>
         {
           /// uint16_t vector type.
           typedef std::vector<uint16_t> value_type;
@@ -560,7 +560,7 @@ namespace ome
 
         /// Properties of UInt16Compression1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Compression1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Compression1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::Compression value_type;
@@ -568,7 +568,7 @@ namespace ome
 
         /// Properties of UInt16FillOrder1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16FillOrder1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16FillOrder1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::FillOrder value_type;
@@ -576,7 +576,7 @@ namespace ome
 
         /// Properties of UInt16Orientation1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Orientation1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Orientation1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::Orientation value_type;
@@ -584,7 +584,7 @@ namespace ome
 
         /// Properties of UInt16PhotometricInterpretation1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16PhotometricInterpretation1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16PhotometricInterpretation1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::PhotometricInterpretation value_type;
@@ -592,7 +592,7 @@ namespace ome
 
         /// Properties of UInt16PlanarConfiguration1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16PlanarConfiguration1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16PlanarConfiguration1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::PlanarConfiguration value_type;
@@ -600,7 +600,7 @@ namespace ome
 
         /// Properties of UInt16Predictor1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Predictor1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Predictor1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::Predictor value_type;
@@ -608,7 +608,7 @@ namespace ome
 
         /// Properties of UInt16SampleFormat1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16SampleFormat1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16SampleFormat1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::SampleFormat value_type;
@@ -616,7 +616,7 @@ namespace ome
 
         /// Properties of UInt16Threshholding1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Threshholding1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Threshholding1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::Threshholding value_type;
@@ -624,7 +624,7 @@ namespace ome
 
         /// Properties of UInt16YCbCrPosition1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16YCbCrPosition1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16YCbCrPosition1>
         {
           /// uint16_t type.
           typedef ::ome::bioformats::tiff::YCbCrPosition value_type;
@@ -632,7 +632,7 @@ namespace ome
 
         /// Properties of UInt16Tag2 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Tag2>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Tag2>
         {
           /// uint16_t array type.
           typedef ome::compat::array<uint16_t, 2> value_type;
@@ -640,7 +640,7 @@ namespace ome
 
         /// Properties of UInt16Tag6 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16Tag6>
+        struct TagProperties<::ome::bioformats::tiff::UInt16Tag6>
         {
           /// uint16 array type.
           typedef ome::compat::array<uint16_t, 6> value_type;
@@ -648,15 +648,15 @@ namespace ome
 
         /// Properties of UInt16ExtraSamplesArray1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16ExtraSamplesArray1>
+        struct TagProperties<::ome::bioformats::tiff::UInt16ExtraSamplesArray1>
         {
           /// uint16_t vector type.
-          typedef std::vector< ::ome::bioformats::tiff::ExtraSamples> value_type;
+          typedef std::vector<::ome::bioformats::tiff::ExtraSamples> value_type;
         };
 
         /// Properties of UInt16TagArray3 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt16TagArray3>
+        struct TagProperties<::ome::bioformats::tiff::UInt16TagArray3>
         {
           /// uint16_t array type.
           typedef ome::compat::array<std::vector<uint16_t>, 3> value_type;
@@ -664,7 +664,7 @@ namespace ome
 
         /// Properties of UInt32Tag1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt32Tag1>
+        struct TagProperties<::ome::bioformats::tiff::UInt32Tag1>
         {
           /// uint32_t type.
           typedef uint32_t value_type;
@@ -672,7 +672,7 @@ namespace ome
 
         /// Properties of UInt32TagArray1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt32TagArray1>
+        struct TagProperties<::ome::bioformats::tiff::UInt32TagArray1>
         {
           /// uint32_t vector type.
           typedef std::vector<uint32_t> value_type;
@@ -680,7 +680,7 @@ namespace ome
 
         /// Properties of UInt64TagArray1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::UInt64TagArray1>
+        struct TagProperties<::ome::bioformats::tiff::UInt64TagArray1>
         {
           /// uint64_t vector type.
           typedef std::vector<uint64_t> value_type;
@@ -688,7 +688,7 @@ namespace ome
 
         /// Properties of RawDataTag1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::RawDataTag1>
+        struct TagProperties<::ome::bioformats::tiff::RawDataTag1>
         {
           /// uint32_t vector type.
           typedef std::vector<uint8_t> value_type;
@@ -696,7 +696,7 @@ namespace ome
 
         /// Properties of FloatTag1 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::FloatTag1>
+        struct TagProperties<::ome::bioformats::tiff::FloatTag1>
         {
           /// float type.
           typedef float value_type;
@@ -704,7 +704,7 @@ namespace ome
 
         /// Properties of FloatTag2 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::FloatTag2>
+        struct TagProperties<::ome::bioformats::tiff::FloatTag2>
         {
           /// float array type.
           typedef ome::compat::array<float, 2> value_type;
@@ -712,7 +712,7 @@ namespace ome
 
         /// Properties of FloatTag3 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::FloatTag3>
+        struct TagProperties<::ome::bioformats::tiff::FloatTag3>
         {
           /// float array type.
           typedef ome::compat::array<float, 3> value_type;
@@ -720,7 +720,7 @@ namespace ome
 
         /// Properties of FloatTag6 tags.
         template<>
-        struct TagProperties< ::ome::bioformats::tiff::FloatTag6>
+        struct TagProperties<::ome::bioformats::tiff::FloatTag6>
         {
           /// float array type.
           typedef ome::compat::array<float, 6> value_type;

--- a/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
@@ -168,7 +168,7 @@ namespace ome
         getTIFF()
         {
           getIFD()->makeCurrent();
-          ::TIFF *tiff = reinterpret_cast< ::TIFF *>(getIFD()->getTIFF()->getWrapped());
+          ::TIFF *tiff = reinterpret_cast<::TIFF *>(getIFD()->getTIFF()->getWrapped());
           return tiff;
         }
       };

--- a/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.cpp
@@ -63,7 +63,7 @@ namespace ome
       {
       public:
         /// Weak reference to the parent IFD.
-        ome::compat::weak_ptr<IFD>  ifd;
+        std::weak_ptr<IFD>  ifd;
         /// Whether the image is chunky or planar.
         TileType type;
         /// Width of a tile.
@@ -90,7 +90,7 @@ namespace ome
          *
          * @param ifd the directory the tile belongs to.
          */
-        Impl(ome::compat::shared_ptr<IFD>& ifd):
+        Impl(std::shared_ptr<IFD>& ifd):
           ifd(ifd),
           tilewidth(),
           tileheight(),
@@ -147,10 +147,10 @@ namespace ome
          *
          * @returns the directory.
          */
-        ome::compat::shared_ptr<IFD>
+        std::shared_ptr<IFD>
         getIFD() const
         {
-          ome::compat::shared_ptr<IFD> sifd = ome::compat::shared_ptr<IFD>(ifd);
+          std::shared_ptr<IFD> sifd = std::shared_ptr<IFD>(ifd);
           if (!sifd)
             throw Exception("TileInfo reference to IFD no longer valid");
 
@@ -173,8 +173,8 @@ namespace ome
         }
       };
 
-      TileInfo::TileInfo(ome::compat::shared_ptr<IFD> ifd):
-        impl(ome::compat::shared_ptr<Impl>(new Impl(ifd)))
+      TileInfo::TileInfo(std::shared_ptr<IFD> ifd):
+        impl(std::shared_ptr<Impl>(new Impl(ifd)))
       {
       }
 

--- a/cpp/lib/ome/bioformats/tiff/TileInfo.h
+++ b/cpp/lib/ome/bioformats/tiff/TileInfo.h
@@ -38,10 +38,10 @@
 #ifndef OME_BIOFORMATS_TIFF_TILEINFO_H
 #define OME_BIOFORMATS_TIFF_TILEINFO_H
 
+#include <memory>
+
 #include <ome/bioformats/PlaneRegion.h>
 #include <ome/bioformats/tiff/Types.h>
-
-#include <ome/compat/memory.h>
 
 namespace ome
 {
@@ -68,7 +68,7 @@ namespace ome
          *
          * @param ifd the directory the tile belongs to.
          */
-        TileInfo(ome::compat::shared_ptr<IFD> ifd);
+        TileInfo(std::shared_ptr<IFD> ifd);
 
       public:
         /// Destructor.
@@ -227,7 +227,7 @@ namespace ome
       protected:
         class Impl;
         /// Private implementation details.
-        ome::compat::shared_ptr<Impl> impl;
+        std::shared_ptr<Impl> impl;
       };
 
     }

--- a/cpp/lib/ome/bioformats/tiff/Types.h
+++ b/cpp/lib/ome/bioformats/tiff/Types.h
@@ -40,7 +40,7 @@
 
 #include <ome/bioformats/Types.h>
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/bioformats/tiff/Util.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Util.cpp
@@ -180,7 +180,7 @@ namespace ome
           {
             try
               {
-                ome::compat::array<std::vector<uint16_t>, 3> cmap;
+                std::array<std::vector<uint16_t>, 3> cmap;
                 ifd.getField(tiff::COLORMAP).get(cmap);
                 core.indexed = true;
               }

--- a/cpp/lib/ome/bioformats/tiff/Util.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Util.cpp
@@ -133,10 +133,10 @@ namespace ome
 
       }
 
-      ome::compat::shared_ptr<CoreMetadata>
+      std::shared_ptr<CoreMetadata>
       makeCoreMetadata(const IFD& ifd)
       {
-        ome::compat::shared_ptr<CoreMetadata> m(ome::compat::make_shared<CoreMetadata>());
+        std::shared_ptr<CoreMetadata> m(std::make_shared<CoreMetadata>());
         getCoreMetadata(ifd, *m);
         return m;
       }

--- a/cpp/lib/ome/bioformats/tiff/Util.h
+++ b/cpp/lib/ome/bioformats/tiff/Util.h
@@ -38,12 +38,11 @@
 #ifndef OME_BIOFORMATS_TIFF_UTIL_H
 #define OME_BIOFORMATS_TIFF_UTIL_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <ome/common/filesystem.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/bioformats/CoreMetadata.h>
 #include <ome/bioformats/TileCoverage.h>
@@ -71,7 +70,7 @@ namespace ome
        * @param ifd the IFD to use.
        * @returns the CoreMetadata.
        */
-      ome::compat::shared_ptr<CoreMetadata>
+      std::shared_ptr<CoreMetadata>
       makeCoreMetadata(const IFD& ifd);
 
       /**

--- a/cpp/lib/ome/qtwidgets/GLView2D.cpp
+++ b/cpp/lib/ome/qtwidgets/GLView2D.cpp
@@ -74,7 +74,7 @@ namespace ome
   namespace qtwidgets
   {
 
-    GLView2D::GLView2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+    GLView2D::GLView2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                        ome::bioformats::dimension_size_type                    series,
                        QWidget                                                * /* parent */):
       GLWindow(),
@@ -109,7 +109,7 @@ namespace ome
       return QSize(800, 600);
     }
 
-    ome::compat::shared_ptr<ome::bioformats::FormatReader>
+    std::shared_ptr<ome::bioformats::FormatReader>
     GLView2D::getReader()
     {
       return reader;

--- a/cpp/lib/ome/qtwidgets/GLView2D.h
+++ b/cpp/lib/ome/qtwidgets/GLView2D.h
@@ -39,9 +39,9 @@
 #ifndef OME_QTWIDGETS_GLVIEW2D_H
 #define OME_QTWIDGETS_GLVIEW2D_H
 
-#include <ome/bioformats/FormatReader.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/bioformats/FormatReader.h>
 
 #include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/GLWindow.h>
@@ -82,7 +82,7 @@ namespace ome
        * @param series the image series.
        * @param parent the parent of this object.
        */
-      GLView2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+      GLView2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                ome::bioformats::dimension_size_type                    series,
                QWidget                                                *parent = 0);
 
@@ -174,7 +174,7 @@ namespace ome
        *
        * @returns the reader.
        */
-      ome::compat::shared_ptr<ome::bioformats::FormatReader>
+      std::shared_ptr<ome::bioformats::FormatReader>
       getReader();
 
       /**
@@ -455,7 +455,7 @@ namespace ome
       /// Grid to render.
       gl::Grid2D *grid;
       /// The image reader.
-      ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
+      std::shared_ptr<ome::bioformats::FormatReader> reader;
       /// The image series.
       ome::bioformats::dimension_size_type series;
     };

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -228,7 +228,7 @@ namespace ome
               dimension_size_type mt = reader->getModuloT().size();
               dimension_size_type mc = reader->getModuloC().size();
 
-              ome::compat::array<dimension_size_type, 3> coords(reader->getZCTCoords(plane));
+              std::array<dimension_size_type, 3> coords(reader->getZCTCoords(plane));
               reader->setSeries(oldseries);
 
               // Effective and modulo dimension positions

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -137,8 +137,8 @@ namespace ome
 
     void
     NavigationDock2D::setReader(std::shared_ptr<ome::bioformats::FormatReader> reader,
-                                ome::bioformats::dimension_size_type                   series,
-                                ome::bioformats::dimension_size_type                   plane)
+                                ome::bioformats::dimension_size_type           series,
+                                ome::bioformats::dimension_size_type           plane)
     {
       this->reader = reader;
       this->series = series;

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.cpp
@@ -136,7 +136,7 @@ namespace ome
     }
 
     void
-    NavigationDock2D::setReader(ome::compat::shared_ptr<ome::bioformats::FormatReader> reader,
+    NavigationDock2D::setReader(std::shared_ptr<ome::bioformats::FormatReader> reader,
                                 ome::bioformats::dimension_size_type                   series,
                                 ome::bioformats::dimension_size_type                   plane)
     {

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.h
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.h
@@ -39,9 +39,9 @@
 #ifndef OME_QTWIDGETS_NAVIGATIONDOCK2D_H
 #define OME_QTWIDGETS_NAVIGATIONDOCK2D_H
 
-#include <ome/bioformats/FormatReader.h>
+#include <memory>
 
-#include <ome/compat/memory.h>
+#include <ome/bioformats/FormatReader.h>
 
 #include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/GLWindow.h>
@@ -91,7 +91,7 @@ namespace ome
        * @param plane the image plane.
        */
       void
-      setReader(ome::compat::shared_ptr<ome::bioformats::FormatReader> reader,
+      setReader(std::shared_ptr<ome::bioformats::FormatReader> reader,
                 ome::bioformats::dimension_size_type                   series = 0,
                 ome::bioformats::dimension_size_type                   plane = 0);
 
@@ -156,7 +156,7 @@ namespace ome
 
     private:
       /// The image reader.
-      ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
+      std::shared_ptr<ome::bioformats::FormatReader> reader;
       /// The image series.
       ome::bioformats::dimension_size_type series;
       /// The image plane.

--- a/cpp/lib/ome/qtwidgets/NavigationDock2D.h
+++ b/cpp/lib/ome/qtwidgets/NavigationDock2D.h
@@ -92,8 +92,8 @@ namespace ome
        */
       void
       setReader(std::shared_ptr<ome::bioformats::FormatReader> reader,
-                ome::bioformats::dimension_size_type                   series = 0,
-                ome::bioformats::dimension_size_type                   plane = 0);
+                ome::bioformats::dimension_size_type           series = 0,
+                ome::bioformats::dimension_size_type           plane = 0);
 
       /**
        * Get the current plane for the series.

--- a/cpp/lib/ome/qtwidgets/TexelProperties.cpp
+++ b/cpp/lib/ome/qtwidgets/TexelProperties.cpp
@@ -60,37 +60,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::internal_format;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::internal_format;
+          internal_format = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::internal_format;
           break;
         }
 
@@ -105,37 +105,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::external_format;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::external_format;
+          external_format = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::external_format;
           break;
         }
 
@@ -150,37 +150,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::external_type;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::external_type;
+          external_type = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::external_type;
           break;
         }
 
@@ -195,37 +195,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::fallback_pixeltype;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::fallback_pixeltype;
+          fallback_pixeltype = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::fallback_pixeltype;
           break;
         }
 
@@ -240,37 +240,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::conversion_required;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::conversion_required;
+          conversion_required = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::conversion_required;
           break;
         }
 
@@ -285,37 +285,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::normalization_required;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::normalization_required;
+          normalization_required = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::normalization_required;
           break;
         }
 
@@ -329,37 +329,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::minification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::minification_filter;
+          minification_filter = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::minification_filter;
           break;
         }
 
@@ -373,37 +373,37 @@ namespace ome
       switch(pixeltype)
         {
         case ::ome::xml::model::enums::PixelType::INT8:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::INT8>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::INT16:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::INT16>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::INT32:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::INT32>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::UINT8:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::UINT8>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::UINT16:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::UINT16>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::UINT32:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::UINT32>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::FLOAT:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::FLOAT>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLE:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::BIT:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::BIT>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::COMPLEX:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX>::magnification_filter;
           break;
         case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::magnification_filter;
+          magnification_filter = TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::magnification_filter;
           break;
         }
 

--- a/cpp/lib/ome/qtwidgets/TexelProperties.h
+++ b/cpp/lib/ome/qtwidgets/TexelProperties.h
@@ -86,8 +86,8 @@ namespace ome
 
     /// Properties of INT8 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::INT8> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::INT8>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::INT8> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::INT8>
     {
       /// Internal pixel format (single 8-bit channel).
       static const GLenum internal_format = GL_R8;
@@ -109,8 +109,8 @@ namespace ome
 
     /// Properties of INT16 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::INT16> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::INT16>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::INT16> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::INT16>
     {
       /// Internal pixel format (single 16-bit channel).
       static const GLenum internal_format = GL_R16;
@@ -132,8 +132,8 @@ namespace ome
 
     /// Properties of INT32 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::INT32> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::INT32>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::INT32> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::INT32>
     {
       /// Internal pixel format (single 16-bit channel; note precision loss).
       static const GLenum internal_format = GL_R16;
@@ -155,8 +155,8 @@ namespace ome
 
     /// Properties of UINT8 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::UINT8> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::UINT8> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::UINT8>
     {
       /// Internal pixel format (single 8-bit channel).
       static const GLenum internal_format = GL_R8;
@@ -178,8 +178,8 @@ namespace ome
 
     /// Properties of UINT16 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::UINT16> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::UINT16> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::UINT16>
     {
       /// Internal pixel format (single 16-bit channel).
       static const GLenum internal_format = GL_R16;
@@ -201,8 +201,8 @@ namespace ome
 
     /// Properties of UINT32 texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::UINT32> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::UINT32> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::UINT32>
     {
       /// Internal pixel format (single 16-bit channel; note precision loss).
       static const GLenum internal_format = GL_R16;
@@ -224,8 +224,8 @@ namespace ome
 
     /// Properties of FLOAT texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::FLOAT> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::FLOAT>
     {
       /// Internal pixel format (single 32-bit float channel).
       static const GLenum internal_format = GL_R32F;
@@ -247,8 +247,8 @@ namespace ome
 
     /// Properties of DOUBLE texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::DOUBLE> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::DOUBLE>
     {
       /// Internal pixel format (single 32-bit float channel; note precision loss).
       static const GLenum internal_format = GL_R32F;
@@ -270,8 +270,8 @@ namespace ome
 
     /// Properties of BIT texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::BIT> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::BIT> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::BIT>
     {
       /// Internal pixel format (single 8-bit float channel).
       static const GLenum internal_format = GL_R8;
@@ -293,8 +293,8 @@ namespace ome
 
     /// Properties of COMPLEX texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::COMPLEX> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::COMPLEX>
     {
       /// Internal pixel format (double 32-bit float channels).
       static const GLenum internal_format = GL_RG32F;
@@ -316,8 +316,8 @@ namespace ome
 
     /// Properties of DOUBLECOMPLEX texels.
     template<>
-    struct TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> :
-      public ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>
+    struct TexelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> :
+      public ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>
     {
       /// Internal pixel format (double 32-bit float channels; note precision loss).
       static const GLenum internal_format = GL_RG32F;

--- a/cpp/lib/ome/qtwidgets/gl/Axis2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Axis2D.cpp
@@ -49,8 +49,8 @@ namespace ome
     {
 
       Axis2D::Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                     ome::bioformats::dimension_size_type                    series,
-                     QObject                                                *parent):
+                     ome::bioformats::dimension_size_type            series,
+                     QObject                                        *parent):
         QObject(parent),
         xaxis_vertices(QOpenGLBuffer::VertexBuffer),
         yaxis_vertices(QOpenGLBuffer::VertexBuffer),

--- a/cpp/lib/ome/qtwidgets/gl/Axis2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Axis2D.cpp
@@ -48,7 +48,7 @@ namespace ome
     namespace gl
     {
 
-      Axis2D::Axis2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+      Axis2D::Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                      ome::bioformats::dimension_size_type                    series,
                      QObject                                                *parent):
         QObject(parent),

--- a/cpp/lib/ome/qtwidgets/gl/Axis2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Axis2D.h
@@ -39,6 +39,8 @@
 #ifndef OME_QTWIDGETS_GL_AXIS2D_H
 #define OME_QTWIDGETS_GL_AXIS2D_H
 
+#include <memory>
+
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
@@ -46,8 +48,6 @@
 
 #include <ome/bioformats/Types.h>
 #include <ome/bioformats/FormatReader.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
 #include <ome/qtwidgets/glsl/v110/GLFlatShader2D.h>
@@ -78,7 +78,7 @@ namespace ome
          * @param series the image series.
          * @param parent the parent of this object.
          */
-        explicit Axis2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+        explicit Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                         ome::bioformats::dimension_size_type                    series,
                         QObject                                                *parent = 0);
 
@@ -128,7 +128,7 @@ namespace ome
         /// The elements for both axes.
         QOpenGLBuffer axis_elements;
         /// The image reader.
-        ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
+        std::shared_ptr<ome::bioformats::FormatReader> reader;
         /// The image series.
         ome::bioformats::dimension_size_type series;
       };

--- a/cpp/lib/ome/qtwidgets/gl/Axis2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Axis2D.h
@@ -79,8 +79,8 @@ namespace ome
          * @param parent the parent of this object.
          */
         explicit Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                        ome::bioformats::dimension_size_type                    series,
-                        QObject                                                *parent = 0);
+                        ome::bioformats::dimension_size_type            series,
+                        QObject                                        *parent = 0);
 
         /// Destructor.
         virtual

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -107,8 +107,8 @@ namespace ome
     {
 
       Grid2D::Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                     ome::bioformats::dimension_size_type                    series,
-                     QObject                                                *parent):
+                     ome::bioformats::dimension_size_type            series,
+                     QObject                                        *parent):
         QObject(parent),
         grid_vertices(QOpenGLBuffer::VertexBuffer),
         grid_elements(QOpenGLBuffer::IndexBuffer),

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -106,7 +106,7 @@ namespace ome
     namespace gl
     {
 
-      Grid2D::Grid2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+      Grid2D::Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                      ome::bioformats::dimension_size_type                    series,
                      QObject                                                *parent):
         QObject(parent),

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.cpp
@@ -39,7 +39,7 @@
 #include <ome/qtwidgets/gl/Grid2D.h>
 #include <ome/qtwidgets/gl/Util.h>
 
-#include <ome/compat/array.h>
+#include <array>
 #include <cmath>
 #include <iostream>
 
@@ -135,7 +135,7 @@ namespace ome
       Grid2D::setSize(const glm::vec2& xlim,
                       const glm::vec2& ylim)
       {
-        ome::compat::array<glm::vec3, 3> gridcol;
+        std::array<glm::vec3, 3> gridcol;
         gridcol[0] = glm::vec3(0.5f, 0.5f, 0.5f);
         gridcol[1] = glm::vec3(0.7f, 0.7f, 0.7f);
         gridcol[2] = glm::vec3(0.9f, 0.9f, 0.9f);

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.h
@@ -39,6 +39,8 @@
 #ifndef OME_QTWIDGETS_GL_GRID2D_H
 #define OME_QTWIDGETS_GL_GRID2D_H
 
+#include <memory>
+
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
@@ -46,8 +48,6 @@
 
 #include <ome/bioformats/Types.h>
 #include <ome/bioformats/FormatReader.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -78,7 +78,7 @@ namespace ome
          * @param series the image series.
          * @param parent the parent of this object.
          */
-        explicit Grid2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+        explicit Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                         ome::bioformats::dimension_size_type                    series,
                         QObject                                                *parent = 0);
 
@@ -127,7 +127,7 @@ namespace ome
         /// The elements for the grid.
         QOpenGLBuffer grid_elements;
         /// The image reader.
-        ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
+        std::shared_ptr<ome::bioformats::FormatReader> reader;
         /// The image series.
         ome::bioformats::dimension_size_type series;
       };

--- a/cpp/lib/ome/qtwidgets/gl/Grid2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Grid2D.h
@@ -79,8 +79,8 @@ namespace ome
          * @param parent the parent of this object.
          */
         explicit Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                        ome::bioformats::dimension_size_type                    series,
-                        QObject                                                *parent = 0);
+                        ome::bioformats::dimension_size_type            series,
+                        QObject                                        *parent = 0);
 
         /// Destructor.
         virtual

--- a/cpp/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -257,7 +257,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, void
       >::type
-    operator() (const std::shared_ptr<PixelBuffer<T> >& v)
+    operator() (const std::shared_ptr<PixelBuffer<T>>& v)
     {
       /// @todo Conversion from complex.
     }

--- a/cpp/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -257,7 +257,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, void
       >::type
-    operator() (const ome::compat::shared_ptr<PixelBuffer<T> >& v)
+    operator() (const std::shared_ptr<PixelBuffer<T> >& v)
     {
       /// @todo Conversion from complex.
     }
@@ -273,7 +273,7 @@ namespace ome
     namespace gl
     {
 
-      Image2D::Image2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+      Image2D::Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                        ome::bioformats::dimension_size_type                    series,
                        QObject                                                *parent):
         QObject(parent),

--- a/cpp/lib/ome/qtwidgets/gl/Image2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/Image2D.cpp
@@ -274,8 +274,8 @@ namespace ome
     {
 
       Image2D::Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                       ome::bioformats::dimension_size_type                    series,
-                       QObject                                                *parent):
+                       ome::bioformats::dimension_size_type            series,
+                       QObject                                        *parent):
         QObject(parent),
         image_vertices(QOpenGLBuffer::VertexBuffer),
         image_texcoords(QOpenGLBuffer::VertexBuffer),

--- a/cpp/lib/ome/qtwidgets/gl/Image2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Image2D.h
@@ -83,8 +83,8 @@ namespace ome
          */
         explicit
         Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                ome::bioformats::dimension_size_type                    series,
-                QObject                                                *parent = 0);
+                ome::bioformats::dimension_size_type            series,
+                QObject                                        *parent = 0);
 
         /// Destructor.
         virtual

--- a/cpp/lib/ome/qtwidgets/gl/Image2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/Image2D.h
@@ -39,6 +39,8 @@
 #ifndef OME_QTWIDGETS_GL_IMAGE2D_H
 #define OME_QTWIDGETS_GL_IMAGE2D_H
 
+#include <memory>
+
 #include <QtCore/QObject>
 #include <QtGui/QOpenGLBuffer>
 #include <QtGui/QOpenGLShader>
@@ -46,8 +48,6 @@
 
 #include <ome/bioformats/Types.h>
 #include <ome/bioformats/FormatReader.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/glm.h>
 
@@ -82,7 +82,7 @@ namespace ome
          * @param parent the parent of this object.
          */
         explicit
-        Image2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+        Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                 ome::bioformats::dimension_size_type                    series,
                 QObject                                                *parent = 0);
 
@@ -219,7 +219,7 @@ namespace ome
         /// Linear contrast correction multipliers.
         glm::vec3 texcorr;
         /// The image reader.
-        ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
+        std::shared_ptr<ome::bioformats::FormatReader> reader;
         /// The image series.
         ome::bioformats::dimension_size_type series;
         /// The current image plane.

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.cpp
@@ -51,8 +51,8 @@ namespace ome
       {
 
         Axis2D::Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                       ome::bioformats::dimension_size_type                    series,
-                       QObject                                                *parent):
+                       ome::bioformats::dimension_size_type            series,
+                       QObject                                        *parent):
           gl::Axis2D(reader, series, parent),
           axis_shader(new glsl::v110::GLFlatShader2D(this))
         {

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.cpp
@@ -50,7 +50,7 @@ namespace ome
       namespace v20
       {
 
-        Axis2D::Axis2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+        Axis2D::Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                        ome::bioformats::dimension_size_type                    series,
                        QObject                                                *parent):
           gl::Axis2D(reader, series, parent),

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.h
@@ -78,7 +78,7 @@ namespace ome
            * @param series the image series.
            * @param parent the parent of this object.
            */
-          explicit Axis2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+          explicit Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                           ome::bioformats::dimension_size_type                    series,
                           QObject                                                *parent = 0);
 

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Axis2D.h
@@ -79,8 +79,8 @@ namespace ome
            * @param parent the parent of this object.
            */
           explicit Axis2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                          ome::bioformats::dimension_size_type                    series,
-                          QObject                                                *parent = 0);
+                          ome::bioformats::dimension_size_type            series,
+                          QObject                                        *parent = 0);
 
           /// Destructor.
           ~Axis2D();

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.cpp
@@ -50,7 +50,7 @@ namespace ome
       namespace v20
       {
 
-        Grid2D::Grid2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+        Grid2D::Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                        ome::bioformats::dimension_size_type                    series,
                        QObject                                                *parent):
           gl::Grid2D(reader, series, parent),

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.cpp
@@ -51,8 +51,8 @@ namespace ome
       {
 
         Grid2D::Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                       ome::bioformats::dimension_size_type                    series,
-                       QObject                                                *parent):
+                       ome::bioformats::dimension_size_type            series,
+                       QObject                                        *parent):
           gl::Grid2D(reader, series, parent),
           grid_shader(new glsl::v110::GLLineShader2D(this))
         {

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.h
@@ -78,7 +78,7 @@ namespace ome
            * @param series the image series.
            * @param parent the parent of this object.
            */
-          explicit Grid2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+          explicit Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                           ome::bioformats::dimension_size_type                    series,
                           QObject                                                *parent = 0);
 

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Grid2D.h
@@ -79,8 +79,8 @@ namespace ome
            * @param parent the parent of this object.
            */
           explicit Grid2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                          ome::bioformats::dimension_size_type                    series,
-                          QObject                                                *parent = 0);
+                          ome::bioformats::dimension_size_type            series,
+                          QObject                                        *parent = 0);
 
           /// Destructor.
           ~Grid2D();

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.cpp
@@ -51,8 +51,8 @@ namespace ome
       {
 
         Image2D::Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                         ome::bioformats::dimension_size_type                    series,
-                         QObject                                                *parent):
+                         ome::bioformats::dimension_size_type            series,
+                         QObject                                        *parent):
           gl::Image2D(reader, series, parent),
           image_shader(new glsl::v110::GLImageShader2D(this))
         {

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.cpp
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.cpp
@@ -50,7 +50,7 @@ namespace ome
       namespace v20
       {
 
-        Image2D::Image2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+        Image2D::Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                          ome::bioformats::dimension_size_type                    series,
                          QObject                                                *parent):
           gl::Image2D(reader, series, parent),

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.h
@@ -83,7 +83,7 @@ namespace ome
            * @param series the image series.
            * @param parent the parent of this object.
            */
-          explicit Image2D(ome::compat::shared_ptr<ome::bioformats::FormatReader>  reader,
+          explicit Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
                            ome::bioformats::dimension_size_type                    series,
                            QObject                                                *parent = 0);
 

--- a/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.h
+++ b/cpp/lib/ome/qtwidgets/gl/v20/V20Image2D.h
@@ -84,8 +84,8 @@ namespace ome
            * @param parent the parent of this object.
            */
           explicit Image2D(std::shared_ptr<ome::bioformats::FormatReader>  reader,
-                           ome::bioformats::dimension_size_type                    series,
-                           QObject                                                *parent = 0);
+                           ome::bioformats::dimension_size_type            series,
+                           QObject                                        *parent = 0);
 
           /// Destructor.
           virtual ~Image2D();

--- a/cpp/lib/ome/xml/meta/BaseMetadata.h
+++ b/cpp/lib/ome/xml/meta/BaseMetadata.h
@@ -39,9 +39,8 @@
 #define OME_BIOFORMATS_META_BASEMETADATA_H
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/meta/MetadataRoot.h
+++ b/cpp/lib/ome/xml/meta/MetadataRoot.h
@@ -38,7 +38,7 @@
 #ifndef OME_BIOFORMATS_META_METADATAROOT_H
 #define OME_BIOFORMATS_META_METADATAROOT_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/meta/OMEXMLMetadataRoot.h
+++ b/cpp/lib/ome/xml/meta/OMEXMLMetadataRoot.h
@@ -38,11 +38,10 @@
 #ifndef OME_BIOFORMATS_OME_OMEXMLMETADATAROOT_H
 #define OME_BIOFORMATS_OME_OMEXMLMETADATAROOT_H
 
-#include <ome/compat/cstdint.h>
-
 #include <ome/xml/meta/MetadataRoot.h>
 #include <ome/xml/model/OME.h>
 
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -146,7 +146,7 @@ namespace ome
 
       bool
       MapPairs::link (std::shared_ptr<Reference>&                          reference,
-                      std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                      std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
       {
         if (detail::OMEModelObject::link(reference, object))
           {

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -145,7 +145,7 @@ namespace ome
       }
 
       bool
-      MapPairs::link (std::shared_ptr<Reference>&                          reference,
+      MapPairs::link (std::shared_ptr<Reference>&                         reference,
                       std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
       {
         if (detail::OMEModelObject::link(reference, object))

--- a/cpp/lib/ome/xml/model/MapPairs.cpp
+++ b/cpp/lib/ome/xml/model/MapPairs.cpp
@@ -145,8 +145,8 @@ namespace ome
       }
 
       bool
-      MapPairs::link (ome::compat::shared_ptr<Reference>&                          reference,
-                      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      MapPairs::link (std::shared_ptr<Reference>&                          reference,
+                      std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
       {
         if (detail::OMEModelObject::link(reference, object))
           {

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -128,7 +128,7 @@ namespace ome
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
         link (std::shared_ptr<Reference>&                          reference,
-              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+              std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -127,7 +127,7 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (std::shared_ptr<Reference>&                          reference,
+        link (std::shared_ptr<Reference>&                         reference,
               std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
         /**

--- a/cpp/lib/ome/xml/model/MapPairs.h
+++ b/cpp/lib/ome/xml/model/MapPairs.h
@@ -41,10 +41,9 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-
-#include <ome/compat/memory.h>
 
 #include <ome/common/xml/dom/Document.h>
 #include <ome/common/xml/dom/Element.h>
@@ -128,8 +127,8 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (ome::compat::shared_ptr<Reference>&                          reference,
-              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+        link (std::shared_ptr<Reference>&                          reference,
+              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/cpp/lib/ome/xml/model/OMEModel.h
+++ b/cpp/lib/ome/xml/model/OMEModel.h
@@ -62,9 +62,9 @@ namespace ome
       {
       public:
         /// A list of Reference objects.
-        typedef std::vector<std::shared_ptr<Reference> > reference_list_type;
+        typedef std::vector<std::shared_ptr<Reference>> reference_list_type;
         /// A map of string model object identifiers to model objects.
-        typedef std::map<std::string, std::shared_ptr<OMEModelObject> > object_map_type;
+        typedef std::map<std::string, std::shared_ptr<OMEModelObject>> object_map_type;
         /// A map of model objects to list of Reference objects.
         typedef std::map<std::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
         /// Size type for reference map.

--- a/cpp/lib/ome/xml/model/OMEModel.h
+++ b/cpp/lib/ome/xml/model/OMEModel.h
@@ -40,10 +40,9 @@
 #define OME_XML_MODEL_OMEMODEL_H
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/model/OMEModelObject.h>
 
@@ -63,11 +62,11 @@ namespace ome
       {
       public:
         /// A list of Reference objects.
-        typedef std::vector<ome::compat::shared_ptr<Reference> > reference_list_type;
+        typedef std::vector<std::shared_ptr<Reference> > reference_list_type;
         /// A map of string model object identifiers to model objects.
-        typedef std::map<std::string, ome::compat::shared_ptr<OMEModelObject> > object_map_type;
+        typedef std::map<std::string, std::shared_ptr<OMEModelObject> > object_map_type;
         /// A map of model objects to list of Reference objects.
-        typedef std::map<ome::compat::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
+        typedef std::map<std::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
         /// Size type for reference map.
         typedef reference_map_type::size_type size_type;
 
@@ -105,9 +104,9 @@ namespace ome
          * Should it be possible to insert null objects?
          */
         virtual
-        ome::compat::shared_ptr<OMEModelObject>
+        std::shared_ptr<OMEModelObject>
         addModelObject (const std::string&                       id,
-                        ome::compat::shared_ptr<OMEModelObject>& object) = 0;
+                        std::shared_ptr<OMEModelObject>& object) = 0;
 
         /**
          * Remove a model object from the model.
@@ -118,7 +117,7 @@ namespace ome
          * not exist.
          */
         virtual
-        ome::compat::shared_ptr<OMEModelObject>
+        std::shared_ptr<OMEModelObject>
         removeModelObject (const std::string& id) = 0;
 
         /**
@@ -132,7 +131,7 @@ namespace ome
          * @todo: Would a const reference be better for the return?
          */
         virtual
-        ome::compat::shared_ptr<OMEModelObject>
+        std::shared_ptr<OMEModelObject>
         getModelObject (const std::string& id) const = 0;
 
         /**
@@ -161,8 +160,8 @@ namespace ome
          */
         virtual
         bool
-        addReference (ome::compat::shared_ptr<OMEModelObject>& a,
-                      ome::compat::shared_ptr<Reference>&      b) = 0;
+        addReference (std::shared_ptr<OMEModelObject>& a,
+                      std::shared_ptr<Reference>&      b) = 0;
 
         /**
          * Retrieve all references from the model.

--- a/cpp/lib/ome/xml/model/OMEModel.h
+++ b/cpp/lib/ome/xml/model/OMEModel.h
@@ -105,7 +105,7 @@ namespace ome
          */
         virtual
         std::shared_ptr<OMEModelObject>
-        addModelObject (const std::string&                       id,
+        addModelObject (const std::string&               id,
                         std::shared_ptr<OMEModelObject>& object) = 0;
 
         /**

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -49,8 +50,6 @@
 #include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
-
-#include <ome/compat/memory.h>
 
 #include <ome/common/xml/dom/Element.h>
 #include <ome/common/xml/dom/Document.h>
@@ -74,7 +73,7 @@ namespace ome
        * could just be Object, since it's really an
        * ome::xml::model::Object.
        */
-      class OMEModelObject : public ome::compat::enable_shared_from_this<OMEModelObject>
+      class OMEModelObject : public std::enable_shared_from_this<OMEModelObject>
       {
       protected:
         /**
@@ -89,7 +88,7 @@ namespace ome
             Ptr<T>, // value type
             boost::multi_index::indexed_by<
               boost::multi_index::random_access<>, // insertion order
-              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, ome::compat::owner_less<Ptr<T> > > // sorted order
+              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, std::owner_less<Ptr<T> > > // sorted order
               >
             > type;
         };
@@ -186,8 +185,8 @@ namespace ome
          * to all generated model objects implementing this interface.
          */
         virtual bool
-        link (ome::compat::shared_ptr<Reference>&      reference,
-              ome::compat::shared_ptr<OMEModelObject>& object) = 0;
+        link (std::shared_ptr<Reference>&      reference,
+              std::shared_ptr<OMEModelObject>& object) = 0;
 
         /**
          * Get the XML namespace for this model object.

--- a/cpp/lib/ome/xml/model/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/OMEModelObject.h
@@ -88,7 +88,7 @@ namespace ome
             Ptr<T>, // value type
             boost::multi_index::indexed_by<
               boost::multi_index::random_access<>, // insertion order
-              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, std::owner_less<Ptr<T> > > // sorted order
+              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T>>, std::owner_less<Ptr<T>>> // sorted order
               >
             > type;
         };

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -170,7 +170,7 @@ namespace ome
     }
 
       bool
-      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
+      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                         reference,
                                         std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
       {
         if (XMLAnnotation::link(reference, object))

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -171,7 +171,7 @@ namespace ome
 
       bool
       OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
-                                        std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                                        std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
       {
         if (XMLAnnotation::link(reference, object))
           {

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -170,8 +170,8 @@ namespace ome
     }
 
       bool
-      OriginalMetadataAnnotation::link (ome::compat::shared_ptr<Reference>&                          reference,
-                                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
+                                        std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
       {
         if (XMLAnnotation::link(reference, object))
           {

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
@@ -39,10 +39,9 @@
 #ifndef OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
 #define OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
 
+#include <memory>
 #include <string>
 #include <utility>
-
-#include <ome/compat/memory.h>
 
 #include <ome/common/xml/dom/Document.h>
 #include <ome/common/xml/dom/Element.h>
@@ -124,8 +123,8 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (ome::compat::shared_ptr<Reference>&                          reference,
-              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+        link (std::shared_ptr<Reference>&                          reference,
+              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
@@ -123,7 +123,7 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (std::shared_ptr<Reference>&                          reference,
+        link (std::shared_ptr<Reference>&                         reference,
               std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
         /**

--- a/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/cpp/lib/ome/xml/model/OriginalMetadataAnnotation.h
@@ -124,7 +124,7 @@ namespace ome
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
         link (std::shared_ptr<Reference>&                          reference,
-              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+              std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/cpp/lib/ome/xml/model/detail/OMEModel.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.cpp
@@ -37,9 +37,8 @@
  */
 
 #include <map>
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/model/detail/OMEModel.h>
 #include <ome/xml/model/Reference.h>
@@ -65,12 +64,12 @@ namespace ome
         {
         }
 
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::addModelObject(const std::string&                                   id,
-                                 ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                                 std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
         {
           // Don't store references.
-          if (ome::compat::dynamic_pointer_cast<Reference>(object))
+          if (std::dynamic_pointer_cast<Reference>(object))
             return object;
 
           object_map_type::iterator i = modelObjects.find(id);
@@ -82,10 +81,10 @@ namespace ome
           return object;
         }
 
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::removeModelObject(const std::string& id)
         {
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -97,10 +96,10 @@ namespace ome
           return ret;
         }
 
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::getModelObject(const std::string& id) const
         {
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::const_iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -116,8 +115,8 @@ namespace ome
         }
 
         bool
-        OMEModel::addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                                    ome::compat::shared_ptr<Reference>&                      b)
+        OMEModel::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                                    std::shared_ptr<Reference>&                      b)
         {
           reference_map_type::iterator i = references.find(a);
 
@@ -146,7 +145,7 @@ namespace ome
                i != references.end();
                ++i)
             {
-              const ome::compat::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+              const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
 
               if (!a)
                 {
@@ -183,7 +182,7 @@ namespace ome
                         {
                           const std::string& referenceID = (*ref)->getID();
 
-                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                          std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                           if (!b)
                             {
                               BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -194,7 +193,7 @@ namespace ome
                             }
                           else
                             {
-                              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> aw(ome::compat::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                              std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
                               aw->link(*ref, b);
                             }
                         }

--- a/cpp/lib/ome/xml/model/detail/OMEModel.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.cpp
@@ -64,9 +64,9 @@ namespace ome
         {
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         OMEModel::addModelObject(const std::string&                                   id,
-                                 std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                                 std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
         {
           // Don't store references.
           if (std::dynamic_pointer_cast<Reference>(object))
@@ -81,10 +81,10 @@ namespace ome
           return object;
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         OMEModel::removeModelObject(const std::string& id)
         {
-          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr<::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -96,10 +96,10 @@ namespace ome
           return ret;
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         OMEModel::getModelObject(const std::string& id) const
         {
-          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr<::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::const_iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -115,7 +115,7 @@ namespace ome
         }
 
         bool
-        OMEModel::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+        OMEModel::addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
                                     std::shared_ptr<Reference>&                      b)
         {
           reference_map_type::iterator i = references.find(a);
@@ -182,7 +182,7 @@ namespace ome
                         {
                           const std::string& referenceID = (*ref)->getID();
 
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                          std::shared_ptr<::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                           if (!b)
                             {
                               BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -193,7 +193,7 @@ namespace ome
                             }
                           else
                             {
-                              std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                              std::shared_ptr<::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast<::ome::xml::model::OMEModelObject>(a));
                               aw->link(*ref, b);
                             }
                         }

--- a/cpp/lib/ome/xml/model/detail/OMEModel.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.cpp
@@ -65,7 +65,7 @@ namespace ome
         }
 
         std::shared_ptr<::ome::xml::model::OMEModelObject>
-        OMEModel::addModelObject(const std::string&                                   id,
+        OMEModel::addModelObject(const std::string&                                  id,
                                  std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
         {
           // Don't store references.
@@ -116,7 +116,7 @@ namespace ome
 
         bool
         OMEModel::addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
-                                    std::shared_ptr<Reference>&                      b)
+                                std::shared_ptr<Reference>&                         b)
         {
           reference_map_type::iterator i = references.find(a);
 

--- a/cpp/lib/ome/xml/model/detail/OMEModel.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.h
@@ -74,16 +74,16 @@ namespace ome
           ~OMEModel ();
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr<::ome::xml::model::OMEModelObject>
           addModelObject (const std::string&                                   id,
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                          std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr<::ome::xml::model::OMEModelObject>
           removeModelObject (const std::string& id);
 
           // Documented in parent.
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr<::ome::xml::model::OMEModelObject>
           getModelObject (const std::string& id) const;
 
           // Documented in parent.
@@ -92,7 +92,7 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModel::addReference
           bool
-          addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+          addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
                         std::shared_ptr<Reference>&                          b);
 
           // Documented in parent.

--- a/cpp/lib/ome/xml/model/detail/OMEModel.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.h
@@ -75,7 +75,7 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
           std::shared_ptr<::ome::xml::model::OMEModelObject>
-          addModelObject (const std::string&                                   id,
+          addModelObject (const std::string&                                  id,
                           std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.
@@ -93,7 +93,7 @@ namespace ome
           /// @copydoc ome::xml::model::OMEModel::addReference
           bool
           addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
-                        std::shared_ptr<Reference>&                          b);
+                        std::shared_ptr<Reference>&                         b);
 
           // Documented in parent.
           const reference_map_type&

--- a/cpp/lib/ome/xml/model/detail/OMEModel.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModel.h
@@ -74,16 +74,16 @@ namespace ome
           ~OMEModel ();
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr< ::ome::xml::model::OMEModelObject>
           addModelObject (const std::string&                                   id,
-                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr< ::ome::xml::model::OMEModelObject>
           removeModelObject (const std::string& id);
 
           // Documented in parent.
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr< ::ome::xml::model::OMEModelObject>
           getModelObject (const std::string& id) const;
 
           // Documented in parent.
@@ -92,8 +92,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModel::addReference
           bool
-          addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                        ome::compat::shared_ptr<Reference>&                          b);
+          addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                        std::shared_ptr<Reference>&                          b);
 
           // Documented in parent.
           const reference_map_type&

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -87,7 +87,7 @@ namespace ome
         }
 
         bool
-        OMEModelObject::link (std::shared_ptr<Reference>&                          /* reference */,
+        OMEModelObject::link (std::shared_ptr<Reference>&                         /* reference */,
                               std::shared_ptr<::ome::xml::model::OMEModelObject>& /* object */)
         {
           return false;
@@ -95,7 +95,7 @@ namespace ome
 
         std::vector<common::xml::dom::Element>
         OMEModelObject::getChildrenByTagName (const common::xml::dom::Element& parent,
-                                              const std::string&          name)
+                                              const std::string&               name)
         {
           // TODO: May need to be a shared_ptr<element> if element is not refcounting.
           std::vector<common::xml::dom::Element> ret;

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -88,7 +88,7 @@ namespace ome
 
         bool
         OMEModelObject::link (std::shared_ptr<Reference>&                          /* reference */,
-                              std::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
+                              std::shared_ptr<::ome::xml::model::OMEModelObject>& /* object */)
         {
           return false;
         }

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -87,8 +87,8 @@ namespace ome
         }
 
         bool
-        OMEModelObject::link (ome::compat::shared_ptr<Reference>&                          /* reference */,
-                              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
+        OMEModelObject::link (std::shared_ptr<Reference>&                          /* reference */,
+                              std::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
         {
           return false;
         }

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.h
@@ -109,7 +109,7 @@ namespace ome
           /// @copydoc ome::xml::model::OMEModelObject::link
           virtual bool
           link (std::shared_ptr<Reference>&                          reference,
-                std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
           /**
            * Retrieve all the children of an element that have a given

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.h
@@ -108,8 +108,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModelObject::link
           virtual bool
-          link (ome::compat::shared_ptr<Reference>&                          reference,
-                ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+          link (std::shared_ptr<Reference>&                          reference,
+                std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           /**
            * Retrieve all the children of an element that have a given
@@ -149,7 +149,7 @@ namespace ome
           {
           private:
             /// The element to compare other elements with.
-            const ome::compat::shared_ptr<const T>& cmp;
+            const std::shared_ptr<const T>& cmp;
 
           public:
             /**
@@ -157,7 +157,7 @@ namespace ome
              *
              * @param cmp the element to compare other elements with.
              */
-            compare_element(const ome::compat::shared_ptr<const T>& cmp):
+            compare_element(const std::shared_ptr<const T>& cmp):
               cmp(cmp)
             {}
 
@@ -169,7 +169,7 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::shared_ptr<T>& element)
+            operator () (const std::shared_ptr<T>& element)
             {
               return cmp && element && cmp == element;
             }
@@ -181,7 +181,7 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::shared_ptr<const T>& element)
+            operator () (const std::shared_ptr<const T>& element)
             {
               return cmp && element && cmp == element;
             }
@@ -193,9 +193,9 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::weak_ptr<T>& element)
+            operator () (const std::weak_ptr<T>& element)
             {
-              ome::compat::shared_ptr<const T> shared_element(element);
+              std::shared_ptr<const T> shared_element(element);
               return cmp && shared_element && cmp == shared_element;
             }
 
@@ -206,9 +206,9 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::weak_ptr<const T>& element)
+            operator () (const std::weak_ptr<const T>& element)
             {
-              ome::compat::shared_ptr<const T> shared_element(element);
+              std::shared_ptr<const T> shared_element(element);
               return cmp && shared_element && cmp == shared_element;
             }
           };
@@ -226,7 +226,7 @@ namespace ome
           template<class C, typename T>
           bool
           contains(const C&                  container,
-                   const ome::compat::shared_ptr<T>& element)
+                   const std::shared_ptr<T>& element)
           {
             return (std::find_if(container.begin(),
                                  container.end(),

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.h
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.h
@@ -108,7 +108,7 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModelObject::link
           virtual bool
-          link (std::shared_ptr<Reference>&                          reference,
+          link (std::shared_ptr<Reference>&                         reference,
                 std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
           /**

--- a/cpp/lib/ome/xml/model/detail/Parse.h
+++ b/cpp/lib/ome/xml/model/detail/Parse.h
@@ -73,7 +73,7 @@ namespace ome
 
         /// Type trait for shared_ptr.
         template <class T>
-        struct is_shared_ptr<std::shared_ptr<T> >
+        struct is_shared_ptr<std::shared_ptr<T>>
           : boost::true_type {};
 
         /**

--- a/cpp/lib/ome/xml/model/detail/Parse.h
+++ b/cpp/lib/ome/xml/model/detail/Parse.h
@@ -73,7 +73,7 @@ namespace ome
 
         /// Type trait for shared_ptr.
         template <class T>
-        struct is_shared_ptr<ome::compat::shared_ptr<T> >
+        struct is_shared_ptr<std::shared_ptr<T> >
           : boost::true_type {};
 
         /**
@@ -198,7 +198,7 @@ namespace ome
         {
           typedef typename boost::remove_const<typename boost::remove_reference<T>::type>::type raw_type;
 
-          raw_type attr(ome::compat::make_shared<typename raw_type::element_type>());
+          raw_type attr(std::make_shared<typename raw_type::element_type>());
           parse_value(text, *attr, klass, property);
           return attr;
         }

--- a/cpp/lib/ome/xml/model/primitives/Color.h
+++ b/cpp/lib/ome/xml/model/primitives/Color.h
@@ -39,10 +39,9 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_COLOR_H
 #define OME_XML_MODEL_PRIMITIVES_COLOR_H
 
+#include <cstdint>
 #include <limits>
 #include <string>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -129,7 +129,7 @@ namespace ome
                                            boost::multipliable2<ConstrainedNumeric<N, C, E>, N,
                                            boost::multipliable<ConstrainedNumeric<N, C, E>,
                                            boost::incrementable<ConstrainedNumeric<N, C, E>,
-                                           boost::decrementable<ConstrainedNumeric<N, C, E> > > > > > > > > > > > > > >
+                                           boost::decrementable<ConstrainedNumeric<N, C, E>>>>>>>>>>>>>>>
         {
         public:
           /// The type to constrain.

--- a/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/cpp/lib/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -39,14 +39,13 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_CONSTRAINEDNUMERIC_H
 #define OME_XML_MODEL_PRIMITIVES_CONSTRAINEDNUMERIC_H
 
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <sstream>
 
 #include <boost/format.hpp>
 #include <boost/operators.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeFloat.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeFloat.h
@@ -54,7 +54,7 @@ namespace ome
         /**
          * Double-precision floating point value greater than or equal to zero.
          */
-        typedef ConstrainedNumeric<double, NonNegativeFloatConstraint<double> > NonNegativeFloat;
+        typedef ConstrainedNumeric<double, NonNegativeFloatConstraint<double>> NonNegativeFloat;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.h
@@ -39,10 +39,10 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_NONNEGATIVEINTEGER_H
 #define OME_XML_MODEL_PRIMITIVES_NONNEGATIVEINTEGER_H
 
-#include <ome/compat/cstdint.h>
-
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>
+
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeInteger.h
@@ -56,7 +56,7 @@ namespace ome
         /**
          * Integer (signed 32-bit) value greater than or equal to zero.
          */
-        typedef ConstrainedNumeric<int32_t, NonNegativeIntegerConstraint<int32_t> > NonNegativeInteger;
+        typedef ConstrainedNumeric<int32_t, NonNegativeIntegerConstraint<int32_t>> NonNegativeInteger;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeLong.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeLong.h
@@ -39,10 +39,10 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_NONNEGATIVELONG_H
 #define OME_XML_MODEL_PRIMITIVES_NONNEGATIVELONG_H
 
-#include <ome/compat/cstdint.h>
-
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>
+
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/primitives/NonNegativeLong.h
+++ b/cpp/lib/ome/xml/model/primitives/NonNegativeLong.h
@@ -56,7 +56,7 @@ namespace ome
         /**
          * Long integer (signed 64-bit) value greater than or equal to zero.
          */
-        typedef ConstrainedNumeric<int64_t, NonNegativeIntegerConstraint<int64_t> > NonNegativeLong;
+        typedef ConstrainedNumeric<int64_t, NonNegativeIntegerConstraint<int64_t>> NonNegativeLong;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/PercentFraction.h
+++ b/cpp/lib/ome/xml/model/primitives/PercentFraction.h
@@ -55,7 +55,7 @@ namespace ome
          * Double-precision floating point value between 0.0 minimum
          * and 1.0 maximum.
          */
-        typedef ConstrainedNumeric<float, PercentFractionConstraint<float> > PercentFraction;
+        typedef ConstrainedNumeric<float, PercentFractionConstraint<float>> PercentFraction;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/PositiveFloat.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveFloat.h
@@ -55,7 +55,7 @@ namespace ome
          * Double-precision floating point value greater than zero.
          * This value does not include zero.
          */
-        typedef ConstrainedNumeric<double, PositiveFloatConstraint<double> > PositiveFloat;
+        typedef ConstrainedNumeric<double, PositiveFloatConstraint<double>> PositiveFloat;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/PositiveInteger.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveInteger.h
@@ -57,7 +57,7 @@ namespace ome
          * Integer (signed 32-bit) value greater than zero.  This
          * value does not include zero.
          */
-        typedef ConstrainedNumeric<int32_t, PositiveIntegerConstraint<int32_t> > PositiveInteger;
+        typedef ConstrainedNumeric<int32_t, PositiveIntegerConstraint<int32_t>> PositiveInteger;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/PositiveInteger.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveInteger.h
@@ -39,10 +39,10 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_POSITIVEINTEGER_H
 #define OME_XML_MODEL_PRIMITIVES_POSITIVEINTEGER_H
 
-#include <ome/compat/cstdint.h>
-
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>
+
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/primitives/PositiveLong.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveLong.h
@@ -57,7 +57,7 @@ namespace ome
          * Long integer (signed 64-bit) value greater than zero.  This
          * value does not include zero.
          */
-        typedef ConstrainedNumeric<int64_t, PositiveIntegerConstraint<int64_t> > PositiveLong;
+        typedef ConstrainedNumeric<int64_t, PositiveIntegerConstraint<int64_t>> PositiveLong;
 
       }
     }

--- a/cpp/lib/ome/xml/model/primitives/PositiveLong.h
+++ b/cpp/lib/ome/xml/model/primitives/PositiveLong.h
@@ -39,10 +39,10 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_POSITIVELONG_H
 #define OME_XML_MODEL_PRIMITIVES_POSITIVELONG_H
 
-#include <ome/compat/cstdint.h>
-
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>
+
+#include <cstdint>
 
 namespace ome
 {

--- a/cpp/lib/ome/xml/model/primitives/Timestamp.h
+++ b/cpp/lib/ome/xml/model/primitives/Timestamp.h
@@ -39,13 +39,12 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_TIMESTAMP_H
 #define OME_XML_MODEL_PRIMITIVES_TIMESTAMP_H
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <stdexcept>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/cpp/libexec/info/ImageInfo.cpp
+++ b/cpp/libexec/info/ImageInfo.cpp
@@ -78,7 +78,7 @@ namespace info
   }
 
   void
-  ImageInfo::setReader(ome::compat::shared_ptr<FormatReader>& reader)
+  ImageInfo::setReader(std::shared_ptr<FormatReader>& reader)
   {
     this->reader = reader;
   }
@@ -87,7 +87,7 @@ namespace info
   ImageInfo::testRead(std::ostream& stream)
   {
     if (!reader)
-      reader = ome::compat::make_shared<in::OMETIFFReader>();
+      reader = std::make_shared<in::OMETIFFReader>();
 
     preInit(stream);
 
@@ -127,12 +127,12 @@ namespace info
     if (opts.showomexml)
       {
         reader->setOriginalMetadataPopulated(opts.showsa);
-        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> store(ome::compat::make_shared<ome::xml::meta::OMEXMLMetadata>());
+        std::shared_ptr<ome::xml::meta::MetadataStore> store(std::make_shared<ome::xml::meta::OMEXMLMetadata>());
         reader->setMetadataStore(store);
       }
 
     /// @todo ImageReader format detection.
-    ome::compat::shared_ptr<ome::bioformats::detail::FormatReader> detail = ome::compat::dynamic_pointer_cast<ome::bioformats::detail::FormatReader>(reader);
+    std::shared_ptr<ome::bioformats::detail::FormatReader> detail = std::dynamic_pointer_cast<ome::bioformats::detail::FormatReader>(reader);
     if (detail)
       stream << "Using reader: " << detail->getFormat()
              << " (" << detail->getFormatDescription() << ")\n";
@@ -303,15 +303,15 @@ namespace info
   {
     try
       {
-        ome::compat::shared_ptr<ome::xml::meta::MetadataStore> ms(reader->getMetadataStore());
-        ome::compat::shared_ptr<ome::xml::meta::MetadataRetrieve> mr(ome::compat::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(ms));
+        std::shared_ptr<ome::xml::meta::MetadataStore> ms(reader->getMetadataStore());
+        std::shared_ptr<ome::xml::meta::MetadataRetrieve> mr(std::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(ms));
       }
     catch (const std::exception& e)
       {
         std::cerr << "Failed to get metadata: " << e.what() << '\n';
       }
 
-    ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadata> omemeta(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(reader->getMetadataStore()));
+    std::shared_ptr<ome::xml::meta::OMEXMLMetadata> omemeta(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadata>(reader->getMetadataStore()));
     if (omemeta)
       {
         ome::common::xml::Platform xmlplat;

--- a/cpp/libexec/info/ImageInfo.h
+++ b/cpp/libexec/info/ImageInfo.h
@@ -38,14 +38,13 @@
 #ifndef SHOWINF_IMAGEINFO_H
 #define SHOWINF_IMAGEINFO_H
 
+#include <memory>
 #include <string>
 #include <stdexcept>
 
 #include <boost/program_options.hpp>
 
 #include <ome/common/log.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/bioformats/FormatReader.h>
 #include <ome/bioformats/Types.h>
@@ -69,7 +68,7 @@ namespace info
     virtual ~ImageInfo ();
 
     void
-    setReader(ome::compat::shared_ptr<ome::bioformats::FormatReader>& reader);
+    setReader(std::shared_ptr<ome::bioformats::FormatReader>& reader);
 
     void
     testRead(std::ostream& stream);
@@ -137,7 +136,7 @@ namespace info
     /// Command-line options.
     options opts;
     /// FormatReader instance.
-    ome::compat::shared_ptr<ome::bioformats::FormatReader> reader;
+    std::shared_ptr<ome::bioformats::FormatReader> reader;
   };
 
 }

--- a/cpp/libexec/info/options.cpp
+++ b/cpp/libexec/info/options.cpp
@@ -164,7 +164,7 @@ namespace info
       ("no-used", "Do not display used files");
 
     hidden.add_options()
-      ("files", opt::value<std::vector<std::string> >(&this->files),
+      ("files", opt::value<std::vector<std::string>>(&this->files),
        "Files to read");
 
     positional.add("files", -1);

--- a/cpp/libexec/info/options.h
+++ b/cpp/libexec/info/options.h
@@ -38,12 +38,11 @@
 #ifndef SHOWINF_OPTIONS_H
 #define SHOWINF_OPTIONS_H
 
+#include <memory>
 #include <string>
 #include <stdexcept>
 
 #include <boost/program_options.hpp>
-
-#include <ome/compat/memory.h>
 
 #include <ome/bioformats/Types.h>
 

--- a/cpp/libexec/view/Window.cpp
+++ b/cpp/libexec/view/Window.cpp
@@ -36,14 +36,14 @@
  * #L%
  */
 
+#include <memory>
+
 #include <view/Window.h>
 
 #include <ome/bioformats/FormatReader.h>
 #include <ome/bioformats/in/OMETIFFReader.h>
 
 #include <ome/common/module.h>
-
-#include <ome/compat/memory.h>
 
 #include <ome/qtwidgets/GLContainer.h>
 
@@ -235,7 +235,7 @@ namespace view
     QFileInfo info(file);
     if (info.exists())
       {
-        ome::compat::shared_ptr<ome::bioformats::FormatReader> reader(ome::compat::make_shared<ome::bioformats::in::OMETIFFReader>());
+        std::shared_ptr<ome::bioformats::FormatReader> reader(std::make_shared<ome::bioformats::in::OMETIFFReader>());
         reader->setId(file.toStdString());
         GLView2D *newGlView = new GLView2D(reader, 0, this);
         QWidget *glContainer = new GLContainer(this, newGlView);
@@ -283,7 +283,7 @@ namespace view
       }
     else
       {
-        navigation->setReader(ome::compat::shared_ptr<ome::bioformats::FormatReader>(), 0, 0);
+        navigation->setReader(std::shared_ptr<ome::bioformats::FormatReader>(), 0, 0);
       }
 
     bool enable(newGlView != 0);

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -141,10 +141,10 @@ protected:
     return in == "Valid file content";
   }
 
-  ome::compat::shared_ptr<CoreMetadata>
+  std::shared_ptr<CoreMetadata>
   makeCore()
   {
-    ome::compat::shared_ptr<CoreMetadata> c(ome::compat::make_shared<CoreMetadata>());
+    std::shared_ptr<CoreMetadata> c(std::make_shared<CoreMetadata>());
 
     c->sizeX = 512;
     c->sizeY = 1024;
@@ -208,7 +208,7 @@ protected:
         // 5 series, 3 with subresolutions
         core.clear();
         {
-          ome::compat::shared_ptr<CoreMetadata> c(makeCore());
+          std::shared_ptr<CoreMetadata> c(makeCore());
           c->resolutionCount = 3;
           core.push_back(c);
           core.push_back(makeCore());
@@ -216,7 +216,7 @@ protected:
         }
 
         {
-          ome::compat::shared_ptr<CoreMetadata> c(makeCore());
+          std::shared_ptr<CoreMetadata> c(makeCore());
           c->resolutionCount = 2;
           core.push_back(c);
           core.push_back(makeCore());
@@ -226,7 +226,7 @@ protected:
         core.push_back(makeCore());
 
         {
-          ome::compat::shared_ptr<CoreMetadata> c(makeCore());
+          std::shared_ptr<CoreMetadata> c(makeCore());
           c->resolutionCount = 2;
           core.push_back(c);
           core.push_back(makeCore());
@@ -969,17 +969,17 @@ TEST_P(FormatReaderTest, FlatMetadata)
 
 TEST_P(FormatReaderTest, DefaultMetadataStore)
 {
-  ome::compat::shared_ptr<MetadataStore> store(ome::compat::make_shared<OMEXMLMetadata>());
+  std::shared_ptr<MetadataStore> store(std::make_shared<OMEXMLMetadata>());
 
   EXPECT_NO_THROW(r.setMetadataStore(store));
-  EXPECT_EQ(store, ome::compat::dynamic_pointer_cast<OMEXMLMetadata>(r.getMetadataStore()));
+  EXPECT_EQ(store, std::dynamic_pointer_cast<OMEXMLMetadata>(r.getMetadataStore()));
 }
 
 TEST_P(FormatReaderTest, FlatMetadataStore)
 {
   r.setId("flat");
 
-  ome::compat::shared_ptr<MetadataStore> store(ome::compat::make_shared<OMEXMLMetadata>());
+  std::shared_ptr<MetadataStore> store(std::make_shared<OMEXMLMetadata>());
 
   EXPECT_THROW(r.setMetadataStore(store), std::logic_error);
 }

--- a/cpp/test/ome-bioformats/formatreader.cpp
+++ b/cpp/test/ome-bioformats/formatreader.cpp
@@ -68,8 +68,8 @@ using ome::xml::meta::OMEXMLMetadata;
 using ome::xml::model::enums::PixelType;
 
 typedef ome::xml::model::enums::PixelType PT;
-typedef ome::compat::array<dimension_size_type, 3> dim;
-typedef ome::compat::array<dimension_size_type, 6> moddim;
+typedef std::array<dimension_size_type, 3> dim;
+typedef std::array<dimension_size_type, 6> moddim;
 
 class FormatReaderTestParameters
 {
@@ -585,9 +585,9 @@ struct dims
     z(z), t(t), c(c)
   {}
 
-  operator ome::compat::array<dimension_size_type, 3>() const
+  operator std::array<dimension_size_type, 3>() const
   {
-    ome::compat::array<dimension_size_type, 3> ret;
+    std::array<dimension_size_type, 3> ret;
     ret[0] = z;
     ret[1] = c;
     ret[2] = t;
@@ -613,9 +613,9 @@ struct moddims
     z(z), t(t), c(c), mz(mz), mt(mt), mc(mc)
   {}
 
-  operator ome::compat::array<dimension_size_type, 6>() const
+  operator std::array<dimension_size_type, 6>() const
   {
-    ome::compat::array<dimension_size_type, 6> ret;
+    std::array<dimension_size_type, 6> ret;
     ret[0] = z;
     ret[1] = c;
     ret[2] = t;
@@ -737,9 +737,9 @@ TEST_P(FormatReaderTest, SubresolutionFlattenedSeries)
 
   EXPECT_EQ(0U, r.getIndex(0, 0, 0));
   EXPECT_EQ(0U, r.getIndex(0, 0, 0, 0, 0, 0));
-  ome::compat::array<dimension_size_type, 3> coords;
+  std::array<dimension_size_type, 3> coords;
   coords[0] = coords[1] = coords[2] = 0;
-  ome::compat::array<dimension_size_type, 6> modcoords;
+  std::array<dimension_size_type, 6> modcoords;
   modcoords[0] = modcoords[1] = modcoords[2] = modcoords[3] = modcoords[4] = modcoords[5] = 0;
 
   // EXPECT_EQ should work here, but fails for Boost 1.42; works
@@ -768,9 +768,9 @@ TEST_P(FormatReaderTest, SubresolutionUnflattenedSeries)
 
   EXPECT_EQ(0U, r.getIndex(0, 0, 0));
   EXPECT_EQ(0U, r.getIndex(0, 0, 0, 0, 0, 0));
-  ome::compat::array<dimension_size_type, 3> coords;
+  std::array<dimension_size_type, 3> coords;
   coords[0] = coords[1] = coords[2] = 0;
-  ome::compat::array<dimension_size_type, 6> modcoords;
+  std::array<dimension_size_type, 6> modcoords;
   modcoords[0] = modcoords[1] = modcoords[2] = modcoords[3] = modcoords[4] = modcoords[5] = 0;
 
   // EXPECT_EQ should work here, but fails for Boost 1.42; works

--- a/cpp/test/ome-bioformats/formattools.cpp
+++ b/cpp/test/ome-bioformats/formattools.cpp
@@ -50,8 +50,8 @@ using ome::bioformats::getIndex;
 using ome::bioformats::getZCTCoords;
 using ome::xml::model::enums::DimensionOrder;
 
-typedef ome::compat::array<dimension_size_type, 3> dims;
-typedef ome::compat::array<dimension_size_type, 6> moddims;
+typedef std::array<dimension_size_type, 3> dims;
+typedef std::array<dimension_size_type, 6> moddims;
 
 namespace std
 {

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -230,7 +230,7 @@ public:
 
 private:
   void
-  makeMetadata(std::shared_ptr< ::ome::xml::meta::MetadataStore> store,
+  makeMetadata(std::shared_ptr<::ome::xml::meta::MetadataStore> store,
                dimension_size_type                                       series,
                std::shared_ptr<CoreMetadata>                     core)
   {
@@ -291,7 +291,7 @@ public:
   {
     if (!currentId)
       {
-        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+        std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> m(std::make_shared<::ome::xml::meta::OMEXMLMetadata>());
 
         if (id == "output.test")
           {
@@ -302,7 +302,7 @@ public:
             makeMetadata(m, 3, makeCore());
           }
 
-        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
+        std::shared_ptr<::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast<::ome::xml::meta::MetadataRetrieve>(m));
         setMetadataRetrieve(mr);
 
         FormatWriter::setId(id);
@@ -613,8 +613,8 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
 
 TEST_P(FormatWriterTest, DefaultMetadataRetrieve)
 {
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
-  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
+  std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> m(std::make_shared<::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr<::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast<::ome::xml::meta::MetadataRetrieve>(m));
 
   EXPECT_NO_THROW(w.getMetadataRetrieve());
   EXPECT_NO_THROW(w.setMetadataRetrieve(mr));
@@ -626,8 +626,8 @@ TEST_P(FormatWriterTest, DefaultMetadataRetrieve)
 TEST_P(FormatWriterTest, OutputMetadataRetrieve)
 {
   std::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr;
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m2(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
-  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr2(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m2));
+  std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> m2(std::make_shared<::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr<::ome::xml::meta::MetadataRetrieve> mr2(std::static_pointer_cast<::ome::xml::meta::MetadataRetrieve>(m2));
 
   w.setId("output.test");
 

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -230,9 +230,9 @@ public:
 
 private:
   void
-  makeMetadata(ome::compat::shared_ptr< ::ome::xml::meta::MetadataStore> store,
+  makeMetadata(std::shared_ptr< ::ome::xml::meta::MetadataStore> store,
                dimension_size_type                                       series,
-               ome::compat::shared_ptr<CoreMetadata>                     core)
+               std::shared_ptr<CoreMetadata>                     core)
   {
     store->setImageID(createID("Image", series), series);
     store->setImageAcquisitionDate
@@ -257,10 +257,10 @@ private:
       }
   }
 
-  ome::compat::shared_ptr<CoreMetadata>
+  std::shared_ptr<CoreMetadata>
   makeCore()
   {
-    ome::compat::shared_ptr<CoreMetadata> c(ome::compat::make_shared<CoreMetadata>());
+    std::shared_ptr<CoreMetadata> c(std::make_shared<CoreMetadata>());
 
     c->sizeX = 512;
     c->sizeY = 1024;
@@ -291,7 +291,7 @@ public:
   {
     if (!currentId)
       {
-        ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+        std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
 
         if (id == "output.test")
           {
@@ -302,7 +302,7 @@ public:
             makeMetadata(m, 3, makeCore());
           }
 
-        ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
+        std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
         setMetadataRetrieve(mr);
 
         FormatWriter::setId(id);
@@ -613,8 +613,8 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
 
 TEST_P(FormatWriterTest, DefaultMetadataRetrieve)
 {
-  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
-  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
+  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m));
 
   EXPECT_NO_THROW(w.getMetadataRetrieve());
   EXPECT_NO_THROW(w.setMetadataRetrieve(mr));
@@ -625,9 +625,9 @@ TEST_P(FormatWriterTest, DefaultMetadataRetrieve)
 
 TEST_P(FormatWriterTest, OutputMetadataRetrieve)
 {
-  ome::compat::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr;
-  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m2(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
-  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr2(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m2));
+  std::shared_ptr<const ::ome::xml::meta::MetadataRetrieve> mr;
+  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> m2(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> mr2(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(m2));
 
   w.setId("output.test");
 

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -118,7 +118,7 @@ namespace std
 }
 
 typedef ome::xml::model::enums::PixelType PT;
-typedef ome::compat::array<dimension_size_type, 3> dim;
+typedef std::array<dimension_size_type, 3> dim;
 
 class FormatWriterTestParameters
 {

--- a/cpp/test/ome-bioformats/formatwriter.cpp
+++ b/cpp/test/ome-bioformats/formatwriter.cpp
@@ -231,8 +231,8 @@ public:
 private:
   void
   makeMetadata(std::shared_ptr<::ome::xml::meta::MetadataStore> store,
-               dimension_size_type                                       series,
-               std::shared_ptr<CoreMetadata>                     core)
+               dimension_size_type                              series,
+               std::shared_ptr<CoreMetadata>                    core)
   {
     store->setImageID(createID("Image", series), series);
     store->setImageAcquisitionDate

--- a/cpp/test/ome-bioformats/metadatatools.cpp
+++ b/cpp/test/ome-bioformats/metadatatools.cpp
@@ -499,7 +499,7 @@ TEST_P(CorrectionTest, ValidateAndCorrectModel)
 
   ASSERT_EQ(std::string("2013-06"), ome::bioformats::getModelVersion(doc));
 
-  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(doc));
+  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(doc));
 
   {
     const ModelState& state(current.before);

--- a/cpp/test/ome-bioformats/metadatatools.cpp
+++ b/cpp/test/ome-bioformats/metadatatools.cpp
@@ -499,7 +499,7 @@ TEST_P(CorrectionTest, ValidateAndCorrectModel)
 
   ASSERT_EQ(std::string("2013-06"), ome::bioformats::getModelVersion(doc));
 
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(doc));
+  std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(doc));
 
   {
     const ModelState& state(current.before);

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -161,7 +161,7 @@ TEST_P(TIFFWriterTest, setId)
       ifd->readImage(buf);
 
       // Make a second buffer to ensure correct ordering for saveBytes.
-      ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+      std::array<VariantPixelBuffer::size_type, 9> shape;
       shape[ome::bioformats::DIM_SPATIAL_X] = ifd->getImageWidth();
       shape[ome::bioformats::DIM_SPATIAL_Y] = ifd->getImageHeight();
       shape[ome::bioformats::DIM_SUBCHANNEL] = ifd->getSamplesPerPixel();

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -131,7 +131,7 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
-  std::vector<std::shared_ptr<CoreMetadata> > seriesList;
+  std::vector<std::shared_ptr<CoreMetadata>> seriesList;
   for (TIFF::const_iterator i = tiff->begin();
        i != tiff->end();
        ++i)

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -91,7 +91,7 @@ operator<< (std::basic_ostream<charT,traits>& os,
 class TIFFWriterTest : public ::testing::TestWithParam<TileTestParameters>
 {
 public:
-  ome::compat::shared_ptr<TIFF> tiff;
+  std::shared_ptr<TIFF> tiff;
   uint32_t iwidth;
   uint32_t iheight;
   ome::bioformats::tiff::PlanarConfiguration planarconfig;
@@ -110,7 +110,7 @@ public:
 
     ASSERT_NO_THROW(tiff = TIFF::open(params.file, "r"));
     ASSERT_TRUE(static_cast<bool>(tiff));
-    ome::compat::shared_ptr<IFD> ifd;
+    std::shared_ptr<IFD> ifd;
     ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
     ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -131,18 +131,18 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
-  std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList;
+  std::vector<std::shared_ptr<CoreMetadata> > seriesList;
   for (TIFF::const_iterator i = tiff->begin();
        i != tiff->end();
        ++i)
     {
-      ome::compat::shared_ptr<CoreMetadata> c = ome::bioformats::tiff::makeCoreMetadata(**i);
+      std::shared_ptr<CoreMetadata> c = ome::bioformats::tiff::makeCoreMetadata(**i);
       seriesList.push_back(c);
     }
 
-  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
   ome::bioformats::fillMetadata(*meta, seriesList);
-  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
+  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
 
@@ -156,7 +156,7 @@ TEST_P(TIFFWriterTest, setId)
   dimension_size_type currentSeries = 0U;
   for (dimension_size_type i = 0U; i < seriesList.size(); ++i)
     {
-      ome::compat::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
+      std::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
       ASSERT_TRUE(static_cast<bool>(ifd));
       ifd->readImage(buf);
 

--- a/cpp/test/ome-bioformats/minimaltiffwriter.cpp
+++ b/cpp/test/ome-bioformats/minimaltiffwriter.cpp
@@ -140,9 +140,9 @@ TEST_P(TIFFWriterTest, setId)
       seriesList.push_back(c);
     }
 
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared<::ome::xml::meta::OMEXMLMetadata>());
   ome::bioformats::fillMetadata(*meta, seriesList);
-  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
+  std::shared_ptr<::ome::xml::meta::MetadataRetrieve> retrieve(std::static_pointer_cast<::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
 

--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -132,7 +132,7 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
-  std::vector<std::shared_ptr<CoreMetadata> > seriesList;
+  std::vector<std::shared_ptr<CoreMetadata>> seriesList;
   for (TIFF::const_iterator i = tiff->begin();
        i != tiff->end();
        ++i)

--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -91,7 +91,7 @@ operator<< (std::basic_ostream<charT,traits>& os,
 class TIFFWriterTest : public ::testing::TestWithParam<TileTestParameters>
 {
 public:
-  ome::compat::shared_ptr<TIFF> tiff;
+  std::shared_ptr<TIFF> tiff;
   uint32_t iwidth;
   uint32_t iheight;
   ome::bioformats::tiff::PlanarConfiguration planarconfig;
@@ -111,7 +111,7 @@ public:
 
     ASSERT_NO_THROW(tiff = TIFF::open(params.file, "r"));
     ASSERT_TRUE(static_cast<bool>(tiff));
-    ome::compat::shared_ptr<IFD> ifd;
+    std::shared_ptr<IFD> ifd;
     ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
     ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -132,18 +132,18 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
-  std::vector<ome::compat::shared_ptr<CoreMetadata> > seriesList;
+  std::vector<std::shared_ptr<CoreMetadata> > seriesList;
   for (TIFF::const_iterator i = tiff->begin();
        i != tiff->end();
        ++i)
     {
-      ome::compat::shared_ptr<CoreMetadata> c = ome::bioformats::tiff::makeCoreMetadata(**i);
+      std::shared_ptr<CoreMetadata> c = ome::bioformats::tiff::makeCoreMetadata(**i);
       seriesList.push_back(c);
     }
 
-  ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(ome::compat::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
   ome::bioformats::fillMetadata(*meta, seriesList);
-  ome::compat::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(ome::compat::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
+  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
 
@@ -157,7 +157,7 @@ TEST_P(TIFFWriterTest, setId)
   dimension_size_type currentSeries = 0U;
   for (dimension_size_type i = 0U; i < seriesList.size(); ++i)
     {
-      ome::compat::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
+      std::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
       ASSERT_TRUE(static_cast<bool>(ifd));
       ifd->readImage(buf);
 

--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -141,9 +141,9 @@ TEST_P(TIFFWriterTest, setId)
       seriesList.push_back(c);
     }
 
-  std::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+  std::shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(std::make_shared<::ome::xml::meta::OMEXMLMetadata>());
   ome::bioformats::fillMetadata(*meta, seriesList);
-  std::shared_ptr< ::ome::xml::meta::MetadataRetrieve> retrieve(std::static_pointer_cast< ::ome::xml::meta::MetadataRetrieve>(meta));
+  std::shared_ptr<::ome::xml::meta::MetadataRetrieve> retrieve(std::static_pointer_cast<::ome::xml::meta::MetadataRetrieve>(meta));
 
   tiffwriter.setMetadataRetrieve(retrieve);
 

--- a/cpp/test/ome-bioformats/ometiffwriter.cpp
+++ b/cpp/test/ome-bioformats/ometiffwriter.cpp
@@ -162,7 +162,7 @@ TEST_P(TIFFWriterTest, setId)
       ifd->readImage(buf);
 
       // Make a second buffer to ensure correct ordering for saveBytes.
-      ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+      std::array<VariantPixelBuffer::size_type, 9> shape;
       shape[ome::bioformats::DIM_SPATIAL_X] = ifd->getImageWidth();
       shape[ome::bioformats::DIM_SPATIAL_Y] = ifd->getImageHeight();
       shape[ome::bioformats::DIM_SUBCHANNEL] = ifd->getSamplesPerPixel();

--- a/cpp/test/ome-bioformats/pixel.h
+++ b/cpp/test/ome-bioformats/pixel.h
@@ -43,7 +43,7 @@
 #include <ome/bioformats/PixelProperties.h>
 #include <ome/bioformats/VariantPixelBuffer.h>
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 /// Helpers to create pixel values of all supported types from integers.
 

--- a/cpp/test/ome-bioformats/pixel.h
+++ b/cpp/test/ome-bioformats/pixel.h
@@ -119,12 +119,12 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typedef typename ::ome::bioformats::PixelProperties<P>::std_type src_type;
   typedef ::ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
 
-  const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > *src;
+  const std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > *src;
   ::ome::bioformats::VariantPixelBuffer& dest;
 
   PixelTypeConversionVisitor(const ::ome::bioformats::VariantPixelBuffer& src,
                              ::ome::bioformats::VariantPixelBuffer& dest):
-    src(boost::get<ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > >(&src.vbuffer())),
+    src(boost::get<std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > >(&src.vbuffer())),
     dest(dest)
   {
 
@@ -141,7 +141,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_integral<T>::value, void
     >::type
-  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -167,7 +167,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_floating_point<T>::value, void
     >::type
-  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -192,7 +192,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_complex<T>::value, void
     >::type
-  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -216,7 +216,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   // and the upper part being set to true for the destination boolean
   // pixel type.
   void
-  operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& lhs)
   {
     const src_type *src_buf = (*src)->data();
     bit_type *dest_buf = lhs->data();

--- a/cpp/test/ome-bioformats/pixel.h
+++ b/cpp/test/ome-bioformats/pixel.h
@@ -119,12 +119,12 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typedef typename ::ome::bioformats::PixelProperties<P>::std_type src_type;
   typedef ::ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
 
-  const std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > *src;
+  const std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type>> *src;
   ::ome::bioformats::VariantPixelBuffer& dest;
 
   PixelTypeConversionVisitor(const ::ome::bioformats::VariantPixelBuffer& src,
                              ::ome::bioformats::VariantPixelBuffer& dest):
-    src(boost::get<std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type> > >(&src.vbuffer())),
+    src(boost::get<std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type>>>(&src.vbuffer())),
     dest(dest)
   {
 
@@ -141,7 +141,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_integral<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -167,7 +167,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_floating_point<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -192,7 +192,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_complex<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -216,7 +216,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   // and the upper part being set to true for the destination boolean
   // pixel type.
   void
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& lhs)
+  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     bit_type *dest_buf = lhs->data();

--- a/cpp/test/ome-bioformats/pixel.h
+++ b/cpp/test/ome-bioformats/pixel.h
@@ -67,45 +67,45 @@ pixel_value_complex(uint32_t value)
 template<>
 inline
 ::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
-                                          ::ome::bioformats::ENDIAN_BIG>::type
+                                         ::ome::bioformats::ENDIAN_BIG>::type
 pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
-                                                       ::ome::bioformats::ENDIAN_BIG>::type>(uint32_t value)
+                                                     ::ome::bioformats::ENDIAN_BIG>::type>(uint32_t value)
 {
   return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
-                                                                        ::ome::bioformats::ENDIAN_BIG>::type>(value);
+    ::ome::bioformats::ENDIAN_BIG>::type>(value);
 }
 
 template<>
 inline
 ::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
-                                          ::ome::bioformats::ENDIAN_LITTLE>::type
+                                         ::ome::bioformats::ENDIAN_LITTLE>::type
 pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
-                                                       ::ome::bioformats::ENDIAN_LITTLE>::type>(uint32_t value)
+                                                     ::ome::bioformats::ENDIAN_LITTLE>::type>(uint32_t value)
 {
   return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
-                                                                        ::ome::bioformats::ENDIAN_LITTLE>::type>(value);
+    ::ome::bioformats::ENDIAN_LITTLE>::type>(value);
 }
 
 template<>
 inline
 ::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
-                                          ::ome::bioformats::ENDIAN_BIG>::type
+                                         ::ome::bioformats::ENDIAN_BIG>::type
 pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
-                                                       ::ome::bioformats::ENDIAN_BIG>::type>(uint32_t value)
+                                                     ::ome::bioformats::ENDIAN_BIG>::type>(uint32_t value)
 {
   return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
-                                                                        ::ome::bioformats::ENDIAN_BIG>::type>(value);
+    ::ome::bioformats::ENDIAN_BIG>::type>(value);
 }
 
 template<>
 inline
 ::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
-                                          ::ome::bioformats::ENDIAN_LITTLE>::type
+                                         ::ome::bioformats::ENDIAN_LITTLE>::type
 pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
-                                                       ::ome::bioformats::ENDIAN_LITTLE>::type>(uint32_t value)
+                                                     ::ome::bioformats::ENDIAN_LITTLE>::type>(uint32_t value)
 {
   return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
-                                                                        ::ome::bioformats::ENDIAN_LITTLE>::type>(value);
+    ::ome::bioformats::ENDIAN_LITTLE>::type>(value);
 }
 
 /*
@@ -289,11 +289,11 @@ namespace std
   {
     os << '(';
     for (uint16_t i = 0; i <::ome::bioformats::PixelBufferBase::dimensions; ++i)
-    {
-      os << order.ordering(i) << '/' << order.ascending(i);
-      if (i + 1 != ::ome::bioformats::PixelBufferBase::dimensions)
-        os << ',';
-    }
+      {
+        os << order.ordering(i) << '/' << order.ascending(i);
+        if (i + 1 != ::ome::bioformats::PixelBufferBase::dimensions)
+          os << ',';
+      }
     os << ')';
     return os;
   }

--- a/cpp/test/ome-bioformats/pixel.h
+++ b/cpp/test/ome-bioformats/pixel.h
@@ -66,45 +66,45 @@ pixel_value_complex(uint32_t value)
 
 template<>
 inline
-::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
                                           ::ome::bioformats::ENDIAN_BIG>::type
-pixel_value< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
                                                        ::ome::bioformats::ENDIAN_BIG>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+  return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
                                                                         ::ome::bioformats::ENDIAN_BIG>::type>(value);
 }
 
 template<>
 inline
-::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
                                           ::ome::bioformats::ENDIAN_LITTLE>::type
-pixel_value< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
                                                        ::ome::bioformats::ENDIAN_LITTLE>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+  return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::COMPLEX,
                                                                         ::ome::bioformats::ENDIAN_LITTLE>::type>(value);
 }
 
 template<>
 inline
-::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
                                           ::ome::bioformats::ENDIAN_BIG>::type
-pixel_value< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
                                                        ::ome::bioformats::ENDIAN_BIG>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+  return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
                                                                         ::ome::bioformats::ENDIAN_BIG>::type>(value);
 }
 
 template<>
 inline
-::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
                                           ::ome::bioformats::ENDIAN_LITTLE>::type
-pixel_value< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+pixel_value<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
                                                        ::ome::bioformats::ENDIAN_LITTLE>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::bioformats::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+  return pixel_value_complex<::ome::bioformats::PixelEndianProperties<::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
                                                                         ::ome::bioformats::ENDIAN_LITTLE>::type>(value);
 }
 
@@ -117,14 +117,14 @@ template<int P>
 struct PixelTypeConversionVisitor : public boost::static_visitor<>
 {
   typedef typename ::ome::bioformats::PixelProperties<P>::std_type src_type;
-  typedef ::ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
+  typedef ::ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
 
-  const std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type>> *src;
+  const std::shared_ptr<::ome::bioformats::PixelBuffer<src_type>> *src;
   ::ome::bioformats::VariantPixelBuffer& dest;
 
   PixelTypeConversionVisitor(const ::ome::bioformats::VariantPixelBuffer& src,
                              ::ome::bioformats::VariantPixelBuffer& dest):
-    src(boost::get<std::shared_ptr< ::ome::bioformats::PixelBuffer<src_type>>>(&src.vbuffer())),
+    src(boost::get<std::shared_ptr<::ome::bioformats::PixelBuffer<src_type>>>(&src.vbuffer())),
     dest(dest)
   {
 
@@ -141,7 +141,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_integral<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& lhs)
+  operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -167,7 +167,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_floating_point<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& lhs)
+  operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -192,7 +192,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   typename boost::enable_if_c<
     boost::is_complex<T>::value, void
     >::type
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& lhs)
+  operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     T *dest_buf = lhs->data();
@@ -216,7 +216,7 @@ struct PixelTypeConversionVisitor : public boost::static_visitor<>
   // and the upper part being set to true for the destination boolean
   // pixel type.
   void
-  operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type>>& lhs)
+  operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<bit_type>>& lhs)
   {
     const src_type *src_buf = (*src)->data();
     bit_type *dest_buf = lhs->data();
@@ -288,7 +288,7 @@ namespace std
               const ::ome::bioformats::PixelBufferBase::storage_order_type& order)
   {
     os << '(';
-    for (uint16_t i = 0; i < ::ome::bioformats::PixelBufferBase::dimensions; ++i)
+    for (uint16_t i = 0; i <::ome::bioformats::PixelBufferBase::dimensions; ++i)
     {
       os << order.ordering(i) << '/' << order.ascending(i);
       if (i + 1 != ::ome::bioformats::PixelBufferBase::dimensions)

--- a/cpp/test/ome-bioformats/pixelbuffer.h
+++ b/cpp/test/ome-bioformats/pixelbuffer.h
@@ -198,8 +198,8 @@ void test_operators(const PixelBuffer<T>& buf1,
 }
 
 template<typename T>
-void test_operators(const PixelBuffer<std::complex<T> >& /* buf1 */,
-                    const PixelBuffer<std::complex<T> >& /* buf2 */)
+void test_operators(const PixelBuffer<std::complex<T>>& /* buf1 */,
+                    const PixelBuffer<std::complex<T>>& /* buf2 */)
 {
 }
 

--- a/cpp/test/ome-bioformats/pixelbuffer.h
+++ b/cpp/test/ome-bioformats/pixelbuffer.h
@@ -89,7 +89,7 @@ TYPED_TEST_P(PixelBufferType, ConstructExtent)
   for (uint32_t i = 0; i < 10; ++i)
     source.push_back(pixel_value<TypeParam>(i));
 
-  ome::compat::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
+  std::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
   extents[0] = 5;
   extents[1] = 2;
   extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;
@@ -107,11 +107,11 @@ TYPED_TEST_P(PixelBufferType, ConstructExtent)
 
 TYPED_TEST_P(PixelBufferType, ConstructExtentRef)
 {
-  ome::compat::array<TypeParam, 10> source;
+  std::array<TypeParam, 10> source;
   for (uint32_t i = 0; i < 10; ++i)
     source[i] = pixel_value<TypeParam>(i);
 
-  ome::compat::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
+  std::array<typename PixelBuffer<TypeParam>::size_type, 9> extents;
   extents[0] = 5;
   extents[1] = 2;
   extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;
@@ -146,7 +146,7 @@ TYPED_TEST_P(PixelBufferType, ConstructRange)
 
 TYPED_TEST_P(PixelBufferType, ConstructRangeRef)
 {
-  ome::compat::array<TypeParam, 10> source;
+  std::array<TypeParam, 10> source;
   for (uint32_t i = 0; i < 10; ++i)
     source[i] = pixel_value<TypeParam>(i);
 

--- a/cpp/test/ome-bioformats/pixelproperties.cpp
+++ b/cpp/test/ome-bioformats/pixelproperties.cpp
@@ -95,8 +95,8 @@ typedef ::testing::Types<PixelTypeParam<PT::INT8,         int8_t>,
                          PixelTypeParam<PT::BIT,          bool>,
                          PixelTypeParam<PT::FLOAT,        float>,
                          PixelTypeParam<PT::DOUBLE,       double>,
-                         PixelTypeParam<PT::COMPLEX,      std::complex<float> >,
-                         PixelTypeParam<PT::DOUBLECOMPLEX,std::complex<double> > > TestTypes;
+                         PixelTypeParam<PT::COMPLEX,      std::complex<float>>,
+                         PixelTypeParam<PT::DOUBLECOMPLEX,std::complex<double>>> TestTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(PixelPropertiesTypeTest, PixelPropertiesType, TestTypes);
 
 class PixelPropertiesTestParameters

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -83,7 +83,7 @@ namespace
 
   struct DumpPixelBufferVisitor : public boost::static_visitor<>
   {
-    typedef ::ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
+    typedef ::ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
 
     std::ostream& stream;
 
@@ -95,7 +95,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_integral<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       float v = static_cast<float>(buf->at(idx));
@@ -108,7 +108,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_floating_point<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -119,7 +119,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -130,7 +130,7 @@ namespace
     // and the upper half being set to true for the destination boolean
     // pixel type.
     float
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<bit_type>>& buf,
          const ::ome::bioformats::PixelBuffer<bit_type>::indices_type& idx)
     {
       return buf->at(idx) ? 1.0f : 0.0f;

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -535,7 +535,7 @@ TEST(TIFFTest, FieldWrapUInt16Pair)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  ome::compat::array<uint16_t, 2> value;
+  std::array<uint16_t, 2> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::DOTRANGE).get(value), ome::bioformats::tiff::Exception);
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::HALFTONEHINTS).get(value), ome::bioformats::tiff::Exception);
@@ -573,7 +573,7 @@ TEST(TIFFTest, FieldWrapFloat2)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  ome::compat::array<float, 2> value;
+  std::array<float, 2> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::WHITEPOINT).get(value), ome::bioformats::tiff::Exception);
 }
@@ -588,7 +588,7 @@ TEST(TIFFTest, FieldWrapFloat3)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  ome::compat::array<float, 3> value;
+  std::array<float, 3> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::YCBCRCOEFFICIENTS).get(value), ome::bioformats::tiff::Exception);
 }
@@ -604,7 +604,7 @@ TEST(TIFFTest, FieldWrapFloat6)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  ome::compat::array<float, 6> value;
+  std::array<float, 6> value;
 
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::PRIMARYCHROMATICITIES).get(value), ome::bioformats::tiff::Exception);
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::REFERENCEBLACKWHITE).get(value), ome::bioformats::tiff::Exception);
@@ -634,7 +634,7 @@ TEST(TIFFTest, FieldWrapUInt16Array3)
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
-  ome::compat::array<std::vector<uint16_t>, 3> value;
+  std::array<std::vector<uint16_t>, 3> value;
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::COLORMAP).get(value), ome::bioformats::tiff::Exception);
   ASSERT_THROW(ifd->getField(ome::bioformats::tiff::TRANSFERFUNCTION).get(value), ome::bioformats::tiff::Exception);
 }
@@ -874,7 +874,7 @@ public:
     png_set_interlace_handling(pngptr);
     png_read_update_info(pngptr, infoptr);
 
-    ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+    std::array<VariantPixelBuffer::size_type, 9> shape;
     shape[::ome::bioformats::DIM_SPATIAL_X] = pwidth;
     shape[::ome::bioformats::DIM_SPATIAL_Y] = pheight;
     shape[::ome::bioformats::DIM_SUBCHANNEL] = 3U;
@@ -1456,7 +1456,7 @@ TEST_P(PixelTest, WriteTIFF)
       {
         const PlaneRegion& r = *i;
 
-        ome::compat::array<VariantPixelBuffer::size_type, 9> shape;
+        std::array<VariantPixelBuffer::size_type, 9> shape;
         shape[::ome::bioformats::DIM_SPATIAL_X] = r.w;
         shape[::ome::bioformats::DIM_SPATIAL_Y] = r.h;
         shape[::ome::bioformats::DIM_SUBCHANNEL] = 3U;

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -95,7 +95,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_integral<T>::value, float
       >::type
-    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>&       buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       float v = static_cast<float>(buf->at(idx));
@@ -108,7 +108,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_floating_point<T>::value, float
       >::type
-    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>&       buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -119,7 +119,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, float
       >::type
-    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf,
+    dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<T>>&       buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -131,7 +131,7 @@ namespace
     // pixel type.
     float
     dump(const std::shared_ptr<::ome::bioformats::PixelBuffer<bit_type>>& buf,
-         const ::ome::bioformats::PixelBuffer<bit_type>::indices_type& idx)
+         const ::ome::bioformats::PixelBuffer<bit_type>::indices_type&    idx)
     {
       return buf->at(idx) ? 1.0f : 0.0f;
     }

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -95,7 +95,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_integral<T>::value, float
       >::type
-    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       float v = static_cast<float>(buf->at(idx));
@@ -108,7 +108,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_floating_point<T>::value, float
       >::type
-    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -119,7 +119,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, float
       >::type
-    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -130,7 +130,7 @@ namespace
     // and the upper half being set to true for the destination boolean
     // pixel type.
     float
-    dump(const ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf,
          const ::ome::bioformats::PixelBuffer<bit_type>::indices_type& idx)
     {
       return buf->at(idx) ? 1.0f : 0.0f;
@@ -215,13 +215,13 @@ TEST(TIFFTest, ConstructFailFile)
 
 TEST(TIFFTest, IFDsByIndex)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t =TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
   for (directory_index_type i = 0; i < 10; ++i)
     {
-      ome::compat::shared_ptr<IFD> ifd;
+      std::shared_ptr<IFD> ifd;
       ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(i));
     }
 
@@ -230,14 +230,14 @@ TEST(TIFFTest, IFDsByIndex)
 
 TEST(TIFFTest, IFDsByOffset)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t =TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
   for (directory_index_type i = 0; i < 10; ++i)
     {
       uint64_t offset = t->getDirectoryByIndex(i)->getOffset();
-      ome::compat::shared_ptr<IFD> ifd;
+      std::shared_ptr<IFD> ifd;
       ASSERT_NO_THROW(ifd = t->getDirectoryByOffset(offset));
       ASSERT_EQ(ifd->getOffset(), offset);
     }
@@ -247,11 +247,11 @@ TEST(TIFFTest, IFDsByOffset)
 
 TEST(TIFFTest, IFDSimpleIter)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd = t->getDirectoryByIndex(0);
+  std::shared_ptr<IFD> ifd = t->getDirectoryByIndex(0);
 
   while(ifd)
     {
@@ -261,7 +261,7 @@ TEST(TIFFTest, IFDSimpleIter)
 
 TEST(TIFFTest, TIFFIter)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
@@ -272,7 +272,7 @@ TEST(TIFFTest, TIFFIter)
 
 TEST(TIFFTest, TIFFConstIter)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
@@ -283,7 +283,7 @@ TEST(TIFFTest, TIFFConstIter)
 
 TEST(TIFFTest, TIFFConstIter2)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
@@ -294,11 +294,11 @@ TEST(TIFFTest, TIFFConstIter2)
 
 TEST(TIFFTest, RawField)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -308,11 +308,11 @@ TEST(TIFFTest, RawField)
 
 TEST(TIFFTest, RawField0)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -322,11 +322,11 @@ TEST(TIFFTest, RawField0)
 
 TEST(TIFFTest, FieldWrapString)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -346,11 +346,11 @@ TEST(TIFFTest, FieldWrapString)
 
 TEST(TIFFTest, FieldWrapStringArray)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -363,11 +363,11 @@ TEST(TIFFTest, FieldWrapStringArray)
 
 TEST(TIFFTest, FieldWrapUInt16)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -389,11 +389,11 @@ TEST(TIFFTest, FieldWrapUInt16)
 
 TEST(TIFFTest, FieldWrapCompression)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -405,11 +405,11 @@ TEST(TIFFTest, FieldWrapCompression)
 
 TEST(TIFFTest, FieldWrapFillOrder)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -420,11 +420,11 @@ TEST(TIFFTest, FieldWrapFillOrder)
 
 TEST(TIFFTest, FieldWrapOrientation)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -435,11 +435,11 @@ TEST(TIFFTest, FieldWrapOrientation)
 
 TEST(TIFFTest, FieldWrapPlanarConfiguration)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -451,11 +451,11 @@ TEST(TIFFTest, FieldWrapPlanarConfiguration)
 
 TEST(TIFFTest, FieldWrapPhotometricInterpretation)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -467,11 +467,11 @@ TEST(TIFFTest, FieldWrapPhotometricInterpretation)
 
 TEST(TIFFTest, FieldWrapPredictor)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -482,11 +482,11 @@ TEST(TIFFTest, FieldWrapPredictor)
 
 TEST(TIFFTest, FieldWrapSampleFormat)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -497,11 +497,11 @@ TEST(TIFFTest, FieldWrapSampleFormat)
 
 TEST(TIFFTest, FieldWrapThreshholding)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -512,11 +512,11 @@ TEST(TIFFTest, FieldWrapThreshholding)
 
 TEST(TIFFTest, FieldWrapYCbCrPosition)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -527,11 +527,11 @@ TEST(TIFFTest, FieldWrapYCbCrPosition)
 
 TEST(TIFFTest, FieldWrapUInt16Pair)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -545,11 +545,11 @@ TEST(TIFFTest, FieldWrapUInt16Pair)
 
 TEST(TIFFTest, FieldWrapFloat)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -565,11 +565,11 @@ TEST(TIFFTest, FieldWrapFloat)
 
 TEST(TIFFTest, FieldWrapFloat2)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -580,11 +580,11 @@ TEST(TIFFTest, FieldWrapFloat2)
 
 TEST(TIFFTest, FieldWrapFloat3)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -596,11 +596,11 @@ TEST(TIFFTest, FieldWrapFloat3)
 
 TEST(TIFFTest, FieldWrapFloat6)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -612,11 +612,11 @@ TEST(TIFFTest, FieldWrapFloat6)
 
 TEST(TIFFTest, FieldWrapUInt16ExtraSamplesArray)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -626,11 +626,11 @@ TEST(TIFFTest, FieldWrapUInt16ExtraSamplesArray)
 
 TEST(TIFFTest, FieldWrapUInt16Array3)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -641,11 +641,11 @@ TEST(TIFFTest, FieldWrapUInt16Array3)
 
 TEST(TIFFTest, FieldWrapUInt32)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -670,11 +670,11 @@ TEST(TIFFTest, FieldWrapUInt32)
 
 TEST(TIFFTest, FieldWrapUInt32Array)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -685,11 +685,11 @@ TEST(TIFFTest, FieldWrapUInt32Array)
 
 TEST(TIFFTest, FieldWrapUInt64Array)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -703,11 +703,11 @@ TEST(TIFFTest, FieldWrapUInt64Array)
 
 TEST(TIFFTest, FieldWrapByteArray)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -722,11 +722,11 @@ TEST(TIFFTest, FieldWrapByteArray)
 
 TEST(TIFFTest, ValueProxy)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -737,11 +737,11 @@ TEST(TIFFTest, ValueProxy)
 
 TEST(TIFFTest, Value)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -751,11 +751,11 @@ TEST(TIFFTest, Value)
 
 TEST(TIFFTest, FieldName)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -771,11 +771,11 @@ TEST(TIFFTest, FieldName)
 
 TEST(TIFFTest, FieldCount)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -787,11 +787,11 @@ TEST(TIFFTest, FieldCount)
 
 TEST(TIFFTest, PixelType)
 {
-  ome::compat::shared_ptr<TIFF> t;
+  std::shared_ptr<TIFF> t;
   ASSERT_NO_THROW(t = TIFF::open(PROJECT_SOURCE_DIR "/components/specification/samples/2010-06/18x24y5z1t2c8b-text.ome.tiff", "r"));
   ASSERT_TRUE(static_cast<bool>(t));
 
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<IFD> ifd;
   ASSERT_NO_THROW(ifd = t->getDirectoryByIndex(0));
   ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -817,8 +817,8 @@ TEST(TIFFCodec, ListCodecs)
 class TIFFTileTest : public ::testing::TestWithParam<TileTestParameters>
 {
 public:
-  ome::compat::shared_ptr<TIFF> tiff;
-  ome::compat::shared_ptr<IFD> ifd;
+  std::shared_ptr<TIFF> tiff;
+  std::shared_ptr<IFD> ifd;
   uint32_t iwidth;
   uint32_t iheight;
   ome::bioformats::tiff::PlanarConfiguration planarconfig;
@@ -887,7 +887,7 @@ public:
     pngdata_chunky.setBuffer(shape, PT::UINT8, order_chunky);
     pngdata_planar.setBuffer(shape, PT::UINT8, order_planar);
 
-    ome::compat::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> >& uint8_pngdata_chunky(boost::get<ome::compat::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> > >(pngdata_chunky.vbuffer()));
+    std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> >& uint8_pngdata_chunky(boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> > >(pngdata_chunky.vbuffer()));
     std::vector<png_bytep> row_pointers(pheight);
     for (dimension_size_type y = 0; y < pheight; ++y)
       {
@@ -1169,10 +1169,10 @@ namespace
   read_test(const std::string& file,
             const VariantPixelBuffer& reference)
   {
-    ome::compat::shared_ptr<TIFF> tiff;
+    std::shared_ptr<TIFF> tiff;
     ASSERT_NO_THROW(tiff = TIFF::open(file, "r"));
     ASSERT_TRUE(static_cast<bool>(tiff));
-    ome::compat::shared_ptr<IFD> ifd;
+    std::shared_ptr<IFD> ifd;
     ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
     ASSERT_TRUE(static_cast<bool>(ifd));
 
@@ -1387,10 +1387,10 @@ TEST_P(PixelTest, WriteTIFF)
 
   // Write TIFF
   {
-    ome::compat::shared_ptr<TIFF> wtiff;
+    std::shared_ptr<TIFF> wtiff;
     ASSERT_NO_THROW(wtiff = TIFF::open(params.filename, "w"));
     ASSERT_TRUE(static_cast<bool>(wtiff));
-    ome::compat::shared_ptr<IFD> wifd;
+    std::shared_ptr<IFD> wifd;
     ASSERT_NO_THROW(wifd = wtiff->getCurrentDirectory());
     ASSERT_TRUE(static_cast<bool>(wifd));
 
@@ -1485,10 +1485,10 @@ TEST_P(PixelTest, WriteTIFF)
   {
     // Note "c" to disable automatic strip chopping so we can verify
     // the exact tag content of ROWSPERSTRIP.
-    ome::compat::shared_ptr<TIFF> tiff;
+    std::shared_ptr<TIFF> tiff;
     ASSERT_NO_THROW(tiff = TIFF::open(params.filename, "rc"));
     ASSERT_TRUE(static_cast<bool>(tiff));
-    ome::compat::shared_ptr<IFD> ifd;
+    std::shared_ptr<IFD> ifd;
     ASSERT_NO_THROW(ifd = tiff->getDirectoryByIndex(0));
     ASSERT_TRUE(static_cast<bool>(ifd));
 

--- a/cpp/test/ome-bioformats/tiff.cpp
+++ b/cpp/test/ome-bioformats/tiff.cpp
@@ -95,7 +95,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_integral<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       float v = static_cast<float>(buf->at(idx));
@@ -108,7 +108,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_floating_point<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -119,7 +119,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, float
       >::type
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<T>>& buf,
          const typename ::ome::bioformats::PixelBuffer<T>::indices_type& idx) const
     {
       // Assume float is already normalised.
@@ -130,7 +130,7 @@ namespace
     // and the upper half being set to true for the destination boolean
     // pixel type.
     float
-    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf,
+    dump(const std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type>>& buf,
          const ::ome::bioformats::PixelBuffer<bit_type>::indices_type& idx)
     {
       return buf->at(idx) ? 1.0f : 0.0f;
@@ -887,7 +887,7 @@ public:
     pngdata_chunky.setBuffer(shape, PT::UINT8, order_chunky);
     pngdata_planar.setBuffer(shape, PT::UINT8, order_planar);
 
-    std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> >& uint8_pngdata_chunky(boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type> > >(pngdata_chunky.vbuffer()));
+    std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type>>& uint8_pngdata_chunky(boost::get<std::shared_ptr<PixelBuffer<PixelProperties<PT::UINT8>::std_type>>>(pngdata_chunky.vbuffer()));
     std::vector<png_bytep> row_pointers(pheight);
     for (dimension_size_type y = 0; y < pheight; ++y)
       {

--- a/cpp/test/ome-bioformats/tilecache.cpp
+++ b/cpp/test/ome-bioformats/tilecache.cpp
@@ -58,7 +58,7 @@ TEST(TileCache, Insert)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
       ASSERT_TRUE(static_cast<bool>(c.find(i)));
       ASSERT_TRUE(static_cast<bool>(cc.find(i)));
     }
@@ -72,11 +72,11 @@ TEST(TileCache, InsertFail)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_FALSE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_FALSE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
 }
 
@@ -93,7 +93,7 @@ TEST(TileCache, IndexOperator)
   c.clear();
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      c[i] = ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)));
+      c[i] = std::shared_ptr<TileBuffer>(new TileBuffer((8192)));
       ASSERT_TRUE(static_cast<bool>(c[i]));
     }
 
@@ -107,7 +107,7 @@ TEST(TileCache, Remove)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
       ASSERT_TRUE(static_cast<bool>(c.find(i)));
       ASSERT_TRUE(static_cast<bool>(cc.find(i)));
     }
@@ -125,7 +125,7 @@ TEST(TileCache, Clear)
 
   for (dimension_size_type i = 0; i < 16; ++i)
     {
-      ASSERT_TRUE(c.insert(i, ome::compat::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
+      ASSERT_TRUE(c.insert(i, std::shared_ptr<TileBuffer>(new TileBuffer((8192)))));
     }
 
   ASSERT_EQ(16U, c.size());

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -165,7 +165,7 @@ struct RandomAssignTestVisitor : public boost::static_visitor<>
   }
 
   void
-  operator() (const ome::compat::shared_ptr<PixelBuffer<PixelProperties<PT::BIT>::std_type> >& v)
+  operator() (const std::shared_ptr<PixelBuffer<PixelProperties<PT::BIT>::std_type> >& v)
   {
     typedef PixelProperties<PT::BIT>::std_type value_type;
 
@@ -240,7 +240,7 @@ struct ConstructExtentRefTestVisitor : public boost::static_visitor<>
 
     // VariantPixelBuffer with unmanaged backing store.
     value_type backing[10];
-    ome::compat::shared_ptr<PixelBuffer<value_type> > buf
+    std::shared_ptr<PixelBuffer<value_type> > buf
       (new PixelBuffer<value_type>(&backing[0], extents));
     VariantPixelBuffer mbuf(buf);
 
@@ -264,7 +264,7 @@ struct ConstructRangeRefTestVisitor : public boost::static_visitor<>
 
     // VariantPixelBuffer with unmanaged backing store.
     value_type backing[100];
-    ome::compat::shared_ptr<PixelBuffer<value_type> > buf
+    std::shared_ptr<PixelBuffer<value_type> > buf
       (new PixelBuffer<value_type>(&backing[0],
                                    boost::extents[10][10][1][1][1][1][1][1][1]));
     VariantPixelBuffer mbuf(buf);
@@ -336,7 +336,7 @@ struct ManagedTestVisitor : public boost::static_visitor<>
     {
       // VariantPixelBuffer with unmanaged backing store.
       value_type backing[100];
-      ome::compat::shared_ptr<PixelBuffer<value_type> > buf
+      std::shared_ptr<PixelBuffer<value_type> > buf
         (new PixelBuffer<value_type>(&backing[0],
                                      boost::extents[10][10][1][1][1][1][1][1][1]));
       VariantPixelBuffer mbuf(buf);

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -165,7 +165,7 @@ struct RandomAssignTestVisitor : public boost::static_visitor<>
   }
 
   void
-  operator() (const std::shared_ptr<PixelBuffer<PixelProperties<PT::BIT>::std_type> >& v)
+  operator() (const std::shared_ptr<PixelBuffer<PixelProperties<PT::BIT>::std_type>>& v)
   {
     typedef PixelProperties<PT::BIT>::std_type value_type;
 
@@ -240,7 +240,7 @@ struct ConstructExtentRefTestVisitor : public boost::static_visitor<>
 
     // VariantPixelBuffer with unmanaged backing store.
     value_type backing[10];
-    std::shared_ptr<PixelBuffer<value_type> > buf
+    std::shared_ptr<PixelBuffer<value_type>> buf
       (new PixelBuffer<value_type>(&backing[0], extents));
     VariantPixelBuffer mbuf(buf);
 
@@ -264,7 +264,7 @@ struct ConstructRangeRefTestVisitor : public boost::static_visitor<>
 
     // VariantPixelBuffer with unmanaged backing store.
     value_type backing[100];
-    std::shared_ptr<PixelBuffer<value_type> > buf
+    std::shared_ptr<PixelBuffer<value_type>> buf
       (new PixelBuffer<value_type>(&backing[0],
                                    boost::extents[10][10][1][1][1][1][1][1][1]));
     VariantPixelBuffer mbuf(buf);
@@ -336,7 +336,7 @@ struct ManagedTestVisitor : public boost::static_visitor<>
     {
       // VariantPixelBuffer with unmanaged backing store.
       value_type backing[100];
-      std::shared_ptr<PixelBuffer<value_type> > buf
+      std::shared_ptr<PixelBuffer<value_type>> buf
         (new PixelBuffer<value_type>(&backing[0],
                                      boost::extents[10][10][1][1][1][1][1][1][1]));
       VariantPixelBuffer mbuf(buf);

--- a/cpp/test/ome-bioformats/variantpixelbuffer.cpp
+++ b/cpp/test/ome-bioformats/variantpixelbuffer.cpp
@@ -233,7 +233,7 @@ struct ConstructExtentRefTestVisitor : public boost::static_visitor<>
   {
     typedef typename T::element_type::value_type value_type;
 
-    ome::compat::array<typename PixelBuffer<value_type>::size_type, 9> extents;
+    std::array<typename PixelBuffer<value_type>::size_type, 9> extents;
     extents[0] = 5;
     extents[1] = 2;
     extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;
@@ -579,7 +579,7 @@ TEST_P(VariantPixelBufferTest, ConstructExtent)
 {
   const VariantPixelBufferTestParameters& params = GetParam();
 
-  ome::compat::array<VariantPixelBuffer::size_type, 9> extents;
+  std::array<VariantPixelBuffer::size_type, 9> extents;
   extents[0] = 5;
   extents[1] = 2;
   extents[2] = extents[3] = extents[4] = extents[5] = extents[6] = extents[7] = extents[8] = 1;

--- a/cpp/test/ome-xml/constrained-numeric.h
+++ b/cpp/test/ome-xml/constrained-numeric.h
@@ -385,7 +385,7 @@ TYPED_TEST_P(NumericTest, OperatorEqual)
        i != this->ops.end();
        ++i)
     if (i->op == EQUAL)
-      compare_test<CompareEqual<TypeParam> >(*this, *i);
+      compare_test<CompareEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorNotEqual)
@@ -394,7 +394,7 @@ TYPED_TEST_P(NumericTest, OperatorNotEqual)
        i != this->ops.end();
        ++i)
     if (i->op == NOT_EQUAL)
-      compare_test<CompareNotEqual<TypeParam> >(*this, *i);
+      compare_test<CompareNotEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorLess)
@@ -403,7 +403,7 @@ TYPED_TEST_P(NumericTest, OperatorLess)
        i != this->ops.end();
        ++i)
     if (i->op == LESS)
-      compare_test<CompareLess<TypeParam> >(*this, *i);
+      compare_test<CompareLess<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorLessOrEqual)
@@ -412,7 +412,7 @@ TYPED_TEST_P(NumericTest, OperatorLessOrEqual)
        i != this->ops.end();
        ++i)
     if (i->op == LESS_OR_EQUAL)
-      compare_test<CompareLessOrEqual<TypeParam> >(*this, *i);
+      compare_test<CompareLessOrEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorGreater)
@@ -421,7 +421,7 @@ TYPED_TEST_P(NumericTest, OperatorGreater)
        i != this->ops.end();
        ++i)
     if (i->op == GREATER)
-      compare_test<CompareGreater<TypeParam> >(*this, *i);
+      compare_test<CompareGreater<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorGreaterOrEqual)
@@ -430,7 +430,7 @@ TYPED_TEST_P(NumericTest, OperatorGreaterOrEqual)
        i != this->ops.end();
        ++i)
     if (i->op == GREATER_OR_EQUAL)
-      compare_test<CompareGreaterOrEqual<TypeParam> >(*this, *i);
+      compare_test<CompareGreaterOrEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorAdd)
@@ -439,7 +439,7 @@ TYPED_TEST_P(NumericTest, OperatorAdd)
        i != this->ops.end();
        ++i)
     if (i->op == ADD)
-      operation_test<OperationAdd<TypeParam> >(*this, *i);
+      operation_test<OperationAdd<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorAddAssign)
@@ -448,7 +448,7 @@ TYPED_TEST_P(NumericTest, OperatorAddAssign)
        i != this->ops.end();
        ++i)
     if (i->op == ADD_ASSIGN)
-      operation_test<OperationAddAssign<TypeParam> >(*this, *i);
+      operation_test<OperationAddAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorSubtract)
@@ -457,7 +457,7 @@ TYPED_TEST_P(NumericTest, OperatorSubtract)
        i != this->ops.end();
        ++i)
     if (i->op == SUBTRACT)
-      operation_test<OperationSubtract<TypeParam> >(*this, *i);
+      operation_test<OperationSubtract<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorSubtractAssign)
@@ -466,7 +466,7 @@ TYPED_TEST_P(NumericTest, OperatorSubtractAssign)
        i != this->ops.end();
        ++i)
     if (i->op == SUBTRACT_ASSIGN)
-      operation_test<OperationSubtractAssign<TypeParam> >(*this, *i);
+      operation_test<OperationSubtractAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorMultiply)
@@ -475,7 +475,7 @@ TYPED_TEST_P(NumericTest, OperatorMultiply)
        i != this->ops.end();
        ++i)
     if (i->op == MULTIPLY)
-      operation_test<OperationMultiply<TypeParam> >(*this, *i);
+      operation_test<OperationMultiply<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorMultiplyAssign)
@@ -484,7 +484,7 @@ TYPED_TEST_P(NumericTest, OperatorMultiplyAssign)
        i != this->ops.end();
        ++i)
     if (i->op == MULTIPLY_ASSIGN)
-      operation_test<OperationMultiplyAssign<TypeParam> >(*this, *i);
+      operation_test<OperationMultiplyAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDivide)
@@ -493,7 +493,7 @@ TYPED_TEST_P(NumericTest, OperatorDivide)
        i != this->ops.end();
        ++i)
     if (i->op == DIVIDE)
-      operation_test<OperationDivide<TypeParam> >(*this, *i);
+      operation_test<OperationDivide<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDivideAssign)
@@ -502,7 +502,7 @@ TYPED_TEST_P(NumericTest, OperatorDivideAssign)
        i != this->ops.end();
        ++i)
     if (i->op == DIVIDE_ASSIGN)
-      operation_test<OperationDivideAssign<TypeParam> >(*this, *i);
+      operation_test<OperationDivideAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorModulo)
@@ -511,7 +511,7 @@ TYPED_TEST_P(NumericTest, OperatorModulo)
        i != this->ops.end();
        ++i)
     if (i->op == MODULO)
-      operation_test<OperationModulo<TypeParam> >(*this, *i);
+      operation_test<OperationModulo<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorModuloAssign)
@@ -520,7 +520,7 @@ TYPED_TEST_P(NumericTest, OperatorModuloAssign)
        i != this->ops.end();
        ++i)
     if (i->op == MODULO_ASSIGN)
-      operation_test<OperationModuloAssign<TypeParam> >(*this, *i);
+      operation_test<OperationModuloAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorIncrement)
@@ -529,7 +529,7 @@ TYPED_TEST_P(NumericTest, OperatorIncrement)
        i != this->ops.end();
        ++i)
     if (i->op == INCREMENT)
-      operation_test<OperationIncrement<TypeParam> >(*this, *i);
+      operation_test<OperationIncrement<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDecrement)
@@ -538,7 +538,7 @@ TYPED_TEST_P(NumericTest, OperatorDecrement)
        i != this->ops.end();
        ++i)
     if (i->op == DECREMENT)
-      operation_test<OperationDecrement<TypeParam> >(*this, *i);
+      operation_test<OperationDecrement<TypeParam>>(*this, *i);
 }
 
 REGISTER_TYPED_TEST_CASE_P(NumericTest,

--- a/cpp/test/ome-xml/enum.cpp
+++ b/cpp/test/ome-xml/enum.cpp
@@ -228,7 +228,7 @@ public:
  {}
 };
 
-class LaserTypeValue : public ::testing::TestWithParam<EnumValueParameters<LaserType> >
+class LaserTypeValue : public ::testing::TestWithParam<EnumValueParameters<LaserType>>
 {
 public:
   typedef LaserType enum_type;

--- a/cpp/test/ome-xml/model.cpp
+++ b/cpp/test/ome-xml/model.cpp
@@ -138,7 +138,7 @@ TEST_P(ModelTest, Update)
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
   root->update(docroot, model);
 }
@@ -148,7 +148,7 @@ TEST_P(ModelTest, CreateXML)
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
   root->update(docroot, model);
 
@@ -164,7 +164,7 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
   ome::xml::model::detail::OMEModel model;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
   root->update(docroot, model);
 
@@ -180,7 +180,7 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
   ome::common::xml::dom::Document doc2(ome::xml::createDocument(omexml));
   ome::xml::meta::OMEXMLMetadata meta2;
   ome::xml::model::detail::OMEModel model2;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root2(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root2(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
   ome::common::xml::dom::Element docroot2(doc2.getDocumentElement());
   root2->update(docroot2, model2);
 

--- a/docs/doxygen/bioformats.dox.cmake
+++ b/docs/doxygen/bioformats.dox.cmake
@@ -1593,10 +1593,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             = OME_HAVE_MEMORY \
-                         OME_HAVE_TUPLE \
-                         OME_HAVE_NOEXCEPT \
-                         OME_HAVE_BOOST_FORMAT \
+PREDEFINED             = OME_HAVE_BOOST_FORMAT \
                          OME_HAVE_BOOST_LOG \
                          OME_HAVE_BOOST_GEOMETRY_INDEX_RTREE_HPP
 

--- a/docs/sphinx/developers/cpp/conversion.txt
+++ b/docs/sphinx/developers/cpp/conversion.txt
@@ -267,17 +267,17 @@ The Bio-Formats API **never** passes pointers allocated with
 “smart” pointers are used throughout to manage memory safely and
 automatically.
 
-:cpp:class:`ome::compat::shared_ptr` as a “smart” pointer
+:cpp:class:`std::shared_ptr` as a “smart” pointer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The unsafe example above, has been rewritten to use
-:cpp:class:`ome::compat::shared_ptr`:
+:cpp:class:`std::shared_ptr`:
 
 .. code-block:: cpp
 
     // Start of block
     {
-      ome::compat::shared_ptr<Image> i(ome::compat::make_shared<Image>(filename));
+      std::shared_ptr<Image> i(std::make_shared<Image>(filename));
 
       i->read_plane(); // throws exception
 
@@ -286,20 +286,20 @@ The unsafe example above, has been rewritten to use
     }
 
 Rather than managing the memory by hand, responsibility for this is
-delegated to a “smart” pointer, :cpp:class:`ome::compat::shared_ptr`.
-The memory is freed by the :cpp:class:`ome::compat::shared_ptr`
+delegated to a “smart” pointer, :cpp:class:`std::shared_ptr`.
+The memory is freed by the :cpp:class:`std::shared_ptr`
 destructor which is run at the end of the block scope, on explicit
 :c:type:`return`, or when cleaned up by exception stack unwinding.
 
 .. note::
 
-    :cpp:class:`ome::compat::shared_ptr` is either a
+    :cpp:class:`std::shared_ptr` is either a
     :cpp:class:`std::shared_ptr` or a :cpp:class:`boost::shared_ptr`,
     depending upon whether C++11 features are avaiable or not,
     respectively.
 
 - :cpp:class:`shared_ptr` object lifetime manages the resource
-- :cpp:class:`new` replaced with :cpp:class:`ome::compat::make_shared`
+- :cpp:class:`new` replaced with :cpp:class:`std::make_shared`
 - May be used as class members; lifetime is tied to class instance
 - Clean up for all exit points is automatic and safe
 - Allows ownership transfer and sharing
@@ -350,20 +350,20 @@ C++ reference variants
                                    Image& i;                                 const Image& i;
 
     // Shared pointer
-           ome::compat::shared_ptr<Image> i;         ome::compat::shared_ptr<const Image> i;
-     const ome::compat::shared_ptr<Image> i;   const ome::compat::shared_ptr<const Image> i;
+           std::shared_ptr<Image> i;         std::shared_ptr<const Image> i;
+     const std::shared_ptr<Image> i;   const std::shared_ptr<const Image> i;
 
     // Shared pointer reference
-          ome::compat::shared_ptr<Image>& i;        ome::compat::shared_ptr<const Image>& i;
-    const ome::compat::shared_ptr<Image>& i;  const ome::compat::shared_ptr<const Image>& i;
+          std::shared_ptr<Image>& i;        std::shared_ptr<const Image>& i;
+    const std::shared_ptr<Image>& i;  const std::shared_ptr<const Image>& i;
 
     // Weak pointer
-             ome::compat::weak_ptr<Image> i;           ome::compat::weak_ptr<const Image> i;
-       const ome::compat::weak_ptr<Image> i;     const ome::compat::weak_ptr<const Image> i;
+             std::weak_ptr<Image> i;           std::weak_ptr<const Image> i;
+       const std::weak_ptr<Image> i;     const std::weak_ptr<const Image> i;
 
    // Weak pointer reference
-            ome::compat::weak_ptr<Image>& i;          ome::compat::weak_ptr<const Image>& i;
-      const ome::compat::weak_ptr<Image>& i;    const ome::compat::weak_ptr<const Image>& i;
+            std::weak_ptr<Image>& i;          std::weak_ptr<const Image>& i;
+      const std::weak_ptr<Image>& i;    const std::weak_ptr<const Image>& i;
 
 Java has one reference type.  Here, we have **22**.  Clearly, not all
 of these will typically be used.  Below, a subset of these are shown
@@ -374,15 +374,15 @@ Class member types:
 .. code-block:: cpp
 
   Image i;                             // Concrete instance
-  ome::compat::shared_ptr<Image> i;    // Reference
-  ome::compat::weak_ptr<Image> i;      // Weak reference
+  std::shared_ptr<Image> i;    // Reference
+  std::weak_ptr<Image> i;      // Weak reference
 
 Wherever possible, a concrete instance should be preferred.  This is
 not possible for polymorphic types, where a reference is required.  In
-this situation, an :cpp:class:`ome::compat::shared_ptr` is preferred
+this situation, an :cpp:class:`std::shared_ptr` is preferred
 if the class owns the member and/or needs control over its lifetime.
 If the class does not have ownership then an
-:cpp:class:`ome::compat::weak_ptr` will allow safe access to the
+:cpp:class:`std::weak_ptr` will allow safe access to the
 object if it still exists.  In circumstances where manual lifetime
 management is required, e.g. for performance, and the member is
 guaranteed to exist for the duration of the object's lifetime, a plain
@@ -399,7 +399,7 @@ Argument types:
   // Ownership retained
   void read_plane(const Image& image);
   // Ownership shared or transferred
-  void read_plane(const ome::compat::shared_ptr<Image>& image);
+  void read_plane(const std::shared_ptr<Image>& image);
 
 Passing primitive types by value is acceptable.  However, passing a
 struct or class by value will implicitly copy the object into the
@@ -409,11 +409,11 @@ polymorphic types).  Passing by reference avoids the need for any
 copying, and passing by :c:type:`const` reference will prevent the
 callee from modifying the object, also making it clear that there is
 no transfer of ownership.  Passing using an
-:cpp:class:`ome::compat::shared_ptr` is possible but not
+:cpp:class:`std::shared_ptr` is possible but not
 recommended---the copy will involve reference counting overhead which
 can kill multi-threaded performance since it requires synchronization
 between all threads; use a :c:type:`const` reference to an
-:cpp:class:`ome::compat::shared_ptr` to avoid the overhead.  If
+:cpp:class:`std::shared_ptr` to avoid the overhead.  If
 ownership should be transferred or shared with the callee, use a
 non-:c:type:`const` reference.
 
@@ -427,8 +427,8 @@ Return types:
 
                             Image get_image(); // Ownership transferred
                            Image& get_image(); // Ownership retained
-   ome::compat::shared_ptr<Image> get_image(); // Ownership shared/trans
-  ome::compat::shared_ptr<Image>& get_image(); // Ownership shared
+   std::shared_ptr<Image> get_image(); // Ownership shared/trans
+  std::shared_ptr<Image>& get_image(); // Ownership shared
 
 If the callee does not retain a copy of the original object, it can't
 pass by reference since it can't guarantee the object remaining in
@@ -437,7 +437,7 @@ pass by value.  If the callee does retain a copy, it has the option of
 passing by reference.  Passing by reference is preferred when
 possible.  Passing by value implies ownership transfer.  Passing by
 reference implies ownership retention.  Passing an
-:cpp:class:`ome::compat::shared_ptr` by value or reference implies
+:cpp:class:`std::shared_ptr` by value or reference implies
 sharing ownership since the caller can retain a reference; if passing
 by value ownership *may* be transferred since this implies the callee
 is not retaining a reference to it (but this is not guaranteed).
@@ -510,11 +510,11 @@ Types with a common base
 
 .. code-block:: cpp
 
-    std::vector<ome::compat::shared_ptr<Base> > v;
-    v.push_back(ome::compat::make_shared<Derived>());
+    std::vector<std::shared_ptr<Base> > v;
+    v.push_back(std::make_shared<Derived>());
 
 This can store any type derived from :cpp:class:`Base`.  An
-:cpp:class:`ome::compat::shared_ptr` is **essential**.  Without it,
+:cpp:class:`std::shared_ptr` is **essential**.  Without it,
 bare pointers to the base would be stored, and memory would be leaked
 when elements are removed from the container (unless externally
 managed [generally unsafe]).  The same applies to passing polymorphic
@@ -578,7 +578,7 @@ code to operate on all of the supported types.  The variant type may
 be used as a class member, passed by value, passed by reference or
 stored in a container like any other type.  Due to the way it is
 implemented to store values, it does not necessarily need wrapping in
-an :cpp:class:`ome::compat::shared_ptr` since it can behave as a value
+an :cpp:class:`std::shared_ptr` since it can behave as a value
 type (depending upon the context).
 
 
@@ -776,7 +776,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_integral<T>::value, void
         >::type
-      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Integer algorithm.
       }
@@ -786,7 +786,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_floating_point<T>::value, void
         >::type
-      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Floating point algorithm.
       }
@@ -796,7 +796,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_complex<T>::value, void
         >::type
-      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Complex floating point algorithm.
       }
@@ -804,7 +804,7 @@ integer, floating point, complex floating point and bitmask cases.
       // BIT/bool pixel type.  Note this is a simple overload since it is
       // a simple type, not a category of different types.
       void
-      operator() (ome::compat::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf)
+      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf)
       {
         // Boolean algorithm.
       }

--- a/docs/sphinx/developers/cpp/conversion.txt
+++ b/docs/sphinx/developers/cpp/conversion.txt
@@ -510,7 +510,7 @@ Types with a common base
 
 .. code-block:: cpp
 
-    std::vector<std::shared_ptr<Base> > v;
+    std::vector<std::shared_ptr<Base>> v;
     v.push_back(std::make_shared<Derived>());
 
 This can store any type derived from :cpp:class:`Base`.  An
@@ -776,7 +776,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_integral<T>::value, void
         >::type
-      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf)
       {
         // Integer algorithm.
       }
@@ -786,7 +786,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_floating_point<T>::value, void
         >::type
-      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf)
       {
         // Floating point algorithm.
       }
@@ -796,7 +796,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_complex<T>::value, void
         >::type
-      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T>>& buf)
       {
         // Complex floating point algorithm.
       }
@@ -804,7 +804,7 @@ integer, floating point, complex floating point and bitmask cases.
       // BIT/bool pixel type.  Note this is a simple overload since it is
       // a simple type, not a category of different types.
       void
-      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<bit_type> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<bit_type>>& buf)
       {
         // Boolean algorithm.
       }

--- a/docs/sphinx/developers/cpp/conversion.txt
+++ b/docs/sphinx/developers/cpp/conversion.txt
@@ -474,22 +474,20 @@ is not known unless passed separately.
 C++ arrays “decay” to “bare” pointers, and pointers have no associated
 size information.
 
-:cpp:class:`ome::compat::array` is a safe alternative.  This is either
-a C++11 :cpp:class:`std::array` or :cpp:class:`boost::array` with
-older compilers.
+:cpp:class:`std::array` is a safe alternative.
 
 .. code-block:: cpp
 
   class Image
   {
-    typedef ome::compat::array<uint8_t, 256> LUT;
+    typedef std::array<uint8_t, 256> LUT;
 
     // Safe; size defined
     const LUT& getLUT() const;
           void setLUT(const LUT&);
   };
 
-:cpp:class:`ome::compat::array` is a array-like object (a class which
+:cpp:class:`std::array` is an array-like object (a class which
 behaves like an array).  Its type and size are defined in the
 template, and it may be passed around like any other object.  Its
 :cpp:func:`array::at()` method provides strict bounds checking, while

--- a/docs/sphinx/developers/cpp/conversion.txt
+++ b/docs/sphinx/developers/cpp/conversion.txt
@@ -268,7 +268,7 @@ The Bio-Formats API **never** passes pointers allocated with
 automatically.
 
 :cpp:class:`std::shared_ptr` as a “smart” pointer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The unsafe example above, has been rewritten to use
 :cpp:class:`std::shared_ptr`:
@@ -286,17 +286,10 @@ The unsafe example above, has been rewritten to use
     }
 
 Rather than managing the memory by hand, responsibility for this is
-delegated to a “smart” pointer, :cpp:class:`std::shared_ptr`.
-The memory is freed by the :cpp:class:`std::shared_ptr`
-destructor which is run at the end of the block scope, on explicit
-:c:type:`return`, or when cleaned up by exception stack unwinding.
-
-.. note::
-
-    :cpp:class:`std::shared_ptr` is either a
-    :cpp:class:`std::shared_ptr` or a :cpp:class:`boost::shared_ptr`,
-    depending upon whether C++11 features are avaiable or not,
-    respectively.
+delegated to a “smart” pointer, :cpp:class:`std::shared_ptr`.  The
+memory is freed by the :cpp:class:`std::shared_ptr` destructor which
+is run at the end of the block scope, on explicit :c:type:`return`, or
+when cleaned up by exception stack unwinding.
 
 - :cpp:class:`shared_ptr` object lifetime manages the resource
 - :cpp:class:`new` replaced with :cpp:class:`std::make_shared`
@@ -340,14 +333,14 @@ C++ reference variants
 
 .. code-block:: cpp
 
-    //              Non-constant                                 Constant
-    // -------------------------------------  ----------------------------------------------
+    //          Non-constant                         Constant
+    // -----------------------------  --------------------------------------
     // Pointer
-                                   Image *i;                                 const Image *i;
-                            Image * const i;                          const Image * const i;
+                           Image *i;                         const Image *i;
+                    Image * const i;                  const Image * const i;
 
     // Reference
-                                   Image& i;                                 const Image& i;
+                           Image& i;                         const Image& i;
 
     // Shared pointer
            std::shared_ptr<Image> i;         std::shared_ptr<const Image> i;
@@ -373,7 +366,7 @@ Class member types:
 
 .. code-block:: cpp
 
-  Image i;                             // Concrete instance
+  Image i;                     // Concrete instance
   std::shared_ptr<Image> i;    // Reference
   std::weak_ptr<Image> i;      // Weak reference
 
@@ -409,12 +402,12 @@ polymorphic types).  Passing by reference avoids the need for any
 copying, and passing by :c:type:`const` reference will prevent the
 callee from modifying the object, also making it clear that there is
 no transfer of ownership.  Passing using an
-:cpp:class:`std::shared_ptr` is possible but not
-recommended---the copy will involve reference counting overhead which
-can kill multi-threaded performance since it requires synchronization
-between all threads; use a :c:type:`const` reference to an
-:cpp:class:`std::shared_ptr` to avoid the overhead.  If
-ownership should be transferred or shared with the callee, use a
+:cpp:class:`std::shared_ptr` is possible but not recommended---the
+copy will involve reference counting overhead which can kill
+multi-threaded performance since it requires synchronization between
+all threads; use a :c:type:`const` reference to an
+:cpp:class:`std::shared_ptr` to avoid the overhead.  If ownership
+should be transferred or shared with the callee, use a
 non-:c:type:`const` reference.
 
 To be absolutely clear, plain pointers are never used and are not
@@ -425,9 +418,9 @@ Return types:
 
 .. code-block:: cpp
 
-                            Image get_image(); // Ownership transferred
-                           Image& get_image(); // Ownership retained
-   std::shared_ptr<Image> get_image(); // Ownership shared/trans
+                    Image get_image(); // Ownership transferred
+                   Image& get_image(); // Ownership retained
+   std::shared_ptr<Image> get_image(); // Ownership shared/transferred
   std::shared_ptr<Image>& get_image(); // Ownership shared
 
 If the callee does not retain a copy of the original object, it can't
@@ -437,10 +430,10 @@ pass by value.  If the callee does retain a copy, it has the option of
 passing by reference.  Passing by reference is preferred when
 possible.  Passing by value implies ownership transfer.  Passing by
 reference implies ownership retention.  Passing an
-:cpp:class:`std::shared_ptr` by value or reference implies
-sharing ownership since the caller can retain a reference; if passing
-by value ownership *may* be transferred since this implies the callee
-is not retaining a reference to it (but this is not guaranteed).
+:cpp:class:`std::shared_ptr` by value or reference implies sharing
+ownership since the caller can retain a reference; if passing by value
+ownership *may* be transferred since this implies the callee is not
+retaining a reference to it (but this is not guaranteed).
 
 Again, to be absolutely clear, plain pointers are never used and are
 not acceptable for ownership transfer.  A plain reference also makes
@@ -514,11 +507,10 @@ Types with a common base
     v.push_back(std::make_shared<Derived>());
 
 This can store any type derived from :cpp:class:`Base`.  An
-:cpp:class:`std::shared_ptr` is **essential**.  Without it,
-bare pointers to the base would be stored, and memory would be leaked
-when elements are removed from the container (unless externally
-managed [generally unsafe]).  The same applies to passing polymorphic
-types.
+:cpp:class:`std::shared_ptr` is **essential**.  Without it, bare
+pointers to the base would be stored, and memory would be leaked when
+elements are removed from the container (unless externally managed
+[generally unsafe]).  The same applies to passing polymorphic types.
 
 Java containers can be problematic:
 
@@ -578,8 +570,8 @@ code to operate on all of the supported types.  The variant type may
 be used as a class member, passed by value, passed by reference or
 stored in a container like any other type.  Due to the way it is
 implemented to store values, it does not necessarily need wrapping in
-an :cpp:class:`std::shared_ptr` since it can behave as a value
-type (depending upon the context).
+an :cpp:class:`std::shared_ptr` since it can behave as a value type
+(depending upon the context).
 
 
 Java uses polymorphism to store and pass the root :cpp:class:`Object`

--- a/docs/sphinx/developers/cpp/conversion.txt
+++ b/docs/sphinx/developers/cpp/conversion.txt
@@ -766,7 +766,7 @@ integer, floating point, complex floating point and bitmask cases.
 
     struct TypeCategoryVisitor : public boost::static_visitor<>
     {
-      typedef ::ome::bioformats::PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
+      typedef ::ome::bioformats::PixelProperties<::ome::xml::model::enums::PixelType::BIT>::std_type bit_type;
 
       TypeCategoryVisitor()
       {}
@@ -776,7 +776,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_integral<T>::value, void
         >::type
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Integer algorithm.
       }
@@ -786,7 +786,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_floating_point<T>::value, void
         >::type
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Floating point algorithm.
       }
@@ -796,7 +796,7 @@ integer, floating point, complex floating point and bitmask cases.
       typename boost::enable_if_c<
         boost::is_complex<T>::value, void
         >::type
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<T> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<T> >& buf)
       {
         // Complex floating point algorithm.
       }
@@ -804,7 +804,7 @@ integer, floating point, complex floating point and bitmask cases.
       // BIT/bool pixel type.  Note this is a simple overload since it is
       // a simple type, not a category of different types.
       void
-      operator() (std::shared_ptr< ::ome::bioformats::PixelBuffer<bit_type> >& buf)
+      operator() (std::shared_ptr<::ome::bioformats::PixelBuffer<bit_type> >& buf)
       {
         // Boolean algorithm.
       }

--- a/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
@@ -97,7 +97,7 @@ namespace
           {
             // Print plane position (for this image index and plane
             // index)
-            ome::compat::array<dimension_size_type, 3> coords =
+            std::array<dimension_size_type, 3> coords =
               reader.getZCTCoords(p);
             stream << "\tPosition of Plane " << p << ':'
                    << "\n\t\tTheZ = " << coords[0]

--- a/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatreader.cpp
@@ -36,17 +36,16 @@
  */
 
 #include <iostream>
+#include <memory>
 
 #include <ome/bioformats/VariantPixelBuffer.h>
 #include <ome/bioformats/in/TIFFReader.h>
 
-#include <ome/compat/memory.h>
-
 #include <ome/common/filesystem.h>
 
 using boost::filesystem::path;
-using ome::compat::make_shared;
-using ome::compat::shared_ptr;
+using std::make_shared;
+using std::shared_ptr;
 using ome::bioformats::dimension_size_type;
 using ome::bioformats::FormatReader;
 using ome::bioformats::MetadataMap;

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
@@ -69,11 +69,11 @@ namespace
 {
 
   /* write-example-start */
-  shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+  shared_ptr<::ome::xml::meta::OMEXMLMetadata>
   createMetadata()
   {
     // OME-XML metadata store.
-    shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+    shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(make_shared<::ome::xml::meta::OMEXMLMetadata>());
 
     // Create simple CoreMetadata and use this to set up the OME-XML
     // metadata.  This is purely for convenience in this example; a
@@ -180,7 +180,7 @@ main(int argc, char *argv[])
 
           /* writer-example-start */
           // Create metadata for the file to be written.
-          shared_ptr< ::ome::xml::meta::MetadataRetrieve> meta(createMetadata());
+          shared_ptr<::ome::xml::meta::MetadataRetrieve> meta(createMetadata());
 
           // Create TIFF writer
           shared_ptr<FormatWriter> writer(make_shared<OMETIFFWriter>());

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
@@ -79,7 +79,7 @@ namespace
     // metadata.  This is purely for convenience in this example; a
     // real writer would typically set up the OME-XML metadata from an
     // existing MetadataRetrieve instance or by hand.
-    std::vector<shared_ptr<CoreMetadata> > seriesList;
+    std::vector<shared_ptr<CoreMetadata>> seriesList;
     shared_ptr<CoreMetadata> core(make_shared<CoreMetadata>());
     core->sizeX = 512U;
     core->sizeY = 512U;
@@ -123,8 +123,8 @@ namespace
             // uint16_t.  It uses the native endianness and has a
             // storage order of XYZTC without interleaving
             // (subchannels are planar).
-            shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> >
-              buffer(make_shared<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> >
+            shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type>>
+              buffer(make_shared<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type>>
                      (boost::extents[512][512][1][1][1][3][1][1][1],
                       PixelType::UINT16, ome::bioformats::ENDIAN_NATIVE,
                       PixelBufferBase::make_storage_order(DimensionOrder::XYZTC, false)));

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
@@ -36,6 +36,7 @@
  */
 
 #include <iostream>
+#include <memory>
 
 #include <ome/bioformats/CoreMetadata.h>
 #include <ome/bioformats/MetadataTools.h>
@@ -43,13 +44,11 @@
 #include <ome/bioformats/out/OMETIFFWriter.h>
 #include <ome/xml/meta/OMEXMLMetadata.h>
 
-#include <ome/compat/memory.h>
-
 #include <ome/common/filesystem.h>
 
 using boost::filesystem::path;
-using ome::compat::make_shared;
-using ome::compat::shared_ptr;
+using std::make_shared;
+using std::shared_ptr;
 using ome::bioformats::dimension_size_type;
 using ome::bioformats::fillMetadata;
 using ome::bioformats::CoreMetadata;

--- a/docs/sphinx/developers/cpp/examples/metadata-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-io.cpp
@@ -36,8 +36,7 @@
  */
 
 #include <iostream>
-
-#include <ome/compat/memory.h>
+#include <memory>
 
 #include <ome/common/filesystem.h>
 #include <ome/common/xml/Platform.h>
@@ -52,8 +51,8 @@
 
 using boost::filesystem::path;
 using ome::compat::array;
-using ome::compat::make_shared;
-using ome::compat::shared_ptr;
+using std::make_shared;
+using std::shared_ptr;
 using ome::bioformats::dimension_size_type;
 using ome::bioformats::addMetadataOnly;
 using ome::bioformats::createOMEXMLMetadata;

--- a/docs/sphinx/developers/cpp/examples/metadata-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-io.cpp
@@ -50,7 +50,7 @@
 #include <ome/bioformats/MetadataTools.h>
 
 using boost::filesystem::path;
-using ome::compat::array;
+using std::array;
 using std::make_shared;
 using std::shared_ptr;
 using ome::bioformats::dimension_size_type;

--- a/docs/sphinx/developers/cpp/examples/model-io.cpp
+++ b/docs/sphinx/developers/cpp/examples/model-io.cpp
@@ -36,8 +36,7 @@
  */
 
 #include <iostream>
-
-#include <ome/compat/memory.h>
+#include <memory>
 
 #include <ome/common/filesystem.h>
 #include <ome/common/xml/Platform.h>
@@ -50,8 +49,8 @@
 #include <ome/xml/model/detail/OMEModel.h>
 
 using boost::filesystem::path;
-using ome::compat::shared_ptr;
-using ome::compat::make_shared;
+using std::shared_ptr;
+using std::make_shared;
 namespace xml = ome::common::xml;
 namespace model = ome::xml::model;
 

--- a/docs/sphinx/developers/cpp/examples/pixeldata.cpp
+++ b/docs/sphinx/developers/cpp/examples/pixeldata.cpp
@@ -136,7 +136,7 @@ namespace
   // any pixel type
   // The static_visitor specialization is the required return type of
   // the operator() methods and boost::apply_visitor()
-  struct MinMaxVisitor : public boost::static_visitor<std::pair<double, double> >
+  struct MinMaxVisitor : public boost::static_visitor<std::pair<double, double>>
   {
     // The min and max values will be returned in a pair.  double is
     // used since it can contain the value for any pixel type
@@ -183,7 +183,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, result_type
       >::type
-    operator() (const std::shared_ptr<PixelBuffer<T> >& v)
+    operator() (const std::shared_ptr<PixelBuffer<T>>& v)
     {
       typedef T value_type;
 

--- a/docs/sphinx/developers/cpp/examples/pixeldata.cpp
+++ b/docs/sphinx/developers/cpp/examples/pixeldata.cpp
@@ -183,7 +183,7 @@ namespace
     typename boost::enable_if_c<
       boost::is_complex<T>::value, result_type
       >::type
-    operator() (const ome::compat::shared_ptr<PixelBuffer<T> >& v)
+    operator() (const std::shared_ptr<PixelBuffer<T> >& v)
     {
       typedef T value_type;
 

--- a/docs/sphinx/developers/cpp/overview.txt
+++ b/docs/sphinx/developers/cpp/overview.txt
@@ -161,7 +161,8 @@ Basic toolchain
 ^^^^^^^^^^^^^^^
 
 A functional compiler, assembler and linker are required to build C++
-code.
+code.  The compiler must support a minimal set of C++11 features to
+provide :file:`memory` (for shared and unique pointers).
 
 If possible, install the following packages:
 
@@ -732,15 +733,6 @@ Run ``cmake -LH`` to see the configurable project options; use
 ``-LAH`` to see advanced options.  The following basic options are
 supported:
 
-cxxstd-autodetect=(ON|OFF)
-  Enable or disable (default) C++ compiler standard autodetection.  If
-  enabled, the compiler will be put into C++11 mode if available,
-  otherwise falling back to C++03 or C++98.  If disabled, the default
-  compiler standard mode is used, and it is the responsibility of the
-  user to add the appropriate compiler options to build using the
-  required standard.  This is useful if autodetection fails or a
-  compiler is buggy in certain modes (e.g. GCC 4.4 or 4.6 require
-  ``-std=gnu++98`` or else ``stdarg`` support is broken).
 doxygen=(ON|OFF)
   Enable doxygen documentation.  These will be enabled by default if
   doxygen is found.
@@ -835,20 +827,6 @@ ome-superbuild_BUILD_${package}=(ON|OFF)
   default, building of all components is disabled. `${package}` is the
   component name.  Look in the :file:`packages` directory for a full
   list of components.
-
-C++11
-^^^^^
-
-C++11 features such as :cpp:class:`std::shared_ptr` are used when
-using a C++11 or C++14 compiler, or when ``-Dcxxstd-autodetect=ON`` is
-used and the compiler can be put into a C++11 or C++14 compatibility
-mode.  When using an older compatbility mode such as C++98, the Boost
-equivalents of C++11 library features will be used as fallbacks to
-provide the same functionality.  In both cases these types are
-imported into the :cpp:class:`ome::compat` namespace, for example as
-:cpp:class:`ome::compat::shared_ptr`, and the types in this namespace
-should be used for portability when using any part of the API which
-use types from this namespace.
 
 Unix, Linux and MacOS X
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tools/test-build
+++ b/tools/test-build
@@ -34,7 +34,7 @@ cpp()
             cmake /usr/src/gtest
             make
         )
-        CXX="g++ -std=gnu++98" GTEST_ROOT="$(pwd)/gtest" cmake -Dcxxstd-autodetect=OFF -Dextended-tests=OFF ../.. || cat CMakeFiles/CMakeError.log
+        GTEST_ROOT="$(pwd)/gtest" cmake -Dextended-tests=OFF ../.. || cat CMakeFiles/CMakeError.log
         make
         make test
         make DESTDIR=../install install


### PR DESCRIPTION
See https://trello.com/c/h4pHPV2h/344-minimal-c-11-features .  This is a rework of the held 5.1 PR from October for the new split repositories now that 5.2 is open, and is reopening https://github.com/openmicroscopy/bioformats/pull/2159 after rebasing onto the current develop)

For review: https://github.com/openmicroscopy/bioformats/pull/2185/files?w=1 without whitespace changes, which makes the diff much smaller.

Library features:
- `std::shared_ptr` and related classes from `<memory>`.
- `std::array` from `<array>`

Language features:
- `<::` is not  a trigraph, but a template opening followed by an absolute namespace
- `>>` is two templates closing not a right-shift operator

There are no changes to the program logic in this PR.  It's all basic search and replace:

- `ome::compat::shared_ptr` to `std::shared_ptr` (and likewise for `weak_ptr`, `enable_shared_from_this`, and `make_shared`)
- `ome::compat::array` to `std::array`
- `< ::` to `<::` (for templates)
- `> >` to `>>` (for templates)

The language changes are simply removing extra spaces where they are no longer needed to avoid parsing ambiguity.  E.g. `std::vector<ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> >` will now be `std::vector<std::shared_ptr<::ome::xml::model::OMEModelObject>>`.

The unused headers are dropped (in ome-compat) and the unneeded feature tests dropped for cmake.

The main point of this PR is not to change to code to take advantage of any significant new C++ functionality, but to verify that the CI build nodes can put the compiler into C++11 mode and successfully build with some very trivial changes.  More useful changes such as `unique_ptr`, `enum class`, `auto` and rvalue references can come later.

See also https://github.com/ome/ome-common-cpp/pull/3

--------

Tested by hand on Windows VC12, Ubuntu 15.10, FreeBSD 10.2, MacOS 10.11.

Testing: Covered entirely by the CI jobs since if it's broken it won't build, or the tests will fail.

--------

Note: None of these changes should affect the current set of supported platforms and compilers; they were all capable of this basic featureset already.  The `shared_ptr` and `array` library features were already used when configured to use C++11; this is simply making them required.  i.e. this is the same in effect as the "ON" rows in https://ci.openmicroscopy.org/job/BIOFORMATS-CPP-5.1-merge-superbuild/; we're basically dropping the "OFF" rows.  The only exception (for further changes) might be centos6; the SCL devtoolset-3 exists for this purpose here.  Note that it was previously tested to work on all currently supported platform in https://github.com/openmicroscopy/bioformats/pull/2159