### PR TITLE
C++: Add model transform resolver for discovery and graph-based query

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -43,7 +43,7 @@ set(OME_TOPLEVEL_INCLUDES
 function(bf_add_test)
   add_test(${ARGV})
   set_tests_properties(${ARGV0}
-    PROPERTIES ENVIRONMENT "BIOFORMATS_SCHEMADIR=${PROJECT_SOURCE_DIR}/components/specification/released-schema")
+    PROPERTIES ENVIRONMENT "BIOFORMATS_SCHEMADIR=${PROJECT_SOURCE_DIR}/components/specification/released-schema;BIOFORMATS_TRANSFORMDIR=${PROJECT_SOURCE_DIR}/components/specification/transforms")
 endfunction()
 
 add_subdirectory(lib)

--- a/cpp/cmake/TemplateCmdWrapper.cmake.in
+++ b/cpp/cmake/TemplateCmdWrapper.cmake.in
@@ -3,5 +3,6 @@
 set "BIOFORMATS_ICONDIR=@PROJECT_SOURCE_DIR@/cpp/share/icons"
 set "BIOFORMATS_MANDIR=@PROJECT_SOURCE_DIR@/cpp/man"
 set "BIOFORMATS_SCHEMADIR=@PROJECT_SOURCE_DIR@/components/specification/released-schema"
+set "BIOFORMATS_TRANSFORMDIR=@PROJECT_SOURCE_DIR@/components/specification/transforms"
 
 %*

--- a/cpp/cmake/TemplateInternalCmdWrapper.cmake.in
+++ b/cpp/cmake/TemplateInternalCmdWrapper.cmake.in
@@ -3,5 +3,6 @@
 set "BIOFORMATS_ICONDIR=@PROJECT_SOURCE_DIR@/cpp/share/icons"
 set "BIOFORMATS_MANDIR=@PROJECT_SOURCE_DIR@/cpp/man"
 set "BIOFORMATS_SCHEMADIR=@PROJECT_SOURCE_DIR@/components/specification/released-schema"
+set "BIOFORMATS_TRANSFORMDIR=@PROJECT_SOURCE_DIR@/components/specification/transforms"
 
 %*

--- a/cpp/cmake/TemplateInternalShellWrapper.cmake.in
+++ b/cpp/cmake/TemplateInternalShellWrapper.cmake.in
@@ -5,6 +5,7 @@ set -e
 export BIOFORMATS_ICONDIR="@PROJECT_SOURCE_DIR@/cpp/share/icons"
 export BIOFORMATS_MANDIR="@PROJECT_BINARY_DIR@/cpp/man"
 export BIOFORMATS_SCHEMADIR="@PROJECT_SOURCE_DIR@/components/specification/released-schema"
+export BIOFORMATS_TRANSFORMDIR="@PROJECT_SOURCE_DIR@/components/specification/transforms"
 
 cmd=$1
 shift

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -197,3 +197,12 @@ foreach(schema ${OME_SCHEMAS})
   install(FILES "${PROJECT_SOURCE_DIR}/components/specification/released-schema/${schema}"
           DESTINATION "${OME_BIOFORMATS_INSTALL_SCHEMADIR}/${SCHEMA_RELEASE}")
 endforeach(schema)
+
+# Find and install all transforms
+file(GLOB OME_TRANSFORMS RELATIVE "${PROJECT_SOURCE_DIR}/components/specification/transforms/"
+     "${PROJECT_SOURCE_DIR}/components/specification/transforms/*.xsl")
+foreach(transform ${OME_TRANSFORMS})
+  get_filename_component(TRANSFORM ${transform} PATH)
+  install(FILES "${PROJECT_SOURCE_DIR}/components/specification/transforms/${transform}"
+          DESTINATION "${OME_BIOFORMATS_INSTALL_TRANSFORMDIR}/${TRANSFORM}")
+endforeach(transform)

--- a/cpp/lib/ome/xml/CMakeLists.txt
+++ b/cpp/lib/ome/xml/CMakeLists.txt
@@ -51,6 +51,7 @@ endforeach(hdr)
 set(OME_XML_STATIC_SOURCES
   Document.cpp
   OMEEntityResolver.cpp
+  OMETransformResolver.cpp
   meta/MetadataException.cpp
   meta/OMEXMLMetadataRoot.cpp
   meta/Convert.cpp
@@ -83,7 +84,8 @@ set(OME_XML_META_STATIC_HEADERS
 
 set(OME_XML_STATIC_HEADERS
     Document.h
-    OMEEntityResolver.h)
+    OMEEntityResolver.h
+    OMETransformResolver.h)
 
 set(OME_XML_STATIC_MODEL_HEADERS
     model/ModelException.h

--- a/cpp/lib/ome/xml/OMETransformResolver.cpp
+++ b/cpp/lib/ome/xml/OMETransformResolver.cpp
@@ -1,0 +1,423 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2016 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/labeled_graph.hpp>
+#include <boost/graph/graphviz.hpp>
+#include <boost/tuple/tuple.hpp> // For tie
+
+#include <ome/common/module.h>
+
+#include <ome/xml/OMETransformResolver.h>
+
+namespace
+{
+
+  using ome::xml::OMETransformResolver;
+
+  /*
+   * Get schema source and target version from filename.
+   *
+   * Requires the file to be named "${source}-to-${target}.xsl".
+   *
+   *
+   * @returns a pair containing the source and target version.
+   * @throws std::runtime_error if the filename is not valid.
+   */
+  std::pair<std::string, std::string>
+  source_and_target_version(const boost::filesystem::path& file)
+  {
+    std::string transformname = file.filename().stem().string();
+
+    if (!file.empty())
+      {
+        const std::string sep("-to-");
+        std::string::size_type pos = transformname.find(sep);
+        if (pos == std::string::npos)
+          throw std::runtime_error("Not a valid XSL transform name");
+
+        return std::make_pair(transformname.substr(0, pos),
+                              transformname.substr(pos + sep.size()));
+      }
+    else
+      {
+        return std::pair<std::string, std::string>();
+      }
+  }
+
+  /*
+   * Get the weight value associated with a Quality enumeration.
+   */
+  uint32_t
+  quality_weight(OMETransformResolver::Quality quality)
+  {
+    return static_cast<uint32_t>(quality);
+  }
+
+  /*
+   * Get the Quality enumeration for a given quality metric.
+   *
+   * Returns the enumeration with the nearest lower value to the
+   * metric.
+   *
+   * @returns the Quality enumeration.
+   */
+  OMETransformResolver::Quality
+  weight_quality(uint32_t weight)
+  {
+    OMETransformResolver::Quality quality;
+
+    if (weight < quality_weight(OMETransformResolver::GOOD))
+      quality = OMETransformResolver::EXCELLENT;
+    else if (weight < quality_weight(OMETransformResolver::FAIR))
+      quality = OMETransformResolver::GOOD;
+    else if (weight < quality_weight(OMETransformResolver::POOR))
+      quality = OMETransformResolver::FAIR;
+    else
+      quality = OMETransformResolver::POOR;
+
+    return quality;
+  }
+
+  /*
+   * Get the Quality of a given transform.
+   *
+   * This matches the historic behaviour of the Python script to
+   * generate ome-transforms.xsl, and the previous hand-created
+   * versions of the same file.
+   *
+   * - upgrades are always of excellent quality
+   * - downgrades are of good quality
+   * - if the target is before 2008 then the quality is fair
+   * - if the target is before 2010-06 then the quality is poor
+   *
+   * @param schemas the source and target schema versions to use.
+   * @returns the Quality enumeration for these versions.
+   */
+  static OMETransformResolver::Quality
+  determine_quality(const std::pair<std::string, std::string>& schemas)
+  {
+    const std::string& source = schemas.first;
+    const std::string& target = schemas.second;
+
+    OMETransformResolver::Quality quality = OMETransformResolver::GOOD;
+
+    if (source < target)
+      quality = OMETransformResolver::EXCELLENT;
+    else if (target < "2008")
+      quality = OMETransformResolver::POOR;
+    else if (target < "2010-06")
+      quality = OMETransformResolver::FAIR;
+
+    return quality;
+  }
+
+}
+
+namespace ome
+{
+  namespace xml
+  {
+
+    std::string
+    OMETransformResolver::quality_name(OMETransformResolver::Quality quality)
+    {
+      std::string name;
+
+      switch(quality)
+        {
+        case OMETransformResolver::POOR:
+          name = "poor";
+          break;
+        case OMETransformResolver::FAIR:
+          name = "fair";
+          break;
+        case OMETransformResolver::GOOD:
+          name = "good";
+          break;
+        case OMETransformResolver::EXCELLENT:
+          name = "excellent";
+          break;
+        default:
+          break;
+        };
+
+      return name;
+    }
+
+    OMETransformResolver::Transform::Transform():
+      file(boost::filesystem::path()),
+      schemas(source_and_target_version(boost::filesystem::path())),
+      weight(quality_weight(EXCELLENT))
+    {
+    }
+
+    OMETransformResolver::Transform::Transform(const boost::filesystem::path& file):
+      file(file),
+      schemas(source_and_target_version(file)),
+      weight(quality_weight(determine_quality(source_and_target_version(file))))
+    {
+    }
+
+    OMETransformResolver::Transform::Transform(const boost::filesystem::path& file,
+                                               Quality                        quality):
+      file(file),
+      schemas(source_and_target_version(file)),
+      weight(quality_weight(quality))
+    {
+    }
+
+    /**
+     * Private implementation details of OMETransformResolver.
+     *
+     * Contains a graph of the schemas and transforms.  This is
+     * private to keep Boost.Graph out of the public interface.
+     */
+    class OMETransformResolverImpl
+    {
+    public:
+      /// Graph type; using our Schema and Transform types as bundled
+      /// properties, with labelled vertices for ease of access.
+      typedef boost::labeled_graph<boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, OMETransformResolver::Schema, OMETransformResolver::Transform>, std::string> Graph;
+      /// Identifier type for vertices.
+      typedef boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor;
+      /// Identifier type for edges.
+      typedef boost::graph_traits<Graph>::edge_descriptor edge_descriptor;
+      /// Iterator type for vertices.
+      typedef boost::graph_traits<Graph>::vertex_iterator vertex_iter;
+
+      /// Graph storing schemas as vertices and transforms as weighted edges.
+      Graph g;
+
+      /**
+       * Fill the graph with transforms.
+       *
+       * @param transformdir the directory containing the XSL
+       * transforms.
+       */
+      void
+      fill_graph(const boost::filesystem::path& transformdir)
+      {
+        if (!boost::filesystem::is_directory(transformdir))
+          {
+            throw std::runtime_error("Transform directory does not exist");
+          }
+
+        std::set<OMETransformResolver::Schema> schemas;
+        std::set<OMETransformResolver::Transform> transforms;
+
+        boost::filesystem::directory_iterator dirent_end;
+        for (boost::filesystem::directory_iterator dirent(transformdir); dirent != dirent_end; ++dirent)
+          {
+            if (boost::filesystem::extension(*dirent) != ".xsl")
+              continue; // not a transform
+
+            try
+              {
+                OMETransformResolver::Transform transform(dirent->path());
+
+                schemas.insert(OMETransformResolver::Schema(transform.schemas.first));
+                schemas.insert(OMETransformResolver::Schema(transform.schemas.second));
+                transforms.insert(transform);
+              }
+            catch(const std::exception& /* e */)
+              {
+                // Not a valid transform name.
+              }
+          }
+
+        // Process backward so newer schemas are at the start of the list.
+        for (std::set<OMETransformResolver::Schema>::const_reverse_iterator schema = schemas.rbegin();
+             schema != schemas.rend();
+             ++schema)
+          boost::add_vertex(schema->name, *schema, g);
+
+        // Process backward so newer transforms are at the start of the list.
+        for (std::set<OMETransformResolver::Transform>::const_reverse_iterator transform = transforms.rbegin();
+             transform != transforms.rend();
+             ++transform)
+          {
+            boost::add_edge_by_label(transform->schemas.first, transform->schemas.second,
+                                     *transform, g);
+          }
+      }
+    };
+
+    OMETransformResolver::OMETransformResolver():
+      impl(ome::compat::make_shared<OMETransformResolverImpl>())
+    {
+      impl->fill_graph(ome::common::module_runtime_path("bf-transform"));
+    }
+
+    OMETransformResolver::OMETransformResolver(const boost::filesystem::path& transformdir):
+      impl(ome::compat::make_shared<OMETransformResolverImpl>())
+    {
+      impl->fill_graph(transformdir);
+    }
+
+    OMETransformResolver::~OMETransformResolver()
+    {
+    }
+
+    std::set<std::string>
+    OMETransformResolver::schema_versions() const
+    {
+      std::set<std::string> ret;
+
+      const OMETransformResolverImpl::Graph& g = impl->g;
+
+      OMETransformResolverImpl::vertex_iter i, end;
+      for (boost::tie(i, end) = boost::vertices(g); i != end; ++i)
+        ret.insert(g.graph()[*i].name);
+
+      return ret;
+    }
+
+    std::pair<std::vector<OMETransformResolver::Transform>, OMETransformResolver::Quality>
+    OMETransformResolver::transform_order(const std::string& source,
+                                          const std::string& target) const
+    {
+      const OMETransformResolverImpl::Graph& g = impl->g;
+
+      std::vector<Transform> order;
+      uint32_t distance;
+
+      OMETransformResolverImpl::vertex_descriptor vsource = g.vertex(source);
+      OMETransformResolverImpl::vertex_descriptor vtarget  = g.vertex(target);
+      if (vsource != boost::graph_traits<OMETransformResolverImpl::Graph>::null_vertex() &&
+          vtarget != boost::graph_traits<OMETransformResolverImpl::Graph>::null_vertex())
+        {
+          std::vector<OMETransformResolverImpl::vertex_descriptor> predecessor(boost::num_vertices(g));
+          std::vector<int64_t> distances(boost::num_vertices(g));
+
+          boost::dijkstra_shortest_paths(g, vsource,
+                                         boost::weight_map(boost::get(&Transform::weight, g))
+                                         .distance_map(boost::make_iterator_property_map(distances.begin(), get(boost::vertex_index, g)))
+                                         .predecessor_map(boost::make_iterator_property_map(predecessor.begin(), boost::get(boost::vertex_index, g))));
+
+          distance = distances[vtarget];
+
+          OMETransformResolverImpl::vertex_descriptor v = vtarget;
+          while (v != predecessor[v])
+            {
+              std::pair<OMETransformResolverImpl::edge_descriptor, bool> found_edge = boost::edge(predecessor[v], v, g);
+              if (!found_edge.second)
+                {
+                  throw std::logic_error("Missing transform in transform sequence between source and target");
+                }
+              const Transform& transform = g[found_edge.first];
+              order.push_back(transform);
+              v = predecessor[v];
+            }
+          if (v != vsource)
+            {
+              throw std::runtime_error("Impossible to transform between source and target schemas: missing transforms");
+            }
+        }
+      else
+        {
+          throw std::runtime_error("Impossible to determine transform order: source or target missing");
+        }
+
+      std::reverse(order.begin(), order.end());
+      return std::make_pair(order, weight_quality(distance));
+    }
+
+    namespace
+    {
+
+      // Write a GraphViz edge label and color.
+      class edge_writer
+      {
+      public:
+        // Construct from graph being written.
+        edge_writer(const OMETransformResolverImpl::Graph& g):
+          g(g)
+        {}
+
+        // Write edge to stream.
+        template <class Edge>
+        void
+        operator() (std::ostream& os,
+                    const Edge&   e) const
+        {
+          const ome::xml::OMETransformResolver::Transform& transform = g[e];
+          ome::xml::OMETransformResolver::Quality quality = weight_quality(transform.weight);
+
+          os << "[label=\"quality="
+             << OMETransformResolver::quality_name(quality)
+             << "\\nweight=" << transform.weight << '"';
+
+          switch(quality)
+            {
+            case OMETransformResolver::GOOD:
+              os << " color=blue";
+              break;
+            case OMETransformResolver::FAIR:
+              os << " color=magenta";
+              break;
+            case OMETransformResolver::POOR:
+              os << " color=red";
+              break;
+            default:
+              os << " color=black";
+              break;
+            }
+
+          os << ']';
+        }
+
+      private:
+        const OMETransformResolverImpl::Graph& g;
+      };
+
+    }
+
+    void
+    OMETransformResolver::write_graphviz(std::ostream& os)
+    {
+      const OMETransformResolverImpl::Graph& g = impl->g;
+
+      boost::write_graphviz(os, g,
+                            boost::make_label_writer(boost::get(&Schema::name, g)),
+                            edge_writer(g));
+    }
+
+  }
+}

--- a/cpp/lib/ome/xml/OMETransformResolver.h
+++ b/cpp/lib/ome/xml/OMETransformResolver.h
@@ -1,0 +1,283 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2016 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#ifndef OME_XML_MODEL_OMETRANSFORMRESOLVER_H
+#define OME_XML_MODEL_OMETRANSFORMRESOLVER_H
+
+#include <ostream>
+#include <set>
+#include <string>
+#include <utility>
+
+#include <boost/filesystem.hpp>
+
+#include <ome/compat/cstdint.h>
+#include <ome/compat/memory.h>
+
+namespace ome
+{
+  namespace xml
+  {
+
+    class OMETransformResolverImpl;
+
+    /**
+     * Discover and query available OME-XML transforms.
+     *
+     * This class will find the available XSL transforms to convert
+     * between different OME-XML model versions, using either the
+     * installed schemas, or schemas in a specified directory.
+     *
+     * In order to convert between different schema versions, one or
+     * more transforms will require applying.  This class will
+     * determine the optimal set of transforms to apply for a given
+     * source and target model version, computed using a graph
+     * representation and shortest path algorithm.
+     */
+    class OMETransformResolver
+    {
+    public:
+      /**
+       * Metadata for a schema version.
+       *
+       * Internally, this is attached to each graph vertex.
+       */
+      struct Schema
+      {
+        /// Default constructor.
+        Schema():
+          name()
+        {}
+
+        /**
+         * Construct with name.
+         *
+         * @param name the name of the schema.
+         */
+        Schema(const std::string& name):
+          name(name)
+        {}
+
+        /**
+         * Compare with other Schema.
+         *
+         * @param rhs the Schema to compare with.
+         * @returns @c true if this schema name is lexicographically
+         * less, @c false otherwise.
+         */
+        bool
+        operator< (const Schema& rhs) const
+        {
+          return name < rhs.name;
+        }
+
+        /// Name of the schema.
+        std::string name;
+      };
+
+      /**
+       * Transformation quality.
+       *
+       * Schema transforms may vary in quality.  Upgrades are
+       * typically lossless and classed as "excellent", while
+       * downgrades may lose information due to the older schemas
+       * lacking the ability to represent metadata added in later
+       * schema versions.  These quality levels are arbitrary
+       * classifications and weightings used to match the existing
+       * manually maintained transform lists used in the Java
+       * implementation.
+       */
+      enum Quality
+      {
+        POOR      = 1000000LU, ///< Extreme data loss.
+        FAIR      = 10000LU,   ///< Moderate data loss.
+        GOOD      = 100LU,     ///< Slight data loss.
+        EXCELLENT = 1LU        ///< No data loss.
+      };
+
+      /**
+       * Get the name associated with a Quality enumeration.
+       *
+       * @param quality the Quality enumeration.
+       * @returns a string representation of the Quality
+       * enumeration.
+       */
+      static std::string
+      quality_name(OMETransformResolver::Quality quality);
+
+      /**
+       * Metadata for a schema transform between two schema versions.
+       *
+       * Internally, this is attached to each graph edge, with the
+       * transformation quality used for determining the optimal set
+       * of transformations to apply.
+       */
+      struct Transform
+      {
+        /// Default constructor.
+        Transform();
+
+        /**
+         * Construct transform from path.
+         *
+         * The quality of the transform will be determined
+         * automatically from the filename.
+         *
+         * @param file the XSL transform.
+         */
+        Transform(const boost::filesystem::path& file);
+
+        /**
+         * Construct transform from path with specified quality.
+         *
+         * @param file the XSL transform.
+         * @param quality the quality of the XSL transform.
+         */
+        Transform(const boost::filesystem::path& file,
+                  Quality                        quality);
+
+        /**
+         * Compare with other Transform.
+         *
+         * @param rhs the Transform to compare with.
+         * @returns @c true if the transform source and target
+         * versions are lexicographically less, @c false otherwise.
+         */
+        bool
+        operator< (const Transform& rhs) const
+        {
+          return schemas < rhs.schemas;
+        }
+
+        /// The XSL transform.
+        boost::filesystem::path file;
+        /// The source and target schema versions.
+        std::pair<std::string, std::string> schemas;
+        /// The quality metric for the transform (less is better).
+        uint32_t weight;
+      };
+
+    public:
+      /**
+       * Default constructor.
+       *
+       * The transform directory used will be the default set at
+       * install time or in the environment.
+       */
+      OMETransformResolver();
+
+      /**
+       * Construct with specified transform directory.
+       *
+       * @param transformdir the directory containing the XSL
+       * transform files.
+       */
+      OMETransformResolver(const boost::filesystem::path& transformdir);
+
+      /// Destructor.
+      ~OMETransformResolver();
+
+      /**
+       * Get the available schema versions for transformation.
+       *
+       * @returns all schema versions found as a source or target for
+       * a transform.
+       */
+      std::set<std::string>
+      schema_versions() const;
+
+      /**
+       * Determine the optimal transform order between schema
+       * versions.
+       *
+       * Run a shortest path search to determine the highest quality
+       * set of transforms between the two versions.
+       *
+       * The returned quality metric is the sum of the quality metrics
+       * for all of the transforms, rounded down to the nearest
+       * quality value.
+       *
+       * @param source the source schema version.
+       * @param target the target schema version.
+       * @returns a vector of Transform objects in the order to apply,
+       * and an aggregate quality metric.
+       */
+      std::pair<std::vector<Transform>, Quality>
+      transform_order(const std::string& source,
+                      const std::string& target) const;
+
+      /**
+       * Write a GraphViz dot representation of the internal graph state.
+       *
+       * Primarily intended for debugging and documentation.
+       *
+       * @param os the stream to write the dot representation to.
+       */
+      void
+      write_graphviz(std::ostream& os);
+
+    private:
+      /// Private implementation details.
+      ome::compat::shared_ptr<OMETransformResolverImpl> impl;
+    };
+
+    /**
+     * Output OMETransformResolver::Quality to output stream.
+     *
+     * @param os the output stream.
+     * @param quality the OMETransformResolver::Quality to output.
+     * @returns the output stream.
+     */
+    template<class charT, class traits>
+      inline std::basic_ostream<charT,traits>&
+      operator<< (std::basic_ostream<charT,traits>& os,
+                  const OMETransformResolver::Quality& quality)
+      {
+        return os << OMETransformResolver::quality_name(quality);
+      }
+
+  }
+}
+
+#endif // OME_XML_MODEL_OMETRANSFORMRESOLVER_H
+
+/*
+ * Local Variables:
+ * mode:C++
+ * End:
+ */

--- a/cpp/test/ome-xml/CMakeLists.txt
+++ b/cpp/test/ome-xml/CMakeLists.txt
@@ -68,6 +68,10 @@ if(BUILD_TESTS)
   target_link_libraries(timestamp OME::XML)
   target_link_libraries(timestamp ome-test)
 
+  add_executable(transform-resolver transform-resolver.cpp)
+  target_link_libraries(transform-resolver OME::Common OME::XML)
+  target_link_libraries(transform-resolver ome-test)
+
   add_executable(model model.cpp)
   target_link_libraries(model OME::XML)
   target_link_libraries(model ome-test)
@@ -76,6 +80,7 @@ if(BUILD_TESTS)
   bf_add_test(ome-xml/enum enum)
   bf_add_test(ome-xml/constrained-numeric constrained-numeric)
   bf_add_test(ome-xml/timestamp timestamp)
+  bf_add_test(ome-xml/transform-resolver transform-resolver)
   bf_add_test(ome-xml/model model)
 
   if(extended-tests)

--- a/cpp/test/ome-xml/transform-resolver.cpp
+++ b/cpp/test/ome-xml/transform-resolver.cpp
@@ -1,0 +1,197 @@
+/*
+ * #%L
+ * OME-XML C++ library for working with OME-XML metadata structures.
+ * %%
+ * Copyright © 2016 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of any organization.
+ * #L%
+ */
+
+#include <iostream>
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+
+#include <ome/xml/OMETransformResolver.h>
+
+#include <ome/test/test.h>
+
+class TransformQueryTest : public ::testing::Test
+{
+public:
+  ome::xml::OMETransformResolver resolver;
+
+  TransformQueryTest():
+    ::testing::Test(),
+    resolver()
+  {
+  }
+
+  void SetUp()
+  {
+    std::cout << "Processed schema versions:\n";
+
+    std::set<std::string> versions = resolver.schema_versions();
+    for (std::set<std::string>::const_iterator v = versions.begin();
+         v != versions.end();
+         ++v)
+      std::cout << "  " << *v << '\n';
+  }
+
+  void
+  write_ome_transforms(const ome::xml::OMETransformResolver& resolver,
+                       std::ostream&                         xmlstream)
+  {
+  const std::string header =
+    "<?xml version = \"1.0\" encoding = \"UTF-8\"?>\n"
+    "<!--\n"
+    "	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+    "	#\n"
+    "	# Copyright (C) 2012-2014 Open Microscopy Environment\n"
+    "	#       Massachusetts Institute of Technology,\n"
+    "	#       National Institutes of Health,\n"
+    "	#       University of Dundee,\n"
+    "	#       University of Wisconsin at Madison\n"
+    "	#\n"
+    "	#    This library is free software; you can redistribute it and/or\n"
+    "	#    modify it under the terms of the GNU Lesser General Public\n"
+    "	#    License as published by the Free Software Foundation; either\n"
+    "	#    version 2.1 of the License, or (at your option) any later version.\n"
+    "	#\n"
+    "	#    This library is distributed in the hope that it will be useful,\n"
+    "	#    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+    "	#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n"
+    "	#    Lesser General Public License for more details.\n"
+    "	#\n"
+    "	#    You should have received a copy of the GNU Lesser General Public\n"
+    "	#    License along with this library; if not, write to the Free Software\n"
+    "	#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n"
+    "	#\n"
+    "	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+    "-->\n"
+    "\n"
+    "<!--\n"
+    "	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+    "	# Written by:  Andrew Patterson: ajpatterson at lifesci.dundee.ac.uk\n"
+    "	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+    "-->\n"
+  "\n";
+
+  xmlstream << header;
+
+  std::set<std::string> versions = resolver.schema_versions();
+  if(!versions.empty())
+    {
+      xmlstream << "<ome-transforms current=\"" << *versions.rbegin() << "\">\n";
+
+      for (std::set<std::string>::const_reverse_iterator from = versions.rbegin();
+           from != versions.rend();
+           ++from)
+        {
+          bool downgrade = false;
+
+          xmlstream << "\t<source schema=\"" << *from << "\">\n"
+                    << "\t\t<upgrades>\n";
+
+          for (std::set<std::string>::const_reverse_iterator to = versions.rbegin();
+               to != versions.rend();
+               ++to)
+            {
+              if (*to < *from && !downgrade)
+                {
+                  xmlstream << "\t\t</upgrades>\n"
+                            << "\t\t<downgrades>\n";
+                  downgrade = true;
+                }
+
+              std::pair<std::vector<ome::xml::OMETransformResolver::Transform>,
+                        ome::xml::OMETransformResolver::Quality> order =
+                resolver.transform_order(*from, *to);
+
+              if (*to == *from)
+                {
+                  if (order.first.size() > 0)
+                    std::cerr << "Transforms exist for same source and target schema!";
+                  continue;
+                }
+
+              xmlstream << "\t\t\t<target schema=\"" << *to
+                        << "\" quality=\"" << order.second << "\">\n";
+              for (std::vector<ome::xml::OMETransformResolver::Transform>::const_iterator o
+                     = order.first.begin();
+                   o != order.first.end();
+                   ++o)
+                {
+                  xmlstream << "\t\t\t\t<transform file=\""
+                          << o->file.filename().string() << "\"/>\n";
+                }
+              xmlstream << "\t\t\t</target>\n";
+            }
+          if (!downgrade)
+            {
+              xmlstream << "\t\t</upgrades>\n"
+                      << "\t\t<downgrades>\n";
+            }
+          xmlstream << "\t\t</downgrades>\n"
+                    << "\t</source>\n";
+        }
+
+      xmlstream << "</ome-transforms>\n";
+    }
+  }
+};
+
+TEST_F(TransformQueryTest, GraphViz)
+{
+  boost::filesystem::path dotfile = PROJECT_BINARY_DIR "/cpp/test/ome-xml/data/ome-transforms.dot";
+  boost::filesystem::path dotdir = dotfile.parent_path();
+  if (!exists(dotdir) && !is_directory(dotdir) && !create_directories(dotdir))
+    throw std::runtime_error("Data directory unavailable and could not be created");
+
+  std::ofstream dotstream(dotfile.string().c_str());
+
+  resolver.write_graphviz(dotstream);
+  resolver.write_graphviz(std::cout);
+}
+
+TEST_F(TransformQueryTest, OmeTransformsXML)
+{
+  boost::filesystem::path xmlfile = PROJECT_BINARY_DIR "/cpp/test/ome-xml/data/ome-transforms.xml";
+  boost::filesystem::path xmldir = xmlfile.parent_path();
+  if (!exists(xmldir) && !is_directory(xmldir) && !create_directories(xmldir))
+    throw std::runtime_error("Data directory unavailable and could not be created");
+
+  std::ofstream xmlstream(xmlfile.string().c_str());
+
+  write_ome_transforms(resolver, xmlstream);
+  write_ome_transforms(resolver, std::cout);
+}


### PR DESCRIPTION
- Install transforms
- Set transform directory inside and outside the build, and when running tests
- `OMETransformResolver` detects all available transforms and builds a graph (vertices are schemas, edges are transforms between schemas)
- This class permits querying of available schemas and of the set of transforms to apply to change from a given source to target schema.  Schemas are discovered by searching the transforms directory for "{source}-to-{target}.xsl" files.
- Transform quality is determined using the same algorithm as in `components/specification/transforms/util/write-transforms.py`, and used to weight the edges for use in a shortest path search.

Note it is based upon https://github.com/openmicroscopy/bioformats/pull/2185 and so includes the commits for this PR as well.  The actual diff for this PR alone in https://github.com/rleigh-dundee/bioformats/compare/cpp-c++11...rleigh-dundee:cpp-transform-graph?expand=1

Update: Removed C++11 support, including delegating constructors, uniform initialisation, automatic type deduction, range-based for, const iterator methods, fstream string constructors, `tie`, `enum class` and `unique_ptr`.  It is now C++98.

This is the transform graph the code will construct and work from:

![ome-transforms](https://cloud.githubusercontent.com/assets/1528953/12392746/3524ab76-bde9-11e5-84b3-a1dc54793d5d.png)

--------

Testing:

In the build log, search for `ome-xml/transform-resolver`.

- Test 1 emits a list of schemas plus a `dot` input graph.  Copy the graph to a file, and run `dot -T ome-transforms.dot > ome-transforms.svg` and look at the SVG file.  This is a readable representation of the internal transform graph, including the transform quality and weighting.  This should be the same as shown above.
- Test 2 emits a list of schemas plus an `ome-transforms.xml` document.  Copy the document to a file and diff with `components/specification/transforms/ome-transforms.xml`.  The two should be identical, confirming that this implementation behaves identically to the existing hardcoded list in `ome-transforms.xml` which is now generated by `write-transforms.py`, i.e. for any given pairing of source and target schema version, the set of transforms is the same.
- Verify that the transforms were installed (check the build archive in the artefacts), and/or the build log.

(You can also find these files in `bioformats-build/cpp/test/ome-xml/data` if you do your own build.  I have them included in the build log for convenience.)