### PR TITLE
Minor fix for reader-guide

### DIFF
--- a/docs/sphinx/developers/reader-guide.txt
+++ b/docs/sphinx/developers/reader-guide.txt
@@ -48,8 +48,8 @@ Methods to override
   name is non-null.
 
 - :javadoc:`openBytes(int, byte[], int, int, int, int) <loci/formats/IFormatReader.html#openBytes(int, byte[], int, int, int, int)>`
-  Returns a byte array containing the pixel data for a subimage specified
-  image from the given file.  The dimensions of the subimage (upper left X
+  Returns a byte array containing the pixel data for a specified subimage
+  from the given file.  The dimensions of the subimage (upper left X
   coordinate, upper left Y coordinate, width, and height) are specified in the
   final four int parameters.  This should throw a
   :javadoc:`FormatException <loci/formats/FormatException.html>` if the image


### PR DESCRIPTION
Fixes `reader-guide.txt` in the Sphinx docs