### PR TITLE
Add missing formats-bsd tests to the testng config file

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -120,4 +120,11 @@
         <class name="loci.formats.utests.AxisGuesserTest"/>
       </classes>
     </test>
+    <test name="FilePatternTests">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.FilePatternBlockTest"/>
+        <class name="loci.formats.utests.FilePatternTest"/>
+      </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Adds `FilePattern{,Block}Test` so they are run with `ant test`