### PR TITLE
Remove artifactories repositories from the profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -722,23 +722,6 @@
     <profile>
       <id>merge-build</id>
 
-      <repositories>
-        <repository>
-          <id>ome.unstable</id>
-          <url>http://artifacts.openmicroscopy.org/artifactory/ome.unstable</url>
-        </repository>
-      </repositories>
-
-      <pluginRepositories>
-        <pluginRepository>
-          <id>ome.unstable</id>
-          <url>http://artifacts.openmicroscopy.org/artifactory/ome.unstable</url>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-
       <distributionManagement>
         <repository>
           <id>ome.unstable</id>
@@ -758,23 +741,6 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-
-      <repositories>
-        <repository>
-          <id>ome.snapshots</id>
-          <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-        </repository>
-      </repositories>
-
-      <pluginRepositories>
-        <pluginRepository>
-          <id>ome.snapshots</id>
-          <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
 
       <distributionManagement>
         <repository>


### PR DESCRIPTION
Latest Travis builds on the dev_5_1 branch have uncached dependencies and the logs show they are is primarily hitting the OME artifactory to retrieve artifacts that should be retrieved from Maven Central.

This PR amends the changes made in https://github.com/openmicroscopy/bioformats/pull/1867 to remove the OME repositories from the profiles. Is there any reason why `ome.snapshots` and `ome.unstable` should not be used for anything other than publishing?

To test this PR:
- clean your local Maven repository
- run `mvn install`
- in the log especially in the initial steps, check `artifacts.openmicroscopy.org` is only hit on purpose (i.e. for artifacts not available via Maven Central).