### PR TITLE
More specific .cpp include patterns

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -158,7 +158,7 @@
     <resource>
       <directory>${project.basedir}</directory>
       <includes>
-        <include>**/*.cpp</include>
+        <include>cppwrap/*.cpp</include>
       </includes>
       <filtering>true</filtering>
     </resource>

--- a/pom.xml
+++ b/pom.xml
@@ -101,13 +101,14 @@
         <directory>${project.basedir}/src</directory>
         <includes>
           <include>**/*.properties</include>
+          <include>**/*.cpp</include>
         </includes>
         <filtering>true</filtering>
       </resource>
       <resource>
         <directory>${project.basedir}</directory>
         <includes>
-          <include>**/*.cpp</include>
+          <include>utils/*.cpp</include>
         </includes>
         <filtering>true</filtering>
       </resource>


### PR DESCRIPTION
In some Maven POM files, include patterns are so general that they also match files under `target` directories. Due to this, some jars end up containing duplicate `.cpp` source files (in the following, stars denote legitimate instances):

```
loci_formats_in_LegacyND2Reader.cpp
  [ ] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/target/classes/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  [*] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  [ ] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  [ ] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  [ ] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
minimum_writer.cpp
  [*] ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/cppwrap/minimum_writer.cpp
  [ ] ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/target/classes/cppwrap/minimum_writer.cpp
showinf.cpp
  [*] ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/cppwrap/showinf.cpp
  [ ] ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/target/classes/cppwrap/showinf.cpp
showinfJNI.cpp
  [ ] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/utils/showinfJNI.cpp
  [*] ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/utils/showinfJNI.cpp
```

Moreover, if the code is compiled repeatedly without cleaning, duplicates are also matched and copied to more deeply nested `target/classes` directories. After several cycles, the repo dir is filled with very long `target/classes/target/classes/target/...` patterns that eventually hit Git's or your OS's maximum path length limit (this is not speculation btw, I've had this problem more than once). This PR fixes the POM files by making `.cpp` include patterns more specific.

Testing the PR
--------------

* check that `mvn test` runs without errors
* check that the BF jars don't have the above `.cpp` duplicates anymore, and that *only* those files are missing from the new jars

I suggest doing something like the following:

```bash
git clean -fdx; rm ~/.m2/repository/ome -rf; mvn -DskipTests install
mkdir -p /tmp/unpack/{before,after}
cd /tmp/unpack/after
find ~/.m2/repository/ome/ -name '*.jar' | while read f; do mkdir $(basename $f); pushd $(basename $f); jar xf $f; popd; done
find . -type f >../after.list
```

Now repeat the above, this time *without* applying this PR, and get a `before.list`. Move to `/tmp/unpack` and run the following Python script:

```python
def getfiles(listfn):
    with open(listfn) as f:
        return set(_.strip() for _ in f)

def getdups(paths):
    dups = {}
    for p in paths:
        chunks = p.split("/")
        jar, bn = chunks[1], chunks[-1]
        if not bn.endswith(".cpp"):
            continue
        dups.setdefault((jar, bn), set()).add(p)
    return dict(_ for _ in dups.iteritems() if len(_[1]) > 1)

def printdups(dups):
    for jar, bn in sorted(dups):
        print bn
        for p in sorted(dups[(jar, bn)]):
            print ' ', p

before = getfiles("before.list")
after = getfiles("after.list")

print "\n--- DUPLICATES BEFORE ---"
printdups(getdups(before))
print "\n--- DUPLICATES AFTER ---"
printdups(getdups(after))
print "\n--- BEFORE - AFTER ---"
for p in sorted(before - after):
    print p
print "\n--- AFTER - BEFORE ---"
for p in sorted(after - before):
    print p
```

You should get:

```
--- DUPLICATES BEFORE ---
minimum_writer.cpp
  ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/cppwrap/minimum_writer.cpp
  ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/target/classes/cppwrap/minimum_writer.cpp
showinf.cpp
  ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/cppwrap/showinf.cpp
  ./formats-bsd-5.2.0-SNAPSHOT-sources.jar/target/classes/cppwrap/showinf.cpp
loci_formats_in_LegacyND2Reader.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/target/classes/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
showinfJNI.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/utils/showinfJNI.cpp
  ./formats-gpl-5.2.0-SNAPSHOT-sources.jar/utils/showinfJNI.cpp

--- DUPLICATES AFTER ---

--- BEFORE - AFTER ---
./formats-bsd-5.2.0-SNAPSHOT-sources.jar/target/classes/cppwrap/minimum_writer.cpp
./formats-bsd-5.2.0-SNAPSHOT-sources.jar/target/classes/cppwrap/showinf.cpp
./formats-gpl-5.2.0-SNAPSHOT-sources.jar/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/src/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/target/classes/loci/formats/in/loci_formats_in_LegacyND2Reader.cpp
./formats-gpl-5.2.0-SNAPSHOT-sources.jar/target/classes/utils/showinfJNI.cpp

--- AFTER - BEFORE ---
```