### PR TITLE
docs: Qu for Matlab only supports up to 4 dimensions

### DIFF
--- a/docs/sphinx/users/qu-matlab/index.txt
+++ b/docs/sphinx/users/qu-matlab/index.txt
@@ -2,7 +2,7 @@ Qu for MATLAB
 =============
 
 `Qu for MATLAB <http://www.scs2.net/home/index.php?option=com_content&view=article&id=46%3Aqu-for-matlab&catid=34%3Aqu&Itemid=55>`_
-is a MATLAB toolbox for the visualization and analysis of N-dimensional
+is a MATLAB toolbox for the visualization and analysis of multi-channel 4-dimensional
 datasets targeted to the field of biomedical imaging, developed by Aaron
 Ponti.
 


### PR DESCRIPTION
The current docs claims that qu-matlab is a toolset analysis of N-dimensional datasets. However, this is not true. On [their website](http://www.scs2.net/next/index.php?id=120):

> It allows the visualization and analysis of 4D (XYZT) datasets with any number of color channels. 

Since colour is another dimension, then technically it should be 5 dimensions. I went with "multi-channel 4 dimensional data" to reflect that qu treats the channel dimension different.