### PR TITLE
Whitelist .ome.xml as an official extension of the OME-XML format (rebased onto dev_5_1)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1656,7 +1656,7 @@ extensions = `.ome.tiff <http://www.openmicroscopy.org/site/support/ome-model/om
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01
-weHave = * an :model_doc:`OME-TIFF specification document <ome-tiff/specification.html>` \n
+weHave = * an :model_doc:`OME-TIFF specification document <ome-tiff/specification.html>` (from 2006 October 19, in HTML) \n
 * many OME-TIFF datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/OME-TIFF/>`__ \n
 * the ability to produce additional datasets
@@ -1679,8 +1679,8 @@ Commercial applications that support OME-TIFF include: \n
   :model_doc:`OME-TIFF technical overview <ome-tiff/index.html>`
 
 [OME-XML]
-indexExtensions = .ome
-extensions = `.ome <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
+indexExtensions = .ome, .ome.xml
+extensions = `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01

--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -85,7 +85,7 @@ public class OMEXMLReader extends FormatReader {
 
   /** Constructs a new OME-XML reader. */
   public OMEXMLReader() {
-    super("OME-XML", "ome");
+    super("OME-XML", new String[] {"ome", "ome.xml"});
     domains = FormatTools.NON_GRAPHICS_DOMAINS;
     suffixNecessary = false;
   }

--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -74,7 +74,7 @@ public class OMEXMLWriter extends FormatWriter {
   // -- Constructor --
 
   public OMEXMLWriter() {
-    super("OME-XML", "ome");
+    super("OME-XML", new String[] {"ome", "ome.xml"});
     compressionTypes =
       new String[] {CompressionType.UNCOMPRESSED.getCompression(),
         CompressionType.ZLIB.getCompression()};

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -315,7 +315,7 @@ to open/import a dataset in a particular format.
      - .ome.tif, .ome.tiff, .companion.ome
      - One or more .ome.tiff files
    * - OME-XML
-     - .ome
+     - .ome, .ome.xml
      - Single file
    * - Olympus APL
      - .apl, .tnb, .mtb, .tif

--- a/docs/sphinx/formats/ome-xml.txt
+++ b/docs/sphinx/formats/ome-xml.txt
@@ -1,10 +1,10 @@
 .. index:: OME-XML
-.. index:: .ome
+.. index:: .ome, .ome.xml
 
 OME-XML
 ===============================================================================
 
-Extensions: `.ome <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
+Extensions: `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
 
 Developer: `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -987,7 +987,7 @@ Supported Formats
      - |yes|
      - |yes|
    * - :doc:`formats/ome-xml`
-     - `.ome <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
+     - `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
      - |Outstanding|
      - |Outstanding|
      - |Outstanding|


### PR DESCRIPTION

This is the same as gh-2142 but rebased onto dev_5_1.

----

This extension is currently supported by the permissive nature of the reader but unsupported by the writer. There are a couple of reasons why we want to consider it as official including our own usage, the symmetry with the OME-TIFF format extension and the usability with other software.

To test this PR, try to convert an OME-XML into another one with the `.ome.xml` extension

```
./tools/bfconvert test.ome.xml test2.ome.xml
```

/cc @rleigh-dundee @mtbc @hflynn @joshmoore @melissalinkert 

Replaces #2133

                