### PR TITLE
Modified setLength(..) method of NIOFileHandle.java for faster save operation. (rebased onto dev_5_1)

### DIFF
--- a/components/formats-common/src/loci/common/NIOFileHandle.java
+++ b/components/formats-common/src/loci/common/NIOFileHandle.java
@@ -198,8 +198,10 @@ public class NIOFileHandle extends AbstractNIOHandle {
   /* @see AbstractNIOHandle.setLength(long) */
   @Override
   public void setLength(long length) throws IOException {
+    if (raf.length() < length) {
+      raf.setLength(length);
+    }
     raf.seek(length - 1);
-    raf.write((byte) 0);
     buffer = null;
   }
 


### PR DESCRIPTION

This is the same as gh-2056 but rebased onto dev_5_1.

----

Modified setLength(..) method for faster saving operation.
With the previous implementation, saving a 700 MB 5D dataset in OME TIFF format was taking about 45 minutes, now it takes about 3 minutes. It's still slow but already a nice improvement.

                