### PR TITLE
OME-TIFF export fixes

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -199,8 +199,6 @@ public final class FormatTools {
 
   // -- Constants - versioning --
 
-  public static final String CREATOR = "OME Bio-Formats";
-
   public static final Properties VERSION_PROPERTIES = loadProperties();
 
   /** Current VCS revision. */
@@ -220,6 +218,9 @@ public final class FormatTools {
   /** Version number of this release. */
   public static final String VERSION =
     VERSION_PROPERTIES.getProperty("release.version");
+
+  /** Value to use when setting creator/software fields in exported files. */
+  public static final String CREATOR = "OME Bio-Formats " + VERSION;
 
   public static final String PROPERTY_FILE = "version.properties";
 

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -199,6 +199,8 @@ public final class FormatTools {
 
   // -- Constants - versioning --
 
+  public static final String CREATOR = "OME Bio-Formats";
+
   public static final Properties VERSION_PROPERTIES = loadProperties();
 
   /** Current VCS revision. */

--- a/components/formats-api/src/loci/formats/services/OMEXMLService.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLService.java
@@ -263,6 +263,11 @@ public interface OMEXMLService extends Service {
   public void removeBinData(OMEXMLMetadata omexmlMeta);
 
   /**
+   * Remove all of the TiffData elements from the given OME-XML metadata object.
+   */
+  public void removeTiffData(OMEXMLMetadata omexmlMeta);
+
+  /**
    * Remove all but the first sizeC valid Channel elements from the given
    * OME-XML metadata object.
    */

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -75,6 +75,7 @@ import ome.xml.model.OMEModel;
 import ome.xml.model.OMEModelImpl;
 import ome.xml.model.OMEModelObject;
 import ome.xml.model.Pixels;
+import ome.xml.model.TiffData;
 import ome.xml.model.Annotation;
 import ome.xml.model.StructuredAnnotations;
 import ome.xml.model.XMLAnnotation;
@@ -885,6 +886,23 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
       List<BinData> binData = pix.copyBinDataList();
       for (BinData bin : binData) {
         pix.removeBinData(bin);
+      }
+      pix.setMetadataOnly(null);
+    }
+    omexmlMeta.setRoot(root);
+  }
+
+  /** @see OMEXMLService#removeTiffData(OMEXMLMetadata) */
+  @Override
+  public void removeTiffData(OMEXMLMetadata omexmlMeta) {
+    omexmlMeta.resolveReferences();
+    OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) omexmlMeta.getRoot();
+    List<Image> images = root.copyImageList();
+    for (Image img : images) {
+      Pixels pix = img.getPixels();
+      List<TiffData> tiffData = pix.copyTiffDataList();
+      for (TiffData tiff : tiffData) {
+        pix.removeTiffData(tiff);
       }
       pix.setMetadataOnly(null);
     }

--- a/components/formats-bsd/src/loci/formats/out/EPSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/EPSWriter.java
@@ -139,7 +139,7 @@ public class EPSWriter extends FormatWriter {
 
     out.writeBytes("%!PS-Adobe-2.0 EPSF-1.2\n");
     out.writeBytes("%%Title: " + currentId + "\n");
-    out.writeBytes("%%Creator: OME Bio-Formats\n");
+    out.writeBytes("%%Creator: " + FormatTools.CREATOR + "\n");
     out.writeBytes("%%Pages: 1\n");
     out.writeBytes("%%BoundingBox: 0 0 " + width + " " + height + "\n");
     out.writeBytes("%%EndComments\n\n");

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveInteger;
 
@@ -250,6 +251,9 @@ public class OMETiffWriter extends TiffWriter {
     // generate UUID and add to OME element
     String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
     omeMeta.setUUID(uuid);
+
+    OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) omeMeta.getRoot();
+    root.setCreator(FormatTools.CREATOR);
 
     String xml;
     try {

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -97,8 +97,9 @@ public class OMETiffWriter extends TiffWriter {
       if (currentId != null) {
         setupServiceAndMetadata();
 
-        // remove any BinData elements from the OME-XML
+        // remove any BinData and old TiffData elements from the OME-XML
         service.removeBinData(omeMeta);
+        service.removeTiffData(omeMeta);
 
         for (int series=0; series<omeMeta.getImageCount(); series++) {
           setSeries(series);

--- a/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMEXMLWriter.java
@@ -57,6 +57,8 @@ import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
 
+import ome.xml.meta.OMEXMLMetadataRoot;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -100,6 +102,9 @@ public class OMEXMLWriter extends FormatWriter {
       xml = service.getOMEXML(retrieve);
       OMEXMLMetadata noBin = service.createOMEXMLMetadata(xml);
       service.removeBinData(noBin);
+
+      OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) noBin.getRoot();
+      root.setCreator(FormatTools.CREATOR);
       xml = service.getOMEXML(noBin);
     }
     catch (DependencyException de) {

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -963,7 +963,7 @@ public class TiffSaver {
       ifd.putIFDValue(IFD.Y_RESOLUTION, new TiffRational(1, 1));
     }
     if (ifd.get(IFD.SOFTWARE) == null) {
-      ifd.putIFDValue(IFD.SOFTWARE, "OME Bio-Formats");
+      ifd.putIFDValue(IFD.SOFTWARE, FormatTools.CREATOR);
     }
     if (ifd.get(IFD.ROWS_PER_STRIP) == null &&
       ifd.get(IFD.TILE_WIDTH) == null && ifd.get(IFD.TILE_LENGTH) == null)


### PR DESCRIPTION
This should resolve https://trello.com/c/R1x1tmaP/78-bfconvert-writes-invalid-ome-tiff and https://trello.com/c/L0Mq3BSV/351-fill-the-creator-field-when-generating-ome-tiff.

To test, use the file mentioned in https://trac.openmicroscopy.org/ome/ticket/13131.  Run ```bfconvert vessels.ome.tiff -channel 0 c0.ome.tiff``` without this change and verify that the reported error occurs during ```showinf c0.ome.tiff```.  The same command with this change should not result in an error upon ```showinf c0.ome.tiff```.  ```tiffcomment c0.ome.tiff``` should show the following:

* 144 TiffData elements
* no TiffData elements representing C > 0
* Creator (on root OME node) set to ```OME Bio-Formats```