### PR TITLE
doc: install and usage instructions for Octave package (issue ome-release 177) (rebased onto dev_5_1)

### DIFF
--- a/docs/sphinx/users/index.txt
+++ b/docs/sphinx/users/index.txt
@@ -98,6 +98,7 @@ Numerical data processing applications
     :maxdepth: 1
     :titlesonly:
 
+    octave/index
     idl/index
     knime/index
     matlab/index

--- a/docs/sphinx/users/octave/index.txt
+++ b/docs/sphinx/users/octave/index.txt
@@ -15,24 +15,25 @@ the only difference being the installation steps.
 Installation
 ------------
 
-Download `bioformats_package.jar` from the Bio-Formats
-:downloads:`downloads page <>` and place it somewhere sensible for
-your system (in Linux, this will probably be `/usr/local/share/java` or
-`~/.local/share/java` for a system-wide or user installation respectively).
+#. Download :downloads:`bioformats_package.jar <artifacts/bioformats_package.jar>`
+   and place it somewhere sensible for your system (in Linux, this will
+   probably be `/usr/local/share/java` or `~/.local/share/java` for a
+   system-wide or user installation respectively).
+#. Add `bioformats_package.jar` to Octave's *static* javaclasspath (see
+   `Octave's documentation <https://www.gnu.org/software/octave/doc/interpreter/How-to-make-Java-classes-available_003f.html>`_).
+#. Download the Octave package from the :downloads:`downloads page <>`.
+#. Start octave and install the package with::
 
-Add `bioformats_package.jar` to Octave's *static* javaclasspath (see
-`Octave's documentation <https://www.gnu.org/software/octave/doc/interpreter/How-to-make-Java-classes-available_003f.html>`_).
-
-Download the Octave package from the Bio-Formats
-:downloads:`downloads page <>`.  Start octave and install the package
-with `pkg install path-to-bioformats-octave-version.tar.gz`.
+      >> pkg install path-to-bioformats-octave-version.tar.gz
 
 Usage
 -----
 
 Usage instructions are the same as Matlab.  The only difference is that
-you need to explicitly load the package.  This is done by running
-`pkg load bioformats` at the Octave prompt.
+you need to explicitly load the package.  This is done by running at the
+Octave prompt::
+
+    >> pkg load bioformats
 
 Upgrading
 ---------

--- a/docs/sphinx/users/octave/index.txt
+++ b/docs/sphinx/users/octave/index.txt
@@ -1,0 +1,41 @@
+GNU Octave
+==========
+
+`GNU Octave <http://www.octave.org>`_ is a high-level interpreted language,
+primarily intended for numerical computations.
+Being an array programming language, it is naturally suited for image
+processing and handling of N dimensional datasets.
+Octave is distributed under the terms of the GNU General Public License.
+
+The Octave language is Matlab compatible so that programs are easily
+portable.
+Indeed, the Octave bioformats package is exactly the same as Matlab's,
+the only difference being the installation steps.
+
+Installation
+------------
+
+Download `bioformats_package.jar` from the Bio-Formats
+:downloads:`downloads page <>` and place it somewhere sensible for
+your system (in Linux, this will probably be `/usr/local/share/java` or
+`~/.local/share/java` for a system-wide or user installation respectively).
+
+Add `bioformats_package.jar` to Octave's *static* javaclasspath (see
+`Octave's documentation <https://www.gnu.org/software/octave/doc/interpreter/How-to-make-Java-classes-available_003f.html>`_).
+
+Download the Octave package from the Bio-Formats
+:downloads:`downloads page <>`.  Start octave and install the package
+with `pkg install path-to-bioformats-octave-version.tar.gz`.
+
+Usage
+-----
+
+Usage instructions are the same as Matlab.  The only difference is that
+you need to explicitly load the package.  This is done by running
+`pkg load bioformats` at the Octave prompt.
+
+Upgrading
+---------
+
+To use a newer version of Bio-Formats, repeat the install instructions.
+Do not follow the Matlab instructions.

--- a/docs/sphinx/users/octave/index.txt
+++ b/docs/sphinx/users/octave/index.txt
@@ -12,6 +12,18 @@ portable.
 Indeed, the Octave bioformats package is exactly the same as Matlab's,
 the only difference being the installation steps.
 
+Requirements
+------------
+
+The bioformats package requires Octave version 4.0.0 or later with
+support for java::
+
+    $ octave
+    >> OCTAVE_VERSION
+    ans = 4.0.0
+    >> octave_config_info ("features").JAVA
+    ans =  1
+
 Installation
 ------------
 


### PR DESCRIPTION

This is the same as gh-2200 but rebased onto dev_5_1.

----

Adding instructions on how to install bioformats package in Octave as requested in openmicroscopy/ome-release#177

Note: I have added octave on the list above idl, and not in alphabetic order, because on the build the link appears as "GNU Octave" (so it is alphabetic order but of the end result).

                