### PR TITLE
TiffParser: always set the stream for any OnDemandLongArrays (rebased onto dev_5_1)

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -672,11 +672,15 @@ public class TiffParser {
 
     if (ifd.get(IFD.STRIP_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.STRIP_BYTE_COUNTS);
-      counts.setStream(in);
+      if (counts != null) {
+        counts.setStream(in);
+      }
     }
     if (ifd.get(IFD.TILE_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.TILE_BYTE_COUNTS);
-      counts.setStream(in);
+      if (counts != null) {
+        counts.setStream(in);
+      }
     }
 
     long[] stripByteCounts = ifd.getStripByteCounts();
@@ -855,11 +859,15 @@ public class TiffParser {
 
     if (ifd.get(IFD.STRIP_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.STRIP_BYTE_COUNTS);
-      counts.setStream(in);
+      if (counts != null) {
+        counts.setStream(in);
+      }
     }
     if (ifd.get(IFD.TILE_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.TILE_BYTE_COUNTS);
-      counts.setStream(in);
+      if (counts != null) {
+        counts.setStream(in);
+      }
     }
 
     long[] stripByteCounts = ifd.getStripByteCounts();

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -672,15 +672,11 @@ public class TiffParser {
 
     if (ifd.get(IFD.STRIP_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.STRIP_BYTE_COUNTS);
-      if (counts != null && counts.getStream() == null) {
-        counts.setStream(in);
-      }
+      counts.setStream(in);
     }
     if (ifd.get(IFD.TILE_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.TILE_BYTE_COUNTS);
-      if (counts != null && counts.getStream() == null) {
-        counts.setStream(in);
-      }
+      counts.setStream(in);
     }
 
     long[] stripByteCounts = ifd.getStripByteCounts();
@@ -707,9 +703,7 @@ public class TiffParser {
 
     if (ifd.getOnDemandStripOffsets() != null) {
       OnDemandLongArray stripOffsets = ifd.getOnDemandStripOffsets();
-      if (stripOffsets.getStream() == null) {
-        stripOffsets.setStream(in);
-      }
+      stripOffsets.setStream(in);
       stripOffset = stripOffsets.get(offsetIndex);
       nStrips = stripOffsets.size();
     }
@@ -852,9 +846,7 @@ public class TiffParser {
 
     if (ifd.getOnDemandStripOffsets() != null) {
       OnDemandLongArray offsets = ifd.getOnDemandStripOffsets();
-      if (offsets.getStream() == null) {
-        offsets.setStream(in);
-      }
+      offsets.setStream(in);
       stripOffsets = offsets.toArray();
     }
     else {
@@ -863,15 +855,11 @@ public class TiffParser {
 
     if (ifd.get(IFD.STRIP_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.STRIP_BYTE_COUNTS);
-      if (counts != null && counts.getStream() == null) {
-        counts.setStream(in);
-      }
+      counts.setStream(in);
     }
     if (ifd.get(IFD.TILE_BYTE_COUNTS) instanceof OnDemandLongArray) {
       OnDemandLongArray counts = (OnDemandLongArray) ifd.get(IFD.TILE_BYTE_COUNTS);
-      if (counts != null && counts.getStream() == null) {
-        counts.setStream(in);
-      }
+      counts.setStream(in);
     }
 
     long[] stripByteCounts = ifd.getStripByteCounts();


### PR DESCRIPTION

This is the same as gh-2196 but rebased onto dev_5_1.

----

This prevents exceptions when an OnDemandLongArray is loaded from a memo
file, resulting in an invalid default stream.

See https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7980

To test, convert the file from QA 16966 to .ome.btf using bfconvert.  Import the .ome.btf into OMERO; without this change, pyramid generation will throw an exception as noted in the forum thread.  With this change, pyramid generation should succeed, and the image should be viewable in OMERO.

                