### PR TITLE
Fixing nifti links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1479,8 +1479,8 @@ notes = .. seealso:: \n
 extensions = .img, .hdr
 developer = `National Institutes of Health <http://www.nih.gov/>`_
 bsd = no
-samples = `Official test data <http://nifti.nimh.nih.gov/nifti-1/data>`_
-weHave = * `NIfTI specification documents <http://nifti.nimh.nih.gov/nifti-1/>`_ \n
+samples = `Official test data <http://afni.nimh.nih.gov/pub/dist/data/>`_
+weHave = * `NIfTI specification documents <http://afni.nimh.nih.gov/pub/dist/doc/nifti/nifti_revised.html>`_ \n
 * several NIfTI datasets
 pixelsRating = Very good
 metadataRating = Good

--- a/docs/sphinx/formats/nifti.txt
+++ b/docs/sphinx/formats/nifti.txt
@@ -24,11 +24,11 @@ Reader: NiftiReader (:bfreader:`Source Code <NiftiReader.java>`, :doc:`Supported
 
 Sample Datasets:
 
-- `Official test data <http://nifti.nimh.nih.gov/nifti-1/data>`_
+- `Official test data <http://afni.nimh.nih.gov/pub/dist/data/>`_
 
 We currently have:
 
-* `NIfTI specification documents <http://nifti.nimh.nih.gov/nifti-1/>`_ 
+* `NIfTI specification documents <http://afni.nimh.nih.gov/pub/dist/doc/nifti/nifti_revised.html>`_ 
 * several NIfTI datasets
 
 We would like to have:


### PR DESCRIPTION
http://nifti.nimh.nih.gov/nifti-1/data and http://nifti.nimh.nih.gov/nifti-1/ have been down since last week and it seems the sysadmin has left so unclear if/when they will work again, so replacing with working links.

Should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/ green again.