### PR TITLE
Micromanager: parse JSON tag in each TIFF

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -445,13 +445,22 @@ public class MicromanagerReader extends FormatReader {
             // using key alone will result in conflicts with metadata.txt values
             addSeriesMeta(String.format("Plane #%0" + digits + "d %s", plane, key), value);
             if (key.equals("XPositionUm")) {
-              p.positions[plane][0] = new Double(value);
+              try {
+                p.positions[plane][0] = new Double(value);
+              }
+              catch (NumberFormatException e) { }
             }
             else if (key.equals("YPositionUm")) {
-              p.positions[plane][1] = new Double(value);
+              try {
+                p.positions[plane][1] = new Double(value);
+              }
+              catch (NumberFormatException e) { }
             }
             else if (key.equals("ZPositionUm")) {
-              p.positions[plane][2] = new Double(value);
+              try {
+                p.positions[plane][2] = new Double(value);
+              }
+              catch (NumberFormatException e) { }
             }
           }
         }

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -343,9 +343,15 @@ public class MicromanagerReader extends FormatReader {
             store.setPlaneDeltaT(new Time(p.timestamps[nextStamp++], UNITS.MS), i, q);
           }
           if (p.positions != null && q < p.positions.length) {
-            store.setPlanePositionX(new Length(p.positions[q][0], UNITS.MICROM), i, q);
-            store.setPlanePositionY(new Length(p.positions[q][1], UNITS.MICROM), i, q);
-            store.setPlanePositionZ(new Length(p.positions[q][2], UNITS.MICROM), i, q);
+            if (p.positions[q][0] != null) {
+              store.setPlanePositionX(new Length(p.positions[q][0], UNITS.MICROM), i, q);
+            }
+            if (p.positions[q][1] != null) {
+              store.setPlanePositionY(new Length(p.positions[q][1], UNITS.MICROM), i, q);
+            }
+            if (p.positions[q][2] != null) {
+              store.setPlanePositionZ(new Length(p.positions[q][2], UNITS.MICROM), i, q);
+            }
           }
         }
 

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -427,6 +427,10 @@ public class MicromanagerReader extends FormatReader {
         IFD firstIFD = parser.getFirstIFD();
         parser.fillInIFD(firstIFD);
         String json = firstIFD.getIFDTextValue(JSON_TAG);
+        parser.getStream().close();
+        if (json == null) {
+          continue;
+        }
         String[] lines = json.split("\n");
         for (String line : lines) {
           String toSplit = line.trim();


### PR DESCRIPTION
See https://trello.com/c/499UGA5U/72-micromanager-stage-positions-and-json

This reads the JSON data from each TIFF and stores the key/value pairs
in the original metadata table.  Stage position values ("*PositionUm")
will also be stored in OME-XML, if they are present.

As each TIFF tag contains a single JSON object, simple parsing of the
key/value pairs without an external library was the easiest solution for now.
We'll likely want to revisit this once we have a better plan for dealing
with JSON data in general though.

To test, use the dataset in ```curated/micromanager/nico/Untitled_4_multi_file``` (config PR forthcoming).  Without this change, ```showinf -omexml``` should not show PositionX, PositionY, or PositionZ values for Plane in the OME-XML.  With this change, all 3 values should be set for every Plane, and the original metadata table should show many entries beginning with ```Plane```.