### PR TITLE
developers/examples/bftest.m: simplify by using Matlab and Octave core functions

### DIFF
--- a/docs/sphinx/developers/examples/bftest.m
+++ b/docs/sphinx/developers/examples/bftest.m
@@ -1,9 +1,7 @@
 bfCheckJavaPath();
 
 % Create local file for testing
-java_tmpdir = char(java.lang.System.getProperty('java.io.tmpdir'));
-uuid = char(java.util.UUID.randomUUID());
-tmpdir = fullfile(java_tmpdir, uuid);
+tmpdir = tempname();
 mkdir(tmpdir);
 
 % Create fake file for testing purposes
@@ -54,8 +52,7 @@ imagesc(series1_plane1);
 % displaying-images-end
 
 % animated-movie-start
-v = linspace(0, 1, 256)';
-cmap = [v v v];
+cmap = gray(256);
 for p = 1 : size(series1, 1)
   M(p) = im2frame(uint8(series1{p, 1}), cmap);
 end


### PR DESCRIPTION
This simplifies the creation of a directory on the tmporary directory by making use of Matlab and Octave core functions instead of the java stuff. While this makes it much simpler, the main reason is Octave compatibility since the example uses Matlab dot notation to call java methods that hasn't been implemented in Octave yet.

With this change, the example runs fine in Octave until the call to im2frame (again, a missing feature in Octave).