### PR TITLE
OME-TIFF: make sure BinaryOnly files reference a valid MetadataFile (rebased onto dev_5_1)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -216,7 +216,11 @@ public class OMETiffReader extends FormatReader {
 
       try {
         String metadataFile = meta.getBinaryOnlyMetadataFile();
-        if (metadataFile != null) {
+        // check the suffix to make sure that the MetadataFile is not
+        // referencing the current OME-TIFF
+        if (metadataFile != null && !checkSuffix(metadataFile, "ome.tiff") &&
+          !checkSuffix(metadataFile, "ome.tif"))
+        {
           return true;
         }
       }


### PR DESCRIPTION

This is the same as gh-2215 but rebased onto dev_5_1.

----

See https://trello.com/c/mVFYhwcJ/87-qa16988

To test, use the file from QA 16990.  Without this change, ```showinf``` on the file should throw an exception as indicated in the QA and above card.  With this change, ```showinf``` should display the image without an error, but note that it will be detected as plain TIFF and not OME-TIFF.

No configuration yet as QA 16990/16991 should be detected as a Micromanager dataset, but that will require a separate more involved PR to fix MicromanagerReader.

                