### PR TITLE
Fix TiffRational integer overflow

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -230,8 +230,16 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     putInt("Model", firstIFD, IFD.MODEL);
     putInt("MinSampleValue", firstIFD, IFD.MIN_SAMPLE_VALUE);
     putInt("MaxSampleValue", firstIFD, IFD.MAX_SAMPLE_VALUE);
-    put("XResolution", firstIFD.getIFDRationalValue(IFD.X_RESOLUTION).doubleValue());
-    put("YResolution", firstIFD.getIFDRationalValue(IFD.Y_RESOLUTION).doubleValue());
+
+    TiffRational xResolution = firstIFD.getIFDRationalValue(IFD.X_RESOLUTION);
+    TiffRational yResolution = firstIFD.getIFDRationalValue(IFD.Y_RESOLUTION);
+
+    if (xResolution != null) {
+      put("XResolution", xResolution.doubleValue());
+    }
+    if (yResolution != null) {
+      put("YResolution", yResolution.doubleValue());
+    }
 
     int planar = firstIFD.getIFDIntValue(IFD.PLANAR_CONFIGURATION);
     String planarConfig = null;

--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -230,8 +230,8 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
     putInt("Model", firstIFD, IFD.MODEL);
     putInt("MinSampleValue", firstIFD, IFD.MIN_SAMPLE_VALUE);
     putInt("MaxSampleValue", firstIFD, IFD.MAX_SAMPLE_VALUE);
-    putInt("XResolution", firstIFD, IFD.X_RESOLUTION);
-    putInt("YResolution", firstIFD, IFD.Y_RESOLUTION);
+    put("XResolution", firstIFD.getIFDRationalValue(IFD.X_RESOLUTION).doubleValue());
+    put("YResolution", firstIFD.getIFDRationalValue(IFD.Y_RESOLUTION).doubleValue());
 
     int planar = firstIFD.getIFDIntValue(IFD.PLANAR_CONFIGURATION);
     String planarConfig = null;

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -571,10 +571,10 @@ public class TiffParser {
     else if (type == IFDType.RATIONAL || type == IFDType.SRATIONAL) {
       // Two LONGs or SLONGs: the first represents the numerator
       // of a fraction; the second, the denominator
-      if (count == 1) return new TiffRational(in.readInt(), in.readInt());
+      if (count == 1) return new TiffRational(in.readInt() & 0xffffffffL, in.readInt() & 0xffffffffL);
       TiffRational[] rationals = new TiffRational[count];
       for (int j=0; j<count; j++) {
-        rationals[j] = new TiffRational(in.readInt(), in.readInt());
+        rationals[j] = new TiffRational(in.readInt() & 0xffffffffL, in.readInt() & 0xffffffffL);
       }
       return rationals;
     }

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -533,11 +533,11 @@ public class TiffParser {
     }
     else if (type == IFDType.LONG || type == IFDType.IFD) {
       // 32-bit (4-byte) unsigned integer
-      if (count == 1) return new Long(in.readInt());
+      if (count == 1) return new Long(in.readUnsignedInt());
       long[] longs = new long[count];
       for (int j=0; j<count; j++) {
         if (in.getFilePointer() + 4 <= in.length()) {
-          longs[j] = in.readInt();
+          longs[j] = in.readUnsignedInt();
         }
       }
       return longs;
@@ -571,10 +571,10 @@ public class TiffParser {
     else if (type == IFDType.RATIONAL || type == IFDType.SRATIONAL) {
       // Two LONGs or SLONGs: the first represents the numerator
       // of a fraction; the second, the denominator
-      if (count == 1) return new TiffRational(in.readInt() & 0xffffffffL, in.readInt() & 0xffffffffL);
+      if (count == 1) return new TiffRational(in.readUnsignedInt(), in.readUnsignedInt());
       TiffRational[] rationals = new TiffRational[count];
       for (int j=0; j<count; j++) {
-        rationals[j] = new TiffRational(in.readInt() & 0xffffffffL, in.readInt() & 0xffffffffL);
+        rationals[j] = new TiffRational(in.readUnsignedInt(), in.readUnsignedInt());
       }
       return rationals;
     }
@@ -1238,7 +1238,7 @@ public class TiffParser {
     if (bigTiff || fakeBigTiff) {
       return in.readLong();
     }
-    long offset = (previous & ~0xffffffffL) | (in.readInt() & 0xffffffffL);
+    long offset = (previous & ~0xffffffffL) | (in.readUnsignedInt());
 
     // Only adjust the offset if we know that the file is too large for 32-bit
     // offsets to be accurate; otherwise, we're making the incorrect assumption

--- a/components/formats-common/src/loci/common/RandomAccessInputStream.java
+++ b/components/formats-common/src/loci/common/RandomAccessInputStream.java
@@ -507,6 +507,13 @@ public class RandomAccessInputStream extends InputStream implements DataInput, C
     return raf.readInt();
   }
 
+  /**
+   * Read four input bytes and return an unsigned value.
+   */
+  public long readUnsignedInt() throws IOException {
+    return readInt() & 0xffffffffL;
+  }
+
   /** Read the next line of text from the input stream. */
   @Override
   public String readLine() throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/GelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GelReader.java
@@ -153,10 +153,10 @@ public class GelReader extends BaseTiffReader {
       }
     }
 
-    super.initStandardMetadata();
-
     IFD firstIFD = ifds.get(0);
     tiffParser.fillInIFD(firstIFD);
+
+    super.initStandardMetadata();
 
     fmt = firstIFD.getIFDLongValue(MD_FILETAG, LINEAR);
     if (fmt == SQUARE_ROOT) core.get(0).pixelType = FormatTools.FLOAT;

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -308,13 +308,16 @@ public class NDPIReader extends BaseTiffReader {
         long prevByteCount =
           i == 0 ? 0 : ifds.get(i - 1).getStripByteCounts()[0];
 
-        while (stripOffsets[j] < prevOffset || stripOffsets[j] < prevOffset + prevByteCount) {
-          long newOffset = stripOffsets[j] + 0x100000000L;
+        long currentOffset = (int) stripOffsets[j];
+
+        while (currentOffset < prevOffset || currentOffset < prevOffset + prevByteCount) {
+          long newOffset = currentOffset + 0x100000000L;
           if (newOffset < stream.length() && ((j > 0 &&
-            (stripOffsets[j] < stripOffsets[j - 1])) ||
-            (i > 0 && stripOffsets[j] < prevOffset + prevByteCount)))
+            (currentOffset < stripOffsets[j - 1])) ||
+            (i > 0 && currentOffset < prevOffset + prevByteCount)))
           {
             stripOffsets[j] = newOffset;
+            currentOffset = stripOffsets[j];
             neededAdjustment = true;
           }
         }
@@ -327,8 +330,9 @@ public class NDPIReader extends BaseTiffReader {
 
       long[] stripByteCounts = ifd.getStripByteCounts();
       for (int j=0; j<stripByteCounts.length; j++) {
-        long newByteCount = stripByteCounts[j] + 0x100000000L;
-        if (stripByteCounts[j] < 0 || neededAdjustment ||
+        long currentCount = (int) stripByteCounts[j];
+        long newByteCount = currentCount + 0x100000000L;
+        if (currentCount < 0 || neededAdjustment ||
           newByteCount + stripOffsets[j] < in.length())
         {
           if (newByteCount < ifd.getImageWidth() * ifd.getImageLength()) {


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-January/005834.html

To test, use the ```myfile.tif``` file attached to the thread.  Without this change, ```showinf -nopix``` should confirm that the ```XResolution``` and ```YResolution``` keys in the original metadata table are both 0.  ```tiffinfo``` on the same file should show ```  Resolution: 42.42, 0 (unitless)``` as mentioned in the thread.

With this change, ```showinf -nopix``` should show ```42.419...``` and ```0.0``` for ```XResolution``` and ```YResolution``` respectively.