### PR TITLE
Micromanager: *_metadata.txt and 51123 tag parsing

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -180,7 +180,7 @@ public class MicromanagerReader extends FormatReader {
       }
       if (!noPixels) {
         for (String tiff : pos.tiffs) {
-          if (new Location(tiff).exists()) {
+          if (new Location(tiff).exists() && !files.contains(tiff)) {
             files.add(tiff);
           }
         }
@@ -204,7 +204,8 @@ public class MicromanagerReader extends FormatReader {
 
     if (file != null && new Location(file).exists()) {
       tiffReader.setId(file);
-      return tiffReader.openBytes(0, buf, x, y, w, h);
+      int index = no % tiffReader.getImageCount();
+      return tiffReader.openBytes(index, buf, x, y, w, h);
     }
     LOGGER.warn("File for image #{} ({}) is missing.", no, file);
     return buf;
@@ -438,13 +439,12 @@ public class MicromanagerReader extends FormatReader {
         IFD firstIFD = parser.getFirstIFD();
         parser.fillInIFD(firstIFD);
 
-        if (getSizeX() == 0 || getSizeY() == 0) {
-          CoreMetadata ms = core.get(posIndex);
-          ms.sizeX = (int) firstIFD.getImageWidth();
-          ms.sizeY = (int) firstIFD.getImageLength();
-          ms.pixelType = firstIFD.getPixelType();
-          ms.littleEndian = firstIFD.isLittleEndian();
-        }
+        // ensure that the plane dimensions and pixel type are correct
+        CoreMetadata ms = core.get(posIndex);
+        ms.sizeX = (int) firstIFD.getImageWidth();
+        ms.sizeY = (int) firstIFD.getImageLength();
+        ms.pixelType = firstIFD.getPixelType();
+        ms.littleEndian = firstIFD.isLittleEndian();
 
         String json = firstIFD.getIFDTextValue(JSON_TAG);
         parser.getStream().close();

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -438,7 +438,12 @@ public class MicromanagerReader extends FormatReader {
     boolean parseMMJSONTag = true;
     for (int plane=0; plane<p.tiffs.size(); ) {
       String path = p.tiffs.get(plane);
-      if (!new Location(path).exists()) {
+      // use getFile(...) lookup if possible, to make sure that
+      // file ordering is correct
+      if (p.tiffs.size() == p.fileNameMap.size() && plane < getImageCount()) {
+        path = p.getFile(plane);
+      }
+      if (path == null || !new Location(path).exists()) {
         plane++;
         continue;
       }

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -513,7 +513,12 @@ public class MicromanagerReader extends FormatReader {
             else if (token.equals("PropType")) {
               propType = token;
             }
-            else if (propType != null && propType.equals("PropType")) {
+            else if ((propType != null && propType.equals("PropType")) ||
+              (key != null && value == null))
+            {
+              if (value == null) {
+                value = token;
+              }
               parseKeyAndValue(key, value, digits, (plane * nIFDs) + i, 1);
               propType = null;
               key = null;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -1036,7 +1036,11 @@ public class MicromanagerReader extends FormatReader {
   }
 
   private String getPrefixMetadataName(String baseName) {
-    return baseName.substring(0, baseName.indexOf(".")) + "_" + METADATA;
+    int dot = baseName.indexOf(".");
+    if (dot > 0) {
+      return baseName.substring(0, dot) + "_" + METADATA;
+    }
+    return baseName + "_" + METADATA;
   }
 
   // -- Helper classes --

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1650,6 +1650,14 @@ public class FormatReaderTest {
             continue;
           }
 
+          // Micromanager datasets cannot be detected with an OME-TIFF file
+          if (reader.getFormat().equals("Micro-Manager") &&
+            (base[i].toLowerCase().endsWith(".ome.tiff") ||
+            base[i].toLowerCase().endsWith(".ome.tif")))
+          {
+            continue;
+          }
+
           // DICOM companion files may not be detected
           if (reader.getFormat().equals("DICOM") && !base[i].equals(file)) {
             continue;
@@ -2183,6 +2191,14 @@ public class FormatReaderTest {
             // extra metadata files, so it is acceptable for the OME-TIFF
             // reader to pick up TIFFs from a Prairie dataset
             if (result && r instanceof PrairieReader &&
+              readers[j] instanceof OMETiffReader)
+            {
+              continue;
+            }
+
+            // Micromanager datasets can consist of OME-TIFF files
+            // with an extra metadata file
+            if (result && r instanceof MicromanagerReader &&
               readers[j] instanceof OMETiffReader)
             {
               continue;


### PR DESCRIPTION
This fixes several issues with the new datasets from Thomas Julou - see https://github.com/openmicroscopy/data_repo_config/pull/76 for configuration and gh-2213 for discussion.

For each of the four new datasets, check that ```showinf``` on the ```*metadata.txt``` file shows images without an error (with this change).  Without this change, ```showinf``` on ```test_sep/Pos0/metadata.txt``` should work, but all others will throw an exception.

For ```test2_sep```, ```test_stack```, and ```test2_stack```, check each image (this may be easier in ImageJ) and verify that each image is unique and not blank.

For ```test_stack``` and ```test2_stack```, the 51123 tag should be parsed for each plane.  Compare the original metadata tables with and without this change; there should be several new ```Plane #...``` keys with this change.