### PR TITLE
getUsedFiles performance fix

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -1043,16 +1043,22 @@ public abstract class FormatReader extends FormatHandler
   /* @see IFormatReader#getUsedFiles() */
   @Override
   public String[] getUsedFiles(boolean noPixels) {
-    if (getSeriesCount() == 1) {
-      return getSeriesUsedFiles(noPixels);
+    String[] seriesUsedFiles;
+    int seriesCount = getSeriesCount();
+    if (seriesCount == 1) {
+      seriesUsedFiles = getSeriesUsedFiles(noPixels);
+      if (null == seriesUsedFiles) {
+        seriesUsedFiles = new String[] {};
+      }
+      return seriesUsedFiles;
     }
     int oldSeries = getSeries();
     Set<String> files = new LinkedHashSet<String>();
-    for (int i=0; i<getSeriesCount(); i++) {
+    for (int i = 0; i < seriesCount; i++) {
       setSeries(i);
-      String[] s = getSeriesUsedFiles(noPixels);
-      if (s != null) {
-        files.addAll(Arrays.asList(s));
+      seriesUsedFiles = getSeriesUsedFiles(noPixels);
+      if (seriesUsedFiles != null) {
+        files.addAll(Arrays.asList(seriesUsedFiles));
       }
     }
     setSeries(oldSeries);

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -35,10 +35,12 @@ package loci.formats;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.Arrays;
 
 import loci.common.DataTools;
 import loci.common.Location;
@@ -1041,17 +1043,16 @@ public abstract class FormatReader extends FormatHandler
   /* @see IFormatReader#getUsedFiles() */
   @Override
   public String[] getUsedFiles(boolean noPixels) {
+    if (getSeriesCount() == 1) {
+      return getSeriesUsedFiles(noPixels);
+    }
     int oldSeries = getSeries();
-    Vector<String> files = new Vector<String>();
+    Set<String> files = new LinkedHashSet<String>();
     for (int i=0; i<getSeriesCount(); i++) {
       setSeries(i);
       String[] s = getSeriesUsedFiles(noPixels);
       if (s != null) {
-        for (String file : s) {
-          if (getSeriesCount() == 1 || !files.contains(file)) {
-            files.add(file);
-          }
-        }
+        files.addAll(Arrays.asList(s));
       }
     }
     setSeries(oldSeries);


### PR DESCRIPTION
This PR addresses a performance issue in `FormatReader.getUsedFiles` that can get very serious for formats with a large number of files in multiple series (e.g., `ScreenReader`).

The current implementation iteratively updates a `Vector` with the contents of arrays returned from `getSeriesUsedFiles`. To avoid duplicates, each filename from `getSeriesUsedFiles` is checked to see if it already belongs to the vector before adding. The problem is that `Vector.contains` is O(n), which makes the whole update operation **quadratic**.

A previous attempt at fixing the problem (see #1028) only made things better for single-series images: updates for subsequent series are still performed in the same way.

On my laptop, `ScreenReader.getUsedFiles` on [a TARA screen file](https://github.com/IDR/idr-metadata/blob/master/idr0015-UNKNOWN-taraoceans/screenA/patterns/TARA_HCS1_H5_G100001472_G100001473--2013_09_28_19_45_25_chamber--U01--V01.screen) takes ~60 seconds without the patch and ~3 seconds with the patch. Note that I've replaced `.ome.tif` entries with `.fake` ones to avoid copying real data.

This problem is also present in develop. I'm opening the PR vs metadata first because `ScreenReader`  allows to better evaluate the performance improvement.

NOTE: I have used `LinkedHashSet` instead of `HashSet` for predictable iteration order.