### PR TITLE
C++: OMETIFFWriter metadata and close fixes

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -51,6 +51,9 @@ target_link_libraries(metadata-formatreader OME::XML OME::BioFormats ${CMAKE_THR
 add_executable(metadata-formatwriter "${exampledir}/metadata-formatwriter.cpp")
 target_link_libraries(metadata-formatwriter OME::XML OME::BioFormats ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(metadata-formatwriter2 "${exampledir}/metadata-formatwriter2.cpp")
+target_link_libraries(metadata-formatwriter2 OME::XML OME::BioFormats ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(pixeldata "${exampledir}/pixeldata.cpp")
 target_link_libraries(pixeldata OME::BioFormats ${CMAKE_THREAD_LIBS_INIT})
 
@@ -59,5 +62,6 @@ if(BUILD_TESTS)
   bf_add_test(examples/metadata-io metadata-io "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
   bf_add_test(examples/metadata-formatreader metadata-formatreader "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/set-1-meta-companion/18x24y5z1t1c8b-text-split-Z1.ome.tiff")
   bf_add_test(examples/metadata-formatwriter metadata-formatwriter "${CMAKE_CURRENT_BINARY_DIR}/test-write.ome.tiff")
+  bf_add_test(examples/metadata-formatwriter2 metadata-formatwriter2 "${CMAKE_CURRENT_BINARY_DIR}/test-write2.ome.tiff")
   bf_add_test(examples/pixeldata pixeldata "${PROJECT_SOURCE_DIR}/components/specification/samples/${MODEL_VERSION}/18x24y1z5t1c8b-text.ome")
 endif(BUILD_TESTS)

--- a/cpp/lib/ome/bioformats/FormatHandler.h
+++ b/cpp/lib/ome/bioformats/FormatHandler.h
@@ -151,8 +151,21 @@ namespace ome
       /**
        * Close the currently open file.
        *
+       * An exception may be thrown when closing the file, for example
+       * if there are problems flushing any pending writes, or if
+       * there are any inconsistencies in the metadata which prevent
+       * completing any final writes.  The causes are reader- or
+       * writer-dependent, and the exception type is dependent upon
+       * the implementation details of the reader or writer in use.
+       * It is advised to always explicitly close writers, since if
+       * this is automatically called at destruction time, any errors
+       * will be lost.  If an exception is thrown, the object may be
+       * left in an inconsistent state and should not be reused.
+       *
        * @param fileOnly close the open file only if @c true, or else
-       * free all internal state if @c false.
+       * free all internal state if @c false; only meaningful for
+       * readers, since writers will always free all internal state.
+       * @throws On error; exception type may vary.
        */
       virtual
       void

--- a/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
+++ b/cpp/lib/ome/bioformats/detail/FormatWriter.cpp
@@ -126,20 +126,16 @@ namespace ome
       }
 
       void
-      FormatWriter::close(bool fileOnly)
+      FormatWriter::close(bool /* fileOnly */)
       {
-        if (out)
-          out.reset(); // set to null.
-        if (!fileOnly)
-          {
-            currentId = boost::none;
-            series = 0;
-            plane = 0;
-            compression = boost::none;
-            sequential = false;
-            framesPerSecond = 0;
-            metadataRetrieve.reset();
-          }
+        out.reset(); // set to null.
+        currentId = boost::none;
+        series = 0;
+        plane = 0;
+        compression = boost::none;
+        sequential = false;
+        framesPerSecond = 0;
+        metadataRetrieve.reset();
       }
 
       bool

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -173,20 +173,29 @@ namespace ome
       void
       MinimalTIFFWriter::close(bool fileOnly)
       {
-        if (tiff)
+        try
           {
-            // Flush last IFD.
-            nextIFD();
-            tiff->close();
+            if (tiff)
+              {
+                // Flush last IFD if unwritten.
+                nextIFD();
+                tiff->close();
+              }
+
             ifd.reset();
             tiff.reset();
+            ifdIndex = 0;
+            seriesIFDRange.clear();
+            bigTIFF = boost::none;
+
+            detail::FormatWriter::close(fileOnly);
           }
-
-        ifdIndex = 0;
-        seriesIFDRange.clear();
-        bigTIFF = boost::none;
-
-        detail::FormatWriter::close(fileOnly);
+        catch (const std::exception&)
+          {
+            tiff.reset(); // Ensure we only flush the last IFD once.
+            detail::FormatWriter::close(fileOnly);
+            throw;
+          }
       }
 
       void

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -181,12 +181,11 @@ namespace ome
             ifd.reset();
             tiff.reset();
           }
-        if (!fileOnly)
-          {
-            ifdIndex = 0;
-            seriesIFDRange.clear();
-            bigTIFF = boost::none;
-          }
+
+        ifdIndex = 0;
+        seriesIFDRange.clear();
+        bigTIFF = boost::none;
+
         detail::FormatWriter::close(fileOnly);
       }
 

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -714,7 +714,6 @@ namespace ome
 
         dimension_size_type seriesCount = getSeriesCount();
 
-        dimension_size_type nextPlane = 0U;
         for (dimension_size_type series = 0U; series < seriesCount; ++series)
           {
             DimensionOrder dimOrder = metadataRetrieve->getPixelsDimensionOrder(series);
@@ -740,8 +739,8 @@ namespace ome
                     path relative(make_relative(baseDir, planeState.id));
                     std::string uuid("urn:uuid:");
                     uuid += t->second.uuid;
-                    omeMeta->setUUIDFileName(relative.generic_string(), series, nextPlane);
-                    omeMeta->setUUIDValue(uuid, series, nextPlane);
+                    omeMeta->setUUIDFileName(relative.generic_string(), series, plane);
+                    omeMeta->setUUIDValue(uuid, series, plane);
 
                     // Fill in non-default TiffData attributes.
                     omeMeta->setTiffDataFirstZ(coords[0], series, plane);
@@ -749,10 +748,6 @@ namespace ome
                     omeMeta->setTiffDataFirstC(coords[1], series, plane);
                     omeMeta->setTiffDataIFD(planeState.ifd, series, plane);
                     omeMeta->setTiffDataPlaneCount(1, series, plane);
-
-                    // The Java writer updates the TIFF IFD count
-                    // here, but not sure it's appropriate for us.
-                    ++nextPlane;
                   }
                 else
                   {

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -572,17 +572,15 @@ namespace ome
              t != tiffs.end();
              ++t)
           t->second.tiff->close();
-        if (!fileOnly)
-          {
-            files.clear();
-            tiffs.clear();
-            currentTIFF = tiffs.end();
-            flags.clear();
-            seriesState.clear();
-            originalMetadataRetrieve.reset();
-            omeMeta.reset();
-            bigTIFF = boost::none;
-          }
+
+        files.clear();
+        tiffs.clear();
+        currentTIFF = tiffs.end();
+        flags.clear();
+        seriesState.clear();
+        originalMetadataRetrieve.reset();
+        omeMeta.reset();
+        bigTIFF = boost::none;
 
         ome::bioformats::detail::FormatWriter::close(fileOnly);
       }

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter.cpp
@@ -91,6 +91,7 @@ namespace
     core->bitsPerPixel = 12U;
     core->dimensionOrder = DimensionOrder::XYZTC;
     seriesList.push_back(core);
+    seriesList.push_back(core); // add two identical series
 
     fillMetadata(*meta, seriesList);
 
@@ -104,7 +105,7 @@ namespace
                  std::ostream& stream)
   {
     // Total number of images (series)
-    dimension_size_type ic = 1;
+    dimension_size_type ic = writer.getMetadataRetrieve()->getImageCount();
     stream << "Image count: " << ic << '\n';
 
     // Loop over images
@@ -114,7 +115,10 @@ namespace
         writer.setSeries(i);
 
         // Total number of planes.
-        dimension_size_type pc = 1;
+        dimension_size_type pc = 1U;
+        pc *= writer.getMetadataRetrieve()->getPixelsSizeZ(i);
+        pc *= writer.getMetadataRetrieve()->getPixelsSizeT(i);
+        pc *= writer.getMetadataRetrieve()->getChannelCount(i);
         stream << "\tPlane count: " << pc << '\n';
 
         // Loop over planes (for this image index)
@@ -202,7 +206,7 @@ main(int argc, char *argv[])
         }
       else
         {
-          std::cerr << "Usage: " << argv[0] << " ome-xml.xml\n";
+          std::cerr << "Usage: " << argv[0] << " ome-xml.ome.tiff\n";
           std::exit(1);
         }
     }

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter2.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter2.cpp
@@ -1,0 +1,235 @@
+/*
+* #%L
+* OME-BIOFORMATS C++ library for image IO.
+* Copyright © 2015 Open Microscopy Environment:
+*   - Massachusetts Institute of Technology
+*   - National Institutes of Health
+*   - University of Dundee
+*   - Board of Regents of the University of Wisconsin-Madison
+*   - Glencoe Software, Inc.
+* %%
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are
+* those of the authors and should not be interpreted as representing official
+* policies, either expressed or implied, of any organization.
+* #L%
+*/
+
+#include <iostream>
+
+#include <ome/bioformats/CoreMetadata.h>
+#include <ome/bioformats/MetadataTools.h>
+#include <ome/bioformats/VariantPixelBuffer.h>
+#include <ome/bioformats/out/OMETIFFWriter.h>
+#include <ome/xml/meta/OMEXMLMetadata.h>
+
+#include <ome/compat/memory.h>
+
+#include <ome/common/filesystem.h>
+
+using boost::filesystem::path;
+using ome::compat::make_shared;
+using ome::compat::shared_ptr;
+using ome::bioformats::dimension_size_type;
+using ome::bioformats::fillMetadata;
+using ome::bioformats::CoreMetadata;
+using ome::bioformats::DIM_SPATIAL_X;
+using ome::bioformats::DIM_SPATIAL_Y;
+using ome::bioformats::DIM_CHANNEL;
+using ome::bioformats::FormatWriter;
+using ome::bioformats::MetadataMap;
+using ome::bioformats::out::OMETIFFWriter;
+using ome::bioformats::PixelBuffer;
+using ome::bioformats::PixelBufferBase;
+using ome::bioformats::PixelProperties;
+using ome::bioformats::VariantPixelBuffer;
+using ome::xml::model::enums::PixelType;
+using ome::xml::model::enums::DimensionOrder;
+
+namespace
+{
+
+  /* write-example-start */
+  shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
+  createMetadata()
+  {
+    // OME-XML metadata store.
+    shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(make_shared< ::ome::xml::meta::OMEXMLMetadata>());
+
+    // Create simple CoreMetadata and use this to set up the OME-XML
+    // metadata.  This is purely for convenience in this example; a
+    // real writer would typically set up the OME-XML metadata from an
+    // existing MetadataRetrieve instance or by hand.
+    std::vector<shared_ptr<CoreMetadata> > seriesList;
+    shared_ptr<CoreMetadata> core(make_shared<CoreMetadata>());
+    core->sizeX = 512U;
+    core->sizeY = 512U;
+    core->sizeC.clear(); // defaults to 1 channel with 1 subchannel; clear this
+    core->sizeC.push_back(1);
+    core->sizeC.push_back(1);
+    core->sizeC.push_back(1);
+    core->pixelType = ome::xml::model::enums::PixelType::UINT16;
+    core->interleaved = false;
+    core->bitsPerPixel = 12U;
+    core->dimensionOrder = DimensionOrder::XYZTC;
+    seriesList.push_back(core);
+    seriesList.push_back(core); // add two identical series
+
+    fillMetadata(*meta, seriesList);
+
+    return meta;
+  }
+  /* write-example-end */
+
+  /* pixel-example-start */
+  void
+  writePixelData(FormatWriter& writer,
+                 std::ostream& stream)
+  {
+    // Total number of images (series)
+    dimension_size_type ic = writer.getMetadataRetrieve()->getImageCount();
+    stream << "Image count: " << ic << '\n';
+
+    // Loop over images
+    for (dimension_size_type i = 0 ; i < ic; ++i)
+      {
+        // Change the current series to this index
+        writer.setSeries(i);
+
+        // Total number of planes.
+        dimension_size_type pc = 1U;
+        pc *= writer.getMetadataRetrieve()->getPixelsSizeZ(i);
+        pc *= writer.getMetadataRetrieve()->getPixelsSizeT(i);
+        pc *= writer.getMetadataRetrieve()->getChannelCount(i);
+        stream << "\tPlane count: " << pc << '\n';
+
+        // Loop over planes (for this image index)
+        for (dimension_size_type p = 0 ; p < pc; ++p)
+          {
+            // Change the current plane to this index.
+            writer.setPlane(p);
+
+            // Pixel buffer; size 512 × 512 with 3 channels of type
+            // uint16_t.  It uses the native endianness and has a
+            // storage order of XYZTC without interleaving
+            // (subchannels are planar).
+            shared_ptr<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> >
+              buffer(make_shared<PixelBuffer<PixelProperties<PixelType::UINT16>::std_type> >
+                     (boost::extents[512][512][1][1][1][1][1][1][1],
+                      PixelType::UINT16, ome::bioformats::ENDIAN_NATIVE,
+                      PixelBufferBase::make_storage_order(DimensionOrder::XYZTC, false)));
+
+            // Fill each subchannel with a different intensity ramp in
+            // the 12-bit range.  In a real program, the pixel data
+            // would typically be obtained from data acquisition or
+            // another image.
+            for (dimension_size_type x = 0; x < 512; ++x)
+              for (dimension_size_type y = 0; y < 512; ++y)
+                {
+                  PixelBufferBase::indices_type idx;
+                  std::fill(idx.begin(), idx.end(), 0);
+                  idx[DIM_SPATIAL_X] = x;
+                  idx[DIM_SPATIAL_Y] = y;
+
+                  idx[DIM_CHANNEL] = 0;
+
+                  switch(p)
+                    {
+                    case 0:
+                      buffer->at(idx) = (static_cast<float>(x) / 512.0f) * 4096.0f;
+                      break;
+                    case 1:
+                      buffer->at(idx) = (static_cast<float>(y) / 512.0f) * 4096.0f;
+                      break;
+                    case 2:
+                      buffer->at(idx) = (static_cast<float>(x+y) / 1024.0f) * 4096.0f;
+                      break;
+                    default:
+                      break;
+                    }
+                }
+
+            VariantPixelBuffer vbuffer(buffer);
+            stream << "PixelBuffer PixelType is " << buffer->pixelType() << '\n';
+            stream << "VariantPixelBuffer PixelType is " << vbuffer.pixelType() << '\n';
+            stream << std::flush;
+
+            // Write the the entire pixel buffer to the plane.
+            writer.saveBytes(p, vbuffer);
+
+            stream << "Wrote " << buffer->num_elements() << ' ' << buffer->pixelType() << " pixels\n";
+          }
+      }
+  }
+  /* pixel-example-end */
+
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      if (argc > 1)
+        {
+          // Portable path
+          path filename(argv[1]);
+
+          /* writer-example-start */
+          // Create metadata for the file to be written.
+          shared_ptr< ::ome::xml::meta::MetadataRetrieve> meta(createMetadata());
+
+          // Create TIFF writer
+          shared_ptr<FormatWriter> writer(make_shared<OMETIFFWriter>());
+
+          // Set writer options before opening a file
+          writer->setMetadataRetrieve(meta);
+          writer->setInterleaved(false);
+
+          // Open the file
+          writer->setId(filename);
+
+          // Write pixel data
+          writePixelData(*writer, std::cout);
+
+          // Explicitly close writer
+          writer->close();
+          /* writer-example-end */
+        }
+      else
+        {
+          std::cerr << "Usage: " << argv[0] << " ome-xml.ome.tiff\n";
+          std::exit(1);
+        }
+    }
+  catch (const std::exception& e)
+    {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+      std::exit(1);
+    }
+  catch (...)
+    {
+      std::cerr << "Caught unknown exception\n";
+      std::exit(1);
+    }
+}


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13154

- Always close and clean up on `close()` in writers
- Use correct plane index when setting UUID metadata in the metadata store
- Update metadata-formatwriter example to use multiple series
- Add metadata-formatwriter2 to use multiple planes
- Make writer close implementations fully idempotent to prevent corruption/double close/inconsistent state

This should ensure that this type of failure will be caught by the unit tests in the future.

--------

Testing: This is tested automatically by the unit tests, so check the jobs are green.  The metadata-formatwriter tests create OME TIFF as output (`cpp/examples/*.tiff`), which can be viewed with the Java showinf or imported into OMERO to check their validity with other implementations, though this is optional since the failures are covered by the tests.