### PR TITLE
Fix spider format links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2065,11 +2065,11 @@ reader = SMCameraReader
 
 [SPIDER]
 extensions = .spi, .stk
-developer = `Wadsworth Center <http://www.wadsworth.org/spider_doc/spider/docs/spider.html>`_
+developer = `Wadsworth Center <http://spider.wadsworth.org/spider_doc/spider/docs/spider.html>`_
 bsd = no
-software = `SPIDER <http://www.wadsworth.org/spider_doc/spider/docs/spider.html>`_
+software = `SPIDER <http://spider.wadsworth.org/spider_doc/spider/docs/spider.html>`_
 weHave = * a few example datasets \n
-* `official file format documentation <http://www.wadsworth.org/spider_doc/spider/docs/image_doc.html>`_
+* `official file format documentation <http://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html>`_
 pixelsRating = Very good
 metadataRating = Very good
 opennessRating = Outstanding

--- a/docs/sphinx/formats/spider.txt
+++ b/docs/sphinx/formats/spider.txt
@@ -6,7 +6,7 @@ SPIDER
 
 Extensions: .spi, .stk
 
-Developer: `Wadsworth Center <http://www.wadsworth.org/spider_doc/spider/docs/spider.html>`_
+Developer: `Wadsworth Center <http://spider.wadsworth.org/spider_doc/spider/docs/spider.html>`_
 
 
 **Support**
@@ -23,13 +23,13 @@ Reader: SpiderReader (:bfreader:`Source Code <SpiderReader.java>`, :doc:`Support
 
 Freely Available Software:
 
-- `SPIDER <http://www.wadsworth.org/spider_doc/spider/docs/spider.html>`_
+- `SPIDER <http://spider.wadsworth.org/spider_doc/spider/docs/spider.html>`_
 
 
 We currently have:
 
 * a few example datasets 
-* `official file format documentation <http://www.wadsworth.org/spider_doc/spider/docs/image_doc.html>`_
+* `official file format documentation <http://spider.wadsworth.org/spider_doc/spider/docs/image_doc.html>`_
 
 We would like to have:
 


### PR DESCRIPTION
The spider docs have been moved. This should make all the BF docs builds green again once rebased.