### PR TITLE
Fix copyrights missed by update_copyright

### DIFF
--- a/components/formats-gpl/test/matlab/TestBfGetReader.m
+++ b/components/formats-gpl/test/matlab/TestBfGetReader.m
@@ -6,7 +6,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2013-2014 Open Microscopy Environment:
+% Copyright (C) 2013 - 2016 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/test/matlab/TestBfMatlab.m
+++ b/components/formats-gpl/test/matlab/TestBfMatlab.m
@@ -6,7 +6,7 @@
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %
-% Copyright (C) 2013-2014 Open Microscopy Environment:
+% Copyright (C) 2013 - 2016 Open Microscopy Environment:
 %   - Board of Regents of the University of Wisconsin-Madison
 %   - Glencoe Software, Inc.
 %   - University of Dundee

--- a/components/formats-gpl/utils/writeMapAnnotationsExample.java
+++ b/components/formats-gpl/utils/writeMapAnnotationsExample.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015 - 2016 Open Microscopy Environment. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/specification/transforms/ome-transforms.xml
+++ b/components/specification/transforms/ome-transforms.xml
@@ -2,7 +2,7 @@
 <!--
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	#
-	# Copyright (C) 2012-2014 Open Microscopy Environment
+	# Copyright (C) 2012 - 2016 Open Microscopy Environment
 	#       Massachusetts Institute of Technology,
 	#       National Institutes of Health,
 	#       University of Dundee,

--- a/components/specification/transforms/util/write-transforms.py
+++ b/components/specification/transforms/util/write-transforms.py
@@ -141,7 +141,7 @@ print """<?xml version = "1.0" encoding = "UTF-8"?>
 <!--
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	#
-	# Copyright (C) 2012-2014 Open Microscopy Environment
+	# Copyright (C) 2012 - 2016 Open Microscopy Environment
 	#       Massachusetts Institute of Technology,
 	#       National Institutes of Health,
 	#       University of Dundee,

--- a/components/specification/transforms/util/write-transforms.py
+++ b/components/specification/transforms/util/write-transforms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015 - 2016 Open Microscopy Environment & University of Dundee.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/cpp/cmake/BioFormatsCommon.cmake
+++ b/cpp/cmake/BioFormatsCommon.cmake
@@ -1,7 +1,7 @@
 # #%L
 # Bio-Formats C++ libraries (cmake build infrastructure)
 # %%
-# Copyright © 2006 - 2014 Open Microscopy Environment:
+# Copyright © 2006 - 2016 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee

--- a/cpp/cmake/TemplateShellWrapper.cmake.in
+++ b/cpp/cmake/TemplateShellWrapper.cmake.in
@@ -169,7 +169,7 @@ EOF
 version() {
   cat <<EOF
 bf-test (OME Bio-Formats) $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH$VERSION_EXTRA ($RELEASE_DATE)
-Copyright © 2006–2015 Open Microscopy Environment
+Copyright © 2006–2016 Open Microscopy Environment
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/MinimalTIFFWriter.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
+++ b/cpp/lib/ome/bioformats/out/OMETIFFWriter.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/tiff/Codec.cpp
+++ b/cpp/lib/ome/bioformats/tiff/Codec.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/cpp/lib/ome/bioformats/tiff/Codec.h
+++ b/cpp/lib/ome/bioformats/tiff/Codec.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-BIOFORMATS C++ library for image IO.
- * Copyright © 2006 - 2014 Open Microscopy Environment:
+ * Copyright © 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee

--- a/docs/sphinx/developers/cpp/examples/metadata-formatwriter2.cpp
+++ b/docs/sphinx/developers/cpp/examples/metadata-formatwriter2.cpp
@@ -1,7 +1,7 @@
 /*
 * #%L
 * OME-BIOFORMATS C++ library for image IO.
-* Copyright © 2015 Open Microscopy Environment:
+* Copyright (C) 2015 - 2016 Open Microscopy Environment:
 *   - Massachusetts Institute of Technology
 *   - National Institutes of Health
 *   - University of Dundee


### PR DESCRIPTION
Bumps the year to 2016, and fixes text so that ```update_copyright``` can pick these up in the future.

See https://github.com/openmicroscopy/bioformats/pull/2239#issuecomment-182476425