### PR TITLE
Fake reader: physical size unit support

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -2,7 +2,7 @@
  * #%L
  * BSD implementations of Bio-Formats readers and writers
  * %%
- * Copyright (C) 2005 - 2015 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -45,6 +45,12 @@ import loci.common.Location;
 import loci.formats.in.FakeReader;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.tools.FakeImage;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.services.OMEXMLService;
+import loci.common.services.ServiceFactory;
+
+import ome.units.UNITS;
+import ome.units.quantity.Length;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -55,6 +61,7 @@ public class FakeReaderTest {
 
   private Path wd;
   private FakeReader reader;
+  private OMEXMLService service;
 
   /** Create a directory under wd */
   private static Location mkSubd(Path parent, String name) throws Exception {
@@ -94,6 +101,8 @@ public class FakeReaderTest {
   public void setUp() throws Exception {
     wd = Files.createTempDirectory(this.getClass().getName());
     reader = new FakeReader();
+    ServiceFactory sf = new ServiceFactory();
+    service = sf.getInstance(OMEXMLService.class);
   }
 
   @AfterMethod
@@ -212,4 +221,11 @@ public class FakeReaderTest {
     assertEquals(reader.getGlobalMetadata().get("foo"), "bar");
   }
 
+  @Test
+  public void testPhysicalSizeX() throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    reader.setId("foo&physicalSizeX=1.fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getPixelsPhysicalSizeX(0), new Length(1.0, UNITS.MICROM));
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -242,9 +242,27 @@ public class FakeReaderTest {
   }
   
   @Test(dataProvider = "physical sizes")
+  public void testPhysicalSizeXIni(String value, Length length) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    mkIni("foo.fake.ini", "physicalSizeX = " + value);
+    reader.setId(wd.resolve("foo.fake").toString());
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getPixelsPhysicalSizeX(0), length);
+  }
+
+  @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeY(String value, Length length) throws Exception {
     reader.setMetadataStore(service.createOMEXMLMetadata());
     reader.setId("foo&physicalSizeY=" + value + ".fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getPixelsPhysicalSizeY(0), length);
+  }
+
+  @Test(dataProvider = "physical sizes")
+  public void testPhysicalSizeYIni(String value, Length length) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    mkIni("foo.fake.ini", "physicalSizeY = " + value);
+    reader.setId(wd.resolve("foo.fake").toString());
     MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
   }
@@ -253,6 +271,15 @@ public class FakeReaderTest {
   public void testPhysicalSizeZ(String value, Length length) throws Exception {
     reader.setMetadataStore(service.createOMEXMLMetadata());
     reader.setId("foo&physicalSizeZ=" + value + ".fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getPixelsPhysicalSizeZ(0), length);
+  }
+
+  @Test(dataProvider = "physical sizes")
+  public void testPhysicalSizeZIni(String value, Length length) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    mkIni("foo.fake.ini", "physicalSizeZ = " + value);
+    reader.setId(wd.resolve("foo.fake").toString());
     MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -240,4 +240,20 @@ public class FakeReaderTest {
     MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
   }
+  
+  @Test(dataProvider = "physical sizes")
+  public void testPhysicalSizeY(String value, Length length) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    reader.setId("foo&physicalSizeY=" + value + ".fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getPixelsPhysicalSizeY(0), length);
+  }
+  
+  @Test(dataProvider = "physical sizes")
+  public void testPhysicalSizeZ(String value, Length length) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    reader.setId("foo&physicalSizeZ=" + value + ".fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getPixelsPhysicalSizeZ(0), length);
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -72,7 +72,6 @@ public class FakeReaderTest {
       {"1mm", new Length(1.0, UNITS.MM)},
       {"1.0mm", new Length(1.0, UNITS.MM)},
       {"1.0 mm", new Length(1.0, UNITS.MM)},
-      {"1.0Å", new Length(1.0, UNITS.ANGSTROM)},
       {"1.0 pixel", new Length(1.0, UNITS.PIXEL)},
       {"1.0 reference frame", new Length(1.0, UNITS.REFERENCEFRAME)},
     };

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -54,6 +54,7 @@ import ome.units.quantity.Length;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -62,6 +63,17 @@ public class FakeReaderTest {
   private Path wd;
   private FakeReader reader;
   private OMEXMLService service;
+
+  @DataProvider(name = "physical sizes")
+  public Object[][] physicalSizes() {
+    return new Object[][] {
+      {"1", new Length(1.0, UNITS.MICROM)},
+      {"1.0", new Length(1.0, UNITS.MICROM)},
+      {"1.0 mm", new Length(1.0, UNITS.MM)},
+      {"1.0 pixel", new Length(1.0, UNITS.PIXEL)},
+      {"1.0 reference frame", new Length(1.0, UNITS.REFERENCEFRAME)},
+    };
+  }
 
   /** Create a directory under wd */
   private static Location mkSubd(Path parent, String name) throws Exception {
@@ -221,11 +233,11 @@ public class FakeReaderTest {
     assertEquals(reader.getGlobalMetadata().get("foo"), "bar");
   }
 
-  @Test
-  public void testPhysicalSizeX() throws Exception {
+  @Test(dataProvider = "physical sizes")
+  public void testPhysicalSizeX(String value, Length length) throws Exception {
     reader.setMetadataStore(service.createOMEXMLMetadata());
-    reader.setId("foo&physicalSizeX=1.fake");
+    reader.setId("foo&physicalSizeX=" + value + ".fake");
     MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getPixelsPhysicalSizeX(0), new Length(1.0, UNITS.MICROM));
+    assertEquals(m.getPixelsPhysicalSizeX(0), length);
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -69,7 +69,10 @@ public class FakeReaderTest {
     return new Object[][] {
       {"1", new Length(1.0, UNITS.MICROM)},
       {"1.0", new Length(1.0, UNITS.MICROM)},
+      {"1mm", new Length(1.0, UNITS.MM)},
+      {"1.0mm", new Length(1.0, UNITS.MM)},
       {"1.0 mm", new Length(1.0, UNITS.MM)},
+      {"1.0Å", new Length(1.0, UNITS.ANGSTROM)},
       {"1.0 pixel", new Length(1.0, UNITS.PIXEL)},
       {"1.0 reference frame", new Length(1.0, UNITS.REFERENCEFRAME)},
     };

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -153,7 +153,7 @@ with their default values, is shown below.
       * the scaling factor for the pixel values on each plane
       * 1
     - * exposureTime
-      * time of exposure, supports units defaulting to seconds
+      * time of exposure
       * null
     - * acquisitionDate
       * timestamp formatted as "yyyy-MM-dd_HH-mm-ss"

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -38,6 +38,13 @@ global metadata map:
     echo "[GlobalMetadata]" >> my-special-test-file.fake.ini
     echo "my.key=some.value" >> my-special-test-file.fake.ini
 
+
+Several keys have support for units and can be expressed as ``KEY=VALUE UNIT`` where ``UNIT`` is the symbol of the desired unit::
+
+    touch "physicalSizesUnits&physicalSizeX=1 nm&physicalSizeY=1 nm&physicalSizeZ=1.5 km.fake"
+    echo "physicalSizeX=1 nm" >> physicalSizes.fake.ini
+    echo "physicalSizeY=10 Å" >> physicalSizes.fake.ini
+
 To generate a simple plate file:
 
 ::

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -41,7 +41,7 @@ global metadata map:
 
 Several keys have support for units and can be expressed as ``KEY=VALUE UNIT`` where ``UNIT`` is the symbol of the desired unit::
 
-    touch "physicalSizesUnits&physicalSizeX=1 nm&physicalSizeY=1 nm&physicalSizeZ=1.5 km.fake"
+    touch "physicalSizesUnits&physicalSizeX=1nm&physicalSizeY=1nm&physicalSizeZ=1.5km.fake"
     echo "physicalSizeX=1 nm" >> physicalSizes.fake.ini
     echo "physicalSizeY=10 Å" >> physicalSizes.fake.ini
 

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -43,7 +43,8 @@ Several keys have support for units and can be expressed as ``KEY=VALUE UNIT`` w
 
     touch "physicalSizesUnits&physicalSizeX=1nm&physicalSizeY=1nm&physicalSizeZ=1.5km.fake"
     echo "physicalSizeX=1 nm" >> physicalSizes.fake.ini
-    echo "physicalSizeY=10 Å" >> physicalSizes.fake.ini
+    echo "physicalSizeY=10 pm" >> physicalSizes.fake.ini
+    echo "physicalSizeZ=.002 mm" >> physicalSizes.fake.ini
 
 To generate a simple plate file:
 


### PR DESCRIPTION
This PR reviews and clarifies the unit support in the `FakeReader` key/value pair in the documentation and the tests:

- add concrete example of the keys with unit support in the documentation with and without INI file
- remove unit support from `exposureTime` (not implemented)
- add unit tests to `FakeReaderTest` covering the `physicalSize{XYZ}` keys

/cc @ximenesuk @chris-allan @jburel 