### PR TITLE
Zeiss TIFF: fix getSeriesUsedFiles to return actual paths on disk

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -217,18 +217,18 @@ public class ZeissTIFFReader extends BaseZeissReader {
     ArrayList<String> files = new ArrayList<String>();
 
     try {
-      if (new CaseInsensitiveLocation(tiffInfo.xmlname).exists()) {
-        files.add(tiffInfo.xmlname);
+      CaseInsensitiveLocation xml = new CaseInsensitiveLocation(tiffInfo.xmlname);
+      if (xml.exists()) {
+        files.add(xml.getAbsolutePath());
       }
     }
     catch (IOException e) {
       LOGGER.debug("Error checking existence of " + tiffInfo.xmlname, e);
     }
     try {
-      if (!noPixels && tiffInfo.origname != null &&
-        new CaseInsensitiveLocation(tiffInfo.origname).exists())
-      {
-        files.add(tiffInfo.origname);
+      CaseInsensitiveLocation origname = new CaseInsensitiveLocation(tiffInfo.origname);
+      if (!noPixels && tiffInfo.origname != null && origname.exists()) {
+        files.add(origname.getAbsolutePath());
       }
     }
     catch (IOException e) {
@@ -237,8 +237,9 @@ public class ZeissTIFFReader extends BaseZeissReader {
     if (!noPixels) {
       for (String tiff : imageFiles) {
         try {
-          if (new CaseInsensitiveLocation(tiff).exists()) {
-            files.add(tiff);
+          CaseInsensitiveLocation tiffLocation = new CaseInsensitiveLocation(tiff);
+          if (tiffLocation.exists()) {
+            files.add(tiffLocation.getAbsolutePath());
           }
         }
         catch (IOException e) {


### PR DESCRIPTION
CaseInsensitiveLocation.exists() can (by design) return true even if the
path from which it was constructed does not actually exist.  This fixes
ZeissTIFFReader to report the CaseInsensitiveLocation's path after
lookup, rather than the path passed to the constructor.

This should fix intermittent test failures, see
https://trello.com/c/EWS9dntP/101-zeiss-zvi-improve-tile-handling

This will be difficult to completely verify, but the test failures noted on the card do seem to correlate with abnormally long build execution times (~20 hours vs. ~14-16).  It might be easiest to just let this sit for a few weeks to see what happens.