### PR TITLE
Specify the encoding (UTF-8) for fake.ini files

### DIFF
--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -12,7 +12,8 @@ Whatever is before the first ``&`` is the image name; the remaining key-value
 pairs, each preceded with ``&``, set the pixel type and image dimensions. Just
 replace the values with whatever you need for testing.
 
-Additionally, you can put such values in a separate :file:`.ini` file:
+Additionally, you can put such values in a separate UTF-8 encoded
+:file:`.ini` file:
 
 ::
 


### PR DESCRIPTION
In order to safely allow encoding unit symbols like
angstroms and micrometers cross-platform, fake.ini
files are now *required* to be UTF-8.

See: https://github.com/openmicroscopy/bioformats/pull/2248