### PR TITLE
Remove "Is SPW file" global metadata stored when reading OME-XML files

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -269,7 +269,6 @@ public class OMEXMLReader extends FormatReader {
     }
 
     hasSPW = omexmlMeta.getPlateCount() > 0;
-    addGlobalMeta("Is SPW file", hasSPW);
 
     // TODO
     //Hashtable originalMetadata = omexmlMeta.getOriginalMetadata();


### PR DESCRIPTION
The "Is SPW file" global metadata was added as part of 2e9d34c9f74213c94ed3c6df3584f08a6c64c87c but has unexpected impact when upgrading OME-XML samples.