### PR TITLE
Updating Improvision format links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -907,7 +907,7 @@ reader = IMODReader
 [Improvision Openlab LIFF]
 extensions = .liff
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <http://www.improvision.com/>`_
+developer = `Improvision <http://www.perkinelmer.com/cellular-imaging>`_
 bsd = no
 versions = 2.0, 5.0
 weHave = * an Openlab specification document (from 2000 February 8, in DOC) \n
@@ -922,13 +922,11 @@ utilityRating = Fair
 privateSpecification = true
 reader = OpenlabReader
 mif = true
-notes = .. seealso:: \n
-  `Openlab software review <http://www.improvision.com/products/openlab/>`_
 
 [Improvision Openlab Raw]
 extensions = .raw
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <http://www.improvision.com/>`_
+developer = `Improvision <http://www.perkinelmer.com/cellular-imaging>`_
 bsd = no
 weHave = * an `Openlab Raw specification document <http://cellularimaging.perkinelmer.com/support/technical_notes/detail.php?id=344>`_ (from 2004 November 09, in HTML) \n
 * a few Openlab Raw datasets
@@ -938,13 +936,11 @@ opennessRating = Very good
 presenceRating = Poor
 utilityRating = Fair
 reader = OpenlabRawReader
-notes = .. seealso:: \n
-  `Openlab software review <http://www.improvision.com/products/openlab/>`_
 
 [Improvision TIFF]
 extensions = .tif
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <http://www.improvision.com/>`_
+developer = `Improvision <http://www.perkinelmer.com/cellular-imaging>`_
 bsd = no
 weHave = * an Improvision TIFF specification document \n
 * a few Improvision TIFF datasets
@@ -955,8 +951,6 @@ presenceRating = Fair
 utilityRating = Good
 privateSpecification = true
 reader = ImprovisionTiffReader
-notes = .. seealso:: \n
-  `Openlab software overview <http://www.improvision.com/products/openlab/>`_
 
 [Imspector OBF]
 extensions = .obf, .msr

--- a/docs/sphinx/formats/improvision-openlab-liff.txt
+++ b/docs/sphinx/formats/improvision-openlab-liff.txt
@@ -6,7 +6,7 @@ Improvision Openlab LIFF
 
 Extensions: .liff
 
-Developer: `Improvision <http://www.improvision.com/>`_
+Developer: `Improvision <http://www.perkinelmer.com/cellular-imaging>`_
 
 Owner: `PerkinElmer <http://www.perkinelmer.com/>`_
 
@@ -51,6 +51,3 @@ Utility: |Fair|
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**
-
-.. seealso:: 
-  `Openlab software review <http://www.improvision.com/products/openlab/>`_

--- a/docs/sphinx/formats/improvision-openlab-raw.txt
+++ b/docs/sphinx/formats/improvision-openlab-raw.txt
@@ -6,7 +6,7 @@ Improvision Openlab Raw
 
 Extensions: .raw
 
-Developer: `Improvision <http://www.improvision.com/>`_
+Developer: `Improvision <http://www.perkinelmer.com/cellular-imaging>`_
 
 Owner: `PerkinElmer <http://www.perkinelmer.com/>`_
 
@@ -44,9 +44,3 @@ Openness: |Very good|
 Presence: |Poor|
 
 Utility: |Fair|
-
-**Additional Information**
-
-
-.. seealso:: 
-  `Openlab software review <http://www.improvision.com/products/openlab/>`_

--- a/docs/sphinx/formats/improvision-tiff.txt
+++ b/docs/sphinx/formats/improvision-tiff.txt
@@ -6,7 +6,7 @@ Improvision TIFF
 
 Extensions: .tif
 
-Developer: `Improvision <http://www.improvision.com/>`_
+Developer: `Improvision <http://www.perkinelmer.com/cellular-imaging>`_
 
 Owner: `PerkinElmer <http://www.perkinelmer.com/>`_
 
@@ -49,6 +49,3 @@ Utility: |Good|
 
 **Please note that while we have specification documents for this
 format, we are not able to distribute them to third parties.**
-
-.. seealso:: 
-  `Openlab software overview <http://www.improvision.com/products/openlab/>`_


### PR DESCRIPTION
This should make the latest docs green again.

The current problem is actually just that their redirect is not working properly but given that Improvision doesn't exist as a separate entity any more, I figured best to just update the links anyway. Also removed the Openlab links as although they weren't breaking the build, the content doesn't exist any more, it was just redirecting to a 'We're sorry' page and searching for Openlab on the main PE page gives no useful results.