### PR TITLE
TIFF: fix predictor handling for tiled data

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffCompression.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffCompression.java
@@ -288,7 +288,7 @@ public enum TiffCompression implements CodedEnum {
       LOGGER.debug("reversing horizontal differencing");
       int[] bitsPerSample = ifd.getBitsPerSample();
       int len = bitsPerSample.length;
-      long width = ifd.getImageWidth();
+      long width = ifd.getTileWidth();
       boolean little = ifd.isLittleEndian();
       int planarConfig = ifd.getPlanarConfiguration();
 
@@ -362,7 +362,7 @@ public enum TiffCompression implements CodedEnum {
     if (predictor == 2) {
       LOGGER.debug("performing horizontal differencing");
       int[] bitsPerSample = ifd.getBitsPerSample();
-      long width = ifd.getImageWidth();
+      long width = ifd.getTileWidth();
       boolean little = ifd.isLittleEndian();
       int planarConfig = ifd.getPlanarConfiguration();
       int bytes = ifd.getBytesPerSample()[0];


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12596.

To test, use the files in ```curated/tiff/samples/tiling-variants```.  Without this change, any of the tiled files with tile width less than 64 should show a "weird" image when viewed with showinf (```*-tiles-*``` where the tile size is at the end of the file name).  The ```*-strips-*``` files show what the image should look like by comparison.

With this change, every test file should show the same image when viewed with showinf; this can be compared with ImageMagick at a minimum.  The pixel values should also be the same across all files (since compression is lossless), so visually checking a few of the files and doing something clever in Matlab or similar to verify that all pixel values are equal may be easier than visually checking all files.

Note that physical size parsing for these files is affected by gh-2221, so it's best to test this from the merge branch and not in isolation.