### PR TITLE
Mark all ome.jxr classes as deprecated

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -356,33 +356,33 @@ Type "ant -p" for a list of targets.
     depends="jar-formats-common, jar-formats-bsd"/>
 
   <target name="compile-ome-jxr" depends="deps-ome-jxr"
-    description="compile classes for OME JPEG XR Java library">
+    description="compile classes for OME JPEG XR Java library (deprecated)">
     <ant dir="components/ome-jxr" target="ome-jxr.compile"/>
   </target>
 
   <target name="jar-ome-jxr" depends="deps-ome-jxr"
-    description="generate JAR file for OME JPEG XR Java library">
+    description="generate JAR file for OME JPEG XR Java library (deprecated)">
     <ant dir="components/ome-jxr" target="ome-jxr.jar"/>
   </target>
 
   <target name="osgi-ome-jxr" depends="jar-ome-jxr"
-    description="generate OSGi bundle for OME JPEG XR Java library">
+    description="generate OSGi bundle for OME JPEG XR Java library (deprecated)">
     <ant dir="components/ome-jxr" target="ome-jxr.osgi"/>
   </target>
 
   <target name="findbugs-ome-jxr" depends="jar-ome-jxr"
-    description="run findbugs on OME JPEG XR Java library">
+    description="run findbugs on OME JPEG XR Java library (deprecated)">
     <ant dir="components/ome-jxr" target="ome-jxr.findbugs"/>
   </target>
 
   <target name="clean-ome-jxr"
     depends="clean-formats-common"
-    description="remove build files for OME JPEG XR Java library">
+    description="remove build files for OME JPEG XR Java library (deprecated)">
     <ant dir="components/ome-jxr" target="ome-jxr.clean"/>
   </target>
 
   <target name="test-ome-jxr" depends="jar-ome-jxr, testing-deps"
-    description="compile and run tests for OME JPEG XR Java library">
+    description="compile and run tests for OME JPEG XR Java library (deprecated)">
     <ant dir="components/ome-jxr" target="test"/>
   </target>
 

--- a/components/ome-jxr/src/ome/jxr/JXRException.java
+++ b/components/ome-jxr/src/ome/jxr/JXRException.java
@@ -28,7 +28,7 @@ package ome.jxr;
 /**
  * JXRException is thrown when an error is encountered during the broadly
  * understood parsing of a JPEG XR image file.
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public class JXRException extends Exception {

--- a/components/ome-jxr/src/ome/jxr/JXRException.java
+++ b/components/ome-jxr/src/ome/jxr/JXRException.java
@@ -28,7 +28,9 @@ package ome.jxr;
 /**
  * JXRException is thrown when an error is encountered during the broadly
  * understood parsing of a JPEG XR image file.
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public class JXRException extends Exception {
 
   /* Auto-generated version number */

--- a/components/ome-jxr/src/ome/jxr/JXRReader.java
+++ b/components/ome-jxr/src/ome/jxr/JXRReader.java
@@ -44,7 +44,9 @@ import ome.jxr.parser.Parser;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class JXRReader {
 
   private DatastreamParser datastreamParser;

--- a/components/ome-jxr/src/ome/jxr/JXRReader.java
+++ b/components/ome-jxr/src/ome/jxr/JXRReader.java
@@ -44,7 +44,7 @@ import ome.jxr.parser.Parser;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class JXRReader {

--- a/components/ome-jxr/src/ome/jxr/constants/File.java
+++ b/components/ome-jxr/src/ome/jxr/constants/File.java
@@ -32,7 +32,10 @@ package ome.jxr.constants;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ *
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class File {
 
   public static final int MINIMAL_HEADER_SIZE = 4;

--- a/components/ome-jxr/src/ome/jxr/constants/File.java
+++ b/components/ome-jxr/src/ome/jxr/constants/File.java
@@ -33,7 +33,7 @@ package ome.jxr.constants;
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
  *
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class File {

--- a/components/ome-jxr/src/ome/jxr/constants/IFD.java
+++ b/components/ome-jxr/src/ome/jxr/constants/IFD.java
@@ -33,7 +33,7 @@ package ome.jxr.constants;
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
  *
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class IFD {

--- a/components/ome-jxr/src/ome/jxr/constants/IFD.java
+++ b/components/ome-jxr/src/ome/jxr/constants/IFD.java
@@ -32,7 +32,10 @@ package ome.jxr.constants;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ *
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class IFD {
 
   public static final short ENTRY_SIZE = 12;

--- a/components/ome-jxr/src/ome/jxr/constants/Image.java
+++ b/components/ome-jxr/src/ome/jxr/constants/Image.java
@@ -31,7 +31,7 @@ package ome.jxr.constants;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class Image {

--- a/components/ome-jxr/src/ome/jxr/constants/Image.java
+++ b/components/ome-jxr/src/ome/jxr/constants/Image.java
@@ -31,7 +31,9 @@ package ome.jxr.constants;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class Image {
 
   public static final String GDI_SIGNATURE = "WMPHOTO\0";

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDContainer.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDContainer.java
@@ -38,7 +38,9 @@ import ome.jxr.constants.IFD;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public class IFDContainer {
 
   private long offset;

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDContainer.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDContainer.java
@@ -38,7 +38,7 @@ import ome.jxr.constants.IFD;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public class IFDContainer {

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDEntry.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDEntry.java
@@ -38,7 +38,7 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum IFDEntry {

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDEntry.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDEntry.java
@@ -38,7 +38,9 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum IFDEntry {
   
   DOCUMENT_NAME(0x010D, IFDEntryType.UTF8, Integer.MAX_VALUE),

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDEntryType.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDEntryType.java
@@ -32,7 +32,7 @@ package ome.jxr.ifd;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum IFDEntryType {

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDEntryType.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDEntryType.java
@@ -32,7 +32,9 @@ package ome.jxr.ifd;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum IFDEntryType {
 
   BYTE(1, 1),

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDMetadata.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDMetadata.java
@@ -46,7 +46,9 @@ import ome.jxr.JXRException;
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
  *
  * <dl>
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public class IFDMetadata {
 
   // TODO: PTM_COLOR_INFO

--- a/components/ome-jxr/src/ome/jxr/ifd/IFDMetadata.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/IFDMetadata.java
@@ -45,8 +45,7 @@ import ome.jxr.JXRException;
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
  *
- * <dl>
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public class IFDMetadata {

--- a/components/ome-jxr/src/ome/jxr/ifd/JXRRational.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/JXRRational.java
@@ -33,7 +33,9 @@ package ome.jxr.ifd;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public class JXRRational {
 
   private int numerator;

--- a/components/ome-jxr/src/ome/jxr/ifd/JXRRational.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/JXRRational.java
@@ -33,7 +33,7 @@ package ome.jxr.ifd;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public class JXRRational {

--- a/components/ome-jxr/src/ome/jxr/ifd/PixelFormat.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/PixelFormat.java
@@ -38,7 +38,9 @@ import ome.jxr.image.OutputColorFormat;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum PixelFormat {
 
   RGB24(0x0D, 3, PixelType.UINT8, OutputColorFormat.RGB),

--- a/components/ome-jxr/src/ome/jxr/ifd/PixelFormat.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/PixelFormat.java
@@ -38,7 +38,7 @@ import ome.jxr.image.OutputColorFormat;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum PixelFormat {

--- a/components/ome-jxr/src/ome/jxr/ifd/PixelType.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/PixelType.java
@@ -31,7 +31,7 @@ package ome.jxr.ifd;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum PixelType {

--- a/components/ome-jxr/src/ome/jxr/ifd/PixelType.java
+++ b/components/ome-jxr/src/ome/jxr/ifd/PixelType.java
@@ -31,7 +31,9 @@ package ome.jxr.ifd;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum PixelType {
 
   UINT1("uint", 1),

--- a/components/ome-jxr/src/ome/jxr/image/BitDepth.java
+++ b/components/ome-jxr/src/ome/jxr/image/BitDepth.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum BitDepth {

--- a/components/ome-jxr/src/ome/jxr/image/BitDepth.java
+++ b/components/ome-jxr/src/ome/jxr/image/BitDepth.java
@@ -36,7 +36,9 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum BitDepth {
 
   BD1WHITE1(0),

--- a/components/ome-jxr/src/ome/jxr/image/ComponentMode.java
+++ b/components/ome-jxr/src/ome/jxr/image/ComponentMode.java
@@ -36,7 +36,9 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum ComponentMode {
 
   UNIFORM(0),

--- a/components/ome-jxr/src/ome/jxr/image/ComponentMode.java
+++ b/components/ome-jxr/src/ome/jxr/image/ComponentMode.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum ComponentMode {

--- a/components/ome-jxr/src/ome/jxr/image/FrequencyBand.java
+++ b/components/ome-jxr/src/ome/jxr/image/FrequencyBand.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum FrequencyBand {

--- a/components/ome-jxr/src/ome/jxr/image/FrequencyBand.java
+++ b/components/ome-jxr/src/ome/jxr/image/FrequencyBand.java
@@ -36,7 +36,9 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum FrequencyBand {
   ALL(4, 0),
   NOFLEXBITS(3, 1),

--- a/components/ome-jxr/src/ome/jxr/image/InternalColorFormat.java
+++ b/components/ome-jxr/src/ome/jxr/image/InternalColorFormat.java
@@ -36,7 +36,9 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum InternalColorFormat {
 
   YONLY(0),

--- a/components/ome-jxr/src/ome/jxr/image/InternalColorFormat.java
+++ b/components/ome-jxr/src/ome/jxr/image/InternalColorFormat.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum InternalColorFormat {

--- a/components/ome-jxr/src/ome/jxr/image/OutputColorFormat.java
+++ b/components/ome-jxr/src/ome/jxr/image/OutputColorFormat.java
@@ -36,7 +36,9 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public enum OutputColorFormat {
 
   YONLY(0),

--- a/components/ome-jxr/src/ome/jxr/image/OutputColorFormat.java
+++ b/components/ome-jxr/src/ome/jxr/image/OutputColorFormat.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public enum OutputColorFormat {

--- a/components/ome-jxr/src/ome/jxr/parser/DatastreamParser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/DatastreamParser.java
@@ -44,7 +44,9 @@ import ome.jxr.image.OutputColorFormat;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class DatastreamParser extends Parser {
 
   // Image header fields

--- a/components/ome-jxr/src/ome/jxr/parser/DatastreamParser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/DatastreamParser.java
@@ -44,7 +44,7 @@ import ome.jxr.image.OutputColorFormat;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class DatastreamParser extends Parser {

--- a/components/ome-jxr/src/ome/jxr/parser/FileParser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/FileParser.java
@@ -39,7 +39,9 @@ import ome.jxr.constants.File;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class FileParser extends Parser {
 
   private int encoderVersion;

--- a/components/ome-jxr/src/ome/jxr/parser/FileParser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/FileParser.java
@@ -39,7 +39,7 @@ import ome.jxr.constants.File;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class FileParser extends Parser {

--- a/components/ome-jxr/src/ome/jxr/parser/IFDParser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/IFDParser.java
@@ -44,7 +44,9 @@ import ome.jxr.ifd.IFDMetadata;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public final class IFDParser extends Parser {
 
   private List<IFDContainer> IFDContainers = new ArrayList<IFDContainer>();

--- a/components/ome-jxr/src/ome/jxr/parser/IFDParser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/IFDParser.java
@@ -44,7 +44,7 @@ import ome.jxr.ifd.IFDMetadata;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public final class IFDParser extends Parser {

--- a/components/ome-jxr/src/ome/jxr/parser/Parser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/Parser.java
@@ -40,7 +40,9 @@ import ome.jxr.JXRException;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
+ * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
+@Deprecated
 public class Parser {
 
   long parsingOffset;

--- a/components/ome-jxr/src/ome/jxr/parser/Parser.java
+++ b/components/ome-jxr/src/ome/jxr/parser/Parser.java
@@ -40,7 +40,7 @@ import ome.jxr.JXRException;
  * <dl>
  *
  * @author Blazej Pindelski bpindelski at dundee.ac.uk
- * @deprecated See <a href="http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-September/005616.html">mailing-list thread</a> and <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
+ * @deprecated See <a href="http://blog.openmicroscopy.org/file-formats/community/2016/01/06/format-support">blog post</a>
  */
 @Deprecated
 public class Parser {

--- a/docs/sphinx/developers/components.txt
+++ b/docs/sphinx/developers/components.txt
@@ -211,17 +211,6 @@ Java implementation of the `Metakit database specification
 :ref:`formats-gpl <formats-gpl>`, but is otherwise independent of the main
 Bio-Formats API.
 
-.. _ome-jxr:
-
-:source:`ome-jxr (OME JPEG XR codec library) <components/ome-jxr>`:
-
-`Ant: jar-ome-jxr`
-
-Experimental implementation of `JPEG-XR
-<http://en.wikipedia.org/wiki/JPEG_XR>`_ in Java.  This uses classes from
-:ref:`formats-common <formats-common>`, but is otherwise independent of
-Bio-Formats.
-
 .. _ome-xml:
 
 :source:`ome-xml (OME-XML Java library) <components/ome-xml>`:


### PR DESCRIPTION
See https://trello.com/c/urA9fvFj/104-deprecate-jpeg-xr-classes

Add references to the corresponding mailing list thread and blog post