### PR TITLE
CellSens .vsi: detect dimensions using the "dimension meaning" tag

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -278,6 +278,14 @@ public class CellSensReader extends FormatReader {
 
   private static final int CHANNEL_NAME = 2419;
 
+  // Dimension types
+  private static final int Z = 1;
+  private static final int T = 2;
+  private static final int LAMBDA = 3;
+  private static final int C = 4;
+  private static final int UNKNOWN = 5;
+  private static final int PHASE = 9;
+
   // Stack properties
   private static final int DISPLAY_LIMITS = 2003;
   private static final int STACK_DISPLAY_LUT = 2004;
@@ -1364,6 +1372,7 @@ public class CellSensReader extends FormatReader {
         int tag = vsi.readInt();
         long nextField = vsi.readInt() & 0xffffffffL;
         int dataSize = vsi.readInt();
+        String storedValue = null;
 
         LOGGER.debug("  tag #{}: fieldType={}, tag={}, nextField={}, dataSize={}",
           new Object[] {i, fieldType, tag, nextField, dataSize});
@@ -1695,6 +1704,7 @@ public class CellSensReader extends FormatReader {
               addGlobalMetaList(tagPrefix + tagName, value);
             }
           }
+          storedValue = value;
         }
 
         if (inDimensionProperties) {
@@ -1719,6 +1729,31 @@ public class CellSensReader extends FormatReader {
           }
           else if (tag == CHANNEL_PROPERTIES) {
             foundChannelTag = true;
+          }
+          else if (tag == DIMENSION_MEANING && storedValue != null) {
+            int dimension = -1;
+            try {
+              dimension = Integer.parseInt(storedValue);
+            }
+            catch (NumberFormatException e) { }
+            switch (dimension) {
+              case Z:
+                p.dimensionOrdering.put("Z", dimensionTag);
+                break;
+              case T:
+                p.dimensionOrdering.put("T", dimensionTag);
+                break;
+              case LAMBDA:
+                p.dimensionOrdering.put("L", dimensionTag);
+                break;
+              case C:
+                p.dimensionOrdering.put("C", dimensionTag);
+                break;
+              case PHASE:
+                p.dimensionOrdering.put("P", dimensionTag);
+              default:
+                throw new FormatException("Invalid dimension: " + dimension);
+            }
           }
         }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13029

To test, use the dataset from QA 11394.  Note that the files as uploaded to the QA system are not in the correct directory structure; ```curated/cellsens/qa-11394``` contains the dataset in the correct directory structure.

Without this change, ```showinf``` on the .vsi file should show that the first series has 38 Z sections and 1 timepoint.  With this change, the same test should show 38 Z sections and 18 timepoints.  The dimensions and images can be compared with Olympus' OlyVIA software (http://www.olympus-lifescience.com/en/support/downloads/#!dlOpen=%23detail847249644).

Note that the dimension type constants are taken from  the ```curated/specs/VSI File Format v1.6.pdf``` document.