### PR TITLE
Zeiss CZI: turn off prestitched flag for separate scenes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -631,7 +631,7 @@ public class ZeissCZIReader extends FormatReader {
     LOGGER.trace("prestitched = {}", prestitched);
     LOGGER.trace("scanDim = {}", scanDim);
 
-    if (mosaics == seriesCount &&
+    if (((mosaics == seriesCount) || (positions == seriesCount)) &&
       seriesCount == (planes.size() / getImageCount()) &&
       prestitched != null && prestitched)
     {


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13095

To test, use the file from QA 16882.  Without this change, ```showinf -minmax``` should show that the first series has non-zero pixels, and the remaining four series have all zero pixels.  With this change, the same test should show that all five series have non-zero pixels (which should also be obvious from looking at the images).  The images and dimensions can also be compared against Zeiss' ZEN software.