### PR TITLE
cpp: ome-xml: Add enum value lists for preprocessor expansion

### DIFF
--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -55,6 +55,9 @@
 
 #include <ome/xml/model/enums/EnumerationException.h>
 
+// All values in the ${klass.langType} enumeration.
+#define ${fu.CLASS_PREFIX}_VALUES {% for value in klass.possibleValues %}(${enum_value_name(value, False).upper()}){% end %}
+
 {% end %}\
 {% if fu.SOURCE_TYPE == "source" %}\
 #include <algorithm>

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -56,11 +56,18 @@ from getopt import gnu_getopt, GetoptError
 from glob import glob
 from xml import sax
 
-def guard(filename):
+def macroname(filename):
     filename = "_".join(filename.split(os.path.sep))
     filename = filename.upper()
     filename = re.sub("[^A-Z0-9]", "_", filename)
     return filename
+
+def guard(filename):
+    return macroname(filename)
+
+def class_prefix(filename):
+    filename, ext = os.path.splitext(filename)
+    return macroname(filename)
 
 def usage(error):
     """
@@ -198,6 +205,7 @@ def main(model, opts):
             continue
 
         fu.GUARD = guard(fullname)
+        fu.CLASS_PREFIX = class_prefix(fullname)
 
         fullname = os.path.join(opts.outdir, fullname)
 
@@ -288,6 +296,7 @@ def enumTypesMain(model, opts):
                 continue
 
             fu.GUARD = guard(fullname)
+            fu.CLASS_PREFIX = class_prefix(fullname)
             fu.SOURCE_TYPE = opts.filetype;
 
             fullname = os.path.join(opts.outdir, fullname)
@@ -329,6 +338,7 @@ def enumTypesIncludeAll(model, opts):
     fullname = os.path.join("ome", "xml", "model", fullname)
 
     fu.GUARD = guard(fullname)
+    fu.CLASS_PREFIX = class_prefix(fullname)
     fu.SOURCE_TYPE = language.TYPE_HEADER;
     fu.HEADERS = sorted(headers);
 

--- a/cpp/test/ome-xml/enum.cpp
+++ b/cpp/test/ome-xml/enum.cpp
@@ -6,6 +6,8 @@
 
 #include <sstream>
 
+#include <boost/preprocessor.hpp>
+
 using ome::xml::model::enums::LaserType;
 using ome::xml::model::enums::PixelType;
 using ome::xml::model::enums::EnumerationException;
@@ -462,6 +464,19 @@ TEST(Enum, PixelTypeStreamInputFail)
   ASSERT_FALSE(!!is);
   ASSERT_EQ(PixelType::UINT16, e); // Unchanged.
 }
+
+#define MAKE_PT(maR, maProperty, maType)        \
+  {                                             \
+    PixelType pt(PixelType::maType);            \
+    ASSERT_EQ(PixelType::maType, pt);           \
+  }                                             \
+
+TEST(Enum, PixelTypePreprocess)
+{
+  BOOST_PP_SEQ_FOR_EACH(MAKE_PT, 0, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
+}
+
+#undef MAKE_PT
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.

--- a/cpp/test/ome-xml/enum.cpp
+++ b/cpp/test/ome-xml/enum.cpp
@@ -480,7 +480,7 @@ check_pt(PixelType::enum_value pt_expected,
 
 TEST(Enum, PixelTypePreprocess)
 {
-  BOOST_PP_SEQ_FOR_EACH(MAKE_PT, 0, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
+  BOOST_PP_SEQ_FOR_EACH(MAKE_PT, %%, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
 }
 
 #undef MAKE_PT

--- a/cpp/test/ome-xml/enum.cpp
+++ b/cpp/test/ome-xml/enum.cpp
@@ -465,10 +465,17 @@ TEST(Enum, PixelTypeStreamInputFail)
   ASSERT_EQ(PixelType::UINT16, e); // Unchanged.
 }
 
+void
+check_pt(PixelType::enum_value pt_expected,
+         PixelType pt)
+{
+  ASSERT_EQ(pt_expected, pt);
+}
+
 #define MAKE_PT(maR, maProperty, maType)        \
   {                                             \
     PixelType pt(PixelType::maType);            \
-    ASSERT_EQ(PixelType::maType, pt);           \
+    check_pt(PixelType::maType, pt);            \
   }                                             \
 
 TEST(Enum, PixelTypePreprocess)
@@ -477,6 +484,63 @@ TEST(Enum, PixelTypePreprocess)
 }
 
 #undef MAKE_PT
+
+#define PP_SEQ_FOR_EACH_R_ID() BOOST_PP_SEQ_FOR_EACH_R
+#define PP_DEFER(x) x BOOST_PP_EMPTY()
+
+void check_nested(LaserType expected_a,
+                  LaserType a,
+                  LaserType expected_b,
+                  LaserType b)
+{
+  std::cout << "Test nested: first=" << a
+            << " second=" << b << '\n';
+  EXPECT_EQ(expected_a, a);
+  EXPECT_EQ(expected_b, b);
+}
+
+#define LT_NESTED(maR, maToplevelType, maNestedType)                    \
+  case LaserType::maNestedType:                                         \
+  {                                                                     \
+    check_nested(a, LaserType(LaserType::maToplevelType),               \
+                 b, LaserType(LaserType::maNestedType));                \
+  }                                                                     \
+  break;
+
+#define LT_TOPLEVEL(maR, maUnused, maType)                              \
+  case LaserType::maType:                                               \
+  {                                                                     \
+    switch(b)                                                           \
+      {                                                                 \
+        PP_DEFER(PP_SEQ_FOR_EACH_R_ID)()(maR, LT_NESTED, maType,        \
+                                         OME_XML_MODEL_ENUMS_LASERTYPE_VALUES); \
+      }                                                                 \
+  }                                                                     \
+  break;
+
+void check_switch(LaserType a,
+                  LaserType b)
+{
+  switch(a)
+    {
+      BOOST_PP_EXPAND(BOOST_PP_SEQ_FOR_EACH(LT_TOPLEVEL, %%, OME_XML_MODEL_ENUMS_LASERTYPE_VALUES));
+    }
+}
+
+#define NESTED_TEST(r, product)                                      \
+  check_switch(LaserType(LaserType::BOOST_PP_SEQ_ELEM(0, product)),  \
+               LaserType(LaserType::BOOST_PP_SEQ_ELEM(1, product)));
+
+TEST(Enum, PixelTypePreprocessNested)
+{
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(NESTED_TEST, (OME_XML_MODEL_ENUMS_LASERTYPE_VALUES)(OME_XML_MODEL_ENUMS_LASERTYPE_VALUES));
+}
+
+#undef PP_SEQ_FOR_EACH_R_ID
+#undef PP_DEFER
+#undef LT_NESTED
+#undef LT_TOPLEVEL
+#undef NESTED_TEST
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.


### PR DESCRIPTION
Add a define to each model enum header containing a list of the valid enumerations for the enum class.  The purpose is to allow code generation for unit conversion and also for other purposes e.g. switching on pixel types.  This will be used for generating nested switch statements to automatically handle all the possible unit conversions.

This is not the nicest code.  But without C++11 support, it's the only way of automatically supporting code generation of this type.  When we support C++11 we can replace or supplement this with a `static constexpr std::array<>` which can be used directly.

See:
http://stackoverflow.com/questions/35360908/alternative-to-expanding-templates-in-a-switch-statement/35366238#35366238

/cc @dgault @mtbc 

--------

Testing:

Check the generated source diff here: https://ci.openmicroscopy.org/view/DEV/job/BIOFORMATS-DEV-merge-generated-sources/.  It should add lines like this:

```
// All values in the LaserType enumeration.
#define OME_XML_MODEL_ENUMS_LASERTYPE_VALUES (EXCIMER)(GAS)(METALVAPOR)(SOLIDSTATE)(DYE)(SEMICONDUCTOR)(FREEELECTRON)(OTHER)

// All values in the PixelType enumeration.
#define OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES (INT8)(INT16)(INT32)(UINT8)(UINT16)(UINT32)(FLOAT)(BIT)(DOUBLE)(COMPLEX)(DOUBLECOMPLEX)
```

Two unit tests will confirm that the expansions work and that the correct nested cases are selected.

The following code is the preprocessed source for the unit tests.  You can generate it yourself with the `-E` compiler option.  It's nasty to read, but I hope it will demonstrate that the expansions are all working as expected.  The first test case is a simple iteration over the PixelType values.  The second test case is a nested iteration over the LaserType values, used to generate a set of nested switch statements to handle a unique action for each pair of the cartesian product of two LaserType sets.  The test case simply verifies that the case statements work as expected.  The test output in the build log will show it iterating over the full test of test cases.

Test 1: Note one `check_pt` call per pixel type.

```
void
check_pt(PixelType::enum_value pt_expected,
         PixelType pt)
{
  switch (0) case 0: default: if (const ::testing::AssertionResult gtest_ar = (::testing::internal:: EqHelper<(sizeof(::testing::internal::IsNullLiteralHelper(pt_expected)) == 1)>::Compare("pt_expected", "pt", pt_expected, pt))) ; else return ::testing::internal::AssertHelper(::testing::TestPartResult::kFatalFailure, "/Users/rleigh/code/bioformats/cpp/test/ome-xml/enum.cpp", 472, gtest_ar.failure_message()) = ::testing::Message();
}

class Enum_PixelTypePreprocess_Test : public ::testing::Test { public: Enum_PixelTypePreprocess_Test() {} private: virtual void TestBody(); static ::testing::TestInfo* const test_info_ __attribute__ ((unused)); Enum_PixelTypePreprocess_Test(Enum_PixelTypePreprocess_Test const &); void operator=(Enum_PixelTypePreprocess_Test const &);};::testing::TestInfo* const Enum_PixelTypePreprocess_Test ::test_info_ = ::testing::internal::MakeAndRegisterTestInfo( "Enum", "PixelTypePreprocess", __null, __null, (::testing::internal::GetTestTypeId()), ::testing::Test::SetUpTestCase, ::testing::Test::TearDownTestCase, new ::testing::internal::TestFactoryImpl< Enum_PixelTypePreprocess_Test>);void Enum_PixelTypePreprocess_Test::TestBody()
{
  { PixelType pt(PixelType::INT8); check_pt(PixelType::INT8, pt); } { PixelType pt(PixelType::INT16); check_pt(PixelType::INT16, pt); } { PixelType pt(PixelType::INT32); check_pt(PixelType::INT32, pt); } { PixelType pt(PixelType::UINT8); check_pt(PixelType::UINT8, pt); } { PixelType pt(PixelType::UINT16); check_pt(PixelType::UINT16, pt); } { PixelType pt(PixelType::UINT32); check_pt(PixelType::UINT32, pt); } { PixelType pt(PixelType::FLOAT); check_pt(PixelType::FLOAT, pt); } { PixelType pt(PixelType::BIT); check_pt(PixelType::BIT, pt); } { PixelType pt(PixelType::DOUBLE); check_pt(PixelType::DOUBLE, pt); } { PixelType pt(PixelType::COMPLEX); check_pt(PixelType::COMPLEX, pt); } { PixelType pt(PixelType::DOUBLECOMPLEX); check_pt(PixelType::DOUBLECOMPLEX, pt); } ;
}
```

Test 2: Note one `check_nested` call for each pairwise combination of LaserType set values within the nested switch and case statements; this is the nested combination generation.  There's also one `check_switch` for each as well; this is the direct cartesian product, not nested, and is purely to drive the unit test for each combination.

```
void check_nested(LaserType expected_a,
                  LaserType a,
                  LaserType expected_b,
                  LaserType b)
{
  std::cout << "Test nested: first=" << a
            << " second=" << b << '\n';
  switch (0) case 0: default: if (const ::testing::AssertionResult gtest_ar = (::testing::internal:: EqHelper<(sizeof(::testing::internal::IsNullLiteralHelper(expected_a)) == 1)>::Compare("expected_a", "a", expected_a, a))) ; else ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, "/Users/rleigh/code/bioformats/cpp/test/ome-xml/enum.cpp", 498, gtest_ar.failure_message()) = ::testing::Message();
  switch (0) case 0: default: if (const ::testing::AssertionResult gtest_ar = (::testing::internal:: EqHelper<(sizeof(::testing::internal::IsNullLiteralHelper(expected_b)) == 1)>::Compare("expected_b", "b", expected_b, b))) ; else ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, "/Users/rleigh/code/bioformats/cpp/test/ome-xml/enum.cpp", 499, gtest_ar.failure_message()) = ::testing::Message();
}
# 522 "/Users/rleigh/code/bioformats/cpp/test/ome-xml/enum.cpp"
void check_switch(LaserType a,
                  LaserType b)
{
  switch(a)
    {
      case LaserType::EXCIMER: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::EXCIMER), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::GAS: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::GAS), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::METALVAPOR: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::METALVAPOR), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::SOLIDSTATE: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::SOLIDSTATE), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::DYE: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::DYE), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::SEMICONDUCTOR: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::SEMICONDUCTOR), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::FREEELECTRON: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::FREEELECTRON), b, LaserType(LaserType::OTHER)); } break; ; } } break; case LaserType::OTHER: { switch(b) { case LaserType::EXCIMER: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::EXCIMER)); } break; case LaserType::GAS: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::GAS)); } break; case LaserType::METALVAPOR: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::METALVAPOR)); } break; case LaserType::SOLIDSTATE: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::SOLIDSTATE)); } break; case LaserType::DYE: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::DYE)); } break; case LaserType::SEMICONDUCTOR: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::SEMICONDUCTOR)); } break; case LaserType::FREEELECTRON: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::FREEELECTRON)); } break; case LaserType::OTHER: { check_nested(a, LaserType(LaserType::OTHER), b, LaserType(LaserType::OTHER)); } break; ; } } break;;
    }
}

class Enum_PixelTypePreprocessNested_Test : public ::testing::Test { public: Enum_PixelTypePreprocessNested_Test() {} private: virtual void TestBody(); static ::testing::TestInfo* const test_info_ __attribute__ ((unused)); Enum_PixelTypePreprocessNested_Test(Enum_PixelTypePreprocessNested_Test const &); void operator=(Enum_PixelTypePreprocessNested_Test const &);};::testing::TestInfo* const Enum_PixelTypePreprocessNested_Test ::test_info_ = ::testing::internal::MakeAndRegisterTestInfo( "Enum", "PixelTypePreprocessNested", __null, __null, (::testing::internal::GetTestTypeId()), ::testing::Test::SetUpTestCase, ::testing::Test::TearDownTestCase, new ::testing::internal::TestFactoryImpl< Enum_PixelTypePreprocessNested_Test>);void Enum_PixelTypePreprocessNested_Test::TestBody()
{
  check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::EXCIMER), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::GAS), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::METALVAPOR), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::SOLIDSTATE), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::DYE), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::SEMICONDUCTOR), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::FREEELECTRON), LaserType(LaserType::OTHER)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::EXCIMER)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::GAS)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::METALVAPOR)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::SOLIDSTATE)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::DYE)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::SEMICONDUCTOR)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::FREEELECTRON)); check_switch(LaserType(LaserType::OTHER), LaserType(LaserType::OTHER)); ;
}
```