### PR TITLE
Fakereader annotations

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -135,6 +135,18 @@ public class FakeReader extends FormatReader {
   /* physical sizes */
   private Length physicalSizeX, physicalSizeY, physicalSizeZ;
 
+  /* annotation counts per file */
+  private int annotationCount = 0;
+  private int annotationBoolCount = 0;
+  private int annotationCommentCount = 0;
+  private int annotationDoubleCount = 0;
+  private int annotationLongCount = 0;
+  private int annotationMapCount = 0;
+  private int annotationTagCount = 0;
+  private int annotationTermCount = 0;
+  private int annotationTimeCount = 0;
+  private int annotationXmlCount = 0;
+
   /** Scale factor for gradient, if any. */
   private double scaleFactor = 1;
 
@@ -439,20 +451,15 @@ public class FakeReader extends FormatReader {
     int fields = 0;
     int plateAcqs = 0;
 
-/*
- *  Other annotation types that could be added
- *  int annFile = 0; // FileAnnotation
- *  int annList = 0; // ListAnnotation
- */
-    int annLong = 0;
-    int annDouble = 0;
-    int annComment = 0;
     int annBool = 0;
+    int annComment = 0;
+    int annDouble = 0;
+    int annLong = 0;
+    int annMap = 0;
     int annTime = 0;
     int annTag = 0;
     int annTerm = 0;
     int annXml = 0;
-    int annMap = 0;
 
     Integer defaultColor = null;
     ArrayList<Integer> color = new ArrayList<Integer>();
@@ -644,21 +651,7 @@ public class FakeReader extends FormatReader {
 
     // populate OME metadata
     boolean planeInfo = (exposureTime != null);
-    // per file counts
-    int annotationCount = 0;
-    int annotationDoubleCount = 0;
-    int annotationLongCount = 0;
-    int annotationBoolCount = 0;
-    int annotationCommentCount = 0;
-    int annotationTagCount = 0;
-    int annotationTermCount = 0;
-    int annotationTimeCount = 0;
-    int annotationXmlCount = 0;
-    int annotationMapCount = 0;
-    // per image count
-    int annotationRefCount = 0;
 
-    String nextAnnotationID;
     MetadataTools.populatePixels(store, this, planeInfo);
     fillExposureTime(store);
     fillPhysicalSizes(store);
@@ -676,112 +669,8 @@ public class FakeReader extends FormatReader {
           store.setChannelColor(channel, currentImageIndex, c);
         }
       }
-
-      // new image so reset annotationRefCount
-      annotationRefCount = 0;
-      for (int currentAnnotation=0; currentAnnotation<annLong; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setLongAnnotationID(nextAnnotationID, annotationLongCount);
-        store.setLongAnnotationNamespace(ANNOTATION_NAMESPACE, annotationLongCount);
-        store.setLongAnnotationValue(ANN_LONG_VALUE+annotationCount, annotationLongCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationLongCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annDouble; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setDoubleAnnotationID(nextAnnotationID, annotationDoubleCount);
-        store.setDoubleAnnotationNamespace(ANNOTATION_NAMESPACE, annotationDoubleCount);
-        store.setDoubleAnnotationValue(ANN_DOUBLE_VALUE*(annotationCount+1), annotationDoubleCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationDoubleCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annMap; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setMapAnnotationID(nextAnnotationID, annotationMapCount);
-        store.setMapAnnotationNamespace(ANNOTATION_NAMESPACE, annotationMapCount);
-        List<MapPair> mapValue = new ArrayList<MapPair>();
-        for (int keyNum=0; keyNum<10; keyNum++) {
-          mapValue.add(new MapPair("keyS" + currentImageIndex + "N" + keyNum, "val" + (keyNum+1)*(annotationCount+1)));
-        }
-        store.setMapAnnotationValue(mapValue, annotationMapCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationMapCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annComment; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setCommentAnnotationID(nextAnnotationID, annotationCommentCount);
-        store.setCommentAnnotationNamespace(ANNOTATION_NAMESPACE, annotationCommentCount);
-        store.setCommentAnnotationValue(ANN_COMMENT_VALUE + (annotationCount+1), annotationCommentCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationCommentCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annBool; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setBooleanAnnotationID(nextAnnotationID, annotationBoolCount);
-        store.setBooleanAnnotationNamespace(ANNOTATION_NAMESPACE, annotationBoolCount);
-        store.setBooleanAnnotationValue(ANN_BOOLEAN_VALUE, annotationBoolCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationBoolCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annTime; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setTimestampAnnotationID(nextAnnotationID, annotationTimeCount);
-        store.setTimestampAnnotationNamespace(ANNOTATION_NAMESPACE, annotationTimeCount);
-        store.setTimestampAnnotationValue(ANN_TIME_VALUE, annotationTimeCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationTimeCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annTag; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setTagAnnotationID(nextAnnotationID, annotationTagCount);
-        store.setTagAnnotationNamespace(ANNOTATION_NAMESPACE, annotationTagCount);
-        store.setTagAnnotationValue(ANN_TAG_VALUE + (annotationCount+1), annotationTagCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationTagCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annTerm; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setTermAnnotationID(nextAnnotationID, annotationTermCount);
-        store.setTermAnnotationNamespace(ANNOTATION_NAMESPACE, annotationTermCount);
-        store.setTermAnnotationValue(ANN_TERM_VALUE + (annotationCount+1), annotationTermCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationTermCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
-      for (int currentAnnotation=0; currentAnnotation<annXml; currentAnnotation++) {
-        nextAnnotationID = ANNOTATION_PREFIX + annotationCount;
-        store.setXMLAnnotationID(nextAnnotationID, annotationXmlCount);
-        store.setXMLAnnotationNamespace(ANNOTATION_NAMESPACE, annotationXmlCount);
-        store.setXMLAnnotationValue(ANN_XML_VALUE_START + (annotationCount+1) + ANN_XML_VALUE_END, annotationXmlCount);
-        store.setImageAnnotationRef(nextAnnotationID, currentImageIndex, annotationRefCount);
-        annotationXmlCount++;
-        annotationCount++;
-        annotationRefCount++;
-      }
-
+      fillAnnotations(store, currentImageIndex, annBool, annComment,
+        annDouble, annLong, annMap, annTag, annTerm, annTime, annXml);
     }
 
     // for indexed color images, create lookup tables
@@ -848,6 +737,114 @@ public class FakeReader extends FormatReader {
     }
   }
 
+  private void fillAnnotations(MetadataStore store, int imageIndex, int annBool, int annComment, int annDouble, int annLong, int annMap, int annTag, int annTerm, int annTime, int annXml) {
+
+    int annotationRefCount = 0;
+    String annotationID;
+
+    for (int i=0; i<annBool; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setBooleanAnnotationID(annotationID, annotationBoolCount);
+      store.setBooleanAnnotationNamespace(ANNOTATION_NAMESPACE, annotationBoolCount);
+      store.setBooleanAnnotationValue(ANN_BOOLEAN_VALUE, annotationBoolCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationBoolCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annComment; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setCommentAnnotationID(annotationID, annotationCommentCount);
+      store.setCommentAnnotationNamespace(ANNOTATION_NAMESPACE, annotationCommentCount);
+      store.setCommentAnnotationValue(ANN_COMMENT_VALUE + (annotationCount+1), annotationCommentCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationCommentCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annDouble; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setDoubleAnnotationID(annotationID, annotationDoubleCount);
+      store.setDoubleAnnotationNamespace(ANNOTATION_NAMESPACE, annotationDoubleCount);
+      store.setDoubleAnnotationValue(ANN_DOUBLE_VALUE*(annotationCount+1), annotationDoubleCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationDoubleCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annLong; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setLongAnnotationID(annotationID, annotationLongCount);
+      store.setLongAnnotationNamespace(ANNOTATION_NAMESPACE, annotationLongCount);
+      store.setLongAnnotationValue(ANN_LONG_VALUE+annotationCount, annotationLongCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationLongCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annMap; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setMapAnnotationID(annotationID, annotationMapCount);
+      store.setMapAnnotationNamespace(ANNOTATION_NAMESPACE, annotationMapCount);
+      List<MapPair> mapValue = new ArrayList<MapPair>();
+      for (int keyNum=0; keyNum<10; keyNum++) {
+        mapValue.add(new MapPair("keyS" + imageIndex + "N" + keyNum, "val" + (keyNum+1)*(annotationCount+1)));
+      }
+      store.setMapAnnotationValue(mapValue, annotationMapCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationMapCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annTag; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setTagAnnotationID(annotationID, annotationTagCount);
+      store.setTagAnnotationNamespace(ANNOTATION_NAMESPACE, annotationTagCount);
+      store.setTagAnnotationValue(ANN_TAG_VALUE + (annotationCount+1), annotationTagCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationTagCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annTerm; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setTermAnnotationID(annotationID, annotationTermCount);
+      store.setTermAnnotationNamespace(ANNOTATION_NAMESPACE, annotationTermCount);
+      store.setTermAnnotationValue(ANN_TERM_VALUE + (annotationCount+1), annotationTermCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationTermCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+
+    for (int i=0; i<annTime; i++) {
+       annotationID = ANNOTATION_PREFIX + annotationCount;
+       store.setTimestampAnnotationID(annotationID, annotationTimeCount);
+       store.setTimestampAnnotationNamespace(ANNOTATION_NAMESPACE, annotationTimeCount);
+       store.setTimestampAnnotationValue(ANN_TIME_VALUE, annotationTimeCount);
+       store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+       annotationTimeCount++;
+       annotationCount++;
+       annotationRefCount++;
+     }
+
+    for (int i=0; i<annXml; i++) {
+      annotationID = ANNOTATION_PREFIX + annotationCount;
+      store.setXMLAnnotationID(annotationID, annotationXmlCount);
+      store.setXMLAnnotationNamespace(ANNOTATION_NAMESPACE, annotationXmlCount);
+      store.setXMLAnnotationValue(ANN_XML_VALUE_START + (annotationCount+1) + ANN_XML_VALUE_END, annotationXmlCount);
+      store.setImageAnnotationRef(annotationID, imageIndex, annotationRefCount);
+      annotationXmlCount++;
+      annotationCount++;
+      annotationRefCount++;
+    }
+  }
 
 // -- Helper methods --
 

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -665,11 +665,7 @@ public class FakeReader extends FormatReader {
     for (int currentImageIndex=0; currentImageIndex<seriesCount; currentImageIndex++) {
       String imageName = currentImageIndex > 0 ? name + " " + (currentImageIndex + 1) : name;
       store.setImageName(imageName, currentImageIndex);
-      if (acquisitionDate != null) {
-        if(DateTools.getTime(acquisitionDate, DateTools.FILENAME_FORMAT) != -1) {
-          store.setImageAcquisitionDate(new Timestamp(DateTools.formatDate(acquisitionDate, DateTools.FILENAME_FORMAT)), currentImageIndex);
-        }
-      }
+      fillAcquisitionDate(store, acquisitionDate, currentImageIndex);
 
       for (int c=0; c<getEffectiveSizeC(); c++) {
         Color channel = defaultColor == null ? null: new Color(defaultColor);
@@ -842,6 +838,16 @@ public class FakeReader extends FormatReader {
     }
     setSeries(oldSeries);
   }
+
+  private void fillAcquisitionDate(MetadataStore store, String date, int imageIndex) {
+    if (date == null) return;
+    if(DateTools.getTime(date, DateTools.FILENAME_FORMAT) != -1) {
+      Timestamp stamp = new Timestamp(
+        DateTools.formatDate(date, DateTools.FILENAME_FORMAT));
+      store.setImageAcquisitionDate(stamp, imageIndex);
+    }
+  }
+
 
 // -- Helper methods --
 

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -320,4 +320,193 @@ public class FakeReaderTest {
       assertEquals(m.getImageAcquisitionDate(i), date);
     }
   }
+
+  @Test
+  public void testBooleanAnnotation() throws Exception {
+    reader.setId("foo&series=5&annBool=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getBooleanAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testBooleanAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannBool = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getBooleanAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testCommentAnnotation() throws Exception {
+    reader.setId("foo&series=5&annComment=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getCommentAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testCommentAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannComment = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getCommentAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testDoubleAnnotation() throws Exception {
+    reader.setId("foo&series=5&annDouble=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getDoubleAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testDoubleAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannDouble = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getDoubleAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testLongAnnotation() throws Exception {
+    reader.setId("foo&series=5&annLong=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getLongAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testLongAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannLong = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getLongAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testMapAnnotation() throws Exception {
+    reader.setId("foo&series=5&annMap=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getMapAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testMapAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannMap = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getMapAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testTagAnnotation() throws Exception {
+    reader.setId("foo&series=5&annTag=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getTagAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testTagAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannTag = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getTagAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testTermAnnotation() throws Exception {
+    reader.setId("foo&series=5&annTerm=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getTermAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testTermAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannTerm = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getTermAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testTimeAnnotation() throws Exception {
+    reader.setId("foo&series=5&annTime=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getTimestampAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testTimeAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannTime = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getTimestampAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testXMLAnnotation() throws Exception {
+    reader.setId("foo&series=5&annXml=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getXMLAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testXMLAnnotationINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\nannXml = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getXMLAnnotationCount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageAnnotationRefCount(0), 10);
+    }
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -68,6 +68,7 @@ public class FakeReaderTest {
   private Path wd;
   private FakeReader reader;
   private OMEXMLService service;
+  private MetadataRetrieve m;
 
   @DataProvider(name = "physical sizes")
   public Object[][] physicalSizes() {
@@ -132,6 +133,7 @@ public class FakeReaderTest {
     reader = new FakeReader();
     ServiceFactory sf = new ServiceFactory();
     service = sf.getInstance(OMEXMLService.class);
+    reader.setMetadataStore(service.createOMEXMLMetadata());
   }
 
   @AfterMethod
@@ -252,77 +254,68 @@ public class FakeReaderTest {
 
   @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeX(String value, Length length) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     reader.setId("foo&physicalSizeX=" + value + ".fake");
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
   }
   
   @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeXIni(String value, Length length) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     mkIni("foo.fake.ini", "physicalSizeX = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
   }
 
   @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeY(String value, Length length) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     reader.setId("foo&physicalSizeY=" + value + ".fake");
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
   }
 
   @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeYIni(String value, Length length) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     mkIni("foo.fake.ini", "physicalSizeY = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
   }
   
   @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeZ(String value, Length length) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     reader.setId("foo&physicalSizeZ=" + value + ".fake");
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
 
   @Test(dataProvider = "physical sizes")
   public void testPhysicalSizeZIni(String value, Length length) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     mkIni("foo.fake.ini", "physicalSizeZ = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
 
   @Test(dataProvider = "acquisition dates")
   public void testAcquisitionDate(String value, Timestamp date) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     reader.setId("foo&acquisitionDate=" + value + ".fake");
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getImageAcquisitionDate(0), date);
   }
 
   @Test(dataProvider = "acquisition dates")
   public void testAcquisitionDateIni(String value, Timestamp date) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
     mkIni("foo.fake.ini", "acquisitionDate = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getImageAcquisitionDate(0), date);
   }
 
   @Test(dataProvider = "acquisition dates")
-  public void testAcquisitionDates(String value, Timestamp date) throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
+  public void testAcquisitionDateMultiSeries(String value, Timestamp date) throws Exception {
     reader.setId("foo&series=10&acquisitionDate=" + value + ".fake");
-    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    m = service.asRetrieve(reader.getMetadataStore());
     for (int i = 0; i < 10; i++) {
       assertEquals(m.getImageAcquisitionDate(i), date);
     }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -55,6 +55,8 @@ import loci.common.services.ServiceFactory;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 
+import ome.xml.model.primitives.Timestamp;
+
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -78,6 +80,14 @@ public class FakeReaderTest {
       {"1.0Å", new Length(1.0, UNITS.ANGSTROM)},
       {"1.0 pixel", new Length(1.0, UNITS.PIXEL)},
       {"1.0 reference frame", new Length(1.0, UNITS.REFERENCEFRAME)},
+    };
+  }
+
+  @DataProvider(name = "acquisition dates")
+  public Object[][] acquisitionDates() {
+    return new Object[][] {
+      {"2016-03-01_16-14-00", new Timestamp("2016-03-01T16:14:00")},
+      {"2016-03-01", null},
     };
   }
 
@@ -289,5 +299,32 @@ public class FakeReaderTest {
     reader.setId(wd.resolve("foo.fake").toString());
     MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
+  }
+
+  @Test(dataProvider = "acquisition dates")
+  public void testAcquisitionDate(String value, Timestamp date) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    reader.setId("foo&acquisitionDate=" + value + ".fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getImageAcquisitionDate(0), date);
+  }
+
+  @Test(dataProvider = "acquisition dates")
+  public void testAcquisitionDateIni(String value, Timestamp date) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    mkIni("foo.fake.ini", "acquisitionDate = " + value);
+    reader.setId(wd.resolve("foo.fake").toString());
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getImageAcquisitionDate(0), date);
+  }
+
+  @Test(dataProvider = "acquisition dates")
+  public void testAcquisitionDates(String value, Timestamp date) throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    reader.setId("foo&series=10&acquisitionDate=" + value + ".fake");
+    MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
+    for (int i = 0; i < 10; i++) {
+      assertEquals(m.getImageAcquisitionDate(i), date);
+    }
   }
 }


### PR DESCRIPTION
In preparation of the upcoming [addition of support for regions](https://trello.com/c/HeAwzPRO/34-regions-in-fakereader) in the fake images reader, this PR:
- refactors the logic filling the acquisition dates and the annotations for each image into helper methods
- adds unit tests covering both cases
