### PR TITLE
Fix FakeReader regex

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -988,7 +988,7 @@ public class FakeReader extends FormatReader {
   }
 
   private Length parseLength(String value, String defaultUnit) {
-      Matcher m = Pattern.compile("\\s*([\\d.]+)\\s*([\\D\\S]*)\\s*").matcher(value);
+      Matcher m = Pattern.compile("\\s*([\\d.]+)\\s*([^\\d\\s].*?)?\\s*").matcher(value);
       if (!m.matches()) {
         throw new RuntimeException(String.format(
                 "%s does not match a physical size!", value));

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -290,4 +290,12 @@ public class FakeReaderTest {
     MetadataRetrieve m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
+
+  @Test(expectedExceptions={ RuntimeException.class })
+  public void testPhysicalSizeZBadParsing() throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    mkIni("foo.fake.ini", "physicalSizeZ = 1 1");
+    reader.setId(wd.resolve("foo.fake").toString());
+  }
+
 }


### PR DESCRIPTION
The regex now looks for:
 * number (potentially a float)
 * optional space
 * a non-digit, non-space
 * any other characters (final space is stripped)

See:
https://trello.com/c/ZMNhFXl7/380-strange-regex-in-fakereader