### PR TITLE
MATLAB: add logging initialization function

### DIFF
--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -78,8 +78,8 @@ public final class DebugTools {
     for (String[] toolClass : toolClasses) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
-        Method m = k.getMethod("enableLogging", String.class);
-        return (Boolean) m.invoke(null);
+        Method m = k.getMethod("isEnabled", String.class);
+        return m.invoke(null);
       }
       catch (Throwable t) {
         // no-op. Ignore error and try the next class.

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -78,7 +78,7 @@ public final class DebugTools {
     for (String[] toolClass : toolClasses) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
-        Method m = k.getMethod("isEnabled", String.class);
+        Method m = k.getMethod("isEnabled");
         return (Boolean) m.invoke(null);
       }
       catch (Throwable t) {

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -65,7 +65,7 @@ public final class DebugTools {
   }
 
   /**
-   * Checks wether SLF4J logging has been enabled via logback or log4j
+   * Checks whether SLF4J logging has been enabled via logback or log4j
    *
    * @return {@code true} if logging was successfully enabled
    */

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -79,7 +79,7 @@ public final class DebugTools {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
         Method m = k.getMethod("isEnabled", String.class);
-        return m.invoke(null);
+        return (Boolean) m.invoke(null);
       }
       catch (Throwable t) {
         // no-op. Ignore error and try the next class.

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -65,12 +65,36 @@ public final class DebugTools {
   }
 
   /**
+   * Checks wether SLF4J logging has been enabled via logback or log4j
+   *
+   * @return {@code true} if logging was successfully enabled
+   */
+  public static synchronized boolean isEnabled() {
+    final String[][] toolClasses = new String[][] {
+      new String[] {"loci.common.", "LogbackTools"},
+      new String[] {"loci.common.", "Log4jTools"}
+    };
+
+    for (String[] toolClass : toolClasses) {
+      try {
+        Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
+        Method m = k.getMethod("enableLogging", String.class);
+        return (Boolean) m.invoke(null);
+      }
+      catch (Throwable t) {
+        // no-op. Ignore error and try the next class.
+      }
+    }
+    return false;
+  }
+
+  /**
    * Attempts to enable SLF4J logging via logback or log4j
    * without an external configuration file.
    *
    * @param level A string indicating the desired level
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
-   * @return true iff logging was successfully enabled
+   * @return {@code} true if logging was successfully enabled
    */
   public static synchronized boolean enableLogging(String level) {
     final String[][] toolClasses = new String[][] {

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -55,11 +55,7 @@ public final class Log4jTools {
       r.exec("import org.apache.log4j.Logger");
       r.exec("root = Logger.getRootLogger()");
       Enumeration en = (Enumeration) r.exec("root.getAllAppenders()");
-      if (!en.hasMoreElements()) {
-        return false;
-      } else {
-        return true;
-      }
+      return en.hasMoreElements();
     } catch (ReflectException exc) {
       return false;
     }

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -44,12 +44,34 @@ public final class Log4jTools {
   private Log4jTools() { }
 
   /**
+   * Checks whether SLF4J logging was enabled via log4j
+   *
+   * @return {@code true} if logging was successfully enabled
+   */
+  public static synchronized boolean isEnabled() {
+    try {
+      ReflectedUniverse r = new ReflectedUniverse();
+      r.exec("import org.apache.log4j.Level");
+      r.exec("import org.apache.log4j.Logger");
+      r.exec("root = Logger.getRootLogger()");
+      Enumeration en = (Enumeration) r.exec("root.getAllAppenders()");
+      if (!en.hasMoreElements()) {
+        return false;
+      } else {
+        return true;
+      }
+    } catch (ReflectException exc) {
+      return false;
+    }
+  }
+  
+  /**
    * Attempts to enable SLF4J logging via log4j
    * without an external configuration file.
    *
    * @param level A string indicating the desired level
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
-   * @return true iff logging was successfully enabled
+   * @return {@code true} if logging was successfully enabled
    */
   public static synchronized boolean enableLogging(String level) {
     try {

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -60,11 +60,7 @@ public final class LogbackTools {
    */
   public static synchronized boolean isEnabled() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-    if (!root.iteratorForAppenders().hasNext()) {
-      return false;
-    } else {
-      return true;
-    }
+    return root.iteratorForAppenders().hasNext();
   }
 
   /**

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -54,12 +54,26 @@ public final class LogbackTools {
   private LogbackTools() { }
 
   /**
-   * Attempts to enable SLF4J logging via logback
-   * without an external configuration file.
+   * Checks whether SLF4J logging was enabled via logback
+   *
+   * @return {@code} true if logging was successfully enabled
+   */
+  public static synchronized boolean isEnabled() {
+    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    if (!root.iteratorForAppenders().hasNext()) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * Attempts to enable SLF4J logging via logback without an external
+   * configuration file.
    *
    * @param level A string indicating the desired level
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
-   * @return true iff logging was successfully enabled
+   * @return {@code} true if logging was successfully enabled
    */
   public static synchronized boolean enableLogging(String level) {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);

--- a/components/formats-gpl/matlab/bfInitLogging.m
+++ b/components/formats-gpl/matlab/bfInitLogging.m
@@ -1,0 +1,35 @@
+function bfInitLogging(varargin)
+% BFINITLOGGING initializes Bio-Formats and its logging level
+%
+%   bfInitLogging() autoloads Bio-Formats is in the Java path and checks
+%   whether log4j is initialized. If not, it initializes logging at the
+%   WARN level.
+%
+%   bfInitLogging(level) sets the logging to the input level.
+%
+% Examples
+%
+%    bfInitLogging();
+%    bfInitLogging('DEBUG');
+%
+% Sebastien Besson, Nov 2014
+
+% Autoload Bio-Formats Java path
+bfCheckJavaPath();
+
+% Return if log4j is alreadyinitialied
+import org.apache.log4j.Logger;
+root = Logger.getRootLogger();
+appenders = root.getAllAppenders();
+if appenders.hasMoreElements(), return; end
+
+% Input check
+import org.apache.log4j.Level;
+levels = Level.getAllPossiblePriorities();
+levels = arrayfun(@(x) char(x.toString()), levels, 'Unif', false);
+ip=inputParser;
+ip.addOptional('level', 'WARN', @(x) ismember(x, levels));
+ip.parse(varargin{:});
+
+% Configure log4j and set debug level
+loci.common.DebugTools.enableLogging(ip.Results.level);

--- a/components/formats-gpl/matlab/bfInitLogging.m
+++ b/components/formats-gpl/matlab/bfInitLogging.m
@@ -1,35 +1,51 @@
 function bfInitLogging(varargin)
-% BFINITLOGGING initializes Bio-Formats and its logging level
+% BFINITLOGGING initializes the Bio-Formats logging system
 %
-%   bfInitLogging() autoloads Bio-Formats is in the Java path and checks
-%   whether log4j is initialized. If not, it initializes logging at the
-%   WARN level.
+%   bfInitLogging() intializes the logging system at WARN level by default.
+%   It allows
 %
-%   bfInitLogging(level) sets the logging to the input level.
+%   bfInitLogging(level) sets the logging level to use when initializing
+%   the logging system
 %
 % Examples
 %
 %    bfInitLogging();
 %    bfInitLogging('DEBUG');
-%
-% Sebastien Besson, Nov 2014
 
-% Autoload Bio-Formats Java path
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2016 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+% Check Bio-Formats is set in the Java class path
 bfCheckJavaPath();
 
-% Return if log4j is alreadyinitialied
-import org.apache.log4j.Logger;
-root = Logger.getRootLogger();
-appenders = root.getAllAppenders();
-if appenders.hasMoreElements(), return; end
+% Return if the logging system is already initialized
+if javaMethod('isEnabled', 'loci.common.DebugTools'), return; end
 
 % Input check
 import org.apache.log4j.Level;
 levels = Level.getAllPossiblePriorities();
 levels = arrayfun(@(x) char(x.toString()), levels, 'Unif', false);
-ip=inputParser;
+ip = inputParser;
 ip.addOptional('level', 'WARN', @(x) ismember(x, levels));
 ip.parse(varargin{:});
 
-% Configure log4j and set debug level
-loci.common.DebugTools.enableLogging(ip.Results.level);
+% Set logging level
+javaMethod('enableLogging', 'loci.common.DebugTools', ip.Results.level)

--- a/components/formats-gpl/matlab/bfInitLogging.m
+++ b/components/formats-gpl/matlab/bfInitLogging.m
@@ -2,7 +2,6 @@ function bfInitLogging(varargin)
 % BFINITLOGGING initializes the Bio-Formats logging system
 %
 %   bfInitLogging() intializes the logging system at WARN level by default.
-%   It allows
 %
 %   bfInitLogging(level) sets the logging level to use when initializing
 %   the logging system

--- a/components/formats-gpl/matlab/bfInitLogging.m
+++ b/components/formats-gpl/matlab/bfInitLogging.m
@@ -1,7 +1,7 @@
 function bfInitLogging(varargin)
 % BFINITLOGGING initializes the Bio-Formats logging system
 %
-%   bfInitLogging() intializes the logging system at WARN level by default.
+%   bfInitLogging() initializes the logging system at WARN level by default.
 %
 %   bfInitLogging(level) sets the logging level to use when initializing
 %   the logging system

--- a/components/formats-gpl/matlab/bfInitLogging.m
+++ b/components/formats-gpl/matlab/bfInitLogging.m
@@ -40,12 +40,10 @@ bfCheckJavaPath();
 if javaMethod('isEnabled', 'loci.common.DebugTools'), return; end
 
 % Input check
-import org.apache.log4j.Level;
-levels = Level.getAllPossiblePriorities();
-levels = arrayfun(@(x) char(x.toString()), levels, 'Unif', false);
+levels = {'ALL', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'OFF', 'TRACE', 'WARN'};
 ip = inputParser;
 ip.addOptional('level', 'WARN', @(x) ismember(x, levels));
 ip.parse(varargin{:});
 
 % Set logging level
-javaMethod('enableLogging', 'loci.common.DebugTools', ip.Results.level)
+javaMethod('enableLogging', 'loci.common.DebugTools', ip.Results.level);

--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -107,8 +107,8 @@ if nargin == 0 || exist(id, 'file') == 0
   if isequal(path, 0) || isequal(file, 0), return; end
 end
 
-% initialize logging
-javaMethod('enableLogging', 'loci.common.DebugTools', 'INFO');
+% Initialize logging
+bfInitLogging();
 
 % Get the channel filler
 r = bfGetReader(id, stitchFiles);

--- a/components/formats-gpl/test/matlab/TestBfInitLogging.m
+++ b/components/formats-gpl/test/matlab/TestBfInitLogging.m
@@ -1,0 +1,110 @@
+% TestBfInitLogging define test cases for bfInitLogging utility function
+%
+% Require MATLAB xUnit Test Framework to be installed
+% http://www.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
+% https://github.com/psexton/matlab-xunit (GitHub source code)
+
+% OME Bio-Formats package for reading and converting biological file formats.
+%
+% Copyright (C) 2016 Open Microscopy Environment:
+%   - Board of Regents of the University of Wisconsin-Madison
+%   - Glencoe Software, Inc.
+%   - University of Dundee
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as
+% published by the Free Software Foundation, either version 2 of the
+% License, or (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+classdef TestBfInitLogging < TestBfMatlab
+    
+    properties
+        root
+    end
+    
+    methods
+        function self = TestBfInitLogging(name)
+            self = self@TestBfMatlab(name);
+            import org.apache.log4j.Logger;
+            self.root = Logger.getRootLogger();
+        end
+        
+        function disableLogging(self)
+            self.root.removeAllAppenders();
+            assertFalse(loci.common.DebugTools.isEnabled());
+        end
+        
+        function testDefault(self)
+            self.disableLogging();
+            bfInitLogging();
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'WARN');
+        end
+        
+        function testALL(self)
+            self.disableLogging();
+            bfInitLogging('ALL');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'ALL');
+        end
+        
+        function testERROR(self)
+            self.disableLogging();
+            bfInitLogging('ERROR');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'ERROR');
+        end
+        
+        function testDEBUG(self)
+            self.disableLogging();
+            bfInitLogging('DEBUG');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'DEBUG');
+        end
+        
+        function testINFO(self)
+            self.disableLogging();
+            bfInitLogging('INFO');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'INFO');
+        end
+        
+        function testFATAL(self)
+            self.disableLogging();
+            bfInitLogging('FATAL');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'FATAL');
+        end
+        
+        function testOFF(self)
+            self.disableLogging();
+            bfInitLogging('OFF');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'OFF');
+        end
+        
+        function testTRACE(self)
+            self.disableLogging();
+            bfInitLogging('TRACE');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'TRACE');
+        end
+        
+        function testWARN(self)
+            self.disableLogging();
+            bfInitLogging('WARN');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'WARN');
+        end
+    end
+end

--- a/components/formats-gpl/test/matlab/TestBfInitLogging.m
+++ b/components/formats-gpl/test/matlab/TestBfInitLogging.m
@@ -41,6 +41,7 @@ classdef TestBfInitLogging < TestBfMatlab
         
         function disableLogging(self)
             self.root.removeAllAppenders();
+            bfCheckJavaPath();
             assertFalse(loci.common.DebugTools.isEnabled());
         end
         

--- a/docs/sphinx/developers/examples/bftest.m
+++ b/docs/sphinx/developers/examples/bftest.m
@@ -120,6 +120,11 @@ bfsave(plane, 'metadata.ome.tiff', 'metadata', metadata);
 % bfsave-metadata-end
 delete('metadata.ome.tiff');
 
+% logging-start
+% Set the logging level to DEBUG
+loci.common.DebugTools.enableLogging('DEBUG');
+% logging-end
+
 % memoizer-start
 % Construct an empty Bio-Formats reader
 r = bfGetReader();
@@ -159,6 +164,8 @@ nWorkers = 4;
 
 % Enter parallel loop
 parfor i = 1 : nWorkers
+    % Initialize logging at INFO level
+    bfInitLogging('INFO');
     % Initialize a new reader per worker as Bio-Formats is not thread safe
     r2 = javaObject('loci.formats.Memoizer', bfGetReader(), 0);
     % Initialization should use the memo file cached before entering the

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -176,6 +176,18 @@ To convert the OME metadata into a string, use the ``dumpXML()`` method:
 
 	omeXML = char(omeMeta.dumpXML());
 
+Changing the logging level
+--------------------------
+
+By default, ``bfopen`` initializes the logging system at the `WARN` level. To
+set the logging level, use
+:javadoc:`loci.common.DebugTools.enableLogging(level) <loci/common/DebugTools.html#enableLogging(java.lang.String)>`:
+
+.. literalinclude:: examples/bftest.m
+  :language: matlab
+  :start-after: logging-start
+  :end-before: logging-end
+
 Reading from an image file
 --------------------------
 


### PR DESCRIPTION
Fixes https://github.com/openmicroscopy/bioformats/issues/2233

This PR addresses the issues reported in https://github.com/openmicroscopy/bioformats/issues/2233 by:
- adding a MATLAB function initializing the logging system with a logic similar to [logging.basicConfig](https://docs.python.org/3/library/logging.html#logging.basicConfig).
- set the default logging level to `WARN` if no argument is passed
- use this logging initialization function in `bfopen` to prevent logging set by the user to be overriden
- add some logic checking whether logging is enabled to `loci.common.DebugTools`

To test this PR:
- try the following workflow from a clear MATLAB session using the test artifacts:

 ```
% Open an image - logging should be initialized at WARN level
data = bfopen(id);
% Check whether logging is enabled
loci.common.DebugTools.isEnabled()
% Set the logging level to debug
loci.common.DebugTools.enableLogging('DEBUG');
% Open the image again - logging should be at DEBUG level
data = bfopen(id);
```

- check the new MATLAB tests are passing
- check `bftest.m` completes as expected in the [CI job](https://ci.openmicroscopy.org/view/DEV/job/BIOFORMATS-DEV-merge-matlab/) and that the individual workers in the `parfor` loop have their logging system properly intialized.