### PR TITLE
FakeReader: regions

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -890,7 +890,7 @@ public class FakeReader extends FormatReader {
         store.setEllipseID(ellipseID, roiCount, 0);
         store.setEllipseX(getX(i) + 5.0, roiCount, 0);
         store.setEllipseY(getY(i) + 5.0, roiCount, 0);
-        store.setEllipseRadiusX(nefw Double(5.0), roiCount, 0);
+        store.setEllipseRadiusX(new Double(5.0), roiCount, 0);
         store.setEllipseRadiusY(new Double(5.0), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -112,6 +112,7 @@ public class FakeReader extends FormatReader {
   private static final String ANN_COMMENT_VALUE = "Comment:";
   private static final String ANN_XML_VALUE_START = "<dummyXml>";
   private static final String ANN_XML_VALUE_END = "</dummyXml>";
+  private static final String ROI_PREFIX = "ROI:";
 
   public static final int BOX_SIZE = 10;
 
@@ -146,6 +147,8 @@ public class FakeReader extends FormatReader {
   private int annotationTermCount = 0;
   private int annotationTimeCount = 0;
   private int annotationXmlCount = 0;
+
+  private int roiCount = 0;
 
   /** Scale factor for gradient, if any. */
   private double scaleFactor = 1;
@@ -451,6 +454,7 @@ public class FakeReader extends FormatReader {
     int fields = 0;
     int plateAcqs = 0;
 
+    // Annotations
     int annBool = 0;
     int annComment = 0;
     int annDouble = 0;
@@ -460,6 +464,9 @@ public class FakeReader extends FormatReader {
     int annTag = 0;
     int annTerm = 0;
     int annXml = 0;
+
+    // Regions
+    int points = 0;
 
     Integer defaultColor = null;
     ArrayList<Integer> color = new ArrayList<Integer>();
@@ -558,6 +565,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("annTag")) annTag = intValue;
       else if (key.equals("annTerm")) annTerm = intValue;
       else if (key.equals("annXml")) annXml = intValue;
+      else if (key.equals("points")) points = intValue;
       else if (key.equals("physicalSizeX")) physicalSizeX = parseLength(value, getPhysicalSizeXUnitXsdDefault());
       else if (key.equals("physicalSizeY")) physicalSizeY = parseLength(value, getPhysicalSizeYUnitXsdDefault());
       else if (key.equals("physicalSizeZ")) physicalSizeZ = parseLength(value, getPhysicalSizeZUnitXsdDefault());
@@ -671,6 +679,7 @@ public class FakeReader extends FormatReader {
       }
       fillAnnotations(store, currentImageIndex, annBool, annComment,
         annDouble, annLong, annMap, annTag, annTerm, annTime, annXml);
+      fillRegions(store, currentImageIndex, points);
     }
 
     // for indexed color images, create lookup tables
@@ -843,6 +852,24 @@ public class FakeReader extends FormatReader {
       annotationXmlCount++;
       annotationCount++;
       annotationRefCount++;
+    }
+  }
+
+  private void fillRegions(MetadataStore store, int imageIndex, int points) {
+    int roiRefCount = 0;
+    String roiID;
+
+    for (int i=0; i<points; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String pointID = "Point:" + roiCount + ":" + i;
+
+        store.setPointID(pointID, roiCount, 0);
+        store.setPointX(new Double(1.0), roiCount, 0);
+        store.setPointY(new Double(1.0), roiCount, 0 );
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -96,6 +96,7 @@ import ome.units.UNITS;
  *  <li>showinf 'SPW&amp;plates=2&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
  *  <li>showinf 'SPW&amp;screens=2&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=1&amp;plateAcqs=1.fake'</li>
  *  <li>showinf 'Plate&amp;screens=0&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
+ *  <li>showinf 'regions&amp;points=10&amp;ellipses=5&amp;rectangles=10.fake'</li>
  * </ul></p>
  */
 public class FakeReader extends FormatReader {
@@ -115,6 +116,7 @@ public class FakeReader extends FormatReader {
   private static final String ROI_PREFIX = "ROI:";
 
   public static final int BOX_SIZE = 10;
+  private static final int ROI_SPACING = 10;
 
   public static final int DEFAULT_SIZE_X = 512;
   public static final int DEFAULT_SIZE_Y = 512;
@@ -868,6 +870,14 @@ public class FakeReader extends FormatReader {
     }
   }
 
+  private Double getX(int i) {
+      return new Double(ROI_SPACING * i % sizeX);
+  }
+
+  private Double getY(int i) {
+      return new Double(ROI_SPACING * ((int) ROI_SPACING * i / sizeX) % sizeY);
+  }
+
   private void fillRegions(MetadataStore store, int imageIndex) {
     int roiRefCount = 0;
     String roiID;
@@ -878,10 +888,10 @@ public class FakeReader extends FormatReader {
         String ellipseID = "Ellipse:" + roiCount + ":" + 0;
 
         store.setEllipseID(ellipseID, roiCount, 0);
-        store.setEllipseX(new Double(i % sizeX), roiCount, 0);
-        store.setEllipseY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
-        store.setEllipseRadiusX(new Double(1), roiCount, 0);
-        store.setEllipseRadiusY(new Double(1), roiCount, 0);
+        store.setEllipseX(getX(i) + 5.0, roiCount, 0);
+        store.setEllipseY(getY(i) + 5.0, roiCount, 0);
+        store.setEllipseRadiusX(nefw Double(5.0), roiCount, 0);
+        store.setEllipseRadiusY(new Double(5.0), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;
@@ -893,8 +903,8 @@ public class FakeReader extends FormatReader {
         String labelID = "Label:" + roiCount + ":" + 0;
 
         store.setLabelID(labelID, roiCount, 0);
-        store.setLabelX(new Double(i % sizeX), roiCount, 0);
-        store.setLabelY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setLabelX(getX(i), roiCount, 0);
+        store.setLabelY(getY(i), roiCount, 0);
         store.setLabelText("Label " + i, roiCount, 0 );
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
@@ -907,10 +917,10 @@ public class FakeReader extends FormatReader {
         String lineID = "Line:" + roiCount + ":" + 0;
 
         store.setLineID(lineID, roiCount, 0);
-        store.setLineX1(new Double(i % sizeX), roiCount, 0);
-        store.setLineY1(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
-        store.setLineX2(new Double(i % sizeX), roiCount, 0);
-        store.setLineY2(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setLineX1(getX(i), roiCount, 0);
+        store.setLineY1(getY(i), roiCount, 0);
+        store.setLineX2(getX(i) + 5.0, roiCount, 0);
+        store.setLineY2(getY(i) + 5.0, roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;
@@ -933,8 +943,8 @@ public class FakeReader extends FormatReader {
         String pointID = "Point:" + roiCount + ":" + 0;
 
         store.setPointID(pointID, roiCount, 0);
-        store.setPointX(new Double(i % sizeX), roiCount, 0);
-        store.setPointY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setPointX(getX(i), roiCount, 0);
+        store.setPointY(getY(i), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;
@@ -970,8 +980,8 @@ public class FakeReader extends FormatReader {
         String rectangleID = "Rectangle:" + roiCount + ":" + 0;
 
         store.setRectangleID(rectangleID, roiCount, 0);
-        store.setRectangleX(new Double(i % sizeX), roiCount, 0);
-        store.setRectangleY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setRectangleX(getX(i), roiCount, 0);
+        store.setRectangleY(getY(i), roiCount, 0);
         store.setRectangleWidth(new Double(5.0), roiCount, 0);
         store.setRectangleHeight(new Double(5.0), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -130,6 +130,13 @@ public class FakeReader extends FormatReader {
 
   // -- Fields --
 
+  /* dimensions per image */
+  public static int sizeX = DEFAULT_SIZE_X;
+  public static int sizeY = DEFAULT_SIZE_Y;
+  public static int sizeZ = DEFAULT_SIZE_Z;
+  public static int sizeC = DEFAULT_SIZE_C;
+  public static int sizeT = DEFAULT_SIZE_T;
+
   /** exposure time per plane info */
   private Time exposureTime = null;
 
@@ -148,6 +155,14 @@ public class FakeReader extends FormatReader {
   private int annotationTimeCount = 0;
   private int annotationXmlCount = 0;
 
+  /* ROIs per image*/
+  private int ellipses = 0;
+  private int labels = 0;
+  private int lines = 0;
+  private int masks = 0;
+  private int points = 0;
+  private int polygons = 0;
+  private int rectangles = 0;
   private int roiCount = 0;
 
   /** Scale factor for gradient, if any. */
@@ -423,11 +438,7 @@ public class FakeReader extends FormatReader {
     }
 
     String name = null;
-    int sizeX = DEFAULT_SIZE_X;
-    int sizeY = DEFAULT_SIZE_Y;
-    int sizeZ = DEFAULT_SIZE_Z;
-    int sizeC = DEFAULT_SIZE_C;
-    int sizeT = DEFAULT_SIZE_T;
+
     int thumbSizeX = 0; // default
     int thumbSizeY = 0; // default
     int pixelType = DEFAULT_PIXEL_TYPE;
@@ -464,9 +475,6 @@ public class FakeReader extends FormatReader {
     int annTag = 0;
     int annTerm = 0;
     int annXml = 0;
-
-    // Regions
-    int points = 0;
 
     Integer defaultColor = null;
     ArrayList<Integer> color = new ArrayList<Integer>();
@@ -679,7 +687,7 @@ public class FakeReader extends FormatReader {
       }
       fillAnnotations(store, currentImageIndex, annBool, annComment,
         annDouble, annLong, annMap, annTag, annTerm, annTime, annXml);
-      fillRegions(store, currentImageIndex, points);
+      fillRegions(store, currentImageIndex);
     }
 
     // for indexed color images, create lookup tables
@@ -855,14 +863,14 @@ public class FakeReader extends FormatReader {
     }
   }
 
-  private void fillRegions(MetadataStore store, int imageIndex, int points) {
+  private void fillRegions(MetadataStore store, int imageIndex) {
     int roiRefCount = 0;
     String roiID;
 
     for (int i=0; i<points; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String pointID = "Point:" + roiCount + ":" + i;
+        String pointID = "Point:" + roiCount + ":" + 0;
 
         store.setPointID(pointID, roiCount, 0);
         store.setPointX(new Double(1.0), roiCount, 0);

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -114,6 +114,7 @@ public class FakeReader extends FormatReader {
   private static final String ANN_XML_VALUE_START = "<dummyXml>";
   private static final String ANN_XML_VALUE_END = "</dummyXml>";
   private static final String ROI_PREFIX = "ROI:";
+  private static final String SHAPE_PREFIX = "Shape:";
 
   public static final int BOX_SIZE = 10;
   private static final int ROI_SPACING = 10;
@@ -885,9 +886,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<ellipses; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String ellipseID = "Ellipse:" + roiCount + ":" + 0;
-
-        store.setEllipseID(ellipseID, roiCount, 0);
+        store.setEllipseID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setEllipseX(getX(i) + 5.0, roiCount, 0);
         store.setEllipseY(getY(i) + 5.0, roiCount, 0);
         store.setEllipseRadiusX(new Double(5.0), roiCount, 0);
@@ -900,9 +899,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<labels; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String labelID = "Label:" + roiCount + ":" + 0;
-
-        store.setLabelID(labelID, roiCount, 0);
+        store.setLabelID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setLabelX(getX(i), roiCount, 0);
         store.setLabelY(getY(i), roiCount, 0);
         store.setLabelText("Label " + i, roiCount, 0 );
@@ -914,9 +911,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<lines; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String lineID = "Line:" + roiCount + ":" + 0;
-
-        store.setLineID(lineID, roiCount, 0);
+        store.setLineID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setLineX1(getX(i), roiCount, 0);
         store.setLineY1(getY(i), roiCount, 0);
         store.setLineX2(getX(i) + 5.0, roiCount, 0);
@@ -929,9 +924,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<masks; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String maskID = "Mask:" + roiCount + ":" + 0;
-
-        store.setMaskID(maskID, roiCount, 0);
+        store.setMaskID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;
@@ -940,9 +933,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<points; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String pointID = "Point:" + roiCount + ":" + 0;
-
-        store.setPointID(pointID, roiCount, 0);
+        store.setPointID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setPointX(getX(i), roiCount, 0);
         store.setPointY(getY(i), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
@@ -953,9 +944,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<polygons; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String polygonID = "Polygon:" + roiCount + ":" + 0;
-
-        store.setPolygonID(polygonID, roiCount, 0);
+        store.setPolygonID(SHAPE_PREFIX + roiCount, roiCount, 0);
         // store.setPolygonPoints(new Double(i % sizeX), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
@@ -965,9 +954,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<polylines; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String polylineID = "Polyline:" + roiCount + ":" + 0;
-
-        store.setPolylineID(polylineID, roiCount, 0);
+        store.setPolylineID(SHAPE_PREFIX + roiCount, roiCount, 0);
         // store.setPolylinePoints(new Double(i % sizeX), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
@@ -977,9 +964,7 @@ public class FakeReader extends FormatReader {
     for (int i=0; i<rectangles; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
-        String rectangleID = "Rectangle:" + roiCount + ":" + 0;
-
-        store.setRectangleID(rectangleID, roiCount, 0);
+        store.setRectangleID(SHAPE_PREFIX + roiCount, roiCount, 0);
         store.setRectangleX(getX(i), roiCount, 0);
         store.setRectangleY(getY(i), roiCount, 0);
         store.setRectangleWidth(new Double(5.0), roiCount, 0);

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -144,6 +144,15 @@ public class FakeReader extends FormatReader {
   private Length physicalSizeX, physicalSizeY, physicalSizeZ;
 
   /* annotation counts per file */
+  private int annBool = 0;
+  private int annComment = 0;
+  private int annDouble = 0;
+  private int annLong = 0;
+  private int annMap = 0;
+  private int annTime = 0;
+  private int annTag = 0;
+  private int annTerm = 0;
+  private int annXml = 0;
   private int annotationCount = 0;
   private int annotationBoolCount = 0;
   private int annotationCommentCount = 0;
@@ -466,17 +475,6 @@ public class FakeReader extends FormatReader {
     int fields = 0;
     int plateAcqs = 0;
 
-    // Annotations
-    int annBool = 0;
-    int annComment = 0;
-    int annDouble = 0;
-    int annLong = 0;
-    int annMap = 0;
-    int annTime = 0;
-    int annTag = 0;
-    int annTerm = 0;
-    int annXml = 0;
-
     Integer defaultColor = null;
     ArrayList<Integer> color = new ArrayList<Integer>();
 
@@ -693,8 +691,7 @@ public class FakeReader extends FormatReader {
           store.setChannelColor(channel, currentImageIndex, c);
         }
       }
-      fillAnnotations(store, currentImageIndex, annBool, annComment,
-        annDouble, annLong, annMap, annTag, annTerm, annTime, annXml);
+      fillAnnotations(store, currentImageIndex);
       fillRegions(store, currentImageIndex);
     }
 
@@ -762,7 +759,7 @@ public class FakeReader extends FormatReader {
     }
   }
 
-  private void fillAnnotations(MetadataStore store, int imageIndex, int annBool, int annComment, int annDouble, int annLong, int annMap, int annTag, int annTerm, int annTime, int annXml) {
+  private void fillAnnotations(MetadataStore store, int imageIndex) {
 
     int annotationRefCount = 0;
     String annotationID;

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -131,11 +131,11 @@ public class FakeReader extends FormatReader {
   // -- Fields --
 
   /* dimensions per image */
-  public static int sizeX = DEFAULT_SIZE_X;
-  public static int sizeY = DEFAULT_SIZE_Y;
-  public static int sizeZ = DEFAULT_SIZE_Z;
-  public static int sizeC = DEFAULT_SIZE_C;
-  public static int sizeT = DEFAULT_SIZE_T;
+  private int sizeX = DEFAULT_SIZE_X;
+  private int sizeY = DEFAULT_SIZE_Y;
+  private int sizeZ = DEFAULT_SIZE_Z;
+  private int sizeC = DEFAULT_SIZE_C;
+  private int sizeT = DEFAULT_SIZE_T;
 
   /** exposure time per plane info */
   private Time exposureTime = null;

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -162,6 +162,7 @@ public class FakeReader extends FormatReader {
   private int masks = 0;
   private int points = 0;
   private int polygons = 0;
+  private int polylines = 0;
   private int rectangles = 0;
   private int roiCount = 0;
 
@@ -573,7 +574,14 @@ public class FakeReader extends FormatReader {
       else if (key.equals("annTag")) annTag = intValue;
       else if (key.equals("annTerm")) annTerm = intValue;
       else if (key.equals("annXml")) annXml = intValue;
+      else if (key.equals("ellipses")) ellipses = intValue;
+      else if (key.equals("labels")) labels = intValue;
+      else if (key.equals("lines")) lines = intValue;
+      else if (key.equals("masks")) masks = intValue;
       else if (key.equals("points")) points = intValue;
+      else if (key.equals("polygons")) polygons = intValue;
+      else if (key.equals("polylines")) polylines = intValue;
+      else if (key.equals("rectangles")) rectangles = intValue;
       else if (key.equals("physicalSizeX")) physicalSizeX = parseLength(value, getPhysicalSizeXUnitXsdDefault());
       else if (key.equals("physicalSizeY")) physicalSizeY = parseLength(value, getPhysicalSizeYUnitXsdDefault());
       else if (key.equals("physicalSizeZ")) physicalSizeZ = parseLength(value, getPhysicalSizeZUnitXsdDefault());

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -991,7 +991,7 @@ public class FakeReader extends FormatReader {
   }
 
   private Length parseLength(String value, String defaultUnit) {
-      Matcher m = Pattern.compile("\\s*([\\d.]+)\\s*([\\D\\S]*)\\s*").matcher(value);
+      Matcher m = Pattern.compile("\\s*([\\d.]+)\\s*([^\\d\\s].*?)?\\s*").matcher(value);
       if (!m.matches()) {
         throw new RuntimeException(String.format(
                 "%s does not match a physical size!", value));

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -875,14 +875,108 @@ public class FakeReader extends FormatReader {
     int roiRefCount = 0;
     String roiID;
 
+    for (int i=0; i<ellipses; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String ellipseID = "Ellipse:" + roiCount + ":" + 0;
+
+        store.setEllipseID(ellipseID, roiCount, 0);
+        store.setEllipseX(new Double(i % sizeX), roiCount, 0);
+        store.setEllipseY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setEllipseRadiusX(new Double(1), roiCount, 0);
+        store.setEllipseRadiusY(new Double(1), roiCount, 0);
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
+    for (int i=0; i<labels; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String labelID = "Label:" + roiCount + ":" + 0;
+
+        store.setLabelID(labelID, roiCount, 0);
+        store.setLabelX(new Double(i % sizeX), roiCount, 0);
+        store.setLabelY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setLabelText("Label " + i, roiCount, 0 );
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
+    for (int i=0; i<lines; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String lineID = "Line:" + roiCount + ":" + 0;
+
+        store.setLineID(lineID, roiCount, 0);
+        store.setLineX1(new Double(i % sizeX), roiCount, 0);
+        store.setLineY1(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setLineX2(new Double(i % sizeX), roiCount, 0);
+        store.setLineY2(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
+    for (int i=0; i<masks; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String maskID = "Mask:" + roiCount + ":" + 0;
+
+        store.setMaskID(maskID, roiCount, 0);
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
     for (int i=0; i<points; i++) {
         roiID = ROI_PREFIX + roiCount;
         store.setROIID(roiID, roiCount);
         String pointID = "Point:" + roiCount + ":" + 0;
 
         store.setPointID(pointID, roiCount, 0);
-        store.setPointX(new Double(1.0), roiCount, 0);
-        store.setPointY(new Double(1.0), roiCount, 0 );
+        store.setPointX(new Double(i % sizeX), roiCount, 0);
+        store.setPointY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
+    for (int i=0; i<polygons; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String polygonID = "Polygon:" + roiCount + ":" + 0;
+
+        store.setPolygonID(polygonID, roiCount, 0);
+        // store.setPolygonPoints(new Double(i % sizeX), roiCount, 0);
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
+    for (int i=0; i<polylines; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String polylineID = "Polyline:" + roiCount + ":" + 0;
+
+        store.setPolylineID(polylineID, roiCount, 0);
+        // store.setPolylinePoints(new Double(i % sizeX), roiCount, 0);
+        store.setImageROIRef(roiID, imageIndex, roiRefCount);
+        roiCount++;
+        roiRefCount++;
+    }
+
+    for (int i=0; i<rectangles; i++) {
+        roiID = ROI_PREFIX + roiCount;
+        store.setROIID(roiID, roiCount);
+        String rectangleID = "Rectangle:" + roiCount + ":" + 0;
+
+        store.setRectangleID(rectangleID, roiCount, 0);
+        store.setRectangleX(new Double(i % sizeX), roiCount, 0);
+        store.setRectangleY(new Double(((int) i / sizeX) % sizeY), roiCount, 0);
+        store.setRectangleWidth(new Double(5.0), roiCount, 0);
+        store.setRectangleHeight(new Double(5.0), roiCount, 0);
         store.setImageROIRef(roiID, imageIndex, roiRefCount);
         roiCount++;
         roiRefCount++;

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -84,6 +84,20 @@ public class FakeReaderTest {
     };
   }
 
+  @DataProvider(name = "shapes")
+  public Object[][] shapes() {
+    return new Object[][] {
+      {"ellipses", "Ellipse"},
+      {"labels", "Label"},
+      {"lines", "Line"},
+      {"masks", "Mask"},
+      {"points", "Point"},
+      {"polygons", "Polygon"},
+      {"polylines", "Polyline"},
+      {"rectangles", "Rectangle"},
+    };
+  }
+
   @DataProvider(name = "acquisition dates")
   public Object[][] acquisitionDates() {
     return new Object[][] {
@@ -521,9 +535,9 @@ public class FakeReaderTest {
     }
   }
 
-  @Test
-  public void testPoints() throws Exception {
-    reader.setId("foo&series=5&points=10.fake");
+  @Test(dataProvider = "shapes")
+  public void testShapes(String key, String type) throws Exception {
+    reader.setId("foo&series=5&" + key + "=10.fake");
     m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getImageCount(), 5);
     assertEquals(m.getROICount(), 50);
@@ -532,13 +546,13 @@ public class FakeReaderTest {
     }
     for (int i = 0; i < m.getROICount(); i++) {
       assertEquals(m.getShapeCount(i), 1);
-      assertEquals(m.getShapeType(i, 0), "Point");
+      assertEquals(m.getShapeType(i, 0), type);
     }
   }
 
-  @Test
-  public void testPointsINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\npoints = 10");
+  @Test(dataProvider = "shapes")
+  public void testShapesINI(String key, String type) throws Exception {
+    mkIni("foo.fake.ini", "series = 5\n" + key + " = 10");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getImageCount(), 5);
@@ -548,7 +562,7 @@ public class FakeReaderTest {
     }
     for (int i = 0; i < m.getROICount(); i++) {
       assertEquals(m.getShapeCount(i), 1);
-      assertEquals(m.getShapeType(i, 0), "Point");
+      assertEquals(m.getShapeType(i, 0), type);
     }
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -520,4 +520,25 @@ public class FakeReaderTest {
       assertEquals(m.getImageAnnotationRefCount(0), 10);
     }
   }
+  
+  @Test
+  public void testPoints() throws Exception {
+    reader.setId("foo&series=5&points=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getROICount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageROIRefCount(0), 10);
+    }
+  }
+
+  @Test
+  public void testPointsINI() throws Exception {
+    mkIni("foo.fake.ini", "series = 5\npoints = 10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getROICount(), 50);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(m.getImageROIRefCount(0), 10);
+    }
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -296,10 +296,14 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
-  
+
   @Test(expectedExceptions={ RuntimeException.class })
   public void testPhysicalSizeZBadParsing() throws Exception {
-    reader.setMetadataStore(service.createOMEXMLMetadata());
+    reader.setId("foo&physicalSizeZ=1 1.fake");
+  }
+
+  @Test(expectedExceptions={ RuntimeException.class })
+  public void testPhysicalSizeZIniBadParsing() throws Exception {
     mkIni("foo.fake.ini", "physicalSizeZ = 1 1");
     reader.setId(wd.resolve("foo.fake").toString());
   }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -279,6 +279,7 @@ public class FakeReaderTest {
   public void testExtraMetadata() throws Exception {
     File fakeIni = mkIni("foo.fake.ini", "[GlobalMetadata]", "foo=bar");
     reader.setId(fakeIni.getAbsolutePath());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(reader.getGlobalMetadata().get("foo"), "bar");
   }
 
@@ -286,6 +287,7 @@ public class FakeReaderTest {
   public void testPhysicalSizeX(String value, Length length) throws Exception {
     reader.setId("foo&physicalSizeX=" + value + ".fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
   }
   
@@ -294,6 +296,7 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "physicalSizeX = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
   }
 
@@ -301,6 +304,7 @@ public class FakeReaderTest {
   public void testPhysicalSizeY(String value, Length length) throws Exception {
     reader.setId("foo&physicalSizeY=" + value + ".fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
   }
 
@@ -309,6 +313,7 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "physicalSizeY = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
   }
   
@@ -316,6 +321,7 @@ public class FakeReaderTest {
   public void testPhysicalSizeZ(String value, Length length) throws Exception {
     reader.setId("foo&physicalSizeZ=" + value + ".fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
 
@@ -324,6 +330,7 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "physicalSizeZ = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
 
@@ -342,6 +349,7 @@ public class FakeReaderTest {
   public void testAcquisitionDate(String value, Timestamp date) throws Exception {
     reader.setId("foo&acquisitionDate=" + value + ".fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getImageAcquisitionDate(0), date);
   }
 
@@ -350,6 +358,7 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "acquisitionDate = " + value);
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getImageAcquisitionDate(0), date);
   }
 
@@ -357,6 +366,7 @@ public class FakeReaderTest {
   public void testAcquisitionDateMultiSeries(String value, Timestamp date) throws Exception {
     reader.setId("foo&series=10&acquisitionDate=" + value + ".fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     for (int i = 0; i < 10; i++) {
       assertEquals(m.getImageAcquisitionDate(i), date);
     }
@@ -366,6 +376,7 @@ public class FakeReaderTest {
   public void testAnnotations(String key, String methodName) throws Exception {
     reader.setId("foo&series=5&" + key + "=10.fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     Method method = Class.forName("loci.formats.meta.MetadataRetrieve").getMethod(methodName);
     assertEquals(method.invoke(m), 50);
     for (int i = 0; i < 5; i++) {
@@ -378,6 +389,7 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "series = 5\n" + key + " = 10");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     Method method = Class.forName("loci.formats.meta.MetadataRetrieve").getMethod(methodName);
     assertEquals(method.invoke(m), 50);
     for (int i = 0; i < 5; i++) {
@@ -389,6 +401,7 @@ public class FakeReaderTest {
   public void testShapes(String key, String type) throws Exception {
     reader.setId("foo&series=5&" + key + "=10.fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getImageCount(), 5);
     assertEquals(m.getROICount(), 50);
     for (int i = 0; i < m.getImageCount(); i++) {
@@ -405,6 +418,7 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "series = 5\n" + key + " = 10");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));    
     assertEquals(m.getImageCount(), 5);
     assertEquals(m.getROICount(), 50);
     for (int i = 0; i < m.getImageCount(); i++) {

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -296,6 +296,13 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
   }
+  
+  @Test(expectedExceptions={ RuntimeException.class })
+  public void testPhysicalSizeZBadParsing() throws Exception {
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+    mkIni("foo.fake.ini", "physicalSizeZ = 1 1");
+    reader.setId(wd.resolve("foo.fake").toString());
+  }
 
   @Test(dataProvider = "acquisition dates")
   public void testAcquisitionDate(String value, Timestamp date) throws Exception {

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -81,6 +82,21 @@ public class FakeReaderTest {
       {"1.0Å", new Length(1.0, UNITS.ANGSTROM)},
       {"1.0 pixel", new Length(1.0, UNITS.PIXEL)},
       {"1.0 reference frame", new Length(1.0, UNITS.REFERENCEFRAME)},
+    };
+  }
+
+  @DataProvider(name = "annotations")
+  public Object[][] annotations() {
+    return new Object[][] {
+      {"annBool", "getBooleanAnnotationCount"},
+      {"annComment", "getCommentAnnotationCount"},
+      {"annDouble", "getDoubleAnnotationCount"},
+      {"annLong", "getLongAnnotationCount"},
+      {"annMap", "getMapAnnotationCount"},
+      {"annTag", "getTagAnnotationCount"},
+      {"annTerm", "getTermAnnotationCount"},
+      {"annTime", "getTimestampAnnotationCount"},
+      {"annXml", "getXMLAnnotationCount"},
     };
   }
 
@@ -346,190 +362,24 @@ public class FakeReaderTest {
     }
   }
 
-  @Test
-  public void testBooleanAnnotation() throws Exception {
-    reader.setId("foo&series=5&annBool=10.fake");
+  @Test(dataProvider = "annotations")
+  public void testAnnotations(String key, String methodName) throws Exception {
+    reader.setId("foo&series=5&" + key + "=10.fake");
     m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getBooleanAnnotationCount(), 50);
+    Method method = Class.forName("loci.formats.meta.MetadataRetrieve").getMethod(methodName);
+    assertEquals(method.invoke(m), 50);
     for (int i = 0; i < 5; i++) {
       assertEquals(m.getImageAnnotationRefCount(0), 10);
     }
   }
 
-  @Test
-  public void testBooleanAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannBool = 10");
+  @Test(dataProvider = "annotations")
+  public void testAnnotationsINI(String key, String methodName) throws Exception {
+    mkIni("foo.fake.ini", "series = 5\n" + key + " = 10");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getBooleanAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testCommentAnnotation() throws Exception {
-    reader.setId("foo&series=5&annComment=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getCommentAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testCommentAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannComment = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getCommentAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testDoubleAnnotation() throws Exception {
-    reader.setId("foo&series=5&annDouble=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getDoubleAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testDoubleAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannDouble = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getDoubleAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testLongAnnotation() throws Exception {
-    reader.setId("foo&series=5&annLong=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getLongAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testLongAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannLong = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getLongAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testMapAnnotation() throws Exception {
-    reader.setId("foo&series=5&annMap=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getMapAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testMapAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannMap = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getMapAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testTagAnnotation() throws Exception {
-    reader.setId("foo&series=5&annTag=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getTagAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testTagAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannTag = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getTagAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testTermAnnotation() throws Exception {
-    reader.setId("foo&series=5&annTerm=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getTermAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testTermAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannTerm = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getTermAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testTimeAnnotation() throws Exception {
-    reader.setId("foo&series=5&annTime=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getTimestampAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testTimeAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannTime = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getTimestampAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testXMLAnnotation() throws Exception {
-    reader.setId("foo&series=5&annXml=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getXMLAnnotationCount(), 50);
-    for (int i = 0; i < 5; i++) {
-      assertEquals(m.getImageAnnotationRefCount(0), 10);
-    }
-  }
-
-  @Test
-  public void testXMLAnnotationINI() throws Exception {
-    mkIni("foo.fake.ini", "series = 5\nannXml = 10");
-    reader.setId(wd.resolve("foo.fake").toString());
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertEquals(m.getXMLAnnotationCount(), 50);
+    Method method = Class.forName("loci.formats.meta.MetadataRetrieve").getMethod(methodName);
+    assertEquals(method.invoke(m), 50);
     for (int i = 0; i < 5; i++) {
       assertEquals(m.getImageAnnotationRefCount(0), 10);
     }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -520,14 +520,19 @@ public class FakeReaderTest {
       assertEquals(m.getImageAnnotationRefCount(0), 10);
     }
   }
-  
+
   @Test
   public void testPoints() throws Exception {
     reader.setId("foo&series=5&points=10.fake");
     m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getImageCount(), 5);
     assertEquals(m.getROICount(), 50);
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < m.getImageCount(); i++) {
       assertEquals(m.getImageROIRefCount(0), 10);
+    }
+    for (int i = 0; i < m.getROICount(); i++) {
+      assertEquals(m.getShapeCount(i), 1);
+      assertEquals(m.getShapeType(i, 0), "Point");
     }
   }
 
@@ -536,9 +541,14 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "series = 5\npoints = 10");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
+    assertEquals(m.getImageCount(), 5);
     assertEquals(m.getROICount(), 50);
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < m.getImageCount(); i++) {
       assertEquals(m.getImageROIRefCount(0), 10);
+    }
+    for (int i = 0; i < m.getROICount(); i++) {
+      assertEquals(m.getShapeCount(i), 1);
+      assertEquals(m.getShapeType(i, 0), "Point");
     }
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -106,10 +106,10 @@ public class FakeReaderTest {
       {"ellipses", "Ellipse"},
       {"labels", "Label"},
       {"lines", "Line"},
-      {"masks", "Mask"},
+      // {"masks", "Mask"},
       {"points", "Point"},
-      {"polygons", "Polygon"},
-      {"polylines", "Polyline"},
+      // {"polygons", "Polygon"},
+      // {"polylines", "Polyline"},
       {"rectangles", "Rectangle"},
     };
   }

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -47,6 +47,9 @@ Several keys have support for units and can be expressed as ``KEY=VALUE UNIT`` w
     echo "physicalSizeY=10 pm" >> physicalSizes.fake.ini
     echo "physicalSizeZ=.002 mm" >> physicalSizes.fake.ini
 
+High-content screening
+----------------------
+
 To generate a simple plate file:
 
 ::
@@ -78,6 +81,9 @@ to zero will be ignored and the defaults used. So, for example, the file:
     one-key-set&screens=0&plates=0&plateRows=0&plateCols=0&plateAcqs=0&fields=1.fake
 
 will create a simple plate with no screen.
+
+Key-value pairs
+---------------
 
 There are several other keys that can be added, a complete list of these,
 with their default values, is shown below.

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -82,6 +82,20 @@ to zero will be ignored and the defaults used. So, for example, the file:
 
 will create a simple plate with no screen.
 
+Regions
+-------
+
+To generate a fake file containing regions of interest:
+
+    touch "regions&points=10.fake"
+    touch "regions&ellipses=20.fake"
+    touch "regions&rectangles=5&lines=25.fake"
+
+For each shape type, the value will specify the number of regions of interest
+to create where each region of interest contains a single shape of the input
+type. By convention, all generated regions of interests are not associated to
+any given Z, C or T plane.
+
 Key-value pairs
 ---------------
 
@@ -201,6 +215,9 @@ with their default values, is shown below.
       * null
     - * color_x
       * the color for channel x, overrides the default color for that channel
+      *
+    - * ellipses, labels, lines, points, rectangles
+      * the number of ROIs containing one shape of the given type to generate
       *
 
 For full details of these keys, how unset and default values are handled and


### PR DESCRIPTION
See https://trello.com/c/HeAwzPRO/34-regions-in-fakereader and https://trello.com/c/ZMNhFXl7/106-strange-regex-in-fakereader

This PR:
- improves the parsing of quantities with units (`physicalSize`) to throw RunTimeException with the corresponding unit tests
- adds a first implementation of regions support in fake files with the corresponding unit tests

The regions support is currently limited to `Point` shapes for initial feedback. It assumes the following semantics: `foo&series=n&points=m.fake` is read as  `n` images containing `m` ROIs each where each ROI contains only one `Point` shape. 

To test this PR, check the following creates 20 `Point` ROIs:

```
./tools/showinf -omexmlonly "foo&series=2&points=10.fake"
```

Currently all shapes are at the same XY position with no ZCT. Should we introduce offsets? Across all dimensions?
