### PR TITLE
FluoviewReader - Null Pointer Fix

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -324,7 +324,7 @@ public class FluoviewReader extends BaseTiffReader {
         }
         
         ArrayList<Double> uniqueZ = new ArrayList<Double>();
-        if (i > 1) {
+        if (i > 1 && stamps != null) {
           zPositions = stamps[i - 2];
           if (zPositions != null) {
             for (Double z : zPositions) {


### PR DESCRIPTION
Issue raised by QA-17055

If MetadataOptions has the MetadataLevel set to minimum then the
readStamps function will not be called and stamps will be equal to null.

This results in the following NPE:
java.lang.NullPointerException
	at loci.formats.in.FluoviewReader.initStandardMetadata(FluoviewReader.java:328)
	at loci.formats.in.BaseTiffReader.initMetadata(BaseTiffReader.java:98)
	at loci.formats.in.BaseTiffReader.initFile(BaseTiffReader.java:577)
	at loci.formats.FormatReader.setId(FormatReader.java:1426)
	at loci.formats.ImageReader.setId(ImageReader.java:835)

To reproduce:
- Import the sample file from QA-17055 via Omero Insight 5.2.2
- Verify that the same Null Pointer Exception is reproduced

To test:
- Update the formats-gpl lib from this branch
- Re import the sample file
- Verify that the file imports sucessfully