### PR TITLE
EM formats: use native physical size units

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -38,6 +38,7 @@ import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.units.quantity.Length;
+import ome.units.UNITS;
 
 /**
  * MRCReader is the file format reader for MRC files.
@@ -219,10 +220,10 @@ public class MRCReader extends FormatReader {
       int my = in.readInt();
       int mz = in.readInt();
 
-      // physical sizes are stored in ångströms, we want them in µm
-      xSize = (in.readFloat() / mx) / 10000.0;
-      ySize = (in.readFloat() / my) / 10000.0;
-      zSize = (in.readFloat() / mz) / 10000.0;
+      // physical sizes are stored in ångströms
+      xSize = (in.readFloat() / mx);
+      ySize = (in.readFloat() / my);
+      zSize = (in.readFloat() / mz);
 
       addGlobalMeta("Pixel size (X)", xSize);
       addGlobalMeta("Pixel size (Y)", ySize);
@@ -313,9 +314,9 @@ public class MRCReader extends FormatReader {
     MetadataTools.populatePixels(store, this);
 
     if (level != MetadataLevel.MINIMUM) {
-      Length sizeX = FormatTools.getPhysicalSizeX(xSize);
-      Length sizeY = FormatTools.getPhysicalSizeY(ySize);
-      Length sizeZ = FormatTools.getPhysicalSizeZ(zSize);
+      Length sizeX = FormatTools.getPhysicalSizeX(xSize, UNITS.ANGSTROM);
+      Length sizeY = FormatTools.getPhysicalSizeY(ySize, UNITS.ANGSTROM);
+      Length sizeZ = FormatTools.getPhysicalSizeZ(zSize, UNITS.ANGSTROM);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -220,9 +220,9 @@ public class MRCReader extends FormatReader {
       int my = in.readInt();
       int mz = in.readInt();
 
-      int xlen = in.readFloat();
-      int ylen = in.readFloat();
-      int zlen = in.readFloat();
+      float xlen = in.readFloat();
+      float ylen = in.readFloat();
+      float zlen = in.readFloat();
 
       // physical sizes are stored in ångströms
       xSize = (xlen / mx);

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -220,14 +220,22 @@ public class MRCReader extends FormatReader {
       int my = in.readInt();
       int mz = in.readInt();
 
-      // physical sizes are stored in ångströms
-      xSize = (in.readFloat() / mx);
-      ySize = (in.readFloat() / my);
-      zSize = (in.readFloat() / mz);
+      int xlen = in.readFloat();
+      int ylen = in.readFloat();
+      int zlen = in.readFloat();
 
-      addGlobalMeta("Pixel size (X)", xSize);
-      addGlobalMeta("Pixel size (Y)", ySize);
-      addGlobalMeta("Pixel size (Z)", zSize);
+      // physical sizes are stored in ångströms
+      xSize = (xlen / mx);
+      ySize = (ylen / my);
+      zSize = (zlen / mz);
+
+      addGlobalMeta("Grid size (X)", mx);
+      addGlobalMeta("Grid size (Y)", my);
+      addGlobalMeta("Grid size (Z)", mz);
+
+      addGlobalMeta("Cell size (X)", xlen);
+      addGlobalMeta("Cell size (Y)", ylen);
+      addGlobalMeta("Cell size (Z)", zlen);
 
       addGlobalMeta("Alpha angle", in.readFloat());
       addGlobalMeta("Beta angle", in.readFloat());

--- a/components/formats-gpl/src/loci/formats/in/SpiderReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SpiderReader.java
@@ -274,9 +274,9 @@ public class SpiderReader extends FormatReader {
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-      Double size = new Double(pixelSize * 0.0001);
-      Length sizeX = FormatTools.getPhysicalSizeX(size);
-      Length sizeY = FormatTools.getPhysicalSizeY(size);
+      Double size = new Double(pixelSize);
+      Length sizeX = FormatTools.getPhysicalSizeX(size, UNITS.ANGSTROM);
+      Length sizeY = FormatTools.getPhysicalSizeY(size, UNITS.ANGSTROM);
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);
       }

--- a/components/formats-gpl/src/loci/formats/in/SpiderReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SpiderReader.java
@@ -38,6 +38,7 @@ import loci.formats.meta.MetadataStore;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.Timestamp;
 import ome.units.quantity.Length;
+import ome.units.UNITS;
 
 /**
  * SpiderReader is the file format reader for SPIDER files.


### PR DESCRIPTION
This PR adds native length support for EM readers. To test this PR, open some MRC and Spider datasets and check the pixel size is stored in Angstroms.

Note the last commit 7a474b2 modifies the content of the original metadata stored for the MRC format to sotre the values read  from the [MRC header](http://bio3d.colorado.edu/imod/doc/mrc_format.txt). 