### PR TITLE
OMEXMLMetadataImpl Template - Remove unwanted comment

### DIFF
--- a/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
+++ b/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
@@ -70,7 +70,6 @@
     ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop))}.get${obj.parentName}(${index_name_string(obj.parentName)});
     return o.getLinked${prop.methodName}().getID();
 {% end %}
-// ${o.parent}
 {% when obj.isConcreteSubstitution or o.isAbstractSubstitution %}\
     // ${obj.parentName} is abstract and not a reference
     ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop))}.get${obj.parentName}(${index_name_string(obj.parentName)});


### PR DESCRIPTION
Fix for issue seen in https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-generated-sources/152/

Extra comments such as the below were appearing in the Java generated version of OMEXMLMetadataImpl:
// <"TiffData" XschemaElement instance at 0x106aaff38>

This was a debug comment which should not be present in the generated file, 

To test: 
- Generate OMEXMLMetadataImpl.java
- Verify that there are no instances of XschemaElement mentioned in any comments in the file