### PR TITLE
Improved OutOfMemory handling in automated tests

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -314,9 +314,12 @@ public class FormatReaderTest {
         try {
           b = reader.openThumbImage(0);
         }
-        catch (OutOfMemoryError e) {
-          result(testName, true, "Image too large");
-          return;
+        catch (Throwable e) {
+          if (TestTools.isOutOfMemory(e)) {
+            result(testName, true, "Image too large");
+            return;
+          }
+          throw e;
         }
 
         int actualX = b.getWidth();
@@ -389,9 +392,12 @@ public class FormatReaderTest {
         try {
           b = reader.openThumbBytes(0);
         }
-        catch (OutOfMemoryError e) {
-          result(testName, true, "Image too large");
-          return;
+        catch (Throwable e) {
+          if (TestTools.isOutOfMemory(e)) {
+            result(testName, true, "Image too large");
+            return;
+          }
+          throw e;
         }
         success = b.length == expected;
         if (!success) {

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -494,4 +494,23 @@ public class TestTools {
     return ir;
   }
 
+  /**
+   * Determine whether or not a Throwable was caused by an OutOfMemoryError.
+   *
+   * @param t Throwable object to check
+   * @return true if <code>t</code> is or was caused by an OutOfMemoryError, false otherwise
+   */
+  public static boolean isOutOfMemory(Throwable t) {
+    if (t instanceof OutOfMemoryError) {
+      return true;
+    }
+    while (t.getCause() != null) {
+      if (t.getCause() instanceof OutOfMemoryError) {
+        return true;
+      }
+      t = t.getCause();
+    }
+    return false;
+  }
+
 }

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -141,7 +141,11 @@ public class TestTools {
   /** Returns true if a byte buffer of the given size will fit in memory. */
   public static boolean canFitInMemory(long bufferSize) {
     Runtime r = Runtime.getRuntime();
-    long mem = r.freeMemory() / 2;
+
+    // better indicator than freeMemory() of how much memory is actually available
+    long mem = r.maxMemory() - (r.totalMemory() - r.freeMemory());
+
+    mem /= 2;
     int threadCount = 1;
     try {
       threadCount = Integer.parseInt(System.getProperty("testng.threadCount"));


### PR DESCRIPTION
See builds 99-103 of https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/

This does a better job of detecting OOMs in thumbnail tests, as well as more accurately reporting the amount of free memory available.

While the latest builds are failing primarily on new CellSens datasets, I wasn't able to find any obvious memory leaks specific to CellSens; as discussed with @joshmoore and @sbesson, it's likely that we're reaching the limit of how much data can reasonably be tested at once.

Apart from code review, the easiest way to test this is likely to observe all of the jobs for a week or two to verify that OOM-related failures are no longer present.