### PR TITLE
FakeReader: fix close() and reopenFile()

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -769,6 +769,10 @@ public class FakeReader extends FormatReader {
     }
   }
 
+  @Override
+  public void reopenFile() throws IOException {
+  }
+
   private void fillPhysicalSizes(MetadataStore store) {
     if (physicalSizeX == null && physicalSizeY == null && physicalSizeZ == null) return;
     for (int s=0; s<getSeriesCount(); s++) {

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -368,6 +368,43 @@ public class FakeReader extends FormatReader {
   @Override
   public void close(boolean fileOnly) throws IOException {
     iniFile = null;
+    sizeX = DEFAULT_SIZE_X;
+    sizeY = DEFAULT_SIZE_Y;
+    sizeZ = DEFAULT_SIZE_Z;
+    sizeC = DEFAULT_SIZE_C;
+    sizeT = DEFAULT_SIZE_T;
+    exposureTime = null;
+    physicalSizeX = null;
+    physicalSizeY = null;
+    physicalSizeZ = null;
+    annBool = 0;
+    annComment = 0;
+    annDouble = 0;
+    annLong = 0;
+    annMap = 0;
+    annTime = 0;
+    annTag = 0;
+    annTerm = 0;
+    annXml = 0;
+    annotationCount = 0;
+    annotationBoolCount = 0;
+    annotationCommentCount = 0;
+    annotationDoubleCount = 0;
+    annotationLongCount = 0;
+    annotationMapCount = 0;
+    annotationTagCount = 0;
+    annotationTermCount = 0;
+    annotationTimeCount = 0;
+    annotationXmlCount = 0;
+    ellipses = 0;
+    labels = 0;
+    lines = 0;
+    masks = 0;
+    points = 0;
+    polygons = 0;
+    polylines = 0;
+    rectangles = 0;
+    roiCount = 0;
     super.close(fileOnly);
   }
 

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -405,6 +405,9 @@ public class FakeReader extends FormatReader {
     polylines = 0;
     rectangles = 0;
     roiCount = 0;
+    scaleFactor = 1;
+    lut8 = null;
+    lut16 = null;
     super.close(fileOnly);
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -173,6 +173,12 @@ public class FakeReaderTest {
   }
 
   @Test
+  public void testReopenFile() throws Exception {
+    reader.setId("foo.fake");
+    reader.reopenFile();
+  }
+
+  @Test
   public void testCompanionFile() throws Exception {
     Files.createFile(wd.resolve("foo.fake.ini"));
     reader.setId(Files.createFile(wd.resolve("foo.fake")).toString());

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -296,6 +296,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
+    reader.close();
+    testDefaultValues();
   }
   
   @Test(dataProvider = "physical sizes")
@@ -305,6 +307,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeX(0), length);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "physical sizes")
@@ -313,6 +317,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "physical sizes")
@@ -322,6 +328,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeY(0), length);
+    reader.close();
+    testDefaultValues();
   }
   
   @Test(dataProvider = "physical sizes")
@@ -330,6 +338,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "physical sizes")
@@ -339,6 +349,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getPixelsPhysicalSizeZ(0), length);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(expectedExceptions={ RuntimeException.class })
@@ -358,6 +370,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getImageAcquisitionDate(0), date);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "acquisition dates")
@@ -367,6 +381,8 @@ public class FakeReaderTest {
     m = service.asRetrieve(reader.getMetadataStore());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(m.getImageAcquisitionDate(0), date);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "acquisition dates")
@@ -377,6 +393,8 @@ public class FakeReaderTest {
     for (int i = 0; i < 10; i++) {
       assertEquals(m.getImageAcquisitionDate(i), date);
     }
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "annotations")
@@ -389,6 +407,8 @@ public class FakeReaderTest {
     for (int i = 0; i < 5; i++) {
       assertEquals(m.getImageAnnotationRefCount(0), 10);
     }
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "annotations")
@@ -402,6 +422,8 @@ public class FakeReaderTest {
     for (int i = 0; i < 5; i++) {
       assertEquals(m.getImageAnnotationRefCount(0), 10);
     }
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "shapes")
@@ -418,6 +440,8 @@ public class FakeReaderTest {
       assertEquals(m.getShapeCount(i), 1);
       assertEquals(m.getShapeType(i, 0), type);
     }
+    reader.close();
+    testDefaultValues();
   }
 
   @Test(dataProvider = "shapes")
@@ -435,5 +459,7 @@ public class FakeReaderTest {
       assertEquals(m.getShapeCount(i), 1);
       assertEquals(m.getShapeType(i, 0), type);
     }
+    reader.close();
+    testDefaultValues();
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -197,7 +197,9 @@ public class FakeReaderTest {
 
   @Test
   public void testDefaultValues() throws Exception {
-    reader.setId("foo.fake");
+    reader.setId("default.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(reader.getSizeX(), FakeReader.DEFAULT_SIZE_X);
     assertEquals(reader.getSizeY(), FakeReader.DEFAULT_SIZE_Y);
     assertEquals(reader.getSizeZ(), FakeReader.DEFAULT_SIZE_Z);
@@ -208,6 +210,11 @@ public class FakeReaderTest {
                  FakeReader.DEFAULT_RGB_CHANNEL_COUNT);
     assertEquals(reader.getDimensionOrder(),
                  FakeReader.DEFAULT_DIMENSION_ORDER);
+    assertEquals(m.getImageAcquisitionDate(0), null);
+    assertEquals(m.getPixelsPhysicalSizeX(0), null);
+    assertEquals(m.getPixelsPhysicalSizeY(0), null);
+    assertEquals(m.getPixelsPhysicalSizeZ(0), null);
+    assertEquals(m.getROICount(), 0);
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -348,8 +348,8 @@ public class MemoizerTest {
     // Try to reopen the file with the Memoizer
     memoizer.setId(newid);
     memoizer.close();
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertFalse(memoizer.isSavedToMemo());
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
See https://trello.com/c/XkVbBZ2X/111-fakereader-reset-variables-when-reader-is-closed and https://trello.com/c/IdLyg8yn/89-fakereader-reopenfile-fails-with-filenotfoundexception


The unit tests additions should cover these test cases so checking Travis and the daily builds should be sufficient. To be thorough, a simple workflow as follows could be tested and should not raise any exception:

```
IFormatReader reader = new FakeReader();
reader.setId("foo&points=10.fake");
reader.reopenFile();
reader.close();
reader.setId("foo.fake");
```
