### PR TITLE
DataTools: add number parsing API 

### DIFF
--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -474,6 +474,7 @@ public final class DataTools {
    * @return {@code null} if the string could not be parsed
    */
   public static Float parseFloat(String value) {
+    if (value == null) return null;
     try {
       return Float.valueOf(sanitizeDecimalString(value));
     } catch (NumberFormatException e) {
@@ -488,6 +489,7 @@ public final class DataTools {
    * @return {@code null} if the string could not be parsed
    */
   public static Double parseDouble(String value) {
+    if (value == null) return null;
     try {
       return Double.valueOf(sanitizeDecimalString(value));
     } catch (NumberFormatException e) {

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -54,6 +54,9 @@ public final class DataTools {
   // -- Static fields --
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTools.class);
 
+  // Character used for the decimal sign in the current locale
+  private static final char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+
   // -- Constructor --
 
   private DataTools() { }
@@ -496,9 +499,8 @@ public final class DataTools {
   /** Normalizes the decimal separator of a string for the user's locale. */
   private static String sanitizeDecimalString(String value) {
     value = value.replaceAll("[^0-9,\\.]", "");
-    char separator = new DecimalFormatSymbols().getDecimalSeparator();
-    char usedSeparator = separator == '.' ? ',' : '.';
-    return value.replace(usedSeparator, separator);
+    char usedSeparator = decimalSeparator == '.' ? ',' : '.';
+    return value.replace(usedSeparator, decimalSeparator);
   }
 
   /**

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -413,7 +413,99 @@ public final class DataTools {
     return sb.toString();
   }
 
-  /** Normalize the decimal separator for the user's locale. */
+  /**
+   * Parses the input string into a short
+   * @return {@code null} if the string could not be parsed
+   */
+  public static Short parseShort(String value) {
+    try {
+      return Short.valueOf(value);
+    } catch (NumberFormatException e) {
+      LOGGER.debug("Could not parse integer value", e);
+    }
+    return null;
+  }
+
+  /**
+   * Parses the input string into a byte
+   * @return {@code null} if the string could not be parsed
+   */
+  public static Byte parseByte(String value) {
+    try {
+      return Byte.valueOf(value);
+    } catch (NumberFormatException e) {
+      LOGGER.debug("Could not parse integer value", e);
+    }
+    return null;
+  }
+
+  /**
+   * Parses the input string into an integer
+   * @return {@code null} if the string could not be parsed
+   */
+  public static Integer parseInteger(String value) {
+    try {
+      return Integer.valueOf(value);
+    } catch (NumberFormatException e) {
+      LOGGER.debug("Could not parse integer value", e);
+    }
+    return null;
+  }
+
+  /**
+   * Parses the input string into a long
+   * @return {@code null} if the string could not be parsed
+   */
+  public static Long parseLong(String value) {
+    try {
+      return Long.valueOf(value);
+    } catch (NumberFormatException e) {
+      LOGGER.debug("Could not parse integer value", e);
+    }
+    return null;
+  }
+
+  /**
+   * Parses the input string into a float accounting for the locale decimal
+   * separator
+   * @return {@code null} if the string could not be parsed
+   */
+  public static Float parseFloat(String value) {
+    try {
+      return Float.valueOf(sanitizeDecimalString(value));
+    } catch (NumberFormatException e) {
+      LOGGER.debug("Could not parse float value", e);
+    }
+    return null;
+  }
+
+  /**
+   * Parses the input string into a double accounting for the locale decimal
+   * separator
+   * @return {@code null} if the string could not be parsed
+   */
+  public static Double parseDouble(String value) {
+    try {
+      return Double.valueOf(sanitizeDecimalString(value));
+    } catch (NumberFormatException e) {
+      LOGGER.debug("Could not parse double value", e);
+    }
+    return null;
+  }
+
+  /** Normalizes the decimal separator of a string for the user's locale. */
+  private static String sanitizeDecimalString(String value) {
+    value = value.replaceAll("[^0-9,\\.]", "");
+    char separator = new DecimalFormatSymbols().getDecimalSeparator();
+    char usedSeparator = separator == '.' ? ',' : '.';
+    return value.replace(usedSeparator, separator);
+  }
+
+  /**
+   * Normalizes the decimal separator for the user's locale.
+   * @deprecated Use {@link parseDouble(String)} instead
+   */
+  @Deprecated
   public static String sanitizeDouble(String value) {
     value = value.replaceAll("[^0-9,\\.]", "");
     char separator = new DecimalFormatSymbols().getDecimalSeparator();

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -503,7 +503,7 @@ public final class DataTools {
 
   /**
    * Normalizes the decimal separator for the user's locale.
-   * @deprecated Use {@link parseDouble(String)} instead
+   * @deprecated Use {@link #parseDouble(String)} instead
    */
   @Deprecated
   public static String sanitizeDouble(String value) {

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -36,6 +36,9 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormatSymbols;
 
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
 /**
  * A utility class with convenience methods for
  * reading, writing and decoding words.
@@ -49,6 +52,7 @@ public final class DataTools {
   // -- Constants --
 
   // -- Static fields --
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataTools.class);
 
   // -- Constructor --
 

--- a/components/formats-common/test/loci/common/utests/DataToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DataToolsTest.java
@@ -150,4 +150,63 @@ public class DataToolsTest {
     fail("Safe multiply succeeded with value: " + actual);
   }
 
+  @Test
+  public void testParseByte() {
+    assertEquals(DataTools.parseByte("0"), new Byte((byte)0));
+    assertEquals(DataTools.parseByte("1"), new Byte((byte)1));
+    assertEquals(DataTools.parseByte("1.0"), null);
+    assertEquals(DataTools.parseByte("0.1"), null);
+    assertEquals(DataTools.parseByte("0,1"), null);
+    assertEquals(DataTools.parseByte("not a number"), null);
+  }
+
+  @Test
+  public void testParseShort() {
+    assertEquals(DataTools.parseShort("0"), new Short((short)0));
+    assertEquals(DataTools.parseShort("1"), new Short((short)1));
+    assertEquals(DataTools.parseShort("1.0"), null);
+    assertEquals(DataTools.parseShort("0.1"), null);
+    assertEquals(DataTools.parseShort("0,1"), null);
+    assertEquals(DataTools.parseShort("not a number"), null);
+  }
+
+  @Test
+  public void testParseInteger() {
+    assertEquals(DataTools.parseInteger("0"), Integer.valueOf(0));
+    assertEquals(DataTools.parseInteger("1"), Integer.valueOf(1));
+    assertEquals(DataTools.parseInteger("1.0"), null);
+    assertEquals(DataTools.parseInteger("0.1"), null);
+    assertEquals(DataTools.parseInteger("0,1"), null);
+    assertEquals(DataTools.parseInteger("not a number"), null);
+  }
+
+  @Test
+  public void testParseLong() {
+    assertEquals(DataTools.parseLong("0"), Long.valueOf(0));
+    assertEquals(DataTools.parseLong("1"), Long.valueOf(1));
+    assertEquals(DataTools.parseLong("1.0"), null);
+    assertEquals(DataTools.parseLong("0.1"), null);
+    assertEquals(DataTools.parseLong("0,1"), null);
+    assertEquals(DataTools.parseLong("not a number"), null);
+  }
+
+  @Test
+  public void testParseFloat() {
+    assertEquals(DataTools.parseFloat("0"), 0.0f);
+    assertEquals(DataTools.parseFloat("1"), 1.0f);
+    assertEquals(DataTools.parseFloat("1.0"), 1.0f);
+    assertEquals(DataTools.parseFloat("0.1"), 0.1f);
+    assertEquals(DataTools.parseFloat("0,1"), 0.1f);
+    assertEquals(DataTools.parseFloat("not a number"), null);
+  }
+
+  @Test
+  public void testParseDouble() {
+    assertEquals(DataTools.parseDouble("0"), 0.0d);
+    assertEquals(DataTools.parseDouble("1"), 1.0d);
+    assertEquals(DataTools.parseDouble("1.0"), 1.0d);
+    assertEquals(DataTools.parseDouble("0.1"), 0.1d);
+    assertEquals(DataTools.parseDouble("0,1"), 0.1d);
+    assertEquals(DataTools.parseDouble("not a number"), null);
+  }
 }

--- a/components/formats-common/test/loci/common/utests/DataToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DataToolsTest.java
@@ -152,6 +152,8 @@ public class DataToolsTest {
 
   @Test
   public void testParseByte() {
+    assertEquals(DataTools.parseByte(null), null);
+    assertEquals(DataTools.parseByte(""), null);
     assertEquals(DataTools.parseByte("0"), new Byte((byte)0));
     assertEquals(DataTools.parseByte("1"), new Byte((byte)1));
     assertEquals(DataTools.parseByte("1.0"), null);
@@ -162,6 +164,8 @@ public class DataToolsTest {
 
   @Test
   public void testParseShort() {
+    assertEquals(DataTools.parseShort(null), null);
+    assertEquals(DataTools.parseShort(""), null);
     assertEquals(DataTools.parseShort("0"), new Short((short)0));
     assertEquals(DataTools.parseShort("1"), new Short((short)1));
     assertEquals(DataTools.parseShort("1.0"), null);
@@ -172,6 +176,8 @@ public class DataToolsTest {
 
   @Test
   public void testParseInteger() {
+    assertEquals(DataTools.parseInteger(null), null);
+    assertEquals(DataTools.parseInteger(""), null);
     assertEquals(DataTools.parseInteger("0"), Integer.valueOf(0));
     assertEquals(DataTools.parseInteger("1"), Integer.valueOf(1));
     assertEquals(DataTools.parseInteger("1.0"), null);
@@ -182,6 +188,8 @@ public class DataToolsTest {
 
   @Test
   public void testParseLong() {
+    assertEquals(DataTools.parseLong(null), null);
+    assertEquals(DataTools.parseLong(""), null);
     assertEquals(DataTools.parseLong("0"), Long.valueOf(0));
     assertEquals(DataTools.parseLong("1"), Long.valueOf(1));
     assertEquals(DataTools.parseLong("1.0"), null);
@@ -192,6 +200,8 @@ public class DataToolsTest {
 
   @Test
   public void testParseFloat() {
+    assertEquals(DataTools.parseFloat(null), null);
+    assertEquals(DataTools.parseFloat(""), null);
     assertEquals(DataTools.parseFloat("0"), 0.0f);
     assertEquals(DataTools.parseFloat("1"), 1.0f);
     assertEquals(DataTools.parseFloat("1.0"), 1.0f);
@@ -202,6 +212,8 @@ public class DataToolsTest {
 
   @Test
   public void testParseDouble() {
+    assertEquals(DataTools.parseDouble(null), null);
+    assertEquals(DataTools.parseDouble(""), null);
     assertEquals(DataTools.parseDouble("0"), 0.0d);
     assertEquals(DataTools.parseDouble("1"), 1.0d);
     assertEquals(DataTools.parseDouble("1.0"), 1.0d);


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/7782

This PR adds a number of utility functions to `DataTools` allowing to generically:
- account for decimal separators in different locales (`.` vs `,`)
- parse a String into Double, Float, Integer...
- handle NumberFormatException thrown when parsing
Unit tests have been added to cover the newly added functions.

As discussed in http://trac.openmicroscopy.org/ome/ticket/7782, following the acceptance of this new API, all readers should be reviewed and string parsing should use this new API. I will review all candidate readers and open a corresponding card. Note this review should likely be done down the development line when we are sure we are not releasing any bug fix 5.1.x release.