### PR TITLE
NativeND2Reader: Fix for the emmission wavelength

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -51,6 +51,7 @@ import loci.formats.meta.MetadataStore;
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
+
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Frequency;
 import ome.units.quantity.Length;
@@ -2233,7 +2234,7 @@ public class NativeND2Reader extends FormatReader {
           if (value.endsWith("Active")) {
             int first = key.lastIndexOf(":") + 1;
             int last = key.lastIndexOf(";");
-            if(last-first < 0){
+            if (last-first < 0){
                 last = first + key.substring(first).indexOf(' ');
             }
             try {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -48,11 +48,9 @@ import loci.formats.codec.CodecOptions;
 import loci.formats.codec.JPEG2000Codec;
 import loci.formats.codec.ZlibCodec;
 import loci.formats.meta.MetadataStore;
-
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
-
 import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Frequency;
 import ome.units.quantity.Length;
@@ -2235,9 +2233,12 @@ public class NativeND2Reader extends FormatReader {
           if (value.endsWith("Active")) {
             int first = key.lastIndexOf(":") + 1;
             int last = key.lastIndexOf(";");
+            if(last-first < 0){
+                last = first + key.substring(first).indexOf(' ');
+            }
             try {
               textEmissionWavelengths.add(
-                new Double(key.substring(first, last)) + 20);
+                new Double(key.substring(first, last).trim()) + 20);
             }
             catch (NumberFormatException nfe) {
               LOGGER.trace("Could not parse emission wavelength", nfe);

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -48,6 +48,7 @@ import loci.formats.codec.CodecOptions;
 import loci.formats.codec.JPEG2000Codec;
 import loci.formats.codec.ZlibCodec;
 import loci.formats.meta.MetadataStore;
+
 import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;


### PR DESCRIPTION
ref: http://trac.openmicroscopy.org/ome/ticket/13179

Testing Instructions : 

Please try opening the 'nd2' file from QA 17099 in FIJI/ImageJ. Without this PR you should be getting a String parsing exception. This PR should fix that issue, and open the image without any issues. Also compare the values for the 'emission wavelengths' between NISElements Viewer and Bio-Formats, and check if the values match.

@melissalinkert @jburel : As always, please let me know if the code change looks fine.