### PR TITLE
SDT: fix width padding calculation for single-pixel image (rebased onto dev_5_1)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -150,12 +150,23 @@ public class SDTReader extends FormatReader {
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     boolean little = isLittleEndian();
 
+    long blockSize = info.allBlockLengths[getSeries()];
+
     int paddedWidth = sizeX + ((4 - (sizeX % 4)) % 4);
     int times = timeBins;
     if (info.mcstaPoints == getSizeT()) {
       times = getSizeT();
     }
     int planeSize = paddedWidth * sizeY * times * bpp;
+
+    // remove width padding if we can be reasonably certain
+    // that the unpadded width is correct
+    if (paddedWidth > sizeX && planeSize * getSizeC() > blockSize &&
+      (planeSize / paddedWidth) * sizeX * getSizeC() <= blockSize)
+    {
+      paddedWidth = sizeX;
+      planeSize = sizeX * sizeY * times * bpp;
+    }
 
     if (preLoad  && !intensity) {
       int channel = no / times;


### PR DESCRIPTION

This is the same as gh-2253 but rebased onto dev_5_1.

----

See https://trello.com/c/57Xzqhzz/95-sdtreader-issue-in-openbytes

To test, use the file from QA 17017.  Without this change, ```showinf``` on the file will throw an exception as noted in the Trello card.  With this change, the entire (single pixel) image should be read without an error.  A configuration PR for QA 17017 is forthcoming.

/cc @imunro for validation with previously-working version of FLIMfit

                