### PR TITLE
Deltavision: new date format and native units (rebased onto dev_5_1)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -64,7 +64,12 @@ public class DeltavisionReader extends FormatReader {
   public static final int DV_MAGIC_BYTES_1 = 0xa0c0;
   public static final int DV_MAGIC_BYTES_2 = 0xc0a0;
 
+  /* Deprecated in favor of DATE_FORMATS */
   public static final String DATE_FORMAT = "E MMM d HH:mm:ss yyyy";
+  public static final String[] DATE_FORMATS = {
+    "E MMM d HH:mm:ss yyyy",
+    "E MMM  d HH:mm:ss yyyy",
+  };
 
   private static final short LITTLE_ENDIAN = -16224;
   private static final int HEADER_LENGTH = 1024;
@@ -1202,7 +1207,7 @@ public class DeltavisionReader extends FormatReader {
       else if (line.startsWith("Image")) prefix = line;
       else if (line.startsWith("Created")) {
         if (line.length() > 8) line = line.substring(8).trim();
-        String date = DateTools.formatDate(line, DATE_FORMAT);
+        String date = DateTools.formatDate(line, DATE_FORMATS);
         if (date != null) {
           for (int series=0; series<getSeriesCount(); series++) {
             store.setImageAcquisitionDate(new Timestamp(date), series);

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2272,7 +2272,7 @@ public class DeltavisionReader extends FormatReader {
       store.setObjectiveCalibratedMagnification(calibratedMagnification, 0, 0);
     }
     if (workingDistance != null) {
-      store.setObjectiveWorkingDistance(new Length(workingDistance * 1000, UNITS.MICROM), 0, 0);
+      store.setObjectiveWorkingDistance(new Length(workingDistance, UNITS.MM), 0, 0);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -64,7 +64,10 @@ public class DeltavisionReader extends FormatReader {
   public static final int DV_MAGIC_BYTES_1 = 0xa0c0;
   public static final int DV_MAGIC_BYTES_2 = 0xc0a0;
 
-  /* Deprecated in favor of DATE_FORMATS */
+ /**
+  * @deprecated Use {@link #DATE_FORMATS} instead
+  */
+  @Deprecated
   public static final String DATE_FORMAT = "E MMM d HH:mm:ss yyyy";
   public static final String[] DATE_FORMATS = {
     "E MMM d HH:mm:ss yyyy",


### PR DESCRIPTION

This is the same as gh-2257 but rebased onto dev_5_1.

----

See https://trello.com/c/y5FN422r/61-deltavision-reader-date-parsing

With this PR included,:
- Deltavision datasets like the one liked from the card should have their date correctly parsed by Bio-Formats 
- working distance should be stored using the native unit (MM)

To test this PR:
- check the automated tests pass agains the repository with the new sample DV file included
- open the sample file with `showinf -nopix -omexml-only ` and check that no warning is output regarding the date format, the `AcquisitionDate` is populated in the OME-XML metadata and the `Objective` `WorkingDistanceUnit` is expressed in `mm`.

                