### PR TITLE
Micromanager: clean up JSON metadata parsing (rebased onto dev_5_1)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -489,6 +489,7 @@ public class MicromanagerReader extends FormatReader {
           IFD ifd = ifds.get(i);
           parser.fillInIFD(ifd);
           json = ifd.getIFDTextValue(MM_JSON_TAG);
+          LOGGER.trace("JSON for IFD #{} = {}", i, json);
           if (json == null) {
             // if one of the files is missing the per-plane JSON tag,
             // assume all files are missing it (for performance)

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2203,6 +2203,13 @@ public class FormatReaderTest {
             {
               continue;
             }
+            if (!result && r instanceof MicromanagerReader &&
+              readers[j] instanceof MicromanagerReader &&
+              (used[i].toLowerCase().endsWith(".ome.tif") ||
+              used[i].toLowerCase().endsWith(".ome.tiff")))
+            {
+              continue;
+            }
 
             if (result && r instanceof TrestleReader &&
               (readers[j] instanceof JPEGReader ||


### PR DESCRIPTION

This is the same as gh-2262 but rebased onto dev_5_1.

----

See QA 17040.  This should correctly parse various types of arrays and
keys with child attributes.  As noted previously, this should eventually be replaced
by use of a real JSON library.

To test, use the *.txt files from QA 17040.  Without this change, as noted in the comments for QA 17040:

```
You should see lines like this in the metadata display:
Plane #0 08 39 -0800
Plane #0 ] Camera-SaturatePixels
Plane #1 08 40 -0800
Plane #1 ] Camera-SaturatePixels
et cetera. 
```

With this change, none of the metadata keys should contain ```]``` or ```[``` or be just numbers, the ```Camera-SaturatePixels``` key should be present for every plane, and in general there shouldn't be anything that looks odd.  It's also possible to double-check against the actual JSON strings by turning on TRACE-level debugging, but that requires some patience as the JSON strings do not contain line breaks and are thus a little tricky to read as-is.

                