### PR TITLE
Gatan: fix physical size parsing and use native units (rebased onto dev_5_1)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -483,12 +483,12 @@ public class GatanReader extends FormatReader {
       if (value != null) {
         addGlobalMeta(labelString, value);
 
-        if (labelString.equals("Scale")) {
+        if (labelString.equals("Scale") && !parent.equals("Calibration")) {
           if (value.indexOf(",") == -1) {
             pixelSizes.add(f.parse(value).doubleValue());
           }
         }
-        else if (labelString.equals("Units")) {
+        else if (labelString.equals("Units") && !parent.equals("Calibration")) {
           // make sure that we don't add more units than sizes
           if (pixelSizes.size() == units.size() + 1) {
             units.add(value);

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -45,6 +45,7 @@ import ome.units.quantity.ElectricPotential;
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
 import ome.units.UNITS;
+import ome.units.unit.Unit;
 
 /**
  * GatanReader is the file format reader for Gatan files.
@@ -252,10 +253,8 @@ public class GatanReader extends FormatReader {
         Double y = pixelSizes.get(index + 1);
         String xUnits = index < units.size() ? units.get(index) : "";
         String yUnits = index + 1 < units.size() ? units.get(index + 1) : "";
-        x = correctForUnits(x, xUnits);
-        y = correctForUnits(y, yUnits);
-        Length sizeX = FormatTools.getPhysicalSizeX(x);
-        Length sizeY = FormatTools.getPhysicalSizeY(y);
+        Length sizeX = FormatTools.getPhysicalSizeX(x, convertUnits(xUnits));
+        Length sizeY = FormatTools.getPhysicalSizeY(y, convertUnits(yUnits));
         if (sizeX != null) {
           store.setPixelsPhysicalSizeX(sizeX, 0);
         }
@@ -266,9 +265,7 @@ public class GatanReader extends FormatReader {
         if (index < pixelSizes.size() - 2) {
           Double z = pixelSizes.get(index + 2);
           String zUnits = index + 2 < units.size() ? units.get(index + 2) : "";
-          z = correctForUnits(z, zUnits);
-          Length sizeZ = FormatTools.getPhysicalSizeZ(z);
-
+          Length sizeZ = FormatTools.getPhysicalSizeZ(z, convertUnits(zUnits));
           if (sizeZ != null) {
             store.setPixelsPhysicalSizeZ(sizeZ, 0);
           }
@@ -616,17 +613,16 @@ public class GatanReader extends FormatReader {
     }
   }
 
-  private Double correctForUnits(Double value, String units) {
-    Double newValue = value;
+  private Unit<Length> convertUnits(String units) {
     Collator c = Collator.getInstance(Locale.ENGLISH);
     if (units != null) {
       if (c.compare("nm", units) == 0) {
-        newValue /= 1000;
+        return UNITS.NM;
       } else if (c.compare("um", units) != 0 && c.compare("µm", units) != 0) {
         LOGGER.warn("Not adjusting for unknown units: {}", units);
       }
     }
-    return newValue;
+    return UNITS.MICROM;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -471,7 +471,7 @@ public class GatanReader extends FormatReader {
         skipPadding();
         skipPadding();
         int num = in.readInt();
-        LOGGER.debug("{}{}: group({}) {", new Object[] {indent, i, num});
+        LOGGER.debug("{}{}: group({}) {} {", new Object[] {indent, i, num, labelString});
         parseTags(num, labelString, indent + "  ");
         LOGGER.debug("{}}", indent);
       }


### PR DESCRIPTION

This is the same as gh-2276 but rebased onto dev_5_1.

----

See https://trello.com/c/11hj6Ixk/47-fix-gatan-dm4-metadata-parsing.

This PR:
- fixes the erroneous metadata parsing reported in https://github.com/openmicroscopy/bioformats/pull/1979#issuecomment-140699287 by excluding the `Scale` key/value pairs associated with `Calibration` groups - the physical sizes of the QA file mentioned in the PR should be 0.01255um in X and Y and 0.05um in Z
- stores the physical sizes using native units instead of converting unilaterally to micrometers

                