### PR TITLE
Add sample image link to formats index page

### DIFF
--- a/docs/sphinx/formats/index.txt
+++ b/docs/sphinx/formats/index.txt
@@ -2,26 +2,29 @@ Formats
 =======
 
 Bio-Formats supports over 140 different file formats. The :doc:`dataset-table`
-explains the file extension you should choose to open/import a dataset in any 
-of these formats, while the :doc:`/supported-formats` table lists all of the 
-formats and gives an indication of how well they are supported and whether 
+explains the file extension you should choose to open/import a dataset in any
+of these formats, while the :doc:`/supported-formats` table lists all of the
+formats and gives an indication of how well they are supported and whether
 Bio-Formats can write, as well as read, each format.  The
 :doc:`/metadata-summary` table shows an overview of the :doc:`OME data model
 </about/index>` fields populated for each format.
 
 .. only:: html
 
-    Further information on each individual format is also provided (click on 
+    Further information on each individual format is also provided (click on
     the entries in the supported formats table).
 
-**We are always looking for examples of files to help us provide better 
-support for different formats.** If you would like to help, you can upload 
-files using our `QA system uploader <http://qa.openmicroscopy.org.uk/qa/upload/>`_. 
-If you have any questions, or would prefer not to use QA, please email the 
+**We are always looking for examples of files to help us provide better
+support for different formats.** If you would like to help, you can upload
+files using our `QA system uploader <http://qa.openmicroscopy.org.uk/qa/upload/>`_.
+If you have any questions, or would prefer not to use QA, please email the
 `ome-users mailing list <http://www.openmicroscopy.org/site/community/mailing-lists>`_.
-If your format is already supported, please refer to the 'we would like to 
-have' section on the individual page for that format, to see if your dataset 
+If your format is already supported, please refer to the 'we would like to
+have' section on the individual page for that format, to see if your dataset
 would be useful to us.
+
+All the example files we have permission to share publicly are freely
+available from our `sample image downloads site <http://downloads.openmicroscopy.org/images/>`_.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
See https://trello.com/c/visx1plk/36-schema-samples-migration
This PR adds a link to the top level of the sample images folder on downloads to the Format index page in the BF docs for completeness-sake. Also fixes whitespace (apologies for doing both on one commit but it is only one short page of content).
Will be staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/formats/index.html once the merge build has run.