### PR TITLE
Fake reader: HCS with regions

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1083,9 +1083,9 @@ public class FakeReader extends FormatReader {
     final XMLMockObjects xml = new XMLMockObjects();
     OME ome = null;
     if (screens==0) {
-      ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs);
+      ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs, false);
     } else {
-      ome = xml.createPopulatedScreen(screens, plates, rows, cols, fields, acqs);
+      ome = xml.createPopulatedScreen(screens, plates, rows, cols, fields, acqs, false);
     }
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     // copy populated SPW metadata into destination MetadataStore

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -505,6 +505,7 @@ public class FakeReader extends FormatReader {
     boolean falseColor = false;
     boolean metadataComplete = true;
     boolean thumbnail = false;
+    boolean withMicrobeam = false;
 
     int seriesCount = 1;
     int lutLength = 3;
@@ -606,6 +607,7 @@ public class FakeReader extends FormatReader {
       else if (key.equals("plateCols")) plateCols = intValue;
       else if (key.equals("fields")) fields = intValue;
       else if (key.equals("plateAcqs")) plateAcqs = intValue;
+      else if (key.equals("withMicrobeam")) withMicrobeam = boolValue;
       else if (key.equals("annLong")) annLong = intValue;
       else if (key.equals("annDouble")) annDouble = intValue;
       else if (key.equals("annMap")) annMap = intValue;
@@ -682,7 +684,7 @@ public class FakeReader extends FormatReader {
       if (plateAcqs<=0) plateAcqs = 1;
       // generate SPW metadata and override series count to match
       int imageCount =
-        populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs);
+        populateSPW(store, screens, plates, plateRows, plateCols, fields, plateAcqs, withMicrobeam);
       if (imageCount > 0) seriesCount = imageCount;
       else hasSPW = false; // failed to generate SPW metadata
     }
@@ -1077,16 +1079,16 @@ public class FakeReader extends FormatReader {
     return !listFakeSeries(path).get(0).equals(path);
   }
 
-  private int populateSPW(MetadataStore store, int screens, int plates, int rows, int cols,
-    int fields, int acqs)
+  private int populateSPW(MetadataStore store, int screens, int plates, int rows, int cols, int fields, int acqs, boolean withMicrobeam)
   {
     final XMLMockObjects xml = new XMLMockObjects();
     OME ome = null;
     if (screens==0) {
-      ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs, false);
+      ome = xml.createPopulatedPlate(plates, rows, cols, fields, acqs, withMicrobeam);
     } else {
-      ome = xml.createPopulatedScreen(screens, plates, rows, cols, fields, acqs, false);
+      ome = xml.createPopulatedScreen(screens, plates, rows, cols, fields, acqs, withMicrobeam);
     }
+    if (withMicrobeam) roiCount = roiCount + plates;;
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     // copy populated SPW metadata into destination MetadataStore
     getOmeXmlService().convertMetadata(omeXmlMetadata, store);

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -468,4 +468,41 @@ public class FakeReaderTest {
     reader.close();
     testDefaultValues();
   }
+
+  @Test(dataProvider = "shapes")
+  public void testHCSShapes(String key, String type) throws Exception {
+    reader.setId("foo&plateRows=10&plateCols=10&" + key + "=10.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getImageCount(), 100);
+    assertEquals(m.getROICount(), 1000);
+    for (int i = 0; i < m.getImageCount(); i++) {
+      assertEquals(m.getImageROIRefCount(0), 10);
+    }
+    for (int i = 0; i < m.getROICount(); i++) {
+      assertEquals(m.getShapeCount(i), 1);
+      assertEquals(m.getShapeType(i, 0), type);
+    }
+    reader.close();
+    testDefaultValues();
+  }
+
+  @Test(dataProvider = "shapes")
+  public void testHCSShapesINI(String key, String type) throws Exception {
+    mkIni("foo.fake.ini", "plateRows=10\nplateCols=10\n" + key + "=10");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getImageCount(), 100);
+    assertEquals(m.getROICount(), 1000);
+    for (int i = 0; i < m.getImageCount(); i++) {
+      assertEquals(m.getImageROIRefCount(0), 10);
+    }
+    for (int i = 0; i < m.getROICount(); i++) {
+      assertEquals(m.getShapeCount(i), 1);
+      assertEquals(m.getShapeType(i, 0), type);
+    }
+    reader.close();
+    testDefaultValues();
+  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -432,20 +432,36 @@ public class FakeReaderTest {
     testDefaultValues();
   }
 
+  private void checkROIs(MetadataRetrieve m, int nImages, int nRoisPerImage,
+      String shapeType) throws Exception {
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getImageCount(), nImages);
+    assertEquals(m.getROICount(), nImages * nRoisPerImage);
+    for (int i = 0; i < m.getImageCount(); i++) {
+    assertEquals(m.getImageROIRefCount(0), nRoisPerImage);
+    }
+    for (int i = 0; i < m.getROICount(); i++) {
+    assertEquals(m.getShapeCount(i), 1);
+    assertEquals(m.getShapeType(i, 0), shapeType);
+    }
+  }
+
   @Test(dataProvider = "shapes")
   public void testShapes(String key, String type) throws Exception {
     reader.setId("foo&series=5&" + key + "=10.fake");
     m = service.asRetrieve(reader.getMetadataStore());
-    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
-    assertEquals(m.getImageCount(), 5);
-    assertEquals(m.getROICount(), 50);
-    for (int i = 0; i < m.getImageCount(); i++) {
-      assertEquals(m.getImageROIRefCount(0), 10);
-    }
-    for (int i = 0; i < m.getROICount(); i++) {
-      assertEquals(m.getShapeCount(i), 1);
-      assertEquals(m.getShapeType(i, 0), type);
-    }
+    checkROIs(m, 5, 10, type);
+
+    reader.close();
+    reader.setId("foo&plateRows=10&plateCols=10&" + key + "=5.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    checkROIs(m, 100, 5, type);
+
+    reader.close();
+    reader.setId("foo&screens=2&plateRows=10&plateCols=10&" + key + "=5.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    checkROIs(m, 200, 5, type);
+
     reader.close();
     testDefaultValues();
   }
@@ -455,53 +471,20 @@ public class FakeReaderTest {
     mkIni("foo.fake.ini", "series = 5\n" + key + " = 10");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
-    assertTrue(service.validateOMEXML(service.getOMEXML(m)));    
-    assertEquals(m.getImageCount(), 5);
-    assertEquals(m.getROICount(), 50);
-    for (int i = 0; i < m.getImageCount(); i++) {
-      assertEquals(m.getImageROIRefCount(0), 10);
-    }
-    for (int i = 0; i < m.getROICount(); i++) {
-      assertEquals(m.getShapeCount(i), 1);
-      assertEquals(m.getShapeType(i, 0), type);
-    }
-    reader.close();
-    testDefaultValues();
-  }
+    checkROIs(m, 5, 10, type);
 
-  @Test(dataProvider = "shapes")
-  public void testHCSShapes(String key, String type) throws Exception {
-    reader.setId("foo&plateRows=10&plateCols=10&" + key + "=10.fake");
-    m = service.asRetrieve(reader.getMetadataStore());
-    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
-    assertEquals(m.getImageCount(), 100);
-    assertEquals(m.getROICount(), 1000);
-    for (int i = 0; i < m.getImageCount(); i++) {
-      assertEquals(m.getImageROIRefCount(0), 10);
-    }
-    for (int i = 0; i < m.getROICount(); i++) {
-      assertEquals(m.getShapeCount(i), 1);
-      assertEquals(m.getShapeType(i, 0), type);
-    }
     reader.close();
-    testDefaultValues();
-  }
-
-  @Test(dataProvider = "shapes")
-  public void testHCSShapesINI(String key, String type) throws Exception {
-    mkIni("foo.fake.ini", "plateRows=10\nplateCols=10\n" + key + "=10");
+    mkIni("foo.fake.ini", "plateRows = 10\nplateCols = 10\n" + key + " = 5");
     reader.setId(wd.resolve("foo.fake").toString());
     m = service.asRetrieve(reader.getMetadataStore());
-    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
-    assertEquals(m.getImageCount(), 100);
-    assertEquals(m.getROICount(), 1000);
-    for (int i = 0; i < m.getImageCount(); i++) {
-      assertEquals(m.getImageROIRefCount(0), 10);
-    }
-    for (int i = 0; i < m.getROICount(); i++) {
-      assertEquals(m.getShapeCount(i), 1);
-      assertEquals(m.getShapeType(i, 0), type);
-    }
+    checkROIs(m, 100, 5, type);
+
+    reader.close();
+    mkIni("foo.fake.ini", "screens = 2\nplateRows = 10\nplateCols = 10\n" + key + " = 5");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    checkROIs(m, 200, 5, type);
+
     reader.close();
     testDefaultValues();
   }

--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -889,8 +889,28 @@ public class XMLMockObjects
       int index, int rows, int columns, int fields,
       int numberOfPlateAcquisition)
   {
+    return createPlate(numberOfPlates, index, rows, columns,
+        fields, numberOfPlateAcquisition, true);
+  }
+
+  /**
+   * Creates a populated plate with images.
+   *
+   * @param numberOfPlates The total number of plates.
+   * @param index The index of the plate.
+   * @param rows  The number of rows.
+   * @param columns The number of columns.
+   * @param fields  The number of fields.
+   * @param numberOfPlateAcquisition  The number of plate acquisition to add.
+   * @param withMicrobeam  Whether the experiment should contain a microbeam
+   * @return See above.
+   */
+  public Plate createPlate(int numberOfPlates,
+      int index, int rows, int columns, int fields,
+      int numberOfPlateAcquisition, boolean withMicrobeam)
+  {
     return createPlate(1, 0, numberOfPlates, index, rows, columns,
-        fields, numberOfPlateAcquisition);
+        fields, numberOfPlateAcquisition, withMicrobeam);
   }
 
   /**
@@ -910,13 +930,40 @@ public class XMLMockObjects
       int numberOfPlates, int plateIndex, int rows, int columns,
       int fields, int numberOfPlateAcquisition)
   {
+      return createPlate(numberOfScreens, screenIndex, numberOfPlates,
+          plateIndex, rows, columns, fields, numberOfPlateAcquisition, true);
+  }
+  /**
+   * Creates a populated plate with images.
+   *
+   * @param numberOfScreens The total number of screens.
+   * @param screenIndex The index of the screen.
+   * @param numberOfPlates The total number of plates.
+   * @param plateIndex The index of the plate.
+   * @param rows  The number of rows.
+   * @param columns The number of columns.
+   * @param fields  The number of fields.
+   * @param numberOfPlateAcquisition  The number of plate acquisition to add.
+   * @param withMicrobeam  Whether the experiment should contain a microbeam
+   * @return See above.
+   */
+  public Plate createPlate(int numberOfScreens, int screenIndex,
+      int numberOfPlates, int plateIndex, int rows, int columns,
+      int fields, int numberOfPlateAcquisition, boolean withMicrobeam)
+  {
     if (numberOfScreens == 0) {
       numberOfScreens = 1;
       screenIndex = 0;
     }
     // ticket:3102
     int totalPlateIndex = numberOfScreens*screenIndex+plateIndex;
-    Experiment exp = createExperiment(plateIndex);
+    Experiment exp;
+    if (withMicrobeam) {
+      exp = createExperimentWithMicrobeam(plateIndex);
+    } else {
+      exp = createExperiment(plateIndex);
+    }
+
     ome.addExperiment(exp);
 
     if (numberOfPlateAcquisition < 0) {
@@ -1536,9 +1583,26 @@ public class XMLMockObjects
   public OME createPopulatedPlate(int plates, int rows, int cols, int fields,
       int acqs)
   {
+      return createPopulatedPlate(plates, rows, cols, fields, acqs, true);
+  }
+
+  /**
+   * Creates several plates but no containing screen.
+   *
+   * @param plates The number of plates to create.
+   * @param rows   The number of rows for plate.
+   * @param cols   The number of columns for plate.
+   * @param fields The number of fields.
+   * @param acqs   The number of plate acquisitions.
+   * @param withMicrobeam  Whether the experiment should contain a microbeam
+   * @return See above.
+   */
+  public OME createPopulatedPlate(int plates, int rows, int cols, int fields,
+      int acqs, boolean withMicrobeam)
+  {
     Plate plate;
     for (int p = 0; p < plates; p++) {
-      plate = createPlate(plates, p, rows, cols, fields, acqs);
+      plate = createPlate(plates, p, rows, cols, fields, acqs, withMicrobeam);
       ome.addPlate(plate);
     }
     return ome;
@@ -1558,12 +1622,32 @@ public class XMLMockObjects
   public OME createPopulatedScreen(int screens, int plates, int rows, int cols,
       int fields, int acqs)
   {
+      return createPopulatedScreen(screens, plates, rows, cols, fields, acqs, 
+          true);
+  }
+
+  /**
+   * Creates several screens each with several plates.
+   *
+   * @param screens The number of screens to create.
+   * @param plates  The number of plates to create.
+   * @param rows    The number of rows for plate.
+   * @param cols    The number of columns for plate.
+   * @param fields  The number of fields.
+   * @param acqs    The number of plate acquisitions.
+   * @param withMicrobeam  Whether the experiment should contain a microbeam
+   * @return See above.
+   */
+  public OME createPopulatedScreen(int screens, int plates, int rows, int cols,
+      int fields, int acqs, boolean withMicrobeam)
+  {
     Screen screen;
     Plate plate;
     for (int s = 0; s < screens; s++) {
       screen = createScreen(s);
       for (int p = 0; p < plates; p++) {
-        plate = createPlate(screens, s, plates, p, rows, cols, fields, acqs);
+        plate = createPlate(screens, s, plates, p, rows, cols, fields, acqs,
+            withMicrobeam);
         screen.linkPlate(plate);
         ome.addPlate(plate);
       }

--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -916,7 +916,7 @@ public class XMLMockObjects
     }
     // ticket:3102
     int totalPlateIndex = numberOfScreens*screenIndex+plateIndex;
-    Experiment exp = createExperimentWithMicrobeam(plateIndex);
+    Experiment exp = createExperiment(plateIndex);
     ome.addExperiment(exp);
 
     if (numberOfPlateAcquisition < 0) {

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -198,6 +198,9 @@ with their default values, is shown below.
     - * fields
       * number of fields per well
       * 0
+    - * withMicrobeam
+      * whether or not a microbeam should be added to the experiment (HCS only)
+      * false
     - * annLong, annDouble, annMap, annComment, annBool, annTime, annTag, annTerm, annXml
       * number of annotations of the given type to generate
       * 0


### PR DESCRIPTION
See https://trello.com/c/hzWe7ZNR/115-fakereader-fix-regions-with-hcs

The default `XMLMockObjects.createPlate()` was creating a `MicrobeamManipulation` object with an associated `ROI` which was conflicting with the annotation indexing in the `FakeReader` semantics. The default is modified to remove this creation although it might be possible to selectively enable it using a flag i.e. `XMLMockObjects.createPlate(int, boolean)`.

The flip effect of this change is that fakes should now be able to combine HCS and Regions features, i.e. the following

```
touch "HCSanalysis&plates=10&plateRows=16&plateCols=24&rectangles=100.fake"
```

should allow us to manipulate objects that approach the scale at which folders should be tested. /cc @mtbc