### PR TITLE
cpp: ome-xml: Add enum value list macros

### DIFF
--- a/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/components/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -55,6 +55,9 @@
 
 #include <ome/xml/model/enums/EnumerationException.h>
 
+// All values in the ${klass.langType} enumeration.
+#define ${fu.CLASS_PREFIX}_VALUES {% for value in klass.possibleValues %}(${enum_value_name(value, False).upper()}){% end %}
+
 {% end %}\
 {% if fu.SOURCE_TYPE == "source" %}\
 #include <algorithm>

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -56,11 +56,18 @@ from getopt import gnu_getopt, GetoptError
 from glob import glob
 from xml import sax
 
-def guard(filename):
+def macroname(filename):
     filename = "_".join(filename.split(os.path.sep))
     filename = filename.upper()
     filename = re.sub("[^A-Z0-9]", "_", filename)
     return filename
+
+def guard(filename):
+    return macroname(filename)
+
+def class_prefix(filename):
+    filename, ext = os.path.splitext(filename)
+    return macroname(filename)
 
 def usage(error):
     """
@@ -198,6 +205,7 @@ def main(model, opts):
             continue
 
         fu.GUARD = guard(fullname)
+        fu.CLASS_PREFIX = class_prefix(fullname)
 
         fullname = os.path.join(opts.outdir, fullname)
 
@@ -288,6 +296,7 @@ def enumTypesMain(model, opts):
                 continue
 
             fu.GUARD = guard(fullname)
+            fu.CLASS_PREFIX = class_prefix(fullname)
             fu.SOURCE_TYPE = opts.filetype;
 
             fullname = os.path.join(opts.outdir, fullname)
@@ -329,6 +338,7 @@ def enumTypesIncludeAll(model, opts):
     fullname = os.path.join("ome", "xml", "model", fullname)
 
     fu.GUARD = guard(fullname)
+    fu.CLASS_PREFIX = class_prefix(fullname)
     fu.SOURCE_TYPE = language.TYPE_HEADER;
     fu.HEADERS = sorted(headers);
 

--- a/cpp/test/ome-xml/enum.cpp
+++ b/cpp/test/ome-xml/enum.cpp
@@ -6,6 +6,8 @@
 
 #include <sstream>
 
+#include <boost/preprocessor.hpp>
+
 using ome::xml::model::enums::LaserType;
 using ome::xml::model::enums::PixelType;
 using ome::xml::model::enums::EnumerationException;
@@ -462,6 +464,84 @@ TEST(Enum, PixelTypeStreamInputFail)
   ASSERT_FALSE(!!is);
   ASSERT_EQ(PixelType::UINT16, e); // Unchanged.
 }
+
+void
+check_pt(PixelType::enum_value pt_expected,
+         PixelType pt)
+{
+  std::cout << "Test type: " << PixelType(pt) <<'\n';
+  ASSERT_EQ(pt_expected, pt);
+}
+
+#define MAKE_PT(maR, maProperty, maType)        \
+  {                                             \
+    PixelType pt(PixelType::maType);            \
+    check_pt(PixelType::maType, pt);            \
+  }                                             \
+
+TEST(Enum, PixelTypePreprocess)
+{
+  BOOST_PP_SEQ_FOR_EACH(MAKE_PT, %%, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
+}
+
+#undef MAKE_PT
+
+#define PP_SEQ_FOR_EACH_R_ID() BOOST_PP_SEQ_FOR_EACH_R
+#define PP_DEFER(x) x BOOST_PP_EMPTY()
+
+void check_nested(LaserType expected_a,
+                  LaserType a,
+                  LaserType expected_b,
+                  LaserType b)
+{
+  std::cout << "Test nested: first=" << a
+            << " second=" << b << '\n';
+  EXPECT_EQ(expected_a, a);
+  EXPECT_EQ(expected_b, b);
+}
+
+#define LT_NESTED(maR, maToplevelType, maNestedType)                    \
+  case LaserType::maNestedType:                                         \
+  {                                                                     \
+    check_nested(a, LaserType(LaserType::maToplevelType),               \
+                 b, LaserType(LaserType::maNestedType));                \
+  }                                                                     \
+  break;
+
+#define LT_TOPLEVEL(maR, maUnused, maType)                              \
+  case LaserType::maType:                                               \
+  {                                                                     \
+    switch(b)                                                           \
+      {                                                                 \
+        PP_DEFER(PP_SEQ_FOR_EACH_R_ID)()(maR, LT_NESTED, maType,        \
+                                         OME_XML_MODEL_ENUMS_LASERTYPE_VALUES); \
+      }                                                                 \
+  }                                                                     \
+  break;
+
+void check_switch(LaserType a,
+                  LaserType b)
+{
+  switch(a)
+    {
+      BOOST_PP_EXPAND(BOOST_PP_SEQ_FOR_EACH(LT_TOPLEVEL, %%, OME_XML_MODEL_ENUMS_LASERTYPE_VALUES));
+    }
+}
+
+#define NESTED_TEST(r, product)                                      \
+  check_switch(LaserType(LaserType::BOOST_PP_SEQ_ELEM(0, product)),  \
+               LaserType(LaserType::BOOST_PP_SEQ_ELEM(1, product)));
+
+TEST(Enum, PixelTypePreprocessNested)
+{
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(NESTED_TEST, (OME_XML_MODEL_ENUMS_LASERTYPE_VALUES)(OME_XML_MODEL_ENUMS_LASERTYPE_VALUES));
+}
+
+#undef PP_SEQ_FOR_EACH_R_ID
+#undef PP_DEFER
+#undef LT_NESTED
+#undef LT_TOPLEVEL
+#undef NESTED_TEST
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.

--- a/cpp/test/ome-xml/enum.cpp
+++ b/cpp/test/ome-xml/enum.cpp
@@ -486,6 +486,9 @@ TEST(Enum, PixelTypePreprocess)
 
 #undef MAKE_PT
 
+// Nested lists don't work on Windows due to its broken preprocessor.
+#ifndef _MSC_VER
+
 #define PP_SEQ_FOR_EACH_R_ID() BOOST_PP_SEQ_FOR_EACH_R
 #define PP_DEFER(x) x BOOST_PP_EMPTY()
 
@@ -542,6 +545,8 @@ TEST(Enum, PixelTypePreprocessNested)
 #undef LT_NESTED
 #undef LT_TOPLEVEL
 #undef NESTED_TEST
+
+#endif // !_MSC_VER
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.


### PR DESCRIPTION
This is to allow direct code generation with the C++ preprocessor by looping over the available enum values.

A better approach would be to use C++11 variadic templates, but this is not yet a possibility, and they too are broken on Windows.  See http://stackoverflow.com/questions/35360908/alternative-to-expanding-templates-in-a-switch-statement/ for further details.

This is the second attempt to make this build.  It's the same as before, but the nested loops are skipped on Windows due to the preprocessor being broken.

Purpose: It will be used to simplify code working with model enums, but the primary intent is model units support (to be added in a future PR).

See also: https://github.com/ome/ome-files-cpp/pull/5

Generated source changes: https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-generated-sources/lastSuccessfulBuild/artifact/ome-xml-model-cpp.diff/*view*/

--------

Testing: check the builds are green; it's tested by the `enum` unit test (and `pixelproperties` test in ome-files).

Optional (because it's tedious) manual verification, on Linux or MacOS X since it requires make to run the preprocessor:

Clone the following repositories:

- ome-cmake-superbuild (branch: develop or develop/merge/files-cpp)
- ome-common-cpp (branch: develop or develop/merge/files-cpp)
- bioformats (branch: rleigh-dundee/preprocess-enums or develop/merge/files-cpp)
- ome-files-cpp (branch: rleigh-dundee/preprocess-enums or develop/merge/files-cpp)

Then run:

```
mkdir /tmp/b
cd /tmp/b
cmake -Dome-common-dir=/path/to/ome-common-cpp -Dome-xml-dir=/path/to/bioformats -Dome-files-dir=/path/to/ome-files-cpp -Dsource-caache=~/sources -Dbuild-prerequisites=OFF /path/to/ome-cmake-superbuild
make
[build will eventually complete]
cd ome-xml-build/cpp/test/ome-xml
make enum.cpp.i
[Look at the contents of CMakeFiles/enum.dir/enum.cpp.i]
cd ../../../..
cd ome-files-build/lib/ome-files
make PixelProperties.cpp.i
[Look at the contents of CMakeFiles/ome-files.dir/PixelProperties.cpp.i]
```

For both of these files, you should see the macros in the original source files (enum.cpp and PixelProperties.cpp) expanded into switch statements, one per enum value.  It's right at the end of both files; ignore the header junk at the top.