### PR TITLE
Fixes for the APL Reader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -302,10 +302,14 @@ public class APLReader extends FormatReader {
     int calibratedHeight = DataTools.indexOf(columnNames, "Height");
     int calibratedWidth = DataTools.indexOf(columnNames, "Width");
     int path = DataTools.indexOf(columnNames, "Image Path");
+    if (path == -1) {
+      path = DataTools.indexOf(columnNames, "Path");
+    }
     int filename = DataTools.indexOf(columnNames, "File Name");
     int magnification = DataTools.indexOf(columnNames, "Magnification");
     int width = DataTools.indexOf(columnNames, "X-Resolution");
     int height = DataTools.indexOf(columnNames, "Y-Resolution");
+    int imageType = DataTools.indexOf(columnNames, "Image Type");
     int imageName = DataTools.indexOf(columnNames, "Image Name");
     int zLayers = DataTools.indexOf(columnNames, "Z-Layers");
 
@@ -358,7 +362,7 @@ public class APLReader extends FormatReader {
     final List<Integer> seriesIndexes = new ArrayList<Integer>();
 
     for (int i=1; i<rows.size(); i++) {
-      String file = rows.get(i)[filename].trim();
+      String file = parseFilename(rows.get(i), filename, path);
       if (file.equals("")) continue;
       file = topDirectory + File.separator + file;
       if (new Location(file).exists() && checkSuffix(file, "tif")) {
@@ -382,17 +386,28 @@ public class APLReader extends FormatReader {
       String[] row2 = rows.get(firstRow);
       String[] row3 = rows.get(secondRow);
 
-      ms.sizeT = parseDimension(row3[frames]);
-      ms.sizeZ = parseDimension(row3[zLayers]);
-      ms.sizeC = parseDimension(row3[colorChannels]);
+      if (frames > -1) {
+        ms.sizeT = parseDimension(row3[frames]);
+      }
+      if (zLayers > -1) {
+        ms.sizeZ = parseDimension(row3[zLayers]);
+      }
+      if (colorChannels > -1) {
+        ms.sizeC = parseDimension(row3[colorChannels]);
+      }
+      else if (imageType > -1) {
+        if (row3[imageType] != null && row3[imageType].equals("RGB")) {
+          ms.sizeC = 3;
+        }
+      }
       ms.dimensionOrder = "XYCZT";
 
       if (ms.sizeZ == 0) ms.sizeZ = 1;
       if (ms.sizeC == 0) ms.sizeC = 1;
       if (ms.sizeT == 0) ms.sizeT = 1;
 
-      xmlFiles[i] = topDirectory + File.separator + row2[filename];
-      tiffFiles[i] = topDirectory + File.separator + row3[filename];
+      xmlFiles[i] = topDirectory + File.separator + parseFilename(row2, filename, path);
+      tiffFiles[i] = topDirectory + File.separator + parseFilename(row3, filename, path);
 
       parser[i] = new TiffParser(tiffFiles[i]);
       parser[i].setDoCaching(false);
@@ -459,6 +474,7 @@ public class APLReader extends FormatReader {
         }
       }
     }
+    setSeries(0);
   }
 
   // -- Helper methods --
@@ -477,4 +493,16 @@ public class APLReader extends FormatReader {
     }
   }
 
+  private String parseFilename(String[] row, int filenameIndex, int pathIndex) {
+    String file = row[filenameIndex].trim();
+    if (file != null && checkSuffix(file, "tif")){
+      return file;
+    }
+    String filePath = row[pathIndex].trim();
+    filePath = filePath.replace('\\', File.separatorChar);
+    filePath = filePath.replaceAll("/", File.separator);
+    String[] dirs = filePath.split(File.separatorChar == '\\' ? "\\\\" : File.separator);
+    file = dirs[dirs.length-1].trim();
+    return file; 
+  }
 }


### PR DESCRIPTION
#2307 This PR is a follow up to the user reported issues in https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8013#p16861
The associated ticket is http://trac.openmicroscopy.org/ome/ticket/13174

There are a number of associated QA files provided in QA-17057 and QA-17107

Testing showed a range off issues causing various failures. This PR will address the following fixes:
- Files which do not have all the dimensions listed will be defaulted
- Files which have filename and file path switched, if the filename does not exist the filepath will be parsed to retrieve the filename 
- Files where the filename is unreadable, some of the data from the mtb files are using unkown charsets. Without being able to tell which charset is used the values, most importantly the filename will be incorrect. In this case the filepath can also be parsed to retrieve the filename. 
- Previously we had retrieved the channel count from the column 'Color Channels'. In some of the provided sample files this is not present but the channel count can instead be found by checking the column 'Image Type' for the values RGB or Mono

To test:
Verify that the provided QA files load sucessfullly
- The files in Plain.zip can be used to test the default dimensions
- The files in LifeScienceDemo will test the instance when filename and path are swapped
- The files in Example2 show the case with the unidentified charset
- The files in MaterialsDemo use the ImageType column instead of Color Channels

Note: The files in ExampleDatabase still do not load due to a remaining unresolved issue