### PR TITLE
Zeiss CZI: fixes for files with multiple mosaics and positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -631,6 +631,12 @@ public class ZeissCZIReader extends FormatReader {
     LOGGER.trace("prestitched = {}", prestitched);
     LOGGER.trace("scanDim = {}", scanDim);
 
+    /* debug */
+    	for (int q=0; q<planes.size(); q++) {
+		LOGGER.trace("plane #{} = {}", q, planes.get(q));
+	}
+    /* end debug */
+
     if (((mosaics == seriesCount) || (positions == seriesCount)) &&
       seriesCount == (planes.size() / getImageCount()) &&
       prestitched != null && prestitched)
@@ -676,6 +682,11 @@ public class ZeissCZIReader extends FormatReader {
         mosaics = 1;
         angles = 1;
         seriesCount = 1;
+      }
+      else if (seriesCount > mosaics && mosaics > 1 && prestitched) {
+        seriesCount /= mosaics;
+        mosaics = 1;
+	prestitched = false;
       }
     }
 
@@ -2879,6 +2890,12 @@ public class ZeissCZIReader extends FormatReader {
       this.stageZ = model.stageZ;
       this.x = model.x;
       this.y = model.y;
+    }
+
+    @Override
+    public String toString() {
+      return "seriesIndex=" + seriesIndex + ", planeIndex=" + planeIndex +
+        ", x=" + x + ", y=" + y + ", row=" + row + ", col=" + col;
     }
 
     @Override


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2016-February/003588.html

To test, use the file in ```curated/zeiss-czi/niko``` (it will be ~100GB).  The images are quite large; the easiest first test would be to select a few ~2kx2k tiles and check the display in ImageJ vs Zeiss' ZEN.  It would be good to try importing into OMERO as well, to validate that all of the pixel data is read correctly, but this will take a while as pyramids will need to be generated.

Configuration PR is: https://github.com/openmicroscopy/data_repo_config/pull/96