### PR TITLE
Leica LIF: fix multi-dimensional data from color cameras

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -2020,17 +2020,22 @@ public class LIFReader extends FormatReader {
     ms.indexed = !ms.rgb;
     ms.imageCount = ms.sizeZ * ms.sizeT;
     if (!ms.rgb) ms.imageCount *= ms.sizeC;
+    else {
+      ms.imageCount *= (ms.sizeC / 3);
+    }
 
     Long[] bytes = bytesPerAxis.keySet().toArray(new Long[0]);
     Arrays.sort(bytes);
     ms.dimensionOrder = "XY";
-    if (getSizeC() > 1 && getSizeT() > 1) {
-      ms.dimensionOrder += "C";
-    }
-    for (Long nBytes : bytes) {
-      String axis = bytesPerAxis.get(nBytes);
-      if (ms.dimensionOrder.indexOf(axis) == -1) {
-        ms.dimensionOrder += axis;
+    if (getRGBChannelCount() == 1 || getRGBChannelCount() == getSizeC()) {
+      if (getSizeC() > 1 && getSizeT() > 1) {
+        ms.dimensionOrder += "C";
+      }
+      for (Long nBytes : bytes) {
+        String axis = bytesPerAxis.get(nBytes);
+        if (ms.dimensionOrder.indexOf(axis) == -1) {
+          ms.dimensionOrder += axis;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13112.

This fixes the case when a color camera is used (so each plane has 3 RGB
channels), and multiple channels are acquired potentially in addition to
multiple timepoints and/or Z sections.

To test, use the files from QA 16911 and QA 16919.  Compare the images as shown in Leica's LAS X or LAS AF Lite software against what is shown by ImageJ with and without this change.  Also verify that with this change, no error messages are shown when opening either file in ImageJ.