### PR TITLE
Improve handling of OME-TIFF multi-file filesets with partial metadata blocks

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -174,7 +174,7 @@ public class OMETiffReader extends FormatReader {
 
       try {
         String xml = readMetadataFile();
-        meta = service.createOMEXMLMetadata(xml);
+        service.createOMEXMLMetadata(xml);
       } catch (ServiceException se) {
         LOGGER.debug("OME-XML parsing failed", se);
         return false;


### PR DESCRIPTION
See https://trello.com/c/mVFYhwcJ/87-ome-tiff-missing-metadata-file

This commit partly reverts a previous bug fix for OME-TIFF with `BinaryOnly`  blocks where the `MetatadaFile` check in `isThisType(RandomAccessInputStream)` was solely based on the file extension. Instead, an extra check is performed at the `isThisType(String, boolean)` level if `metadataFile` has been set by `isThisType(RandomAccessInputStream)` to parse the metadata.

To test this PR:
- check the automated tests pass on the OME-TIFF files of the data repository especially the filesets with companion OME-XML
- test the new sample fileset using a binary-only OME-TIFF with the metadata file being stored into an OME-TIFF file - see also https://github.com/openmicroscopy/bioformats/issues/2308
- test QA 16990 as described in https://github.com/openmicroscopy/bioformats/pull/2215
- optionally, download the multi-file OME-TIFF samples (with and without companion OME-XML) and test one or a couple of the following scenarios: 1- deletion of the metadata file, 2- renaming of the metadata file, 3- corruption of the metadata file e.g. invalidating the OME-XML block by removing a `>`. In all cases, running `showinf` at one of the `BinaryOnly` OME-TIFF should display the image without error but fall back to being detected as TIFF
