### PR TITLE
ICS writer: fix dimension population for split files

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -164,7 +164,9 @@ public class ICSWriter extends FormatWriter {
       }
     }
     lastPlane = no;
-    overwriteDimensions(getMetadataRetrieve());
+    if (lastPlane != getPlaneCount() - 1 || uniqueFiles.size() > 1) {
+      overwriteDimensions(getMetadataRetrieve());
+    }
 
     pixels.close();
     pixels = null;


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/issues/2237 and
https://trello.com/c/L7dtKWsl/96-bio-format-exporter-issues

To test, use the macro from gh-2237 and test cases (1) and (2) from the Trello card.  Verify that no exceptions are thrown during conversion, and that the resulting files are ~4 MB each and are reported by showinf as having 15 Z sections (1 timepoint, 1 channel).  Also verify that converting the ```Organ of corti``` sample to a single .ics file does not behave differently with this change; be sure to test conversion in both ImageJ and bfconvert, and check each plane in the resulting file against the original data.

Note that there are likely still some edge cases here.  The "correct" way to do this across all writers would be to add API similar to suggestions in https://trac.openmicroscopy.org/ome/ticket/8215, so that a writer can be given a mapping between plane indexes and file names prior to ```setId``` - and then we're not trying to guess what the final dimensions of each file might be.  That needs more thought and probably is not in scope for 5.2.0 though. 