### PR TITLE
CZI reader bugfix : For wrongly identified master-files in multi-file datasets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -140,6 +140,10 @@ public class ZeissCZIReader extends FormatReader {
 
   private String zoom;
   private String gain;
+  
+  private String masterFile;
+  private String userSelectedFile;
+  private Boolean wrongMasterFile = false;
 
   private ArrayList<Channel> channels = new ArrayList<Channel>();
   private ArrayList<String> binnings = new ArrayList<String>();
@@ -463,7 +467,8 @@ public class ZeissCZIReader extends FormatReader {
 
     // switch to the master file if this is part of a multi-file dataset
     String base = id.substring(0, id.lastIndexOf("."));
-    if (base.endsWith(")") && isGroupFiles()) {
+    System.out.println(!wrongMasterFile);
+    if (base.endsWith(")") && isGroupFiles() && !wrongMasterFile) {
       LOGGER.info("Checking for master file");
       int lastFileSeparator = base.lastIndexOf(File.separator);
       int end = base.lastIndexOf(" (");
@@ -474,6 +479,8 @@ public class ZeissCZIReader extends FormatReader {
         base = base.substring(0, end) + ".czi";
         if (new Location(base).exists()) {
           LOGGER.info("Initializing master file {}", base);
+          masterFile = base;
+          userSelectedFile = id;
           initFile(base);
           return;
         }
@@ -619,6 +626,12 @@ public class ZeissCZIReader extends FormatReader {
     // finish populating the core metadata
 
     int seriesCount = positions * acquisitions * mosaics * angles;
+
+    if (seriesCount == 1 && masterFile != null && !wrongMasterFile){
+        wrongMasterFile = true;
+        System.out.println(userSelectedFile);
+        initFile(userSelectedFile);
+    }
 
     ms0.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC()) * getSizeT();
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -453,6 +453,11 @@ public class ZeissCZIReader extends FormatReader {
       phaseLabels = null;
       indexIntoPlanes.clear();
       parser = null;
+      
+      wrongMasterFile = false;
+      masterFile = null;
+      userSelectedFile = null;
+      
     }
   }
 
@@ -479,7 +484,6 @@ public class ZeissCZIReader extends FormatReader {
         base = base.substring(0, end) + ".czi";
         if (new Location(base).exists()) {
           LOGGER.info("Initializing master file {}", base);
-          close();
           masterFile = base;
           userSelectedFile = id;
           initFile(base);
@@ -630,7 +634,6 @@ public class ZeissCZIReader extends FormatReader {
     //Current assumption: Datasets with master files will have seriesCount>1,
     //This strategy is not the safest way, will need to be reviewed in future.
     if (seriesCount == 1 && masterFile != null && !wrongMasterFile){
-        close();
         wrongMasterFile = true;
         initFile(userSelectedFile);
         return;

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -467,7 +467,7 @@ public class ZeissCZIReader extends FormatReader {
 
     // switch to the master file if this is part of a multi-file dataset
     String base = id.substring(0, id.lastIndexOf("."));
-    System.out.println(!wrongMasterFile);
+
     if (base.endsWith(")") && isGroupFiles() && !wrongMasterFile) {
       LOGGER.info("Checking for master file");
       int lastFileSeparator = base.lastIndexOf(File.separator);
@@ -479,6 +479,7 @@ public class ZeissCZIReader extends FormatReader {
         base = base.substring(0, end) + ".czi";
         if (new Location(base).exists()) {
           LOGGER.info("Initializing master file {}", base);
+          close();
           masterFile = base;
           userSelectedFile = id;
           initFile(base);
@@ -624,13 +625,15 @@ public class ZeissCZIReader extends FormatReader {
     ms0.sizeT *= phases;
 
     // finish populating the core metadata
-
     int seriesCount = positions * acquisitions * mosaics * angles;
-
+    //Checkpoint for identifying wrong masterfiles.
+    //Current assumption: Datasets with master files will have seriesCount>1,
+    //This strategy is not the safest way, will need to be reviewed in future.
     if (seriesCount == 1 && masterFile != null && !wrongMasterFile){
+        close();
         wrongMasterFile = true;
-        System.out.println(userSelectedFile);
         initFile(userSelectedFile);
+        return;
     }
 
     ms0.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC()) * getSizeT();


### PR DESCRIPTION
ref: https://trac.openmicroscopy.org/ome/ticket/13173

Testing Instructions : 
Try opening all the files individually from QA 17056 on FIJI/ImageJ. Without this PR, all files under the datasets "WT 12 *.czi and WT 0 *.czi" will look the same as : "WT 12.czi and WT 0.czi" respectively.
With this PR the pixel data should look different for the individual files. Note: This is not a multi-file dataset, its just a random coincidence that the user has named them like this.

Please try opening a multi-file dataset as well : QA 7271 and QA 7276
and check if we still open these files properly. (This test should not fail and should open the pixeldata without any issues).

cc : @melissalinkert @jburel 