### PR TITLE
PerkinElmer UltraVIEW VoX link (rebased onto dev_5_1)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1803,12 +1803,12 @@ utilityRating = Good
 reader = OperettaReader
 mif = true
 
-[PerkinElmer UltraView]
+[PerkinElmer UltraVIEW]
 indexExtensions = .tif, .2, .3, .4
 extensions = .tif, .2, .3, .4, etc.
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 bsd = no
-weHave = * several UltraView datasets
+weHave = * several UltraVIEW datasets
 pixelsRating = Very good
 metadataRating = Good
 opennessRating = Fair
@@ -1824,7 +1824,7 @@ Commercial applications that support this format include: \n
 * `Image-Pro Plus <http://www.mediacy.com/>`_ \n
 \n
 .. seealso:: \n
-  `PerkinElmer UltraView system overview <http://www.perkinelmer.com/pages/020/cellularimaging/products/ultraviewvoxsystemsoverview.xhtml>`_
+  `PerkinElmer UltraVIEW system overview <http://www.perkinelmer.com/product/ultraview-vox-3d-live-cell-imaging-system-l7267000>`_
 
 [Portable Any Map]
 pagename = pgm

--- a/docs/sphinx/formats/perkinelmer-ultraview.txt
+++ b/docs/sphinx/formats/perkinelmer-ultraview.txt
@@ -1,7 +1,7 @@
-.. index:: PerkinElmer UltraView
+.. index:: PerkinElmer UltraVIEW
 .. index:: .tif, .2, .3, .4
 
-PerkinElmer UltraView
+PerkinElmer UltraVIEW
 ===============================================================================
 
 Extensions: .tif, .2, .3, .4, etc.
@@ -25,7 +25,7 @@ Reader: PerkinElmerReader (:bfreader:`Source Code <PerkinElmerReader.java>`, :do
 
 We currently have:
 
-* several UltraView datasets
+* several UltraVIEW datasets
 
 We would like to have:
 
@@ -55,4 +55,4 @@ Commercial applications that support this format include:
 * `Image-Pro Plus <http://www.mediacy.com/>`_ 
 
 .. seealso:: 
-  `PerkinElmer UltraView system overview <http://www.perkinelmer.com/product/ultraview-vox-3d-live-cell-imaging-system-l7267000>`_
+  `PerkinElmer UltraVIEW system overview <http://www.perkinelmer.com/product/ultraview-vox-3d-live-cell-imaging-system-l7267000>`_

--- a/docs/sphinx/formats/perkinelmer-ultraview.txt
+++ b/docs/sphinx/formats/perkinelmer-ultraview.txt
@@ -55,4 +55,4 @@ Commercial applications that support this format include:
 * `Image-Pro Plus <http://www.mediacy.com/>`_ 
 
 .. seealso:: 
-  `PerkinElmer UltraView system overview <http://www.perkinelmer.com/pages/020/cellularimaging/products/ultraviewvoxsystemsoverview.xhtml>`_
+  `PerkinElmer UltraView system overview <http://www.perkinelmer.com/product/ultraview-vox-3d-live-cell-imaging-system-l7267000>`_


### PR DESCRIPTION

This is the same as gh-2325 but rebased onto dev_5_1.

----

fixes the broken link to the microscope information

                