### PR TITLE
Zeiss CZI: 5.1.9 backports

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -631,7 +631,7 @@ public class ZeissCZIReader extends FormatReader {
     LOGGER.trace("prestitched = {}", prestitched);
     LOGGER.trace("scanDim = {}", scanDim);
 
-    if (mosaics == seriesCount &&
+    if (((mosaics == seriesCount) || (positions == seriesCount)) &&
       seriesCount == (planes.size() / getImageCount()) &&
       prestitched != null && prestitched)
     {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -631,6 +631,12 @@ public class ZeissCZIReader extends FormatReader {
     LOGGER.trace("prestitched = {}", prestitched);
     LOGGER.trace("scanDim = {}", scanDim);
 
+    /* debug */
+	for (int q=0; q<planes.size(); q++) {
+		LOGGER.trace("plane #{} = {}", q, planes.get(q));
+	}
+    /* end debug */
+
     if (((mosaics == seriesCount) || (positions == seriesCount)) &&
       seriesCount == (planes.size() / getImageCount()) &&
       prestitched != null && prestitched)
@@ -676,6 +682,11 @@ public class ZeissCZIReader extends FormatReader {
         mosaics = 1;
         angles = 1;
         seriesCount = 1;
+      }
+      else if (seriesCount > mosaics && mosaics > 1 && prestitched) {
+        seriesCount /= mosaics;
+        mosaics = 1;
+	prestitched = false;
       }
     }
 
@@ -2879,6 +2890,12 @@ public class ZeissCZIReader extends FormatReader {
       this.stageZ = model.stageZ;
       this.x = model.x;
       this.y = model.y;
+    }
+
+    @Override
+    public String toString() {
+      return "seriesIndex=" + seriesIndex + ", planeIndex=" + planeIndex +
+        ", x=" + x + ", y=" + y + ", row=" + row + ", col=" + col;
     }
 
     @Override

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -314,6 +314,19 @@ public class ZeissCZIReader extends FormatReader {
     Arrays.fill(buf, (byte) 0);
     RandomAccessInputStream stream = new RandomAccessInputStream(currentId);
     try {
+      int minTileX = Integer.MAX_VALUE, minTileY = Integer.MAX_VALUE;
+      for (SubBlock plane : planes) {
+        if ((plane.seriesIndex == currentSeries && plane.planeIndex == no) ||
+          (plane.planeIndex == previousChannel && validScanDim))
+        {
+          if (plane.row < minTileY) {
+            minTileY = plane.row;
+          }
+          if (plane.col < minTileX) {
+            minTileX = plane.col;
+          }
+        }
+      }
       for (SubBlock plane : planes) {
         if ((plane.seriesIndex == currentSeries && plane.planeIndex == no) ||
           (plane.planeIndex == previousChannel && validScanDim))
@@ -330,6 +343,11 @@ public class ZeissCZIReader extends FormatReader {
             if (prestitched != null && prestitched && realX == getSizeX() && realY == getSizeY()) {
               tile.x = 0;
               tile.y = 0;
+            }
+            else if (prestitched != null && prestitched) {
+              // normalize the coordinates such that minimum row/col values are 0
+              tile.x -= minTileX;
+              tile.y -= minTileY;
             }
 
             if (tile.intersects(image)) {
@@ -631,12 +649,6 @@ public class ZeissCZIReader extends FormatReader {
     LOGGER.trace("prestitched = {}", prestitched);
     LOGGER.trace("scanDim = {}", scanDim);
 
-    /* debug */
-	for (int q=0; q<planes.size(); q++) {
-		LOGGER.trace("plane #{} = {}", q, planes.get(q));
-	}
-    /* end debug */
-
     if (((mosaics == seriesCount) || (positions == seriesCount)) &&
       seriesCount == (planes.size() / getImageCount()) &&
       prestitched != null && prestitched)
@@ -686,7 +698,6 @@ public class ZeissCZIReader extends FormatReader {
       else if (seriesCount > mosaics && mosaics > 1 && prestitched) {
         seriesCount /= mosaics;
         mosaics = 1;
-	prestitched = false;
       }
     }
 


### PR DESCRIPTION
This is the same as gh-2268 but rebased onto dev_5_1.

----

Fixes https://trac.openmicroscopy.org/ome/ticket/13095

To test, use the file from QA 16882.  Without this change, ```showinf -minmax``` should show that the first series has non-zero pixels, and the remaining four series have all zero pixels.  With this change, the same test should show that all five series have non-zero pixels (which should also be obvious from looking at the images).  The images and dimensions can also be compared against Zeiss' ZEN software.

This is the same as gh-2305 but rebased onto dev_5_1.

----

See http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2016-February/003588.html

To test, use the file in curated/zeiss-czi/niko (it will be ~100GB). The images are quite large; the easiest first test would be to select a few ~2kx2k tiles and check the display in ImageJ vs Zeiss' ZEN. It would be good to try importing into OMERO as well, to validate that all of the pixel data is read correctly, but this will take a while as pyramids will need to be generated.

Configuration PR is: openmicroscopy/data_repo_config#96
