### PR TITLE
Fake: fix HCS fake files with multiple screens

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -221,6 +221,7 @@ public class FakeReaderTest {
     assertEquals(m.getPixelsPhysicalSizeY(0), null);
     assertEquals(m.getPixelsPhysicalSizeZ(0), null);
     assertEquals(m.getROICount(), 0);
+    assertEquals(m.getExperimentCount(), 0);
   }
 
   @Test
@@ -286,6 +287,45 @@ public class FakeReaderTest {
     while (i >= 0) {
         assertEquals(metadata.getChannelCount(i--), reader.getSizeC());
     }
+  }
+
+  @Test
+  public void testMicrobeamINI() throws Exception {
+    mkIni("foo.fake.ini", "plates=1\nwithMicrobeam = true");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getExperimentCount(), 1);
+    assertEquals(m.getMicrobeamManipulationCount(0), 1);
+    reader.close();
+
+    mkIni("foo.fake.ini", "screens=2\nwithMicrobeam=true");
+    reader.setId(wd.resolve("foo.fake").toString());
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getExperimentCount(), 2);
+    assertEquals(m.getMicrobeamManipulationCount(0), 1);
+    assertEquals(m.getMicrobeamManipulationCount(1), 1);
+    reader.close();
+  }
+
+  @Test
+  public void testMicrobeam() throws Exception {
+    reader.setId("foo&plates=1&withMicrobeam=true.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getExperimentCount(), 1);
+    assertEquals(m.getMicrobeamManipulationCount(0), 1);
+    reader.close();
+
+    reader.setId("foo&screens=2&withMicrobeam=true.fake");
+    m = service.asRetrieve(reader.getMetadataStore());
+    assertTrue(service.validateOMEXML(service.getOMEXML(m)));
+    assertEquals(m.getExperimentCount(), 2);
+    assertEquals(m.getMicrobeamManipulationCount(0), 1);
+    assertEquals(m.getMicrobeamManipulationCount(1), 1);
+    reader.close();
+    testDefaultValues();
   }
 
   @Test

--- a/components/specification/src/ome/specification/XMLMockObjects.java
+++ b/components/specification/src/ome/specification/XMLMockObjects.java
@@ -956,12 +956,12 @@ public class XMLMockObjects
       screenIndex = 0;
     }
     // ticket:3102
-    int totalPlateIndex = numberOfScreens*screenIndex+plateIndex;
+    int totalPlateIndex = numberOfPlates*screenIndex+plateIndex;
     Experiment exp;
     if (withMicrobeam) {
-      exp = createExperimentWithMicrobeam(plateIndex);
+      exp = createExperimentWithMicrobeam(totalPlateIndex);
     } else {
-      exp = createExperiment(plateIndex);
+      exp = createExperiment(totalPlateIndex);
     }
 
     ome.addExperiment(exp);


### PR DESCRIPTION
See https://trello.com/c/pBQgFTMS/117-fakereader-fix-microbeam-with-multiple-screens

This PR fixes an indexing bug in the `XMLMockObjects.createPlate()` method which caused all fake HCS files with multiple screens to be invalid as multiple `Experiment` objects were created with the same ID. Unit tests are also added to `FakeReaderTest` to cover the multiple screens test case and include some testing of the `MicrobeamManipulation` option.

To test these changes, check fake HCS files with more than one screen have a valid OME-XML:

```
$ showinf -nopix -omexml "SPW&screens=2.fake
$ showinf -nopix -omexml "SPW&screens=2&plates=3.fake
$ showinf -nopix -omexml "SPW&screens=2&withMicrobeam=true.fake
```