### PR TITLE
Update PicoQuant reader to always buffer data.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PQBinReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PQBinReader.java
@@ -164,7 +164,7 @@ public class PQBinReader extends FormatReader {
           // corresponding to zeroth timeBin
           int output = ((row * sizeX) + col) * bpp;
           int input = ((col * timeBins) + (currentBlock * blockLength)) * bpp;
-         
+          // copy subset of decay into buffer.
           for (int t = 0; t < storeLength; t++) {
             for (int bb = 0; bb < bpp; bb++) {
               dataStore[output + bb] = rowBuf[input + bb];

--- a/components/formats-gpl/src/loci/formats/in/PQBinReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PQBinReader.java
@@ -263,6 +263,9 @@ public class PQBinReader extends FormatReader {
     while (blockLength * sizeX * sizeY > sizeThreshold)
       blockLength = blockLength/2;
     
+    if (blockLength > timeBins)
+      blockLength = timeBins;
+    
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this);
     

--- a/components/formats-gpl/src/loci/formats/in/PQBinReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PQBinReader.java
@@ -181,7 +181,7 @@ public class PQBinReader extends FormatReader {
       
       int binInStore = timeBin - (currentBlock * blockLength);
       
-      int input = (binSize * binInstore) + (y * iLineSize) + (x * bpp);
+      int input = (binSize * binInStore) + (y * iLineSize) + (x * bpp);
       int output = 0;
 
       for (int row = 0; row < h; row++) {


### PR DESCRIPTION
For very large files this reader was prohibitively slow. See https://trac.openmicroscopy.org/ome/ticket/13183

Test using curated .bin files. A larger example is available in QA 17134. Should now load in < 1min.