### PR TITLE
Add ROI import to ImageJ overlay

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/DisplayHandler.java
@@ -211,7 +211,7 @@ public class DisplayHandler implements StatusListener {
 
   public void displayROIs(ImagePlus[] imps) {
     if (!options.showROIs()) return;
-    ROIHandler.openROIs(process.getOMEMetadata(), imps, options.isOMERO());
+    ROIHandler.openROIs(process.getOMEMetadata(), imps, options.isOMERO(), options.getROIsMode());
     
   }
    

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
@@ -93,7 +93,7 @@ public class ImporterOptions extends OptionsList {
   public static final String LOCATION_OMERO = "OMERO";
 
   //possible values for roiMode
-  public static final String ROIS_MODE_MANAGER = "ROI Manager";
+  public static final String ROIS_MODE_MANAGER = "ROI manager";
   public static final String ROIS_MODE_OVERLAY = "Overlay";
   
   // possible values for stackFormat

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
@@ -66,6 +66,7 @@ public class ImporterOptions extends OptionsList {
   public static final String KEY_SHOW_METADATA   = "showMetadata";
   public static final String KEY_SHOW_OME_XML    = "showOMEXML";
   public static final String KEY_SHOW_ROIS       = "showROIs";
+  public static final String KEY_ROIS_MODE       = "roiMode";
   public static final String KEY_SPECIFY_RANGES  = "specifyRanges";
   public static final String KEY_SPLIT_Z         = "splitFocalPlanes";
   public static final String KEY_SPLIT_T         = "splitTimepoints";
@@ -91,6 +92,10 @@ public class ImporterOptions extends OptionsList {
   public static final String LOCATION_HTTP  = "Internet";
   public static final String LOCATION_OMERO = "OMERO";
 
+  //possible values for roiMode
+  public static final String ROIS_MODE_MANAGER = "ROI Manager";
+  public static final String ROIS_MODE_OVERLAY = "Overlay";
+  
   // possible values for stackFormat
   public static final String VIEW_NONE       = "Metadata only";
   public static final String VIEW_STANDARD   = "Standard ImageJ";
@@ -324,6 +329,12 @@ public class ImporterOptions extends OptionsList {
   public boolean showROIs() { return isSet(KEY_SHOW_ROIS); }
   public void setShowROIs(boolean b) { setValue(KEY_SHOW_ROIS, b); }
 
+  // roisMode
+ public String getROIsModeInfo() { return getInfo(KEY_ROIS_MODE); }
+ public String getROIsMode() { return getValue(KEY_ROIS_MODE); }
+ public String[] getROIsModes() { return getPossible(KEY_ROIS_MODE); }
+ public void setROIsMode(String s) { setValue(KEY_ROIS_MODE, s); }
+  
   // specifyRanges
   public String getSpecifyRangesInfo() { return getInfo(KEY_SPECIFY_RANGES); }
   public boolean isSpecifyRanges() { return isSet(KEY_SPECIFY_RANGES); }

--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -227,6 +227,7 @@ public class MainDialog extends ImporterDialog
     List<Choice> choices = null;
     List<Label> labels = null;
     Label colorModeLabel = null;
+    Label roisModeLabel = null;
     Label stackFormatLabel = null;
     Label stackOrderLabel = null;
     Component[] c = gd.getComponents();
@@ -266,6 +267,7 @@ public class MainDialog extends ImporterDialog
       showOMEXMLBox     = boxes.get(boxIndex++);
       showROIsBox       = boxes.get(boxIndex++);
       roisModeChoice    = choices.get(choiceIndex++);
+      roisModeLabel     = labels.get(labelIndex++);
       specifyRangesBox  = boxes.get(boxIndex++);
       splitZBox         = boxes.get(boxIndex++);
       splitTBox         = boxes.get(boxIndex++);
@@ -298,6 +300,7 @@ public class MainDialog extends ImporterDialog
     infoTable.put(showOMEXMLBox, options.getShowOMEXMLInfo());
     infoTable.put(showROIsBox, options.getShowROIsInfo());
     infoTable.put(roisModeChoice, options.getROIsModeInfo());
+    infoTable.put(roisModeLabel, options.getROIsModeInfo());
     infoTable.put(specifyRangesBox, options.getSpecifyRangesInfo());
     infoTable.put(splitZBox, options.getSplitFocalPlanesInfo());
     infoTable.put(splitTBox, options.getSplitTimepointsInfo());
@@ -316,13 +319,13 @@ public class MainDialog extends ImporterDialog
       // first column
       "pref, 3dlu, pref:grow, " +
       // second column
-      "10dlu, pref, " +
+      "10dlu, pref, 3dlu, pref:grow, " +
       // third column
       "10dlu, fill:150dlu";
 
     String rows =
       // Stack viewing        | Metadata viewing
-      "pref, 3dlu, pref, 3dlu, pref, 3dlu, pref, " +
+      "pref, 3dlu, pref, 3dlu, pref, 3dlu, pref, 3dlu, pref, " +
       // Dataset organization | Memory management
       "9dlu, pref, 3dlu, pref, 3dlu, pref, 3dlu, pref, 3dlu, pref, " +
       "3dlu, pref, " +
@@ -345,7 +348,7 @@ public class MainDialog extends ImporterDialog
     row += 2;
     builder.add(stackOrderLabel, cc.xy(1, row));
     builder.add(stackOrderChoice, cc.xy(3, row));
-    row += 4;
+    row += 6;
     builder.addSeparator("Dataset organization", cc.xyw(1, row, 3));
     row += 2;
     builder.add(groupFilesBox, xyw(cc, 1, row, 3));
@@ -370,43 +373,44 @@ public class MainDialog extends ImporterDialog
 
     // populate 2nd column
     row = 1;
-    builder.addSeparator("Metadata viewing", cc.xy(5, row));
+    builder.addSeparator("Metadata viewing", cc.xyw(5, row, 3));
     row += 2;
-    builder.add(showMetadataBox, xyw(cc, 5, row, 1));
+    builder.add(showMetadataBox, xyw(cc, 5, row, 3));
     row += 2;
-    builder.add(showOMEXMLBox, xyw(cc, 5, row, 1));
+    builder.add(showOMEXMLBox, xyw(cc, 5, row, 3));
     row += 2;
-    builder.add(showROIsBox, xyw(cc, 5, row, 1));
+    builder.add(showROIsBox, xyw(cc, 5, row, 3));
     row += 2;
-    builder.add(roisModeChoice, xyw(cc, 5, row, 1));
+    builder.add(roisModeLabel, cc.xy(5, row));
+    builder.add(roisModeChoice, cc.xy(7, row));
     row += 2;
-    builder.addSeparator("Memory management", cc.xy(5, row));
+    builder.addSeparator("Memory management", cc.xyw(5, row, 3));
     row += 2;
-    builder.add(virtualBox, xyw(cc, 5, row, 1));
+    builder.add(virtualBox, xyw(cc, 5, row, 3));
     row += 2;
-    //builder.add(recordBox, xyw(cc, 5, row, 1));
+    //builder.add(recordBox, xyw(cc, 5, row, 3));
     //row += 2;
-    builder.add(specifyRangesBox, xyw(cc, 5, row, 1));
+    builder.add(specifyRangesBox, xyw(cc, 5, row, 3));
     row += 2;
-    builder.add(cropBox, xyw(cc, 5, row, 1));
+    builder.add(cropBox, xyw(cc, 5, row, 3));
     row += 4;
-    builder.addSeparator("Split into separate windows", cc.xy(5, row));
+    builder.addSeparator("Split into separate windows", cc.xyw(5, row, 3));
     row += 2;
-    builder.add(splitCBox, xyw(cc, 5, row, 1));
+    builder.add(splitCBox, xyw(cc, 5, row, 3));
     row += 2;
-    builder.add(splitZBox, xyw(cc, 5, row, 1));
+    builder.add(splitZBox, xyw(cc, 5, row, 3));
     row += 2;
-    builder.add(splitTBox, xyw(cc, 5, row, 1));
+    builder.add(splitTBox, xyw(cc, 5, row, 3));
     //row += 4;
 
     // information section
-    builder.addSeparator("Information", cc.xy(7, 1));
+    builder.addSeparator("Information", cc.xy(9, 1));
     //row += 2;
     infoPane = new JEditorPane();
     infoPane.setContentType("text/html");
     infoPane.setEditable(false);
     infoPane.setText("<html>" + INFO_DEFAULT);
-    builder.add(new JScrollPane(infoPane), cc.xywh(7, 3, 1, row));
+    builder.add(new JScrollPane(infoPane), cc.xywh(9, 3, 1, row));
     //row += 2;
 
     gd.removeAll();

--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -265,6 +265,7 @@ public class MainDialog extends ImporterDialog
       showMetadataBox   = boxes.get(boxIndex++);
       showOMEXMLBox     = boxes.get(boxIndex++);
       showROIsBox       = boxes.get(boxIndex++);
+      roisModeChoice    = choices.get(choiceIndex++);
       specifyRangesBox  = boxes.get(boxIndex++);
       splitZBox         = boxes.get(boxIndex++);
       splitTBox         = boxes.get(boxIndex++);

--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -442,6 +442,7 @@ public class MainDialog extends ImporterDialog
     //boolean recordEnabled = recordBox.isEnabled();
     boolean showMetadataEnabled = showMetadataBox.isEnabled();
     boolean showOMEXMLEnabled = showOMEXMLBox.isEnabled();
+    boolean roisModeEnabled = roisModeChoice.isEnabled();
     boolean specifyRangesEnabled = specifyRangesBox.isEnabled();
     boolean splitZEnabled = splitZBox.isEnabled();
     boolean splitTEnabled = splitTBox.isEnabled();
@@ -461,6 +462,8 @@ public class MainDialog extends ImporterDialog
     //boolean isRecord = recordBox.getState();
     boolean isShowMetadata = showMetadataBox.getState();
     boolean isShowOMEXML = showOMEXMLBox.getState();
+    boolean isShowROIs = showROIsBox.getState();
+    String roisModeValue = roisModeChoice.getSelectedItem();
     boolean isSpecifyRanges = specifyRangesBox.getState();
     boolean isSplitZ = splitZBox.getState();
     boolean isSplitT = splitTBox.getState();
@@ -515,6 +518,10 @@ public class MainDialog extends ImporterDialog
     // showOMEXMLBox
     // NB: no other options affect showOMEXMLBox
 
+    // roisModeChoice
+    roisModeEnabled = isShowROIs;
+    if (!roisModeEnabled) roisModeValue = ImporterOptions.ROIS_MODE_MANAGER;
+    
     // == Dataset organization ==
 
     // groupFilesBox
@@ -602,6 +609,7 @@ public class MainDialog extends ImporterDialog
     //recordBox.setEnabled(recordEnabled);
     showMetadataBox.setEnabled(showMetadataEnabled);
     showOMEXMLBox.setEnabled(showOMEXMLEnabled);
+    roisModeChoice.setEnabled(roisModeEnabled);
     specifyRangesBox.setEnabled(specifyRangesEnabled);
     splitZBox.setEnabled(splitZEnabled);
     splitTBox.setEnabled(splitTEnabled);
@@ -621,6 +629,7 @@ public class MainDialog extends ImporterDialog
     //recordBox.setState(isRecord);
     showMetadataBox.setState(isShowMetadata);
     showOMEXMLBox.setState(isShowOMEXML);
+    roisModeChoice.select(roisModeValue);
     specifyRangesBox.setState(isSpecifyRanges);
     splitZBox.setState(isSplitZ);
     splitTBox.setState(isSplitT);

--- a/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/MainDialog.java
@@ -82,6 +82,7 @@ public class MainDialog extends ImporterDialog
   protected Checkbox showMetadataBox;
   protected Checkbox showOMEXMLBox;
   protected Checkbox showROIsBox;
+  protected Choice roisModeChoice;
   protected Checkbox specifyRangesBox;
   protected Checkbox splitZBox;
   protected Checkbox splitTBox;
@@ -124,6 +125,7 @@ public class MainDialog extends ImporterDialog
     addCheckbox(gd, ImporterOptions.KEY_SHOW_METADATA);
     addCheckbox(gd, ImporterOptions.KEY_SHOW_OME_XML);
     addCheckbox(gd, ImporterOptions.KEY_SHOW_ROIS);
+    addChoice(gd, ImporterOptions.KEY_ROIS_MODE);
     addCheckbox(gd, ImporterOptions.KEY_SPECIFY_RANGES);
     addCheckbox(gd, ImporterOptions.KEY_SPLIT_Z);
     addCheckbox(gd, ImporterOptions.KEY_SPLIT_T);
@@ -151,6 +153,7 @@ public class MainDialog extends ImporterDialog
     options.setShowMetadata(gd.getNextBoolean());
     options.setShowOMEXML(gd.getNextBoolean());
     options.setShowROIs(gd.getNextBoolean());
+    options.setROIsMode(options.getROIsModes()[gd.getNextChoiceIndex()]);
     options.setSpecifyRanges(gd.getNextBoolean());
     options.setSplitFocalPlanes(gd.getNextBoolean());
     options.setSplitTimepoints(gd.getNextBoolean());
@@ -293,6 +296,7 @@ public class MainDialog extends ImporterDialog
     infoTable.put(showMetadataBox, options.getShowMetadataInfo());
     infoTable.put(showOMEXMLBox, options.getShowOMEXMLInfo());
     infoTable.put(showROIsBox, options.getShowROIsInfo());
+    infoTable.put(roisModeChoice, options.getROIsModeInfo());
     infoTable.put(specifyRangesBox, options.getSpecifyRangesInfo());
     infoTable.put(splitZBox, options.getSplitFocalPlanesInfo());
     infoTable.put(splitTBox, options.getSplitTimepointsInfo());
@@ -372,6 +376,8 @@ public class MainDialog extends ImporterDialog
     builder.add(showOMEXMLBox, xyw(cc, 5, row, 1));
     row += 2;
     builder.add(showROIsBox, xyw(cc, 5, row, 1));
+    row += 2;
+    builder.add(roisModeChoice, xyw(cc, 5, row, 1));
     row += 2;
     builder.addSeparator("Memory management", cc.xy(5, row));
     row += 2;

--- a/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
+++ b/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
@@ -192,6 +192,17 @@ info = <b>Display ROIs</b> - \
   Adds any ROIs in the file to ImageJ's ROI manager.
 default = false
 
+[roiMode]
+label = ROIs_Import Mode
+info = <b>ROI Import Mode</b> - \
+  ROIs can be imported to the ROI Manager or an Overlay.
+type = string
+save = false
+default = ROI Manager
+values = \
+  ROI Manager, \
+  Overlay
+
 [specifyRanges]
 type = boolean
 label = Specify_range for each series

--- a/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
+++ b/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
@@ -189,13 +189,13 @@ default = false
 type = boolean
 label = Display_ROIs
 info = <b>Display ROIs</b> - \
-  Adds any ROIs in the file to ImageJ's ROI manager.
+  Adds any ROIs in the file to ImageJ.
 default = false
 
 [roiMode]
-label = ROIs_Import Mode
+label = ROIs_Import Mode:
 info = <b>ROI Import Mode</b> - \
-  ROIs can be imported to the ROI Manager or an Overlay.
+  ROIs can be imported to the ROI manager or an overlay.
 type = string
 default = ROI Manager
 values = \

--- a/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
+++ b/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
@@ -197,9 +197,9 @@ label = ROIs_Import Mode:
 info = <b>ROI Import Mode</b> - \
   ROIs can be imported to the ROI manager or an overlay.
 type = string
-default = ROI Manager
+default = ROI manager
 values = \
-  ROI Manager, \
+  ROI manager, \
   Overlay
 
 [specifyRanges]

--- a/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
+++ b/components/bio-formats-plugins/src/loci/plugins/in/importer-options.txt
@@ -197,7 +197,6 @@ label = ROIs_Import Mode
 info = <b>ROI Import Mode</b> - \
   ROIs can be imported to the ROI Manager or an Overlay.
 type = string
-save = false
 default = ROI Manager
 values = \
   ROI Manager, \

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -109,7 +109,7 @@ public class ROIHandler {
     int imageCount = images.length;
     for (int imageNum=0; imageNum<imageCount; imageNum++) {
       int roiCount = root.sizeOfROIList();
-      if (roiCount > 0 && manager == null) {
+      if (roiCount > 0 && manager == null && roisMode.equals(ImporterOptions.ROIS_MODE_MANAGER)) {
         manager = new RoiManager();
       }
 

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -96,6 +96,20 @@ public class ROIHandler {
    */
   public static void openROIs(IMetadata retrieve, ImagePlus[] images,
           boolean isOMERO) {
+    openROIs(retrieve, images, isOMERO, ImporterOptions.ROIS_MODE_MANAGER);  
+  }
+  
+  /**
+   * Opens the rois and converts them into ImageJ Rois.
+   *
+   * @param retrieve The OMEXML store.
+   * @param images The imageJ object.
+   * @param isOMERO <code>true</code> if data stored in OMERO,
+   *        <code>false</code> otherwise.
+   * @param roisMode Determines whether to import Rois to overlay or RoiManager
+   */
+  public static void openROIs(IMetadata retrieve, ImagePlus[] images,
+          boolean isOMERO, String roisMode) {
     if (!(retrieve instanceof OMEXMLMetadata)) return;
     int nextRoi = 0;
     RoiManager manager = RoiManager.getInstance();
@@ -109,7 +123,8 @@ public class ROIHandler {
     int imageCount = images.length;
     for (int imageNum=0; imageNum<imageCount; imageNum++) {
       int roiCount = root.sizeOfROIList();
-      if (roiCount > 0 && manager == null && roisMode.equals(ImporterOptions.ROIS_MODE_MANAGER)) {
+      if (roiCount > 0 && manager == null
+    		  && roisMode.equals(ImporterOptions.ROIS_MODE_MANAGER)) {
         manager = new RoiManager();
       }
 
@@ -418,7 +433,6 @@ public class ROIHandler {
         manager.runCommand("show all with labels");
       }
     }
-
   }
 
   /**

--- a/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/ROIHandler.java
@@ -52,6 +52,7 @@ import loci.formats.MetadataTools;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
+import loci.plugins.in.ImporterOptions;
 import ome.units.quantity.Length;
 import ome.units.UNITS;
 import ome.xml.model.Ellipse;
@@ -397,7 +398,18 @@ public class ROIHandler {
             if (sc != null) {
               roi.setStrokeColor(sc);
             }
-            manager.add(images[imageNum], roi, nextRoi++);
+            
+            if (roisMode.equals(ImporterOptions.ROIS_MODE_MANAGER)) {
+                manager.add(images[imageNum], roi, nextRoi++);
+            } else if (roisMode.equals(ImporterOptions.ROIS_MODE_OVERLAY)) {
+                Overlay overlay = images[imageNum].getOverlay();                        
+                if (overlay == null) {
+                    overlay = new Overlay(roi);
+                    images[imageNum].setOverlay(overlay);
+                } else {
+                    overlay.add(roi);
+                }
+            }
           }
         }
       }


### PR DESCRIPTION
The PR adds a choice for the user to determine whether to import ROIs to the ImageJ ROI manager or create a new overlay and add them to that. The choice is disabled if the _Display ROIs_ is disabled.