### PR TITLE
Add officially supported versions to the LaVision Imspector format

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1222,6 +1222,7 @@ Commercial applications that support LIF include: \n
 [LaVision Imspector]
 extensions = .msr
 developer = `LaVision BioTec <http://www.lavisionbiotec.com/>`_
+versions = 4.0, 4.1
 bsd = no
 weHave = * a few .msr files
 pixelsRating = Fair

--- a/docs/sphinx/formats/lavision-imspector.txt
+++ b/docs/sphinx/formats/lavision-imspector.txt
@@ -16,7 +16,7 @@ BSD-licensed: |no|
 
 Export: |no|
 
-Officially Supported Versions: 
+Officially Supported Versions: 4.0, 4.1
 
 Reader: ImspectorReader (:bfreader:`Source Code <ImspectorReader.java>`, :doc:`Supported Metadata Fields </metadata/ImspectorReader>`)
 


### PR DESCRIPTION
Our current representative set of LaVision Imspector files included in the daily automated tests only contain files generated with the 4.0 and 4.1 versions of ImspectorPro. /cc @imunro 