### PR TITLE
NIOFileHandle: reduce default buffer size

### DIFF
--- a/components/formats-common/src/loci/common/NIOFileHandle.java
+++ b/components/formats-common/src/loci/common/NIOFileHandle.java
@@ -63,7 +63,7 @@ public class NIOFileHandle extends AbstractNIOHandle {
   //-- Static fields --
 
   /** Default NIO buffer size to facilitate buffered I/O. */
-  protected static int defaultBufferSize = 1048576;
+  protected static int defaultBufferSize = 16;
 
   /**
    * Default NIO buffer size to facilitate buffered I/O for read/write streams.


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/issues/2255

Compared two consecutive runs of ```test-automated``` on necromancer (4096MB, 4 threads) with 4 directories.  Without this PR:

run | directory | scan time | total time
-----|-------------|-------------|--------------
0 | test_images_good | 107.38s | 32m26s
1 | test_images_good | 74.706s | 33m53s
0 | curated/nd2 | 31.481s | 79m3s
1 | curated/nd2 | 27.971s | 70m31s
0 | curated/zeiss-zvi | 2.953s | 20m42s
1 | curated/zeiss-zvi | 2.266s | 19m4s
0 | curated/ome-tiff | 19.218s | 31m48s
1 | curated/ome-tiff | 14.13s | 28m48s

With this PR:

run | directory | scan time | total time
-----|-------------|-------------|--------------
0 | test_images_good | 42.031s | 26m7s
1 | test_images_good | 34.343s | 23m29s
0 | curated/nd2 | 18.659s | 73m48s
1 | curated/nd2 | 15.17s | 62m42s
0 | curated/zeiss-zvi | 3.168s | 21m2s
1 | curated/zeiss-zvi | 2.074s | 16m30s
0 | curated/ome-tiff | 19.402s | 20m8s
1 | curated/ome-tiff | 9.293s | 18m49s

For each directory/table, run 1 was executed immediately after run 0.  Tests with this PR were run on a separate day from tests without this PR, to reduce impact of filesystem/OS caching.  The above has me reasonably confident that this won't cause harm; this is another PR that will need to be in the builds for a few days before we consider merging though.  The total run times of all DEV-merge jobs, especially https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/, will need to be monitored - I would expect some reduction on average for anything running tests against data_repo.