### PR TITLE
Resolve Plane population errors for Zeiss LSM and OME-TIFF

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1013,7 +1013,7 @@ public class OMETiffReader extends FormatReader {
       }
     }
 
-    MetadataTools.populatePixels(metadataStore, this, false, false);
+    MetadataTools.populatePixels(metadataStore, this, true, false);
     for (int i=0; i<acquiredDates.length; i++) {
       if (acquiredDates[i] != null) {
         metadataStore.setImageAcquisitionDate(

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -970,11 +970,6 @@ public class ZeissLSMReader extends FormatReader {
       if (splitPlanes) ms.imageCount *= getSizeC();
     }
 
-    for (int c=0; c<getEffectiveSizeC(); c++) {
-      String lsid = MetadataTools.createLSID("Channel", series, c);
-      store.setChannelID(lsid, series, c);
-    }
-
     // NB: the Zeiss LSM 5.5 specification indicates that there should be
     //     15 32-bit integers here; however, there are actually 16 32-bit
     //     integers before the tile position offset.
@@ -1007,6 +1002,11 @@ public class ZeissLSMReader extends FormatReader {
       ms.moduloT.end = ms.sizeT * (phases - 1);
       ms.moduloT.type = FormatTools.PHASE;
       ms.sizeT *= phases;
+    }
+
+    for (int c=0; c<getEffectiveSizeC(); c++) {
+      String lsid = MetadataTools.createLSID("Channel", series, c);
+      store.setChannelID(lsid, series, c);
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12978

To test, use the following datasets mentioned in the ticket:

* QA 16996 (OME-TIFF)
* QA 11328 (Zeiss LSM)
* QA 16981 (Zeiss LSM)
* QA 17012 (Zeiss LSM)

Verify that without this change, ```showinf -nopix -omexml``` shows validation errors indicating invalid ```Plane``` elements in the generated OME-XML.  With these changes, there should be no ```Plane``` validation errors.  The Zeiss LSM datasets should also be checked against Zeiss' ZEN Lite software, as the fix for those datasets was to introduce rotation and phase support to the Zeiss LSM reader.
