### PR TITLE
Linking to slidebook6 page (rebased onto dev_5_1)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -22,11 +22,8 @@ preserved. \n
 Free software from 3I can export the files to OME-TIFF post-acquisition, see \n
 https://www.slidebook.com/reader.php.\n
 \n
-As of Bioformats 5.1.2 the native binary file SlideBook6Reader.dll\n
-of the proper architecture (x32 or x64) must be in the java binary path for\n
-this reader to work. This file is available from\n
-`3i Support <mailto: support@intelligent-imaging.com>`_ and is currently\n
-only available for Windows systems.\n
+SlideBook6Reader requires a native binary file to work, see\n
+www.openmicroscopy.org/info/slidebook for details.\n
 \n
 .. seealso:: \n
   `Slidebook software overview <https://www.slidebook.com>`_ \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -23,7 +23,7 @@ Free software from 3I can export the files to OME-TIFF post-acquisition, see \n
 https://www.slidebook.com/reader.php.\n
 \n
 SlideBook6Reader requires a native binary file to work, see\n
-www.openmicroscopy.org/info/slidebook for details.\n
+http://www.openmicroscopy.org/info/slidebook for details.\n
 \n
 .. seealso:: \n
   `Slidebook software overview <https://www.slidebook.com>`_ \n

--- a/docs/sphinx/formats/3i-slidebook.txt
+++ b/docs/sphinx/formats/3i-slidebook.txt
@@ -61,7 +61,7 @@ Free software from 3I can export the files to OME-TIFF post-acquisition, see
 https://www.slidebook.com/reader.php.
 
 SlideBook6Reader requires a native binary file to work, see
-www.openmicroscopy.org/info/slidebook for details.
+http://www.openmicroscopy.org/info/slidebook for details.
 
 .. seealso:: 
   `Slidebook software overview <https://www.slidebook.com>`_ 

--- a/docs/sphinx/formats/3i-slidebook.txt
+++ b/docs/sphinx/formats/3i-slidebook.txt
@@ -60,11 +60,8 @@ preserved.
 Free software from 3I can export the files to OME-TIFF post-acquisition, see 
 https://www.slidebook.com/reader.php.
 
-As of Bioformats 5.1.2 the native binary file SlideBook6Reader.dll
-of the proper architecture (x32 or x64) must be in the java binary path for
-this reader to work. This file is available from
-`3i Support <mailto: support@intelligent-imaging.com>`_ and is currently
-only available for Windows systems.
+SlideBook6Reader requires a native binary file to work, see
+www.openmicroscopy.org/info/slidebook for details.
 
 .. seealso:: 
   `Slidebook software overview <https://www.slidebook.com>`_ 


### PR DESCRIPTION


This is the same as gh-2341 but rebased onto dev_5_1.

----

Updates the slidebook format page to point to how to update the new DLLs. For now the /info/slidebook URL needs to redirect to https://www.openmicroscopy.org/site/support/slidebook but once 3i are sorted, it should be changed to point at their page (see #2289 for context)

cc @sbesson - can you set up the redirect please?

                    