### PR TITLE
Fixes crash when loading large .nii files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -147,7 +147,7 @@ public class NiftiReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    int planeSize = FormatTools.getPlaneSize(this);
+    long planeSize = FormatTools.getPlaneSize(this);
     pixelFile.seek(pixelOffset + no * planeSize);
     readPlane(pixelFile, x, y, w, h, buf);
 


### PR DESCRIPTION
As discussed in the mailing list, I changed planeSize to long to prevent the seek position calculation from overflowing on large .nii files.