### PR TITLE
Update POM version numbers to 5.1.9

### DIFF
--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/bundles/loci-tools/pom.xml
+++ b/components/bundles/loci-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/bundles/ome-tools/pom.xml
+++ b/components/bundles/ome-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/mdbtools/pom.xml
+++ b/components/forks/mdbtools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/turbojpeg/pom.xml
+++ b/components/forks/turbojpeg/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-bsd/src/loci/formats/UpgradeChecker.java
+++ b/components/formats-bsd/src/loci/formats/UpgradeChecker.java
@@ -63,7 +63,7 @@ public class UpgradeChecker {
   // -- Constants --
 
   /** Version number of the latest stable release. */
-  public static final String STABLE_VERSION = "5.1.8";
+  public static final String STABLE_VERSION = "5.1.9";
 
   /** Location of the OME continuous integration server. */
   public static final String CI_SERVER = "http://ci.openmicroscopy.org";

--- a/components/formats-common/pom.xml
+++ b/components/formats-common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-jxr/pom.xml
+++ b/components/ome-jxr/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/stubs/mipav/pom.xml
+++ b/components/stubs/mipav/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/xsd-fu/pom.xml
+++ b/components/xsd-fu/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.1.9-SNAPSHOT</version>
+    <version>5.1.9</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>pom-bio-formats</artifactId>
-  <version>5.1.9-SNAPSHOT</version>
+  <version>5.1.9</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>
@@ -49,7 +49,7 @@
          properties for your dependencies rather than hardcoding them. -->
 
     <vcs.revision>${revision}</vcs.revision>
-    <release.version>5.1.9-SNAPSHOT</release.version>
+    <release.version>5.1.9</release.version>
     <vcs.shortrevision>${shortrevision}</vcs.shortrevision>
     <date>${maven.build.timestamp}</date>
     <year>2016</year>


### PR DESCRIPTION
Repository: openmicroscopy/bioformats
Already up-to-date.



Generated by build [BIOFORMATS-5.1-latest-version-bump#19](https://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest-version-bump/19/).

----
--no-rebase