### PR TITLE
Fix csv pattern blocks

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePatternBlock.java
+++ b/components/formats-bsd/src/loci/formats/FilePatternBlock.java
@@ -194,35 +194,22 @@ public class FilePatternBlock {
     String trimmed = block.substring(
         BLOCK_START.length(), block.length() - BLOCK_END.length()
     );
-    int dash = trimmed.indexOf("-");
-    String b, e, s;
-    if (dash < 0) {
-      // check if this is an enumerated list
-      int comma = trimmed.indexOf(",");
-      if (comma > 0) {
-        elements = trimmed.split(",");
-        setNumeric();
-        setFixed();
-        return;
-      }
-      else {
-        // no range and not a list; assume entire block is a single value
-        b = e = trimmed;
-        s = "1";
-      }
+    elements = trimmed.split(",", -1);
+    if (elements.length > 1) {
+      setNumeric();
+      setFixed();
+      return;
     }
-    else {
-      int colon = trimmed.indexOf(":");
-      b = trimmed.substring(0, dash);
-      if (colon < 0) {
-        e = trimmed.substring(dash + 1);
-        s = "1";
-      }
-      else {
-        e = trimmed.substring(dash + 1, colon);
-        s = trimmed.substring(colon + 1);
-      }
+    elements = elements[0].split("-");
+    if (elements.length < 2) {
+      setNumeric();
+      fixed = true;
+      return;
     }
+    String b = elements[0];
+    elements = elements[1].split(":", -1);
+    String e = elements[0];
+    String s = (elements.length < 2) ? "1" : elements[1];
 
     numeric = true;
 

--- a/components/formats-bsd/src/loci/formats/FilePatternBlock.java
+++ b/components/formats-bsd/src/loci/formats/FilePatternBlock.java
@@ -164,6 +164,29 @@ public class FilePatternBlock {
     );
   }
 
+  private void setNumeric() {
+    numeric = true;
+    for (String s: elements) {
+      try {
+        new BigInteger(s);
+      } catch (NumberFormatException e) {
+        numeric = false;
+        break;
+      }
+    }
+  }
+
+  private void setFixed() {
+    fixed = true;
+    int L = elements[0].length();
+    for (int i = 1; i < elements.length; i++) {
+      if (elements[i].length() != L) {
+        fixed = false;
+        break;
+      }
+    }
+  }
+
   private void explode() {
     if (!block.startsWith(BLOCK_START) || !block.endsWith(BLOCK_END)) {
       throwBadBlock("\"%s\": missing block delimiter(s)");
@@ -178,6 +201,8 @@ public class FilePatternBlock {
       int comma = trimmed.indexOf(",");
       if (comma > 0) {
         elements = trimmed.split(",");
+        setNumeric();
+        setFixed();
         return;
       }
       else {

--- a/components/formats-bsd/test/loci/formats/utests/FilePatternBlockTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FilePatternBlockTest.java
@@ -49,17 +49,18 @@ public class FilePatternBlockTest {
   @DataProvider(name = "range")
   public Object[][] rangeBlocks() {
     return new Object[][] {
-      {"<9>", new String[] {"9"}, true, true},
       {"<0-2>", new String[] {"0", "1", "2"}, true, true},
       {"<9-11>", new String[] {"9", "10", "11"}, false, true},
       {"<09-11>", new String[] {"09", "10", "11"}, true, true},
       {"<1-5:2>", new String[] {"1", "3", "5"}, true, true},
-      {"<Z>", new String[] {"Z"}, true, false},
       {"<A-C>", new String[] {"A", "B", "C"}, true, false},
       {"<A-E:2>", new String[] {"A", "C", "E"}, true, false},
-      {"<z>", new String[] {"z"}, true, false},
+      {"<X-Z>", new String[] {"X", "Y", "Z"}, true, false},
+      {"<V-Z:2>", new String[] {"V", "X", "Z"}, true, false},
       {"<a-c>", new String[] {"a", "b", "c"}, true, false},
-      {"<a-e:2>", new String[] {"a", "c", "e"}, true, false}
+      {"<a-e:2>", new String[] {"a", "c", "e"}, true, false},
+      {"<x-z>", new String[] {"x", "y", "z"}, true, false},
+      {"<v-z:2>", new String[] {"v", "x", "z"}, true, false}
     };
   }
 
@@ -70,7 +71,13 @@ public class FilePatternBlockTest {
       {"<01,03,11>", new String[] {"01", "03", "11"}, true, true},
       {"<1,3,11>", new String[] {"1", "3", "11"}, false, true},
       {"<R,G,B>", new String[] {"R", "G", "B"}, true, false},
-      {"<Cy3,DAPI>", new String[] {"Cy3", "DAPI"}, false, false}
+      {"<Cy3,DAPI>", new String[] {"Cy3", "DAPI"}, false, false},
+      {"<Cy3-B,DAPI>", new String[] {"Cy3-B", "DAPI"}, false, false},
+      {"<Cy3>", new String[] {"Cy3"}, true, false},
+      {"<9>", new String[] {"9"}, true, true},
+      {"<Z>", new String[] {"Z"}, true, false},
+      {"<z>", new String[] {"z"}, true, false},
+      {"<>", new String[] {""}, true, false}
     };
   }
 
@@ -78,7 +85,7 @@ public class FilePatternBlockTest {
   public Object[][] invalidBlocks() {
     return new Object[][] {
       {""}, {"<"}, {">"}, {"9"}, {"<9"}, {"9>"},  // missing block delimiter(s)
-      {"<!-A>"}, {"<A-~>"}, {"<A-C:!>"}, {"<>"}  // invalid range delimiter(s)
+      {"<!-A>"}, {"<A-~>"}, {"<A-C:!>"}  // invalid range delimiter(s)
     };
   }
 


### PR DESCRIPTION
This PR fixes the detection of comma-separated pattern blocks.

The first commit addresses a minor problem where the `fixed` and `numeric` properties where not set for csv blocks, although they are general enough to make sense in all cases.

The second commit fixes a more serious problem where block strings where checked for range structure (`<START-STOP:STEP>`) first and then for csv structure. This made pattern blocks with dashes in their csv elements unusable. For instance, without this PR, FilePatternBlock would try to interpret `<Cy3-B,DAPI>` as a range from `Cy3` to `B,DAPI`, leading to a `NumberFormatException`.

Note that a side effect of this is that now single element blocks, e.g., `<foo>`, are considered comma-separated lists with one element, rather than ranges with step 1, so the `begin, end, step` properties are left to `null`. I'd be very surprised if this broke anything, given that a single-element pattern is a corner case that has no practical purpose.