### PR TITLE
Fixes and unit test for FilePatternBlock (metadata)

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePatternBlock.java
+++ b/components/formats-bsd/src/loci/formats/FilePatternBlock.java
@@ -60,6 +60,9 @@ public class FilePatternBlock {
   /** Whether or not this is a fixed-width block. */
   private boolean fixed;
 
+  /** Whether or not this is a numeric block. */
+  private boolean numeric;
+
   /** The number of leading zeroes. */
   private int zeroes;
 
@@ -89,6 +92,10 @@ public class FilePatternBlock {
     return fixed;
   }
 
+  public boolean isNumeric() {
+    return numeric;
+  }
+
   public BigInteger getFirst() {
     return begin;
   }
@@ -103,47 +110,66 @@ public class FilePatternBlock {
 
   // -- Helper methods --
 
+  private void throwBadBlock(String msgTemplate) {
+    throw new IllegalBlockException(String.format(msgTemplate, block));
+  }
+
+  private void throwBadBlock(String msgTemplate, Throwable cause) {
+    throw new IllegalBlockException(
+        String.format(msgTemplate, block), cause
+    );
+  }
+
   private void explode() {
-    int dash = block.indexOf("-");
+    if (!block.startsWith(BLOCK_START) || !block.endsWith(BLOCK_END)) {
+      throwBadBlock("\"%s\": missing block delimiter(s)");
+    }
+    String trimmed = block.substring(
+        BLOCK_START.length(), block.length() - BLOCK_END.length()
+    );
+    int dash = trimmed.indexOf("-");
     String b, e, s;
     if (dash < 0) {
       // check if this is an enumerated list
-      int comma = block.indexOf(",");
+      int comma = trimmed.indexOf(",");
       if (comma > 0) {
-        elements = block.substring(1, block.length() - 1).split(",");
+        elements = trimmed.split(",");
         return;
       }
       else {
         // no range and not a list; assume entire block is a single value
-        b = e = block.substring(1, block.length() - 1);
+        b = e = trimmed;
         s = "1";
       }
     }
     else {
-      int colon = block.indexOf(":");
-      b = block.substring(1, dash);
+      int colon = trimmed.indexOf(":");
+      b = trimmed.substring(0, dash);
       if (colon < 0) {
-        e = block.substring(dash + 1, block.length() - 1);
+        e = trimmed.substring(dash + 1);
         s = "1";
       }
       else {
-        e = block.substring(dash + 1, colon);
-        s = block.substring(colon + 1, block.length() - 1);
+        e = trimmed.substring(dash + 1, colon);
+        s = trimmed.substring(colon + 1);
       }
     }
 
-    boolean numeric = true;
+    numeric = true;
 
     try {
       begin = new BigInteger(b);
       end = new BigInteger(e);
       step = new BigInteger(s);
-    }
-    catch (NumberFormatException exc) {
+    } catch (NumberFormatException badN) {
       numeric = false;
-      begin = new BigInteger(b, 26);
-      end = new BigInteger(e, 26);
-      step = new BigInteger(s, 26);
+      try {
+        begin = new BigInteger(b, Character.MAX_RADIX);
+        end = new BigInteger(e, Character.MAX_RADIX);
+        step = new BigInteger(s, Character.MAX_RADIX);
+      } catch (NumberFormatException badL) {
+        throwBadBlock("invalid range delimiter(s)", badL);
+      }
     }
 
     fixed = b.length() == e.length();
@@ -157,7 +183,7 @@ public class FilePatternBlock {
 
     for (int i=0; i<count; i++) {
       BigInteger v = begin.add(step.multiply(BigInteger.valueOf(i)));
-      String value = numeric ? v.toString() : v.toString(26);
+      String value = numeric ? v.toString() : v.toString(Character.MAX_RADIX);
       if (!numeric) {
         if (Character.isLowerCase(b.charAt(0))) value = value.toLowerCase();
         else value = value.toUpperCase();

--- a/components/formats-bsd/src/loci/formats/IllegalBlockException.java
+++ b/components/formats-bsd/src/loci/formats/IllegalBlockException.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats;
+
+
+/**
+ * Exception thrown when {@link FilePatternBlock} encounters an
+ * invalid pattern.
+ */
+public class IllegalBlockException extends IllegalArgumentException {
+
+  public IllegalBlockException() {}
+
+  public IllegalBlockException(String message) {
+    super(message);
+  }
+
+  public IllegalBlockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public IllegalBlockException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/FilePatternBlockTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FilePatternBlockTest.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import java.math.BigInteger;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import loci.formats.FilePatternBlock;
+import loci.formats.IllegalBlockException;
+
+
+public class FilePatternBlockTest {
+
+  @DataProvider(name = "valid")
+  public Object[][] validBlocks() {
+    return new Object[][] {
+      {"<9>", new String[] {"9"}, true, true},
+      {"<0-2>", new String[] {"0", "1", "2"}, true, true},
+      {"<9-11>", new String[] {"9", "10", "11"}, false, true},
+      {"<09-11>", new String[] {"09", "10", "11"}, true, true},
+      {"<1-5:2>", new String[] {"1", "3", "5"}, true, true},
+      {"<Z>", new String[] {"Z"}, true, false},
+      {"<A-C>", new String[] {"A", "B", "C"}, true, false},
+      {"<A-E:2>", new String[] {"A", "C", "E"}, true, false},
+      {"<z>", new String[] {"z"}, true, false},
+      {"<a-c>", new String[] {"a", "b", "c"}, true, false},
+      {"<a-e:2>", new String[] {"a", "c", "e"}, true, false}
+    };
+  }
+
+  @DataProvider(name = "invalid")
+  public Object[][] invalidBlocks() {
+    return new Object[][] {
+      {""}, {"<"}, {">"}, {"9"}, {"<9"}, {"9>"},  // missing block delimiter(s)
+      {"<!-A>"}, {"<A-~>"}, {"<A-C:!>"}  // invalid range delimiter(s)
+    };
+  }
+
+  @Test(dataProvider = "valid")
+  public void testValidBlocks(String pattern, String[] elements,
+      boolean fixed, boolean numeric) {
+    FilePatternBlock block = new FilePatternBlock(pattern);
+    String[] blkElements = block.getElements();
+    assertEquals(blkElements.length, elements.length);
+    for (int i = 0; i < blkElements.length; i++) {
+      assertEquals(blkElements[i], elements[i]);
+    }
+    assertEquals(block.getBlock(), pattern);
+    assertEquals(block.isFixed(), fixed);
+    assertEquals(block.isNumeric(), numeric);
+    int radix = numeric ? 10 : Character.MAX_RADIX;
+    BigInteger first = new BigInteger(elements[0], radix);
+    BigInteger last = new BigInteger(elements[elements.length-1], radix);
+    BigInteger step;
+    try {
+      step = new BigInteger(elements[1], radix).subtract(first);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      step = new BigInteger("1");
+    }
+    assertTrue(block.getFirst().equals(first));
+    assertTrue(block.getLast().equals(last));
+    assertTrue(block.getStep().equals(step));
+  }
+
+  @Test(dataProvider = "invalid",
+        expectedExceptions = IllegalBlockException.class)
+  public void testInvalidBlocks(String pattern) {
+    FilePatternBlock block = new FilePatternBlock(pattern);
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -114,4 +114,10 @@
         <class name="loci.formats.utests.MemoizerTest"/>
       </classes>
     </test>
+    <test name="FilePatternTests">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.FilePatternBlockTest"/>
+      </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Same changes as #2145, but rebased onto metadata.

**Update:** also included (part of) #2190 so that the new test is run by `ant`