### PR TITLE
Fix libBlitzBioFormats link

### DIFF
--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -29,4 +29,4 @@ external library.
 
 .. _jar2lib: http://loci.wisc.edu/software/jar2lib
 .. _WiscScan: http://loci.wisc.edu/software/wiscscan
-.. _Video Spot Tracker: 
+.. _Video Spot Tracker: http://cismm.cs.unc.edu/resources/software-manuals/video-spot-tracker-manual

--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -18,6 +18,9 @@ Other projects using the JACE C++ bindings include:
 
 -  WiscScan_ which uses the JACE C++ bindings to write
    :model_doc:`OME-TIFF <ome-tiff>` files.
+-  :doc:`/users/xuvtools/index` which uses an adapted version of the JACE C++
+   bindings called
+   `BlitzBioFormats <http://www.xuvtools.org/doku.php?id=devel:libblitzbioformats>`_.
 -  `Video Spot Tracker`_ which uses the JACE C++ bindings to add Bio-Formats
    support since version 8.10.
 

--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -18,9 +18,6 @@ Other projects using the JACE C++ bindings include:
 
 -  WiscScan_ which uses the JACE C++ bindings to write
    :model_doc:`OME-TIFF <ome-tiff>` files.
--  :doc:`/users/xuvtools/index` which uses an adapted version of the JACE C++
-   bindings called
-   `BlitzBioFormats <http://www.xuvtools.org/doku.php?id=devel:libblitzbioformats>`_.
 -  `Video Spot Tracker`_ which uses the JACE C++ bindings to add Bio-Formats
    support since version 8.10.
 
@@ -32,4 +29,4 @@ external library.
 
 .. _jar2lib: http://loci.wisc.edu/software/jar2lib
 .. _WiscScan: http://loci.wisc.edu/software/wiscscan
-.. _Video Spot Tracker: http://cismm.cs.unc.edu/resources/software-manuals/video-spot-tracker-manual
+.. _Video Spot Tracker: 

--- a/docs/sphinx/developers/jace/overview.txt
+++ b/docs/sphinx/developers/jace/overview.txt
@@ -18,9 +18,6 @@ Other projects using the JACE C++ bindings include:
 
 -  WiscScan_ which uses the JACE C++ bindings to write
    :model_doc:`OME-TIFF <ome-tiff>` files.
--  :doc:`/users/xuvtools/index` which uses an adapted version of the JACE C++
-   bindings called
-   `BlitzBioFormats <http://www.xuvtools.org/devel:libblitzbioformats>`_.
 -  `Video Spot Tracker`_ which uses the JACE C++ bindings to add Bio-Formats
    support since version 8.10.
 


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/213/warnings3Result/ - I deleted the link initially thinking it hadn't been released since 2010, then re-read the page and realised it's now part of the XuvTools download. Not sure if we want to remove the link and leave the text though - the info on the page is rather out of date, linking to LOCI and broken doc links.