### PR TITLE
FilePattern: allow pattern blocks in the dirname

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -327,14 +327,7 @@ public class FilePattern {
    * @return the prefix string as described above.
    */
   public String getPrefix() {
-    int s = pattern.lastIndexOf(File.separator) + 1;
-    int e;
-    if (startIndex.length > 0) e = startIndex[0];
-    else {
-      int dot = pattern.lastIndexOf(".");
-      e = dot < s ? pattern.length() : dot;
-    }
-    return s <= e ? pattern.substring(s, e) : "";
+    return getPrefix(0);
   }
 
   /**
@@ -358,10 +351,9 @@ public class FilePattern {
    */
   public String getPrefix(int i) {
     if (i < 0 || i >= startIndex.length) return null;
-    int s = i > 0 ? endIndex[i - 1] :
-      (pattern.lastIndexOf(File.separator) + 1);
+    int s = i > 0 ? endIndex[i - 1] : 0;
     int e = startIndex[i];
-    return s <= e ? pattern.substring(s, e) : null;
+    return s <= e ? pattern.substring(s, e) : "";
   }
 
   /**

--- a/components/formats-bsd/test/loci/formats/utests/FilePatternTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FilePatternTest.java
@@ -322,7 +322,7 @@ public class FilePatternTest {
     assertEquals(fp.getCount(), new int[] {2});
     assertEquals(fp.getElements(), new String[][] {{"0", "1"}});
     assertEqualsNoOrder(fp.getFiles(), new String[] {
-      "z0/foo.tif", "z1/foo.tif",
+      "z0" + suffix, "z1" + suffix,
     });
     assertEquals(fp.getFirst(), new BigInteger[] {BigInteger.ZERO});
     assertEquals(fp.getLast(), new BigInteger[] {BigInteger.ONE});

--- a/components/formats-bsd/test/loci/formats/utests/FilePatternTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FilePatternTest.java
@@ -299,4 +299,34 @@ public class FilePatternTest {
     assertNotNull(fp.getErrorMessage());
   }
 
+  @Test
+  public void testVarDir() {
+    String[] prefixes = {"z"};
+    String[] blocks = {"<0-1>"};
+    String suffix = SEPARATOR + "foo.tif";
+    String pattern = mkPattern(prefixes, blocks, suffix);
+    FilePattern fp = new FilePattern(pattern);
+    assertTrue(fp.isValid());
+    assertFalse(fp.isRegex());
+    assertEquals(fp.getPattern(), pattern);
+    assertEquals(fp.getPrefixes(), prefixes);
+    for (int i = 0; i < prefixes.length; i++) {
+      assertEquals(fp.getPrefix(i), prefixes[i]);
+    }
+    assertEquals(fp.getPrefix(), prefixes[0]);
+    assertEquals(fp.getBlocks(), blocks);
+    for (int i = 0; i < blocks.length; i++) {
+      assertEquals(fp.getBlock(i), blocks[i]);
+    }
+    assertEquals(fp.getSuffix(), suffix);
+    assertEquals(fp.getCount(), new int[] {2});
+    assertEquals(fp.getElements(), new String[][] {{"0", "1"}});
+    assertEqualsNoOrder(fp.getFiles(), new String[] {
+      "z0/foo.tif", "z1/foo.tif",
+    });
+    assertEquals(fp.getFirst(), new BigInteger[] {BigInteger.ZERO});
+    assertEquals(fp.getLast(), new BigInteger[] {BigInteger.ONE});
+    assertEquals(fp.getStep(), new BigInteger[] {BigInteger.ONE});
+  }
+
 }

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -617,8 +617,13 @@ public class MIASReader extends FormatReader {
 
       Location firstTiff = new Location(tiffFiles[0]);
 
-      FilePattern fp = new FilePattern(
-        firstTiff.getName(), firstTiff.getParentFile().getAbsolutePath());
+      List<String> names = new ArrayList<String>();
+      for (Location f: firstTiff.getParentFile().listFiles()) {
+        names.add(f.getName());
+      }
+
+      FilePattern fp = new FilePattern(FilePattern.findPattern(
+        firstTiff.getName(), null, names.toArray(new String[names.size()])));
       String[] blocks = fp.getPrefixes();
 
       order[j] = "XY";


### PR DESCRIPTION
This PR removes a restriction in `FilePattern.getPrefix` that prevents the definition of patterns where one or more blocks appear in the dirname (rather than in the basename). This allows to match layouts where, for instance, data for different channels is stored in different directories:

```
/tmp/c<1,2>/foo.fake
```

Note that this is not hypotetical: we have exactly this problem with one of the IDR datasets.

As a side effect, this also removes a semantic discrepancy between `FilePattern.getPrefix()` and `FilePattern.getPrefix(int i)`, so that now the former behaves like the latter with an argument of `0`.