### PR TITLE
Add version history for 5.1.8 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -20,6 +20,9 @@ Version history
        - fixed to ignore invalid BinaryOnly elements
    - TIFF
        - fixed caching of BigTIFF files
+   - Slidebook
+       - fixed handling of montages in Slidebook6Reader (thanks to Richard Myers)
+   - Performance improvement for writing files to disk (thanks to Stephane Dallongeville)
    - Build system
        - fixed Maven POMs to reduce calls to artifacts.openmicroscopy.org
        - fixed bioformats_package.jar to include the loci.formats.tools

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -11,7 +11,7 @@ Version history
        - fixed tile reading when a cache (.bfmemo) file is present
    - MicroManager
        - updated to parse JSON data from tags 50839 and 51123
-       - fixed to detect *_metadata.txt files in addition to metadata.txt
+       - fixed to detect :file:`*_metadata.txt` files in addition to metadata.txt
          files
        - fixed to handle datasets with each stack in a single file
    - OME-XML
@@ -32,7 +32,9 @@ Version history
    - clarified description of Qu for MATLAB (thanks to Carnë Draug)
    - added installation instructions for Octave (thanks to Carnë Draug)
 * C++:
-   - no changes, released to keep version numbers in sync with Bio-Formats Java
+   - Bugfixes to the OME-TIFF writer to correct use of the metadata store with
+     multiple series
+   - Ensure file and writer state consistency upon close failure
 
 5.1.7 (2015 December 7)
 -----------------------

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,8 +1,8 @@
 Version history
 ===============
 
-5.1.8 (2016 February 8)
------------------------
+5.1.8 (2016 February 11)
+------------------------
 
 * Java bug fixes, including:
    - FEI TIFF

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -11,7 +11,7 @@ Version history
        - fixed tile reading when a cache (.bfmemo) file is present
    - MicroManager
        - updated to parse JSON data from tags 50839 and 51123
-       - fixed to detect :file:`*_metadata.txt` files in addition to metadata.txt
+       - fixed to detect :file:`*_metadata.txt` files in addition to :file:`metadata.txt`
          files
        - fixed to handle datasets with each stack in a single file
    - OME-XML

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,36 @@
 Version history
 ===============
 
+5.1.8 (2016 February 8)
+-----------------------
+
+* Java bug fixes, including:
+   - FEI TIFF
+       - fixed stage position parsing and whitespace handling (thanks to Antoine Vandecreme)
+   - Pyramid TIFF
+       - fixed tile reading when a cache (.bfmemo) file is present
+   - MicroManager
+       - updated to parse JSON data from tags 50839 and 51123
+       - fixed to detect *_metadata.txt files in addition to metadata.txt
+         files
+       - fixed to handle datasets with each stack in a single file
+   - OME-XML
+       - updated to make .ome.xml an official extension
+   - OME-TIFF
+       - fixed to ignore invalid BinaryOnly elements
+   - TIFF
+       - fixed caching of BigTIFF files
+   - Build system
+       - fixed Maven POMs to reduce calls to artifacts.openmicroscopy.org
+       - fixed bioformats_package.jar to include the loci.formats.tools
+         package
+* Documentation updates, including:
+   - updated format pages to include links to example data
+   - clarified description of Qu for MATLAB (thanks to Carnë Draug)
+   - added installation instructions for Octave (thanks to Carnë Draug)
+* C++:
+   - no changes, released to keep version numbers in sync with Bio-Formats Java
+
 5.1.7 (2015 December 7)
 -----------------------
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.1.8 (2016 February 11)
+5.1.8 (2016 February 15)
 ------------------------
 
 * Java bug fixes, including:


### PR DESCRIPTION

This is the same as gh-2228 but rebased onto develop.

----

As usual, the date is best guess - happy to change it.

I didn't see any C++ PRs since 5.1.7, so assuming a placeholder is enough (/cc @rleigh-dundee).



                