### PR TITLE
Add version history for 5.1.9 (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,45 @@
 Version history
 ===============
 
+5.1.9 (2016 April 11)
+---------------------
+
+* Java bug fixes, including:
+   - SDT
+       - fixed width padding calculation for single-pixel image.
+   - Deltavision
+       - fixed the parsing of the new date format.
+       - added support for parsing and storing the working distance in native units.
+   - Micromanager
+       - cleaned up JSON metadata parsing.
+   - Olympus Fluoview
+       - fixed null pointer exceptions while parsing metadata.
+   - Leica LIF
+       - fixed large milt-tile files from having incorrect plane offsets after the 2GB mark.
+   - EM formats
+       - added native length support for EM readers.
+   - Gatan
+       - fixed erroneous metadata parsing.
+       - added support for parsing and storing the physical sizes in native units.
+   - OME-TIFF
+       - improve handling of OME-TIFF multi-file file-sets with partial metadata blocks.
+   - Nikon ND2
+       - fixed the parsing of emission wavelength.
+   - APL
+       - fixed multiple parsing issues with the mtb file.
+   - SlideBook
+       - removed slidebook dlls from Bio-Formats repository.
+   - Zeiss CZI
+       - fixed parsing of files with multiple mosaics and positions.
+
+* Documentation updates, including:
+   - improved documentation for the export of big-tiff’s in ImageJ.
+
+* C++:
+   - xerces version 3.1.2 is now removed from the mirror.
+   - xerces version updated to Version 3.1.3.
+
+
 5.1.8 (2016 February 15)
 ------------------------
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -22,7 +22,7 @@ Version history
        - fixed erroneous metadata parsing
        - added support for parsing and storing the physical sizes in native units
    - OME-TIFF
-       - improve handling of OME-TIFF multi-file file-sets with partial metadata blocks
+       - improved handling of OME-TIFF multi-file fileset’s with partial metadata blocks
    - Nikon ND2
        - fixed the parsing of emission wavelength
    - Olympus CellR (APL)

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-5.1.9 (2016 April 11)
+5.1.9 (2016 April 14)
 ---------------------
 
 * Java bug fixes, including:
@@ -29,6 +29,7 @@ Version history
        - fixed multiple parsing issues with the mtb file
    - SlideBook
        - removed slidebook dlls from Bio-Formats repository
+       - http://www.openmicroscopy.org/info/slidebook
    - Zeiss CZI
        - fixed parsing of files with multiple mosaics and positions
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -36,8 +36,7 @@ Version history
    - improved documentation for the export of BigTIFFs in ImageJ
 
 * C++:
-   - xerces version 3.1.2 is now removed from the mirror
-   - xerces version updated to Version 3.1.3
+   - no changes.
 
 
 5.1.8 (2016 February 15)

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -6,38 +6,38 @@ Version history
 
 * Java bug fixes, including:
    - SDT
-       - fixed width padding calculation for single-pixel image.
+       - fixed width padding calculation for single-pixel image
    - Deltavision
-       - fixed the parsing of the new date format.
-       - added support for parsing and storing the working distance in native units.
+       - fixed the parsing of the new date format
+       - added support for parsing and storing the working distance in native units
    - Micromanager
-       - cleaned up JSON metadata parsing.
+       - cleaned up JSON metadata parsing
    - Olympus Fluoview
-       - fixed null pointer exceptions while parsing metadata.
+       - fixed null pointer exceptions while parsing metadata
    - Leica LIF
-       - fixed large milt-tile files from having incorrect plane offsets after the 2GB mark.
-   - EM formats
-       - added native length support for EM readers.
+       - fixed large multi-tiled files from having incorrect plane offsets after the 2GB mark
+   - EM formats (MRC and Spider)
+       - added native length support for EM readers
    - Gatan
-       - fixed erroneous metadata parsing.
-       - added support for parsing and storing the physical sizes in native units.
+       - fixed erroneous metadata parsing
+       - added support for parsing and storing the physical sizes in native units
    - OME-TIFF
-       - improve handling of OME-TIFF multi-file file-sets with partial metadata blocks.
+       - improve handling of OME-TIFF multi-file file-sets with partial metadata blocks
    - Nikon ND2
-       - fixed the parsing of emission wavelength.
-   - APL
-       - fixed multiple parsing issues with the mtb file.
+       - fixed the parsing of emission wavelength
+   - Olympus CellR (APL)
+       - fixed multiple parsing issues with the mtb file
    - SlideBook
-       - removed slidebook dlls from Bio-Formats repository.
+       - removed slidebook dlls from Bio-Formats repository
    - Zeiss CZI
-       - fixed parsing of files with multiple mosaics and positions.
+       - fixed parsing of files with multiple mosaics and positions
 
 * Documentation updates, including:
-   - improved documentation for the export of big-tiff’s in ImageJ.
+   - improved documentation for the export of BigTIFFs in ImageJ
 
 * C++:
-   - xerces version 3.1.2 is now removed from the mirror.
-   - xerces version updated to Version 3.1.3.
+   - xerces version 3.1.2 is now removed from the mirror
+   - xerces version updated to Version 3.1.3
 
 
 5.1.8 (2016 February 15)


### PR DESCRIPTION

This is the same as gh-2336 but rebased onto develop.

----

Preliminary draft for the version history. Please feel free to point out edits/corrections.

@melissalinkert @jburel @sbesson @joshmoore 

                