### PR TITLE
Fix reader delegation when the legacy reader is enabled but not working

### DIFF
--- a/components/formats-api/src/loci/formats/DelegateReader.java
+++ b/components/formats-api/src/loci/formats/DelegateReader.java
@@ -192,7 +192,7 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
-    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+    if (callLegacyReader()) {
       return legacyReader.get8BitLookupTable();
     }
     return nativeReader.get8BitLookupTable();
@@ -201,7 +201,7 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatReader#get16BitLookupTable() */
   @Override
   public short[][] get16BitLookupTable() throws FormatException, IOException {
-    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+    if (callLegacyReader()) {
       return legacyReader.get16BitLookupTable();
     }
     return nativeReader.get16BitLookupTable();
@@ -210,7 +210,7 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatReader#getSeriesUsedFiles(boolean) */
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
-    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+    if (callLegacyReader()) {
       return legacyReader.getSeriesUsedFiles(noPixels);
     }
     return nativeReader.getSeriesUsedFiles(noPixels);
@@ -221,7 +221,7 @@ public abstract class DelegateReader extends FormatReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+    if (callLegacyReader()) {
       return legacyReader.openBytes(no, buf, x, y, w, h);
     }
     return nativeReader.openBytes(no, buf, x, y, w, h);
@@ -241,7 +241,7 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
-    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+    if (callLegacyReader()) {
       return legacyReader.getOptimalTileWidth();
     }
     return nativeReader.getOptimalTileWidth();
@@ -250,7 +250,7 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
-    if (useLegacy || (legacyReaderInitialized && !nativeReaderInitialized)) {
+    if (callLegacyReader()) {
       return legacyReader.getOptimalTileHeight();
     }
     return nativeReader.getOptimalTileHeight();
@@ -259,7 +259,7 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatReader#reopenFile() */
   @Override
   public void reopenFile() throws IOException {
-    if (useLegacy) {
+    if (callLegacyReader()) {
       legacyReader.reopenFile();
     }
     else {
@@ -273,7 +273,7 @@ public abstract class DelegateReader extends FormatReader {
   @Override
   public void setId(String id) throws FormatException, IOException {
     super.setId(id);
-    if (useLegacy) {
+    if (useLegacy && !nativeReaderInitialized && !legacyReaderInitialized) {
       try {
         legacyReader.setId(id);
         legacyReaderInitialized = true;
@@ -312,6 +312,10 @@ public abstract class DelegateReader extends FormatReader {
       metadata = legacyReader.getGlobalMetadata();
       metadataStore = legacyReader.getMetadataStore();
     }
+  }
+
+  private boolean callLegacyReader() {
+    return legacyReaderInitialized && (useLegacy || !nativeReaderInitialized);
   }
 
 }


### PR DESCRIPTION
This fixes the edge case where ```setUseLegacy(true)``` was called, but the
legacy reader throws an exception during setId triggering the native
reader instead.

Prior to this commit, the result of calling openBytes after setId would
have been a slightly cryptic exception indicating invalid core metadata.
Now, calling openBytes after setId should pass off to the native reader
without error.

Testing is easiest in ImageJ, preferably on a non-Windows machine.  First open ImageJ and select ```Plugins > Bio-Formats > Bio-Formats Plugins Configuration```, then select ```Nikon ND2``` in the ```Formats``` tab and make sure the ```Use Nikon's ND2 library...``` box is ticked (it shouldn't be by default).  Without this change, opening either of the .nd2 files in test_images_good/nd2 should result in an IllegalArgumentException.  With this change, the same test should result in the file being opened without error.

After testing this PR, reverting the ImageJ configuration change is recommended - I only discovered this issue because I'd forgotten to untick the box after a previous round of testing a few months ago.