### PR TITLE
cpp: transform test: Handle MapAnnotation downgrade

### DIFF
--- a/cpp/test/ome-xml/transform.cpp
+++ b/cpp/test/ome-xml/transform.cpp
@@ -58,6 +58,7 @@ using boost::filesystem::directory_iterator;
 struct TransformTestParameters
 {
   path file;
+  bool throws;
 };
 
 template<class charT, class traits>
@@ -93,6 +94,7 @@ namespace
                   {
                     TransformTestParameters p;
                     p.file = *fi;
+                    p.throws = false;
 
                     // 2008-09/instrument.ome.xml
                     if (schemadir.filename() == path("2008-09") &&
@@ -103,7 +105,7 @@ namespace
                       continue;
                     // Map Annotation cannot be converted
                     if (p.file.filename() == path("mapannotation.ome.xml"))
-                      continue;
+                      p.throws = true;
 
                     if (p.file.extension() == path(".ome") ||
                         p.file.extension() == path(".xml"))
@@ -146,13 +148,23 @@ TEST_P(TransformTest, TransformFileToString)
   const TransformTestParameters& params = GetParam();
 
   std::string result;
-  ASSERT_NO_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, params.file, result,
-                                      entity_resolver, transform_resolver));
-  ASSERT_TRUE(!result.empty());
+  if(params.throws)
+    {
+      ASSERT_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, params.file, result,
+                                       entity_resolver, transform_resolver),
+                   std::runtime_error);
+    }
+  else
+    {
+      ASSERT_NO_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, params.file, result,
+                                          entity_resolver, transform_resolver));
 
-  ome::common::xml::dom::Document resultdoc(ome::common::xml::dom::createDocument(result, entity_resolver));
-  ASSERT_EQ(std::string(OME_XML_MODEL_VERSION),
-            ome::xml::getModelVersion(resultdoc));
+      ASSERT_TRUE(!result.empty());
+
+      ome::common::xml::dom::Document resultdoc(ome::common::xml::dom::createDocument(result, entity_resolver));
+      ASSERT_EQ(std::string(OME_XML_MODEL_VERSION),
+                ome::xml::getModelVersion(resultdoc));
+    }
 }
 
 TEST_P(TransformTest, TransformStreamToString)
@@ -162,13 +174,23 @@ TEST_P(TransformTest, TransformStreamToString)
   boost::filesystem::ifstream input(params.file);
 
   std::string result;
-  ASSERT_NO_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, params.file, result,
-                                      entity_resolver, transform_resolver));
-  ASSERT_TRUE(!result.empty());
+  if(params.throws)
+    {
+      ASSERT_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, params.file, result,
+                                       entity_resolver, transform_resolver),
+                   std::runtime_error);
+    }
+  else
+    {
+      ASSERT_NO_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, params.file, result,
+                                          entity_resolver, transform_resolver));
 
-  ome::common::xml::dom::Document resultdoc(ome::common::xml::dom::createDocument(result, entity_resolver));
-  ASSERT_EQ(std::string(OME_XML_MODEL_VERSION),
-            ome::xml::getModelVersion(resultdoc));
+      ASSERT_TRUE(!result.empty());
+
+      ome::common::xml::dom::Document resultdoc(ome::common::xml::dom::createDocument(result, entity_resolver));
+      ASSERT_EQ(std::string(OME_XML_MODEL_VERSION),
+                ome::xml::getModelVersion(resultdoc));
+    }
 }
 
 TEST_P(TransformTest, TransformStringToString)
@@ -179,13 +201,23 @@ TEST_P(TransformTest, TransformStringToString)
   readFile(params.file, input);
   
   std::string result;
-  ASSERT_NO_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, input, result,
-                                      entity_resolver, transform_resolver));
-  ASSERT_TRUE(!result.empty());
+  if(params.throws)
+    {
+      ASSERT_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, input, result,
+                                       entity_resolver, transform_resolver),
+                   std::runtime_error);
+    }
+  else
+    {
+      ASSERT_NO_THROW(ome::xml::transform(OME_XML_MODEL_VERSION, input, result,
+                                          entity_resolver, transform_resolver));
 
-  ome::common::xml::dom::Document resultdoc(ome::common::xml::dom::createDocument(result, entity_resolver));
-  ASSERT_EQ(std::string(OME_XML_MODEL_VERSION),
-            ome::xml::getModelVersion(resultdoc));
+      ASSERT_TRUE(!result.empty());
+
+      ome::common::xml::dom::Document resultdoc(ome::common::xml::dom::createDocument(result, entity_resolver));
+      ASSERT_EQ(std::string(OME_XML_MODEL_VERSION),
+                ome::xml::getModelVersion(resultdoc));
+    }
 }
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;


### PR DESCRIPTION
With the patched xalan source from https://github.com/ome/ome-cmake-superbuild/pull/56 it's now safe to test downgrade failure for map annotations.  This patch adds the ability to know if a test will throw and exception or not, and check for this accordingly.

**Do not merge before https://github.com/ome/ome-cmake-superbuild/pull/56 **

--------

Testing: Check jobs are green.  The tests will segfault and fail if it's not handled, or else fail if the test passes rather than failing as required.