### PR TITLE
TestNG - OutOfMemory handling

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -314,9 +314,12 @@ public class FormatReaderTest {
         try {
           b = reader.openThumbImage(0);
         }
-        catch (OutOfMemoryError e) {
-          result(testName, true, "Image too large");
-          return;
+        catch (Throwable e) {
+          if (TestTools.isOutOfMemory(e)) {
+            result(testName, true, "Image too large");
+            return;
+          }
+          throw e;
         }
 
         int actualX = b.getWidth();
@@ -389,9 +392,12 @@ public class FormatReaderTest {
         try {
           b = reader.openThumbBytes(0);
         }
-        catch (OutOfMemoryError e) {
-          result(testName, true, "Image too large");
-          return;
+        catch (Throwable e) {
+          if (TestTools.isOutOfMemory(e)) {
+            result(testName, true, "Image too large");
+            return;
+          }
+          throw e;
         }
         success = b.length == expected;
         if (!success) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -192,7 +192,7 @@ public class FormatReaderTest {
         }
 
         if (c > 4 || plane < 0 || plane != checkPlane ||
-          !TestTools.canFitInMemory(plane))
+          !TestTools.canFitInMemory(plane * 3))
         {
           continue;
         }
@@ -262,7 +262,7 @@ public class FormatReaderTest {
           continue;
         }
 
-        if (!TestTools.canFitInMemory(expected) || expected < 0) {
+        if (!TestTools.canFitInMemory(expected * 3) || expected < 0) {
           continue;
         }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -229,6 +229,10 @@ public class FormatReaderTest {
       }
     }
     catch (Throwable t) {
+      if (TestTools.isOutOfMemory(t)) {
+        result(testName, true, "Image too large");
+        return;
+      }
       LOGGER.info("", t);
       success = false;
     }
@@ -275,6 +279,10 @@ public class FormatReaderTest {
       }
     }
     catch (Throwable t) {
+      if (TestTools.isOutOfMemory(t)) {
+        result(testName, true, "Image too large");
+        return;
+      }
       LOGGER.info("", t);
       success = false;
     }
@@ -1463,6 +1471,13 @@ public class FormatReaderTest {
             catch (IOException e) {
               LOGGER.info("", e);
             }
+            catch (Throwable e) {
+              if (TestTools.isOutOfMemory(e)) {
+                result(testName, true, "Image too large");
+                return;
+              }
+              throw e;
+            }
           }
         }
         long t2 = System.currentTimeMillis();
@@ -1907,6 +1922,10 @@ public class FormatReaderTest {
       resolutionReader.close();
     }
     catch (Throwable t) {
+      if (TestTools.isOutOfMemory(t)) {
+        result(testName, true, "Image too large");
+        return;
+      }
       LOGGER.info("", t);
       success = false;
     }
@@ -1954,6 +1973,10 @@ public class FormatReaderTest {
       }
     }
     catch (Throwable t) {
+      if (TestTools.isOutOfMemory(t)) {
+        result(testName, true, "Image too large");
+        return;
+      }
       LOGGER.info("", t);
       success = false;
     }
@@ -2035,7 +2058,11 @@ public class FormatReaderTest {
           try {
             md5 = TestTools.md5(resolutionReader.openBytes(0, 0, 0, w, h));
           }
-          catch (Exception e) {
+          catch (Throwable e) {
+            if (TestTools.isOutOfMemory(e)) {
+              result(testName, true, "Image too large");
+              return;
+            }
             LOGGER.warn("", e);
           }
 
@@ -2084,7 +2111,13 @@ public class FormatReaderTest {
         try {
           md5 = TestTools.md5(reader.openBytes(0, 0, 0, w, h));
         }
-        catch (Exception e) { }
+        catch (Throwable e) {
+          if (TestTools.isOutOfMemory(e)) {
+            result(testName, true, "Image too large");
+            return;
+          }
+          throw e;
+        }
 
         if (md5 == null && expected1 == null && expected2 == null) {
           success = true;
@@ -2390,6 +2423,10 @@ public class FormatReaderTest {
       result(testName, true);
     }
     catch (Throwable t) {
+      if (TestTools.isOutOfMemory(t)) {
+        result(testName, true, "Image too large");
+        return;
+      }
       LOGGER.warn("", t);
       result(testName, false, t.getMessage());
     }

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -494,4 +494,23 @@ public class TestTools {
     return ir;
   }
 
+  /**
+   * Determine whether or not a Throwable was caused by an OutOfMemoryError.
+   *
+   * @param t Throwable object to check
+   * @return true if <code>t</code> is or was caused by an OutOfMemoryError, false otherwise
+   */
+  public static boolean isOutOfMemory(Throwable t) {
+    if (t instanceof OutOfMemoryError) {
+      return true;
+    }
+    while (t.getCause() != null) {
+      if (t.getCause() instanceof OutOfMemoryError) {
+        return true;
+      }
+      t = t.getCause();
+    }
+    return false;
+  }
+
 }

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -141,7 +141,11 @@ public class TestTools {
   /** Returns true if a byte buffer of the given size will fit in memory. */
   public static boolean canFitInMemory(long bufferSize) {
     Runtime r = Runtime.getRuntime();
-    long mem = r.freeMemory() / 2;
+
+    // better indicator than freeMemory() of how much memory is actually available
+    long mem = r.maxMemory() - (r.totalMemory() - r.freeMemory());
+
+    mem /= 2;
     int threadCount = 1;
     try {
       threadCount = Integer.parseInt(System.getProperty("testng.threadCount"));


### PR DESCRIPTION
This is building upon the commits in https://github.com/openmicroscopy/bioformats/pull/2282
This has extended the Out Of Memory exception handling to other tests in the FormatReaderTest.

There are the possibilities of some memory leaks with the tests but those are still being investigated.