### PR TITLE
LiFlimReader: fix ExposureTime check and use native units

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -55,6 +55,7 @@ import loci.formats.UnsupportedCompressionException;
 import loci.formats.meta.MetadataStore;
 
 import ome.units.quantity.Time;
+import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
@@ -135,6 +136,7 @@ public class LiFlimReader extends FormatReader {
   private Map<Integer, ROI> rois;
   private Map<Integer, String> stampValues;
   private Double exposureTime;
+  private Unit<Time> exposureTimeUnit = UNITS.S;
 
   /** True if gzip compression was used to deflate the pixels. */
   private boolean gzip;
@@ -234,6 +236,7 @@ public class LiFlimReader extends FormatReader {
       rois = null;
       stampValues = null;
       exposureTime = null;
+      exposureTimeUnit = UNITS.S;
     }
   }
 
@@ -334,7 +337,9 @@ public class LiFlimReader extends FormatReader {
             double expTime = Double.parseDouble(value.substring(0, space));
             String units = value.substring(space + 1).toLowerCase();
             if (units.equals("ms")) {
-              expTime /= 1000;
+              exposureTimeUnit = UNITS.MS;
+            } else {
+              exposureTimeUnit = UNITS.S;
             }
             exposureTime = new Double(expTime);
           }
@@ -462,7 +467,7 @@ public class LiFlimReader extends FormatReader {
             store.setPlaneDeltaT(new Time(deltaT, UNITS.S), 0, index);
           }
           if (exposureTime != null) {
-            store.setPlaneExposureTime(new Time(exposureTime, UNITS.S), 0, index);
+            store.setPlaneExposureTime(new Time(exposureTime, exposureTimeUnit), 0, index);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -329,7 +329,7 @@ public class LiFlimReader extends FormatReader {
             }
             rois.put(index, roi);
           }
-          else if (metaKey.endsWith("ExposureTime")) {
+          else if (metaKey.equals("ExposureTime")) {
             int space = value.indexOf(" ");
             double expTime = Double.parseDouble(value.substring(0, space));
             String units = value.substring(space + 1).toLowerCase();


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-April/005940.html

This change should fix the issue reported in the ome-users thread while preserving compatiblity with existing `li-flim` filesets. Additionally, the exposure time should now be stored using the native unit in the metadata.

To test this PR, check the automated tests pass and review the sample files under `curated/li-flim`.