### PR TITLE
VSI Pyramidal Format - Slow tag reading

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -131,7 +131,6 @@ public class CellSensReader extends FormatReader {
 
   // Tag values
 
-  private static final int TAG_START  = 2000;
   private static final int COLLECTION_VOLUME = 2000;
   private static final int MULTIDIM_IMAGE_VOLUME = 2001;
   private static final int IMAGE_FRAME_VOLUME = 2002;
@@ -1396,7 +1395,7 @@ public class CellSensReader extends FormatReader {
         LOGGER.debug("  extendedField = {}", extendedField);
         LOGGER.debug("  realType = {}", realType);
 
-        if (tag < TAG_START) {
+        if (tag < COLLECTION_VOLUME) {
           if (!inlineData && dataSize + vsi.getFilePointer() < vsi.length()) {
             vsi.skipBytes(dataSize);
           }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -131,6 +131,7 @@ public class CellSensReader extends FormatReader {
 
   // Tag values
 
+  private static final int TAG_START  = 2000;
   private static final int COLLECTION_VOLUME = 2000;
   private static final int MULTIDIM_IMAGE_VOLUME = 2001;
   private static final int IMAGE_FRAME_VOLUME = 2002;
@@ -1395,7 +1396,7 @@ public class CellSensReader extends FormatReader {
         LOGGER.debug("  extendedField = {}", extendedField);
         LOGGER.debug("  realType = {}", realType);
 
-        if (tag < 0) {
+        if (tag < TAG_START) {
           if (!inlineData && dataSize + vsi.getFilePointer() < vsi.length()) {
             vsi.skipBytes(dataSize);
           }


### PR DESCRIPTION
Issue was raised in forum post https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=7501&start=40 with sample files provided in QA-17158.

After analysing the timing of commands within the file reader it was found that a large amount of time was spent reading an unkown tag (tag = 0, tagName = null, type = INT2, datasize = 16711680). As such I have modified the check for valid tags to use the minimum tag value that we recognise.

To reproduce:
- Download the files from QA-17158
- Verify that the 'Slow' and 'Very Slow' filesets load in a noticeably longer timeframe

To test:
- After applying the code changes retest with files from QA-17158
- Verify that the slower file sets load in a timeframe in line with the 'Fast' fileset
- Verify that the image data and metadata on the file sets remains unchanged

--breaking
