### PR TITLE
AxisGuesser: public axis prefixes

### DIFF
--- a/components/formats-bsd/src/loci/formats/AxisGuesser.java
+++ b/components/formats-bsd/src/loci/formats/AxisGuesser.java
@@ -40,6 +40,8 @@ import loci.common.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * AxisGuesser guesses which blocks in a file pattern correspond to which
  * dimensional axes (Z, T, C or S), potentially recommending an adjustment in
@@ -71,18 +73,24 @@ public class AxisGuesser {
   public static final int S_AXIS = 4;
 
   /** Prefixes indicating space dimension. */
-  public static final String[] Z_PREFIXES = {
+  public static final ImmutableSet<String> Z_PREFIXES = ImmutableSet.of(
     "fp", "sec", "z", "zs", "focal", "focalplane"
-  };
+  );
 
   /** Prefixes indicating time dimension. */
-  public static final String[] T_PREFIXES = {"t", "tl", "tp", "time"};
+  public static final ImmutableSet<String> T_PREFIXES = ImmutableSet.of(
+      "t", "tl", "tp", "time"
+  );
 
   /** Prefixes indicating channel dimension. */
-  public static final String[] C_PREFIXES = {"c", "ch", "w", "wavelength"};
+  public static final ImmutableSet<String> C_PREFIXES = ImmutableSet.of(
+      "c", "ch", "w", "wavelength"
+  );
 
   /** Prefixes indicating series dimension. */
-  public static final String[] S_PREFIXES = {"s", "series", "sp"};
+  public static final ImmutableSet<String> S_PREFIXES = ImmutableSet.of(
+      "s", "series", "sp"
+  );
 
   protected static final String ONE = "1";
   protected static final String TWO = "2";
@@ -178,44 +186,26 @@ public class AxisGuesser {
       while (f >= 0 && ch[f] >= 'a' && ch[f] <= 'z') f--;
       p = p.substring(f + 1, l + 1);
 
-      // check against known Z prefixes
-      for (String knownP : Z_PREFIXES) {
-        if (p.equals(knownP)) {
-          axisTypes[i] = Z_AXIS;
-          foundZ = true;
-          break;
-        }
+      // check against known prefixes
+      if (Z_PREFIXES.contains(p)) {
+        axisTypes[i] = Z_AXIS;
+        foundZ = true;
+        continue;
       }
-      if (axisTypes[i] != UNKNOWN_AXIS) continue;
-
-      // check against known T prefixes
-      for (String knownP : T_PREFIXES) {
-        if (p.equals(knownP)) {
-          axisTypes[i] = T_AXIS;
-          foundT = true;
-          break;
-        }
+      if (T_PREFIXES.contains(p)) {
+        axisTypes[i] = T_AXIS;
+        foundT = true;
+        continue;
       }
-      if (axisTypes[i] != UNKNOWN_AXIS) continue;
-
-      // check against known C prefixes
-      for (String knownP : C_PREFIXES) {
-        if (p.equals(knownP)) {
-          axisTypes[i] = C_AXIS;
-          foundC = true;
-          break;
-        }
+      if (C_PREFIXES.contains(p)) {
+        axisTypes[i] = C_AXIS;
+        foundC = true;
+        continue;
       }
-      if (axisTypes[i] != UNKNOWN_AXIS) continue;
-
-      // check against known series prefixes
-      for (String knownP : S_PREFIXES) {
-        if (p.equals(knownP)) {
-          axisTypes[i] = S_AXIS;
-          break;
-        }
+      if (S_PREFIXES.contains(p)) {
+        axisTypes[i] = S_AXIS;
+        continue;
       }
-      if (axisTypes[i] != UNKNOWN_AXIS) continue;
 
       // check special case: <2-3>, <1-3> (Bio-Rad PIC)
       if (suffix.equalsIgnoreCase(".pic") && i == axisTypes.length - 1 &&

--- a/components/formats-bsd/src/loci/formats/AxisGuesser.java
+++ b/components/formats-bsd/src/loci/formats/AxisGuesser.java
@@ -71,18 +71,18 @@ public class AxisGuesser {
   public static final int S_AXIS = 4;
 
   /** Prefixes indicating space dimension. */
-  protected static final String[] Z = {
+  public static final String[] Z_PREFIXES = {
     "fp", "sec", "z", "zs", "focal", "focalplane"
   };
 
   /** Prefixes indicating time dimension. */
-  protected static final String[] T = {"t", "tl", "tp", "time"};
+  public static final String[] T_PREFIXES = {"t", "tl", "tp", "time"};
 
   /** Prefixes indicating channel dimension. */
-  protected static final String[] C = {"c", "ch", "w", "wavelength"};
+  public static final String[] C_PREFIXES = {"c", "ch", "w", "wavelength"};
 
   /** Prefixes indicating series dimension. */
-  protected static final String[] S = {"s", "series", "sp"};
+  public static final String[] S_PREFIXES = {"s", "series", "sp"};
 
   protected static final String ONE = "1";
   protected static final String TWO = "2";
@@ -179,8 +179,8 @@ public class AxisGuesser {
       p = p.substring(f + 1, l + 1);
 
       // check against known Z prefixes
-      for (int j=0; j<Z.length; j++) {
-        if (p.equals(Z[j])) {
+      for (String knownP : Z_PREFIXES) {
+        if (p.equals(knownP)) {
           axisTypes[i] = Z_AXIS;
           foundZ = true;
           break;
@@ -189,8 +189,8 @@ public class AxisGuesser {
       if (axisTypes[i] != UNKNOWN_AXIS) continue;
 
       // check against known T prefixes
-      for (int j=0; j<T.length; j++) {
-        if (p.equals(T[j])) {
+      for (String knownP : T_PREFIXES) {
+        if (p.equals(knownP)) {
           axisTypes[i] = T_AXIS;
           foundT = true;
           break;
@@ -199,8 +199,8 @@ public class AxisGuesser {
       if (axisTypes[i] != UNKNOWN_AXIS) continue;
 
       // check against known C prefixes
-      for (int j=0; j<C.length; j++) {
-        if (p.equals(C[j])) {
+      for (String knownP : C_PREFIXES) {
+        if (p.equals(knownP)) {
           axisTypes[i] = C_AXIS;
           foundC = true;
           break;
@@ -209,8 +209,8 @@ public class AxisGuesser {
       if (axisTypes[i] != UNKNOWN_AXIS) continue;
 
       // check against known series prefixes
-      for (int j=0; j<S.length; j++) {
-        if (p.equals(S[j])) {
+      for (String knownP : S_PREFIXES) {
+        if (p.equals(knownP)) {
           axisTypes[i] = S_AXIS;
           break;
         }
@@ -370,19 +370,25 @@ public class AxisGuesser {
 
   // -- Static API methods --
 
-  /** Returns a best guess of the given label's axis type. */
+  /** Convert the given label to an axis type. If the label ends with
+   * one of the known prefixes for the Z, C, T or S axis (as defined
+   * in <code>Z_PREFIXES, C_PREFIXES, T_PREFIXES, S_PREFIXES</code>),
+   * return the corresponding axis type; otherwise, return
+   * <code>UNKNOWN_AXIS</code>. Note that the match is
+   * case-insensitive.
+   */
   public static int getAxisType(String label) {
     String lowerLabel = label.toLowerCase();
-    for (String p : Z) {
+    for (String p : Z_PREFIXES) {
       if (p.equals(lowerLabel) || lowerLabel.endsWith(p)) return Z_AXIS;
     }
-    for (String p : C) {
+    for (String p : C_PREFIXES) {
       if (p.equals(lowerLabel) || lowerLabel.endsWith(p)) return C_AXIS;
     }
-    for (String p : T) {
+    for (String p : T_PREFIXES) {
       if (p.equals(lowerLabel) || lowerLabel.endsWith(p)) return T_AXIS;
     }
-    for (String p : S) {
+    for (String p : S_PREFIXES) {
       if (p.equals(lowerLabel) || lowerLabel.endsWith(p)) return S_AXIS;
     }
     return UNKNOWN_AXIS;

--- a/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
@@ -47,17 +47,13 @@ import static loci.formats.AxisGuesser.T_AXIS;
 import static loci.formats.AxisGuesser.C_AXIS;
 import static loci.formats.AxisGuesser.S_AXIS;
 import static loci.formats.AxisGuesser.UNKNOWN_AXIS;
+import static loci.formats.AxisGuesser.Z_PREFIXES;
+import static loci.formats.AxisGuesser.T_PREFIXES;
+import static loci.formats.AxisGuesser.C_PREFIXES;
+import static loci.formats.AxisGuesser.S_PREFIXES;
 
 
 public class AxisGuesserTest {
-
-  // These arrays are protected in AxisGuesser
-  private static final String[] Z = new String[] {
-    "fp", "sec", "z", "zs", "focal", "focalplane"
-  };
-  private static final String[] T = new String[] {"t", "tl", "tp", "time"};
-  private static final String[] C = new String[] {"c", "ch", "w", "wavelength"};
-  private static final String[] S = new String[] {"s", "series", "sp"};
 
   @DataProvider(name = "booleanStates")
   public Object[][] createBooleans() {
@@ -68,10 +64,10 @@ public class AxisGuesserTest {
   public Object[][] createPrefixCases() {
     List<Object[]> cases = new ArrayList<Object[]>();
     String template = "%s_<0-1>%s_<2-3>%s_<4-5>%s_<6-7>";
-    for (String z: Z) {
-      for (String t: T) {
-        for (String c: C) {
-          for (String s: S) {
+    for (String z: Z_PREFIXES) {
+      for (String t: T_PREFIXES) {
+        for (String c: C_PREFIXES) {
+          for (String s: S_PREFIXES) {
             cases.add(new Object[] {String.format(template, z, t, c, s)});
             cases.add(new Object[] {String.format(template,
               z.toUpperCase(), t.toUpperCase(), c.toUpperCase(), s.toUpperCase()
@@ -220,16 +216,16 @@ public class AxisGuesserTest {
 
   @Test(dataProvider = "booleanStates")
   public void testGetAxisType(Boolean upperCase) {
-    for (String s: Z) {
+    for (String s: Z_PREFIXES) {
       assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), Z_AXIS);
     }
-    for (String s: T) {
+    for (String s: T_PREFIXES) {
       assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), T_AXIS);
     }
-    for (String s: C) {
+    for (String s: C_PREFIXES) {
       assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), C_AXIS);
     }
-    for (String s: S) {
+    for (String s: S_PREFIXES) {
       assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), S_AXIS);
     }
   }

--- a/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
@@ -59,6 +59,11 @@ public class AxisGuesserTest {
   private static final String[] C = new String[] {"c", "ch", "w", "wavelength"};
   private static final String[] S = new String[] {"s", "series", "sp"};
 
+  @DataProvider(name = "booleanStates")
+  public Object[][] createBooleans() {
+    return new Object[][] {{true}, {false}};
+  }
+
   @DataProvider(name = "prefixCases")
   public Object[][] createPrefixCases() {
     List<Object[]> cases = new ArrayList<Object[]>();
@@ -146,6 +151,13 @@ public class AxisGuesserTest {
     checkAxisCount(ag, types);
   }
 
+  private String mkPrefix(String baseTag, Boolean upperCase) {
+    if (upperCase) {
+      baseTag = baseTag.toUpperCase();
+    }
+    return String.format("_%s", baseTag);
+  }
+
   private void checkAxisCount(AxisGuesser ag, int[] axisTypes) {
     // Should be as simple as possible
     int countZ = 0, countT = 0, countC = 0, countS = 0;
@@ -206,19 +218,19 @@ public class AxisGuesserTest {
     check(pattern, order, sZ, sT, sC, true, order, types);
   }
 
-  @Test
-  public void testGetAxisType() {
+  @Test(dataProvider = "booleanStates")
+  public void testGetAxisType(Boolean upperCase) {
     for (String s: Z) {
-      assertEquals(AxisGuesser.getAxisType(String.format("_%s", s)), Z_AXIS);
+      assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), Z_AXIS);
     }
     for (String s: T) {
-      assertEquals(AxisGuesser.getAxisType(String.format("_%s", s)), T_AXIS);
+      assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), T_AXIS);
     }
     for (String s: C) {
-      assertEquals(AxisGuesser.getAxisType(String.format("_%s", s)), C_AXIS);
+      assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), C_AXIS);
     }
     for (String s: S) {
-      assertEquals(AxisGuesser.getAxisType(String.format("_%s", s)), S_AXIS);
+      assertEquals(AxisGuesser.getAxisType(mkPrefix(s, upperCase)), S_AXIS);
     }
   }
 


### PR DESCRIPTION
This PR changes `AxisGuesser`'s static fields that define known axis prefixes (`AxisGuesser.{Z,C,T,S}`) to `public`. Users need to know what pattern block prefixes lead to automatic axis assignments, and this is indeed documented in the [sphinx docs](https://www.openmicroscopy.org/site/support/bio-formats5.1/formats/pattern-file.html).

Another problem with those fields is that their names are too short, making the code harder to read and debug. Since they're going public, this was the last chance to make them longer, so I've changed them to `AxisGuesser.{Z,C,T,S}_PREFIXES`