### PR TITLE
TiffSaver: fix recorded offsets to non-interleaved RGB tiles (5.1)

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -504,7 +504,7 @@ public class TiffSaver {
     int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
     for (int i=0; i<strips.length; i++) {
       out.seek(out.length());
-      int index = interleaved ? i : i / nChannels;
+      int index = interleaved ? i : (i / nChannels) * nChannels;
       int c = interleaved ? 0 : i % nChannels;
       int thisOffset = firstOffset + index + c * tileCount;
       offsets.set(thisOffset, out.getFilePointer());

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -353,14 +353,14 @@ public class TiffSaver {
                   }
                   else {
                     off = c * blockSize + ndx + n;
+                    int realStrip = c * (nStrips / nChannels) + strip;
                     if (row >= h || col >= w) {
-                      stripOut[strip].writeByte(0);
+                      stripOut[realStrip].writeByte(0);
                     } else if (off < buf.length) {
-                      stripOut[c * (nStrips / nChannels) + strip].writeByte(
-                          buf[off]);
+                      stripOut[realStrip].writeByte(buf[off]);
                     }
                     else {
-                      stripOut[strip].writeByte(0);
+                      stripOut[realStrip].writeByte(0);
                     }
                   }
                 }
@@ -504,7 +504,9 @@ public class TiffSaver {
     int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
     for (int i=0; i<strips.length; i++) {
       out.seek(out.length());
-      int thisOffset = firstOffset + i * tileCount;
+      int index = interleaved ? i : i / nChannels;
+      int c = interleaved ? 0 : i % nChannels;
+      int thisOffset = firstOffset + index + c * tileCount;
       offsets.set(thisOffset, out.getFilePointer());
       byteCounts.set(thisOffset, new Long(strips[i].length));
       if (LOGGER.isDebugEnabled()) {

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -501,9 +501,10 @@ public class TiffSaver {
     long fp = out.getFilePointer();
     writeIFD(ifd, 0);
 
+    int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
     for (int i=0; i<strips.length; i++) {
       out.seek(out.length());
-      int thisOffset = firstOffset + i;
+      int thisOffset = firstOffset + i * tileCount;
       offsets.set(thisOffset, out.getFilePointer());
       byteCounts.set(thisOffset, new Long(strips[i].length));
       if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION
--rebased-from #2168

See the above PR for testing instructions.
Also see https://www.openmicroscopy.org/community/viewtopic.php?t=8042&p=17018#p17018 for a sample SVS file (http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs) which fails to convert with bfconvert without this PR.