### PR TITLE
Logging improvements

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -129,7 +129,7 @@ public final class ImageConverter {
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-") && args.length > 1) {
         if (args[i].equals("-debug")) {
-          DebugTools.setLogging("DEBUG");
+          DebugTools.setRootLevel("DEBUG");
         }
         else if (args[i].equals("-stitch")) stitch = true;
         else if (args[i].equals("-separate")) separate = true;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -285,7 +285,6 @@ public final class ImageConverter {
   {
     nextOutputIndex.clear();
     firstTile = true;
-    DebugTools.enableLogging("INFO");
     boolean success = parseArgs(args);
     if (!success) {
       return false;
@@ -860,6 +859,7 @@ public final class ImageConverter {
   // -- Main method --
 
   public static void main(String[] args) throws FormatException, IOException {
+    DebugTools.enableLogging("INFO");
     if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1) {
       UpgradeChecker checker = new UpgradeChecker();
       boolean canUpgrade =

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -129,7 +129,7 @@ public final class ImageConverter {
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-") && args.length > 1) {
         if (args[i].equals("-debug")) {
-          DebugTools.enableLogging("DEBUG");
+          DebugTools.setLogging("DEBUG");
         }
         else if (args[i].equals("-stitch")) stitch = true;
         else if (args[i].equals("-separate")) separate = true;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageFaker.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageFaker.java
@@ -80,7 +80,7 @@ public class ImageFaker {
         } else if (args[i].equals("-fields")) {
           fields = Integer.parseInt(args[++i]);
         } else if (args[i].equals("-debug")) {
-          DebugTools.enableLogging("DEBUG");
+          DebugTools.setLogging("DEBUG");
         }
       } else {
         if (targetDirectoryPath == null) {

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageFaker.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageFaker.java
@@ -80,7 +80,7 @@ public class ImageFaker {
         } else if (args[i].equals("-fields")) {
           fields = Integer.parseInt(args[++i]);
         } else if (args[i].equals("-debug")) {
-          DebugTools.setLogging("DEBUG");
+          DebugTools.setRootLevel("DEBUG");
         }
       } else {
         if (targetDirectoryPath == null) {

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -215,15 +215,15 @@ public class ImageInfo {
         else if (args[i].equals("-novalid")) validate = false;
         else if (args[i].equals("-noflat")) flat = false;
         else if (args[i].equals("-debug")) {
-          DebugTools.enableLogging("DEBUG");
+          DebugTools.setLogging("DEBUG");
         }
         else if (args[i].equals("-trace")) {
-          DebugTools.enableLogging("TRACE");
+          DebugTools.setLogging("TRACE");
         }
         else if (args[i].equals("-omexml-only")) {
           omexmlOnly = true;
           omexml = true;
-          DebugTools.enableLogging("OFF");
+          DebugTools.setLogging("OFF");
         }
         else if (args[i].equals("-preload")) preload = true;
         else if (args[i].equals("-ascii")) ascii = true;
@@ -969,12 +969,12 @@ public class ImageInfo {
       }
 
       if (omexmlOnly) {
-        DebugTools.enableLogging("INFO");
+        DebugTools.setLogging("INFO");
       }
       String xml = service.getOMEXML((MetadataRetrieve) ms);
       LOGGER.info("{}", XMLTools.indentXML(xml, xmlSpaces, true));
       if (omexmlOnly) {
-        DebugTools.enableLogging("OFF");
+        DebugTools.setLogging("OFF");
       }
       if (validate) {
         service.validateOMEXML(xml);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -999,7 +999,6 @@ public class ImageInfo {
   public boolean testRead(String[] args)
     throws FormatException, ServiceException, IOException
   {
-    DebugTools.enableLogging("INFO");
 
     for (final String arg : args) {
       if (HELP_ARGUMENTS.contains(arg)) {
@@ -1110,6 +1109,7 @@ public class ImageInfo {
   // -- Main method --
 
   public static void main(String[] args) throws Exception {
+    DebugTools.enableLogging("INFO");
     if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1) {
       UpgradeChecker checker = new UpgradeChecker();
       boolean canUpgrade =

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -215,15 +215,15 @@ public class ImageInfo {
         else if (args[i].equals("-novalid")) validate = false;
         else if (args[i].equals("-noflat")) flat = false;
         else if (args[i].equals("-debug")) {
-          DebugTools.setLogging("DEBUG");
+          DebugTools.setRootLevel("DEBUG");
         }
         else if (args[i].equals("-trace")) {
-          DebugTools.setLogging("TRACE");
+          DebugTools.setRootLevel("TRACE");
         }
         else if (args[i].equals("-omexml-only")) {
           omexmlOnly = true;
           omexml = true;
-          DebugTools.setLogging("OFF");
+          DebugTools.setRootLevel("OFF");
         }
         else if (args[i].equals("-preload")) preload = true;
         else if (args[i].equals("-ascii")) ascii = true;
@@ -969,12 +969,12 @@ public class ImageInfo {
       }
 
       if (omexmlOnly) {
-        DebugTools.setLogging("INFO");
+        DebugTools.setRootLevel("INFO");
       }
       String xml = service.getOMEXML((MetadataRetrieve) ms);
       LOGGER.info("{}", XMLTools.indentXML(xml, xmlSpaces, true));
       if (omexmlOnly) {
-        DebugTools.setLogging("OFF");
+        DebugTools.setRootLevel("OFF");
       }
       if (validate) {
         service.validateOMEXML(xml);

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -116,8 +116,7 @@ public final class DebugTools {
    * Attempts to enable SLF4J logging via logback or log4j without an
    * external configuration file.
    * This will first check whether logging has been enabled either via a
-   * configuration file or a previous call. If not enabled, calls
-   * {@link #setRootLevel(String)} at INFO level.
+   * configuration file or a previous call.
    *
    * @return {@code true} if logging was successfully enabled by this method
    */

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
  */
 public final class DebugTools {
 
-  final static String[][] TOOLCLASSES = new String[][] {
+  final static String[][] TOOL_CLASSES = new String[][] {
     new String[] {"loci.common.", "LogbackTools"},
     new String[] {"loci.common.", "Log4jTools"}
   };
@@ -74,7 +74,7 @@ public final class DebugTools {
    * @return {@code true} if logging has been successfully enabled
    */
   public static synchronized boolean isEnabled() {
-    for (String[] toolClass : TOOLCLASSES) {
+    for (String[] toolClass : TOOL_CLASSES) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
         Method m = k.getMethod("isEnabled");
@@ -96,7 +96,7 @@ public final class DebugTools {
    * @param level A string indicating the desired level
    */
   public static synchronized void setRootLevel(String level) {
-    for (String[] toolClass : TOOLCLASSES) {
+    for (String[] toolClass : TOOL_CLASSES) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
         Method m = k.getMethod("setRootLevel", String.class);
@@ -120,7 +120,7 @@ public final class DebugTools {
    */
   public static synchronized boolean enableLogging() {
     if (isEnabled()) return false;
-    for (String[] toolClass : TOOLCLASSES) {
+    for (String[] toolClass : TOOL_CLASSES) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
         Method m = k.getMethod("enableLogging");

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -122,7 +122,19 @@ public final class DebugTools {
    * @return {@code true} if logging was successfully enabled by this method
    */
   public static synchronized boolean enableLogging() {
-    return enableLogging("INFO");
+    if (isEnabled()) return false;
+    for (String[] toolClass : TOOLCLASSES) {
+      try {
+        Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
+        Method m = k.getMethod("enableLogging", String.class);
+        m.invoke(null);
+        return true;
+      }
+      catch (Throwable t) {
+        // no-op. Ignore error and try the next class.
+      }
+    }
+    return false;
   }
   
   /**
@@ -137,19 +149,9 @@ public final class DebugTools {
    * @return {@code true} if logging was successfully enabled by this method
    */
   public static synchronized boolean enableLogging(String level) {
-    if (isEnabled()) return false;
-    for (String[] toolClass : TOOLCLASSES) {
-      try {
-        Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
-        Method m = k.getMethod("enableLogging", String.class);
-        m.invoke(null, level);
-        return true;
-      }
-      catch (Throwable t) {
-        // no-op. Ignore error and try the next class.
-      }
-    }
-    return false;
+    boolean status = enableLogging();
+    if (status) setRootLevel(level);
+    return status;
   }
 
   /**

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -126,7 +126,7 @@ public final class DebugTools {
     for (String[] toolClass : TOOLCLASSES) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
-        Method m = k.getMethod("enableLogging", String.class);
+        Method m = k.getMethod("enableLogging");
         m.invoke(null);
         return true;
       }

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -80,7 +80,7 @@ public final class DebugTools {
         Method m = k.getMethod("isEnabled");
         return (Boolean) m.invoke(null);
       }
-      catch (Throwable t) {
+      catch (ReflectiveOperationException t) {
         // no-op. Ignore error and try the next class.
       }
     }
@@ -103,7 +103,7 @@ public final class DebugTools {
         m.invoke(null, level);
         return;
       }
-      catch (Throwable t) {
+      catch (ReflectiveOperationException t) {
         // no-op. Ignore error and try the next class.
       }
     }
@@ -127,7 +127,7 @@ public final class DebugTools {
         m.invoke(null);
         return true;
       }
-      catch (Throwable t) {
+      catch (ReflectiveOperationException t) {
         // no-op. Ignore error and try the next class.
       }
     }

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -47,13 +47,12 @@ import java.util.Arrays;
  */
 public final class DebugTools {
 
-  // -- Constructor --
-
   final static String[][] TOOLCLASSES = new String[][] {
     new String[] {"loci.common.", "LogbackTools"},
     new String[] {"loci.common.", "Log4jTools"}
   };
 
+  // -- Constructor --
   private DebugTools() { }
 
   // -- DebugTools methods --
@@ -70,7 +69,7 @@ public final class DebugTools {
   }
 
   /**
-   * Checks whether SLF4J logging has been enabled via logback or log4j
+   * Checks whether the SLF4J logging has been enabled via logback of log4j.
    *
    * @return {@code true} if logging has been successfully enabled
    */
@@ -89,13 +88,12 @@ public final class DebugTools {
   }
 
   /**
-   * Sets the level of the root logger
-   * This method will override the root logger level whether it was initialized
-   * via a configuration file or another logger call.
+   * Sets the root logger level.
+   *
+   * This method will override the root logger level independently of the way
+   * the logging framework has been enabled.
    *
    * @param level A string indicating the desired level
-   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
-   * @return {@code} true if the  was successfully enabled
    */
   public static synchronized void setRootLevel(String level) {
     for (String[] toolClass : TOOLCLASSES) {
@@ -113,10 +111,10 @@ public final class DebugTools {
   }
 
   /**
-   * Attempts to enable SLF4J logging via logback or log4j without an
-   * external configuration file.
-   * This will first check whether logging has been enabled either via a
-   * configuration file or a previous call.
+   * Attempts to enable SLF4J logging via logback or log4j.
+   *
+   * This will first check whether the logging has been enabled using the
+   * return value of {@link #isEnabled()}.
    *
    * @return {@code true} if logging was successfully enabled by this method
    */
@@ -137,14 +135,14 @@ public final class DebugTools {
   }
   
   /**
-   * Attempts to enable SLF4J logging via logback or log4j without an
-   * external configuration file.
-   * This will first check whether logging has been enabled either via a
-   * configuration file or a previous call. If not enabled, dlee
-   * {@link #setRootLevel(String)} with the desired level.
+   * Attempts to enable SLF4J logging and set the root logger level.
+   *
+   * This method will first try to initialize the logging using
+   * {@link #enableLogging()}. If this method returns {@code true}, the root
+   * logger level is also set via {@link #setRootLevel(String)} using the
+   * input level.
    *
    * @param level A string indicating the desired level
-   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code true} if logging was successfully enabled by this method
    */
   public static synchronized boolean enableLogging(String level) {
@@ -155,6 +153,7 @@ public final class DebugTools {
 
   /**
    * Enable SLF4J logging using logback, in the context of ImageJ.
+   *
    * This allows logging events to be echoed to the ImageJ status bar,
    * regardless of how the logging configuration file was set up.
    *

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -67,7 +67,7 @@ public final class DebugTools {
   /**
    * Checks whether SLF4J logging has been enabled via logback or log4j
    *
-   * @return {@code true} if logging was successfully enabled
+   * @return {@code true} if logging has been successfully enabled
    */
   public static synchronized boolean isEnabled() {
     final String[][] toolClasses = new String[][] {
@@ -89,14 +89,15 @@ public final class DebugTools {
   }
 
   /**
-   * Attempts to enable SLF4J logging via logback or log4j
-   * without an external configuration file.
+   * Sets the SLF4J logging via logback or log4j
+   * This method will override any logging previously configured either via a
+   * configuration file or another {@link DebugTools} call.
    *
    * @param level A string indicating the desired level
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code} true if logging was successfully enabled
    */
-  public static synchronized boolean enableLogging(String level) {
+  public static synchronized boolean setLogging(String level) {
     final String[][] toolClasses = new String[][] {
       new String[] {"loci.common.", "LogbackTools"},
       new String[] {"loci.common.", "Log4jTools"}
@@ -112,6 +113,38 @@ public final class DebugTools {
       catch (Throwable t) {
         // no-op. Ignore error and try the next class.
       }
+    }
+    return false;
+  }
+
+  /**
+   * Attempts to enable SLF4J logging via logback or log4j without an
+   * external configuration file.
+   * This will first check whether logging has been enabled either via a
+   * configuration file or a previous call. If not enabled, calls
+   * {@link #setLogging(String)} at INFO level.
+   *
+   * @return {@code true} if logging was successfully enabled by this method
+   */
+  public static synchronized boolean enableLogging() {
+    return enableLogging("INFO");
+  }
+  
+  /**
+   * Attempts to enable SLF4J logging via logback or log4j without an
+   * external configuration file.
+   * This will first check whether logging has been enabled either via a
+   * configuration file or a previous call. If not enabled, calls
+   * {@link #setLogging(String)} with the desired level.
+   *
+   * @param level A string indicating the desired level
+   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
+   * @return {@code true} if logging was successfully enabled by this method
+   */
+  public static synchronized boolean enableLogging(String level) {
+    if (!isEnabled()) {
+      boolean status = setLogging(level);
+      return status;
     }
     return false;
   }

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -97,19 +97,19 @@ public final class DebugTools {
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code} true if the  was successfully enabled
    */
-  public static synchronized boolean setRootLevel(String level) {
+  public static synchronized void setRootLevel(String level) {
     for (String[] toolClass : TOOLCLASSES) {
       try {
         Class<?> k = Class.forName(toolClass[0] + toolClass[1]);
         Method m = k.getMethod("setRootLevel", String.class);
         m.invoke(null, level);
-        return true;
+        return;
       }
       catch (Throwable t) {
         // no-op. Ignore error and try the next class.
       }
     }
-    return false;
+    return;
   }
 
   /**

--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -69,7 +69,7 @@ public final class DebugTools {
   }
 
   /**
-   * Checks whether the SLF4J logging has been enabled via logback of log4j.
+   * Checks whether SLF4J logging has been enabled via logback or log4j.
    *
    * @return {@code true} if logging has been successfully enabled
    */

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -60,6 +60,25 @@ public final class Log4jTools {
       return false;
     }
   }
+
+  /**
+   * Sets the level of the root logger
+   *
+   * @param level A string indicating the desired level
+   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
+   */
+  public static synchronized void setRootLevel(String level) {
+    try {
+      ReflectedUniverse r = new ReflectedUniverse();
+      r.exec("import org.apache.log4j.Level");
+      r.exec("import org.apache.log4j.Logger");
+      r.exec("root = Logger.getRootLogger()");
+      r.exec("root.setLevel(Level." + level + ")");
+    } catch (ReflectException exc) {
+      return;
+    }
+    return;
+  }
   
   /**
    * Attempts to enable SLF4J logging via log4j

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -44,7 +44,7 @@ public final class Log4jTools {
   private Log4jTools() { }
 
   /**
-   * Checks whether SLF4J logging was enabled via log4j
+   * Checks whether the log4j framework was successfully enabled
    *
    * @return {@code true} if logging was successfully enabled
    */
@@ -94,7 +94,6 @@ public final class Log4jTools {
       r.exec("import org.apache.log4j.Level");
       r.exec("import org.apache.log4j.Logger");
       r.exec("root = Logger.getRootLogger()");
-      r.exec("root.setLevel(Level." + level + ")");
       Enumeration en = (Enumeration) r.exec("root.getAllAppenders()");
       if (!en.hasMoreElements()) {
         // no appenders yet; attach a simple console appender

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -88,7 +88,7 @@ public final class Log4jTools {
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code true} if logging was successfully enabled
    */
-  public static synchronized boolean enableLogging(String level) {
+  public static synchronized boolean enableLogging() {
     try {
       ReflectedUniverse r = new ReflectedUniverse();
       r.exec("import org.apache.log4j.Level");

--- a/components/formats-common/src/loci/common/Log4jTools.java
+++ b/components/formats-common/src/loci/common/Log4jTools.java
@@ -84,8 +84,6 @@ public final class Log4jTools {
    * Attempts to enable SLF4J logging via log4j
    * without an external configuration file.
    *
-   * @param level A string indicating the desired level
-   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code true} if logging was successfully enabled
    */
   public static synchronized boolean enableLogging() {

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -41,7 +41,7 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
-
+import ch.qos.logback.core.joran.util.ConfigurationWatchListUtil;
 
 
 /**
@@ -54,13 +54,14 @@ public final class LogbackTools {
   private LogbackTools() { }
 
   /**
-   * Checks whether SLF4J logging was enabled via logback
+   * Checks whether logback has been configured
    *
    * @return {@code} true if logging was successfully enabled
    */
   public static synchronized boolean isEnabled() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-    return root.iteratorForAppenders().hasNext();
+    LoggerContext loggerContext = root.getLoggerContext();
+    return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) == null);
   }
 
   /**

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -64,6 +64,17 @@ public final class LogbackTools {
   }
 
   /**
+   * Sets the level of the root logger
+   *
+   * @param level A string indicating the desired level
+   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
+   */
+  public static synchronized void setRootLevel(String level) {
+    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    root.setLevel(Level.toLevel(level));
+  }
+
+  /**
    * Attempts to enable SLF4J logging via logback without an external
    * configuration file.
    *

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -83,7 +83,7 @@ public final class LogbackTools {
    *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code} true if logging was successfully enabled
    */
-  public static synchronized boolean enableLogging(String level) {
+  public static synchronized boolean enableLogging() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     LoggerContext context = root.getLoggerContext();
     if (!root.iteratorForAppenders().hasNext()) {
@@ -114,8 +114,6 @@ public final class LogbackTools {
         root.addAppender(defaultAppender);
       }
     }
-    root.setLevel(Level.toLevel(level));
-
     return true;
   }
 

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -51,6 +51,8 @@ public final class LogbackTools {
 
   // -- Constructor --
 
+  public static String CALLER = "Bio-Formats";
+
   private LogbackTools() { }
 
   /**
@@ -67,7 +69,7 @@ public final class LogbackTools {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     LoggerContext loggerContext = root.getLoggerContext();
     return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) != null
-            || (loggerContext.getProperty("caller") == "Bio-Formats"));
+            || (loggerContext.getProperty("caller") == CALLER));
   }
 
   /**
@@ -94,7 +96,7 @@ public final class LogbackTools {
     LoggerContext context = root.getLoggerContext();
     if (!root.iteratorForAppenders().hasNext()) {
       context.reset();
-      context.putProperty("caller", "Bio-Formats");
+      context.putProperty("caller", CALLER);
       PatternLayoutEncoder layout = new PatternLayoutEncoder();
       layout.setContext(context);
       layout.setPattern("%m%n");
@@ -110,7 +112,7 @@ public final class LogbackTools {
       Appender defaultAppender = root.iteratorForAppenders().next();
       if (defaultAppender instanceof ConsoleAppender) {
         context.reset();
-        context.putProperty("caller", "Bio-Formats");
+        context.putProperty("caller", CALLER);
 
         PatternLayoutEncoder layout = new PatternLayoutEncoder();
         layout.setContext(context);

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -62,7 +62,7 @@ public final class LogbackTools {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     LoggerContext loggerContext = root.getLoggerContext();
     return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) != null
-            || root.iteratorForAppenders().hasNext());
+            || (loggerContext.getProperty("caller") == "Bio-Formats"));
   }
 
   /**
@@ -87,6 +87,7 @@ public final class LogbackTools {
     LoggerContext context = root.getLoggerContext();
     if (!root.iteratorForAppenders().hasNext()) {
       context.reset();
+      context.putProperty("caller", "Bio-Formats");
       PatternLayoutEncoder layout = new PatternLayoutEncoder();
       layout.setContext(context);
       layout.setPattern("%m%n");
@@ -102,6 +103,8 @@ public final class LogbackTools {
       Appender defaultAppender = root.iteratorForAppenders().next();
       if (defaultAppender instanceof ConsoleAppender) {
         context.reset();
+        context.putProperty("caller", "Bio-Formats");
+
         PatternLayoutEncoder layout = new PatternLayoutEncoder();
         layout.setContext(context);
         layout.setPattern("%m%n");

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -61,7 +61,7 @@ public final class LogbackTools {
   public static synchronized boolean isEnabled() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     LoggerContext loggerContext = root.getLoggerContext();
-    return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) == null);
+    return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) != null);
   }
 
   /**
@@ -79,8 +79,6 @@ public final class LogbackTools {
    * Attempts to enable SLF4J logging via logback without an external
    * configuration file.
    *
-   * @param level A string indicating the desired level
-   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
    * @return {@code} true if logging was successfully enabled
    */
   public static synchronized boolean enableLogging() {

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -61,7 +61,8 @@ public final class LogbackTools {
   public static synchronized boolean isEnabled() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     LoggerContext loggerContext = root.getLoggerContext();
-    return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) != null);
+    return (ConfigurationWatchListUtil.getMainWatchURL(loggerContext) != null
+            || root.iteratorForAppenders().hasNext());
   }
 
   /**

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -51,7 +51,7 @@ public final class LogbackTools {
 
   // -- Constructor --
 
-  public static final String CALLER = "Bio-Formats";
+  private static final String CALLER = "Bio-Formats";
 
   private LogbackTools() { }
 

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -51,7 +51,7 @@ public final class LogbackTools {
 
   // -- Constructor --
 
-  public static String CALLER = "Bio-Formats";
+  public static final String CALLER = "Bio-Formats";
 
   private LogbackTools() { }
 

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -54,9 +54,14 @@ public final class LogbackTools {
   private LogbackTools() { }
 
   /**
-   * Checks whether logback has been configured
+   * Checks whether logback has been enabled.
    *
-   * @return {@code} true if logging was successfully enabled
+   * This method will check if the root logger has been initialized via either
+   * a configuration file or a previous call to {@link #enableLogging()}. The
+   * logger context property will be used to discriminate the latter case from
+   * other initializations.
+   *
+   * @return {@code true} if logging was successfully enabled
    */
   public static synchronized boolean isEnabled() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
@@ -69,7 +74,7 @@ public final class LogbackTools {
    * Sets the level of the root logger
    *
    * @param level A string indicating the desired level
-   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN).
+   *   (i.e.: ALL, DEBUG, ERROR, FATAL, INFO, OFF, WARN).
    */
   public static synchronized void setRootLevel(String level) {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
@@ -77,10 +82,12 @@ public final class LogbackTools {
   }
 
   /**
-   * Attempts to enable SLF4J logging via logback without an external
-   * configuration file.
+   * Initializes logback without an external configuration file.
    *
-   * @return {@code} true if logging was successfully enabled
+   * The logging initialization also sets a logger context property to record
+   * the initalization provenance.
+   *
+   * @return {@code true} if logging was successfully enabled
    */
   public static synchronized boolean enableLogging() {
     Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);

--- a/components/formats-common/src/loci/common/LogbackTools.java
+++ b/components/formats-common/src/loci/common/LogbackTools.java
@@ -137,8 +137,6 @@ public final class LogbackTools {
 
       if (debug) {
         root.setLevel(Level.DEBUG);
-      } else {
-        root.setLevel(Level.INFO);
       }
       appender.setContext(root.getLoggerContext());
       root.addAppender(appender);

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -61,11 +62,24 @@ public class DebugToolsTest {
         {"INFO"}, {"WARN"}, {"ERROR"}, {"DEBUG"}, {"TRACE"}, {"ALL"}};
   }
 
+  @BeforeClass
+  public void testConfigurationFile() {
+    // Logback should be initialized via a configuration file
+    assertTrue(DebugTools.isEnabled());
+    status = DebugTools.enableLogging();
+    assertFalse(status);
+    assertEquals(root.getLevel(), Level.toLevel("WARN"));
+    status = DebugTools.enableLogging("INFO");
+    assertFalse(status);
+    assertEquals(root.getLevel(), Level.toLevel("WARN"));
+  }
+
   @BeforeMethod
   public void setUp() {
-    // Make sure logger context is reset
+    // Reset the logger context before each test method
     root.getLoggerContext().reset();
     assertFalse(DebugTools.isEnabled());
+    assertEquals(root.getLevel(), Level.toLevel("DEBUG"));
   }
 
   // -- Tests --

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -73,21 +73,40 @@ public class DebugToolsTest {
   public void testEnableLogging() {
     status = DebugTools.enableLogging();
     assertTrue(status);
+    assertTrue(DebugTools.isEnabled());
     status = DebugTools.enableLogging();
     assertFalse(status);
+    assertTrue(DebugTools.isEnabled());
+  }
+
+  @Test
+  public void testEnableLoggingDefaultLevel() {
+    status = DebugTools.enableLogging("INFO");
+    assertTrue(status);
+    assertTrue(DebugTools.isEnabled());
+    assertEquals(root.getLevel(), Level.toLevel("INFO"));
+    status = DebugTools.enableLogging("DEBUG");
+    assertFalse(status);
+    assertTrue(DebugTools.isEnabled());
+    assertEquals(root.getLevel(), Level.toLevel("INFO"));
   }
 
   @Test(dataProvider = "levels")
   public void testEnableLoggingLevels(String level) {
     status = DebugTools.enableLogging(level);
     assertTrue(status);
+    assertTrue(DebugTools.isEnabled());
     assertEquals(root.getLevel(), Level.toLevel(level));
-    status = DebugTools.enableLogging(level);
+    status = DebugTools.enableLogging();
     assertFalse(status);
+    assertTrue(DebugTools.isEnabled());
   }
 
   @Test(dataProvider = "levels")
   public void testSetRootLevel(String level) {
+    status = DebugTools.enableLogging();
+    assertTrue(status);
+    assertTrue(DebugTools.isEnabled());
     DebugTools.setRootLevel(level);
     assertEquals(root.getLevel(), Level.toLevel(level));
   }

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -32,6 +32,7 @@
 
 package loci.common.utests;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 
@@ -51,7 +52,7 @@ import org.testng.annotations.Test;
  */
 public class DebugToolsTest {
 
-  Logger root;
+  Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
   @DataProvider(name = "levels")
   public Object[][] createLevels() {
@@ -62,7 +63,6 @@ public class DebugToolsTest {
   @BeforeMethod
   public void setUp() {
     // Make sure logger context is reset
-    root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     root.getLoggerContext().reset();
     assertFalse(DebugTools.isEnabled());
   }
@@ -78,6 +78,6 @@ public class DebugToolsTest {
   public void testEnableLoggingLevels(String level) {
     boolean status = DebugTools.enableLogging(level);
     assertTrue(status);
-    assertEquals(root.getLevel(), level);
+    assertEquals(root.getLevel(), Level.toLevel(level));
   }
 }

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -53,6 +53,7 @@ import org.testng.annotations.Test;
 public class DebugToolsTest {
 
   Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+  boolean status;
 
   @DataProvider(name = "levels")
   public Object[][] createLevels() {
@@ -70,14 +71,20 @@ public class DebugToolsTest {
   // -- Tests --
   @Test
   public void testEnableLogging() {
-    boolean status = DebugTools.enableLogging();
+    status = DebugTools.enableLogging();
     assertTrue(status);
   }
 
   @Test(dataProvider = "levels")
   public void testEnableLoggingLevels(String level) {
-    boolean status = DebugTools.enableLogging(level);
+    status = DebugTools.enableLogging(level);
     assertTrue(status);
+    assertEquals(root.getLevel(), Level.toLevel(level));
+  }
+
+  @Test(dataProvider = "levels")
+  public void testSetRootLevel(String level) {
+    DebugTools.setRootLevel(level);
     assertEquals(root.getLevel(), Level.toLevel(level));
   }
 }

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * Common package for I/O and related utilities
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.common.utests;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+
+import org.slf4j.LoggerFactory;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+import loci.common.DebugTools;
+
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link loci.common.DebugTools}.
+ */
+public class DebugToolsTest {
+
+  // -- Tests --
+
+  @Test
+  public void testDefault() {
+    assertTrue(DebugTools.isEnabled());
+    boolean status = DebugTools.enableLogging();
+    assertFalse(status);
+  }
+
+  @Test
+  public void testResetContext() {
+    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    root.getLoggerContext().reset();
+    assertFalse(DebugTools.isEnabled());
+    boolean status = DebugTools.enableLogging();
+    assertTrue(status);
+  }
+}

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -35,12 +35,15 @@ package loci.common.utests;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 
+import loci.common.DebugTools;
+
 import org.slf4j.LoggerFactory;
 
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
-import loci.common.DebugTools;
-
+import static org.testng.AssertJUnit.assertEquals;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -48,21 +51,33 @@ import org.testng.annotations.Test;
  */
 public class DebugToolsTest {
 
-  // -- Tests --
+  Logger root;
 
-  @Test
-  public void testDefault() {
-    assertTrue(DebugTools.isEnabled());
-    boolean status = DebugTools.enableLogging();
-    assertFalse(status);
+  @DataProvider(name = "levels")
+  public Object[][] createLevels() {
+    return new Object[][] {
+        {"INFO"}, {"WARN"}, {"ERROR"}, {"DEBUG"}, {"TRACE"}, {"ALL"}};
   }
 
-  @Test
-  public void testResetContext() {
-    Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+  @BeforeMethod
+  public void setUp() {
+    // Make sure logger context is reset
+    root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     root.getLoggerContext().reset();
     assertFalse(DebugTools.isEnabled());
+  }
+
+  // -- Tests --
+  @Test
+  public void testEnableLogging() {
     boolean status = DebugTools.enableLogging();
     assertTrue(status);
+  }
+
+  @Test(dataProvider = "levels")
+  public void testEnableLoggingLevels(String level) {
+    boolean status = DebugTools.enableLogging(level);
+    assertTrue(status);
+    assertEquals(root.getLevel(), level);
   }
 }

--- a/components/formats-common/test/loci/common/utests/DebugToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DebugToolsTest.java
@@ -73,6 +73,8 @@ public class DebugToolsTest {
   public void testEnableLogging() {
     status = DebugTools.enableLogging();
     assertTrue(status);
+    status = DebugTools.enableLogging();
+    assertFalse(status);
   }
 
   @Test(dataProvider = "levels")
@@ -80,6 +82,8 @@ public class DebugToolsTest {
     status = DebugTools.enableLogging(level);
     assertTrue(status);
     assertEquals(root.getLevel(), Level.toLevel(level));
+    status = DebugTools.enableLogging(level);
+    assertFalse(status);
   }
 
   @Test(dataProvider = "levels")

--- a/components/formats-common/test/loci/common/utests/testng-template.xml
+++ b/components/formats-common/test/loci/common/utests/testng-template.xml
@@ -208,6 +208,11 @@
         <class name="loci.common.utests.DateToolsTest"/>
       </classes>
     </test>
+    <test name="DebugTools">
+        <classes>
+            <class name="loci.common.utests.DebugToolsTest"/>
+        </classes>
+    </test>
     <!--
     <test name="Encoding">
       <classes>

--- a/components/formats-gpl/matlab/bfInitLogging.m
+++ b/components/formats-gpl/matlab/bfInitLogging.m
@@ -35,9 +35,6 @@ function bfInitLogging(varargin)
 % Check Bio-Formats is set in the Java class path
 bfCheckJavaPath();
 
-% Return if the logging system is already initialized
-if javaMethod('isEnabled', 'loci.common.DebugTools'), return; end
-
 % Input check
 levels = {'ALL', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'OFF', 'TRACE', 'WARN'};
 ip = inputParser;

--- a/components/formats-gpl/test/matlab/ReaderTest.m
+++ b/components/formats-gpl/test/matlab/ReaderTest.m
@@ -50,7 +50,7 @@ classdef ReaderTest < TestBfMatlab
             self.sizeZ = self.reader.DEFAULT_SIZE_Z;
             self.sizeC = self.reader.DEFAULT_SIZE_C;
             self.sizeT = self.reader.DEFAULT_SIZE_T;
-            loci.common.DebugTools.enableLogging('ERROR');
+            loci.common.DebugTools.setLogging('ERROR');
             import ome.units.UNITS.*;
         end
         

--- a/components/formats-gpl/test/matlab/ReaderTest.m
+++ b/components/formats-gpl/test/matlab/ReaderTest.m
@@ -50,7 +50,7 @@ classdef ReaderTest < TestBfMatlab
             self.sizeZ = self.reader.DEFAULT_SIZE_Z;
             self.sizeC = self.reader.DEFAULT_SIZE_C;
             self.sizeT = self.reader.DEFAULT_SIZE_T;
-            loci.common.DebugTools.setLogging('ERROR');
+            loci.common.DebugTools.setRootLevel('ERROR');
             import ome.units.UNITS.*;
         end
         

--- a/components/formats-gpl/test/matlab/TestBfInitLogging.m
+++ b/components/formats-gpl/test/matlab/TestBfInitLogging.m
@@ -50,6 +50,9 @@ classdef TestBfInitLogging < TestBfMatlab
             bfInitLogging();
             assertTrue(loci.common.DebugTools.isEnabled());
             assertEqual(char(self.root.getLevel.toString()), 'WARN');
+            bfInitLogging('INFO');
+            assertTrue(loci.common.DebugTools.isEnabled());
+            assertEqual(char(self.root.getLevel.toString()), 'WARN');
         end
         
         function testALL(self)
@@ -106,6 +109,16 @@ classdef TestBfInitLogging < TestBfMatlab
             bfInitLogging('WARN');
             assertTrue(loci.common.DebugTools.isEnabled());
             assertEqual(char(self.root.getLevel.toString()), 'WARN');
+        end
+
+        function testSetRootLevel(self)
+            self.disableLogging();
+            loci.common.DebugTools.enableLogging();
+            assertTrue(loci.common.DebugTools.isEnabled());
+            loci.common.DebugTools.setRootLevel('INFO');
+            assertEqual(char(self.root.getLevel.toString()), 'INFO');
+            loci.common.DebugTools.setRootLevel('DEBUG');
+            assertEqual(char(self.root.getLevel.toString()), 'DEBUG');
         end
     end
 end


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/13151

This PR reviews the `loci.common.DebugTools` class and its logging framework implementations `loci.common.Log4jTools` and `loci.common.LogbackTools` to:
- respect logging frameworks (log4j/logback) initialized via a binding-specific configuration file
- prevent `DebugTools.enableLogging(String)` from overriding initialized logger levels

### Major  API changes:
- addition of a new `DebugTools.setRootLevel(String)` to set the level of the root logger with its `Log4jTools` and `LogbackTools` implementations
- addition of `DebugTools.enableLogging()` the core function for initialization the logging system which is conditional to the return code of  `DebugTools.isEnabled()` and delegates the initialization to the corresponding logging framework classes
- modification of `DebugTools.enableLogging(String)` to set the root logger level via `DebugTools.setRootLevel(String)` on sucessful initialization of the logging framework via `DebugTools.enableLogging()`
- improvement of the `LogbackTools.isEnabled()` implementation to return true if
  1. a binding-specific configuration file has been used to initialize the logging framework or
  2. the logging framework has been initialized via `DebugTools` (using an internal registration mechanism via the logger context properties)

### Plugins/tools
- ImageJ plugin is unmodified and should call `DebugTools.enableLogging(INFO)`. Using a binding-specific configuration file (`logback.xml`) should take precedence over this logging call
- Command-line tools: should be initialized via `tools/logback.xml`. All options-specific logging calls are converted to use `DebugTools.setRootLevel(String)`
- MATLAB toolbox: the `DebugTools.isEnabled` condition is now moved to the downstream method and removed as superfluous

### Test coverage

Tests are available for the 2 main logging frameworks supported by Bio-Formats
- logback: a new `DebugToolsTest` class has been added to the TestNG suite and should be included in Maven/Ant test targets
- log4j: the principal consumer being the MATLAB toolbox, the `DebugTools` happens via the `TestBfInitLogging` unit tests and should be run in the Jenkins MATLAB jobs

 