### PR TITLE
Add Varian owner link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2203,7 +2203,8 @@ reader = UnisokuReader
 
 [Varian FDF]
 extensions = .fdf
-developer = `Varian, Inc. <http://www.varianinc.com>`_
+owner = `Agilent Technologies <http://www.agilent.com/home>`_
+developer = Varian, Inc.
 bsd = no
 weHave = * a few Varian FDF datasets
 weWant = * an official specification document \n

--- a/docs/sphinx/formats/varian-fdf.txt
+++ b/docs/sphinx/formats/varian-fdf.txt
@@ -6,8 +6,9 @@ Varian FDF
 
 Extensions: .fdf
 
-Developer: `Varian, Inc. <http://www.varianinc.com>`_
+Developer: Varian, Inc.
 
+Owner: `Agilent Technologies <http://www.agilent.com/home>`_
 
 **Support**
 


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-latest-docs/124/warnings3Result/ - Varian link was breaking the build as it was being redirected to Agilent, who bought the company some years ago according to their website.

I followed the existing examples which have owner above developer on the autogen page despite it being the other way around on the built format pages so hopefully it will work ok and not upset the autogen build!