### PR TITLE
Update cpp downloads link in sidebar

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -171,10 +171,8 @@ extlinks = {
     'omerodoc' : (omerodoc_uri + '/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),
-    'downloads_cpp' : (downloads_root + '/latest/bio-formats-cpp5.1/%s', ''),
-    'javadoc' : (downloads_root + '/latest/bio-formats5.1/api/%s', ''),
-    'doxygen' : (downloads_root + '/latest/bio-formats-cpp5.1/api/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats5.2/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats5.2/api/%s', ''),
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', '')

--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.1/">{{ _('Bio-Formats Java Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.2/">{{ _('Bio-Formats Downloads') }}</a></br>
 <a href="http://downloads.openmicroscopy.org/latest/ome-files-cpp/">{{ _('OME Files C++ Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>

--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.1/">{{ _('Main Downloads') }}</a></br>
-<a href="http://downloads.openmicroscopy.org/latest/bio-formats-cpp5.1/">{{ _('C++ Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.1/">{{ _('Bio-Formats Java Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/ome-files-cpp/">{{ _('C++ Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>

--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
 <a href="http://downloads.openmicroscopy.org/latest/bio-formats5.1/">{{ _('Bio-Formats Java Downloads') }}</a></br>
-<a href="http://downloads.openmicroscopy.org/latest/ome-files-cpp/">{{ _('C++ Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/ome-files-cpp/">{{ _('OME Files C++ Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
See https://trello.com/c/K0EpMdAx/128-bf-docs-sidebar-menu-still-links-to-bf-c-downloads

Staged at http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/

Not to be backported