### PR TITLE
Fix Bio-Formats importer bug for file grouped with the "Dimensions" option (rebased onto dev_5_1)

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -220,7 +220,9 @@ public class FilePatternDialog extends ImporterDialog {
 
         FilePatternBlock block = new FilePatternBlock(fp.getBlock(i));
 
-        fileCount = fileCount.subtract(BigInteger.ONE).multiply(increment);
+        // Last image of each axis is defined as
+        // (number of images - 1) * axis increment + axis first image
+        fileCount = fileCount.subtract(BigInteger.ONE).multiply(increment).add(first);
 
         pattern += fp.getPrefix(i);
         pattern += "<";


### PR DESCRIPTION

This is the same as gh-2380 but rebased onto dev_5_1.

----

The issue can be reproduced by opening a set of images grouped using a pattern where the index of the first image is not zero. Instead adding the index of the first image to calculate the index of the last image should be sufficient to group all files together.

See http://forum.imagej.net/t/little-bug-in-bio-formats-importer/1461

To test this PR:
- open the fileset included in the ImageJ forum thread, check the original issue using Bio-Formats 5.1.9 (only 2 files grouped) and check all 6 files are grouped using either Pattern or Dimensions is restored with this PR included
- modify filenames to vary the first index and increment of each axis and check the grouping still works as expected when using the Dimensions option. For instance, a fileset with the following pattern:
  ```
export_T001_Z001_C02.tif	export_T001_Z002_C03.tif
export_T001_Z001_C03.tif	export_T001_Z003_C02.tif
export_T001_Z002_C02.tif	export_T001_Z003_C03.tif
```
  should throw in a `IOException` without this PR but group all 6 files with this PR included.

                