### PR TITLE
ScreenReader enhancements

### DIFF
--- a/components/formats-bsd/src/loci/formats/AxisGuesser.java
+++ b/components/formats-bsd/src/loci/formats/AxisGuesser.java
@@ -114,6 +114,24 @@ public class AxisGuesser {
   /** Whether the guesser is confident that all axis types are correct. */
   protected boolean certain;
 
+  // -- Helpers --
+
+  private boolean swapZT(int sizeZ, int sizeT, boolean haveZ, boolean haveT) {
+    boolean wrongZ = haveZ && !haveT && sizeZ > 1 && sizeT == 1;
+    boolean wrongT = haveT && !haveZ && sizeT > 1 && sizeZ == 1;
+    if (wrongZ || wrongT) {
+        int indexZ = newOrder.indexOf('Z');
+        int indexT = newOrder.indexOf('T');
+        char[] ch = newOrder.toCharArray();
+        ch[indexZ] = 'T';
+        ch[indexT] = 'Z';
+        newOrder = new String(ch);
+        return true;
+    } else {
+      return false;
+    }
+  }
+
   // -- Constructor --
 
   /**
@@ -249,16 +267,7 @@ public class AxisGuesser {
     // -- 2) check for special cases where dimension order should be swapped --
 
     if (!isCertain) { // only switch if dimension order is uncertain
-      if (foundZ && !foundT && sizeZ > 1 && sizeT == 1 ||
-        foundT && !foundZ && sizeT > 1 && sizeZ == 1)
-      {
-        // swap Z and T dimensions
-        int indexZ = newOrder.indexOf('Z');
-        int indexT = newOrder.indexOf('T');
-        char[] ch = newOrder.toCharArray();
-        ch[indexZ] = 'T';
-        ch[indexT] = 'Z';
-        newOrder = new String(ch);
+      if (swapZT(sizeZ, sizeT, foundZ, foundT)) {
         int sz = sizeT;
         sizeT = sizeZ;
         sizeZ = sz;
@@ -301,6 +310,32 @@ public class AxisGuesser {
       }
     }
   }
+
+  /**
+   * Alternate constuctor where axis types are externally assigned. In
+   * this case, {@link #getAxisTypes} simply returns the given array,
+   * but other methods are still useful. Note that if this constructor
+   * is used, {@link #getFilePattern} will return <code>null</code>.
+   */
+  public AxisGuesser(int[] axisTypes, String dimOrder,
+      int sizeZ, int sizeT, int sizeC, boolean isCertain) {
+    this.axisTypes = axisTypes;
+    this.dimOrder = newOrder = dimOrder;
+    certain = isCertain;
+    if (!certain) {
+      boolean haveZ = false, haveT = false;
+      for (int t : axisTypes) {
+        if (t == Z_AXIS) {
+          haveZ = true;
+        }
+        if (t == T_AXIS) {
+          haveT = true;
+        }
+      }
+      swapZT(sizeZ, sizeT, haveZ, haveT);
+    }
+  }
+
 
   // -- AxisGuesser API methods --
 

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -84,6 +84,9 @@ public class FileStitcher extends ReaderWrapper {
   /** Component lengths for each axis type. */
   private int[][] lenZ, lenC, lenT;
 
+  /** Axis types for all series patterns. */
+  private int[] axisTypes;
+
   /** Core metadata. */
   private ArrayList<CoreMetadata> core = new ArrayList<CoreMetadata>();
 
@@ -170,6 +173,13 @@ public class FileStitcher extends ReaderWrapper {
 
   public boolean canChangePattern() {
     return !doNotChangePattern;
+  }
+
+  /**
+   * Call before setId to override axis types for all series patterns.
+   */
+  public void overrideAxisTypes(int[] axisTypes) {
+    this.axisTypes = axisTypes;
   }
 
   /** Gets the reader appropriate for use with the given image plane. */
@@ -937,7 +947,8 @@ public class FileStitcher extends ReaderWrapper {
     externals = new ExternalSeries[patterns.length];
 
     for (int i=0; i<externals.length; i++) {
-      externals[i] = new ExternalSeries(new FilePattern(patterns[i]));
+      externals[i] = new ExternalSeries(
+          new FilePattern(patterns[i]), axisTypes);
     }
     fp = new FilePattern(patterns[0]);
 
@@ -962,9 +973,16 @@ public class FileStitcher extends ReaderWrapper {
       return;
     }
 
-    AxisGuesser guesser = new AxisGuesser(fp, reader.getDimensionOrder(),
-      reader.getSizeZ(), reader.getSizeT(), reader.getEffectiveSizeC(),
-      reader.isOrderCertain());
+    AxisGuesser guesser = null;
+    if (null != axisTypes) {
+      guesser = new AxisGuesser(axisTypes, reader.getDimensionOrder(),
+        reader.getSizeZ(), reader.getSizeT(), reader.getEffectiveSizeC(),
+        reader.isOrderCertain());
+    } else {
+      guesser = new AxisGuesser(fp, reader.getDimensionOrder(),
+        reader.getSizeZ(), reader.getSizeT(), reader.getEffectiveSizeC(),
+        reader.isOrderCertain());
+    }
 
     // use the dimension order recommended by the axis guesser
     ((DimensionSwapper) reader).swapDimensions(guesser.getAdjustedOrder());
@@ -1266,6 +1284,12 @@ public class FileStitcher extends ReaderWrapper {
     private int imagesPerFile;
 
     public ExternalSeries(FilePattern pattern)
+        throws FormatException, IOException
+    {
+      this(pattern, null);
+    }
+
+    public ExternalSeries(FilePattern pattern, int[] axisTypes)
       throws FormatException, IOException
     {
       this.pattern = pattern;
@@ -1283,9 +1307,15 @@ public class FileStitcher extends ReaderWrapper {
         readers[i].setMetadataOptions(getMetadataOptions());
       }
 
-      ag = new AxisGuesser(this.pattern, readers[0].getDimensionOrder(),
-        readers[0].getSizeZ(), readers[0].getSizeT(),
-        readers[0].getSizeC(), readers[0].isOrderCertain());
+      if (null != axisTypes) {
+        ag = new AxisGuesser(axisTypes, readers[0].getDimensionOrder(),
+          readers[0].getSizeZ(), readers[0].getSizeT(),
+          readers[0].getSizeC(), readers[0].isOrderCertain());
+      } else {
+        ag = new AxisGuesser(this.pattern, readers[0].getDimensionOrder(),
+          readers[0].getSizeZ(), readers[0].getSizeT(),
+          readers[0].getSizeC(), readers[0].isOrderCertain());
+      }
 
       blankThumbBytes = new byte[FormatTools.getPlaneSize(readers[0],
         readers[0].getThumbSizeX(), readers[0].getThumbSizeY())];

--- a/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
@@ -147,6 +147,16 @@ public class AxisGuesserTest {
     checkAxisCount(ag, types);
   }
 
+  private void checkAlt(
+      int[] types, String order, int sZ, int sT, int sC, boolean cert,  // IN
+      String newOrder) {                                                // OUT
+    AxisGuesser ag = new AxisGuesser(types, order, sZ, sT, sC, cert);
+    assertEquals(ag.getOriginalOrder(), order);
+    assertEquals(ag.getAdjustedOrder(), newOrder);
+    assertEquals(ag.getAxisTypes(), types);
+    checkAxisCount(ag, types);
+  }
+
   private String mkPrefix(String baseTag, Boolean upperCase) {
     if (upperCase) {
       baseTag = baseTag.toUpperCase();
@@ -206,6 +216,7 @@ public class AxisGuesserTest {
     String order = "XYZCT";
     String newOrder = isCertain ? order : "XYTCZ";
     check(pattern, order, sZ, sT, 1, isCertain, newOrder, types);
+    checkAlt(types, order, sZ, sT, 1, isCertain, newOrder);
   }
 
   @Test(dataProvider = "fillInCases")

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -81,6 +81,7 @@ public class ScreenReader extends FormatReader {
   private String[][] files;
   private String[] ordering;
   private int[][] axisTypes;
+  private String[][] channelNames;
   private int[][][] fileIndexes;
 
   private Class<? extends IFormatReader> chosenReader = null;
@@ -238,6 +239,7 @@ public class ScreenReader extends FormatReader {
       files = null;
       ordering = null;
       axisTypes = null;
+      channelNames = null;
       fileIndexes = null;
     }
   }
@@ -302,6 +304,7 @@ public class ScreenReader extends FormatReader {
     files = new String[wells * fields][1];
     ordering = new String[wells * fields];
     axisTypes = new int[wells * fields][];
+    channelNames = new String[wells * fields][];
     fileIndexes = new int[wells * fields][][];
 
     for (int well=0; well<wells; well++) {
@@ -328,6 +331,10 @@ public class ScreenReader extends FormatReader {
           ordering[index] = "XY" + ordering[index];
         }
         axisTypes[index] = readAxisTypes(wellTable.get("AxisTypes"));
+        String channelNamesEntry = wellTable.get("ChannelNames");
+        if (null != channelNamesEntry) {
+          channelNames[index] = channelNamesEntry.split(",", -1);
+        }
       }
     }
 
@@ -466,6 +473,11 @@ public class ScreenReader extends FormatReader {
             store.setWellSampleImageRef(imageID, 0, well, nextWellSample);
             store.setWellSampleIndex(
               new NonNegativeInteger(seriesIndex), 0, well, nextWellSample);
+            if (null != channelNames[well]) {
+              for (int i = 0; i < channelNames[well].length; i++) {
+                store.setChannelName(channelNames[well][i], seriesIndex, i);
+              }
+            }
             nextWellSample++;
           }
         }


### PR DESCRIPTION
Adds two new features to `ScreenReader`:

 * An `AxisTypes` setting can be added to each `Well` entry to override the automatic type guessing performed by `AxisGuesser`. The value should be a string of `Z|C|T` characters, one for each pattern block (e.g., `AxisTypes = CT`)
 * A `ChannelNames` setting can be added to each `Well` entry to override the channel names. The value should be a comma-separated list, e.g., `ChannelNames = DAPI,Cy3`

Also adds a new `overrideAxisTypes` method to `FileStitcher`, which allows to externally set the axis types before `setId` is called. In this case, `FileStitcher` uses the new `AxisGuesser(int[], ...)` (see 19ef8e25d6a8244575a78d031c8715331da6e337) that sidesteps axis types guessing (i.e., the `AxisGuesser` is only used for `getAdjustedOrder`).

Note that, without `overrideAxisTypes`, `ScreenReader` would have to call `FileStitcher.setAxisTypes` *after* the call to `setId`, so `AxisGuesser` would perform its guessing work for nothing. After that, `ScreenReader` would have to call `reader.setId` again to make the wrapping `DimensionSwapper` pick up the changes, with an additional performance hit.