### PR TITLE
Slidebook DLL warnings (rebased onto dev_5_1)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -79,9 +79,11 @@ public class SlideBook6Reader  extends FormatReader {
 
 	// -- Static initializers --
 
+	private static boolean initialized = false;
 	private static boolean libraryFound = false;
 
-	static {
+	private static boolean isLibraryFound() {
+		if (initialized) return libraryFound;
 		try {
 			// load JNI wrapper of SBReadFile.dll
 			NativeLibraryUtil.Architecture arch = NativeLibraryUtil.getArchitecture();
@@ -102,6 +104,8 @@ public class SlideBook6Reader  extends FormatReader {
 			LOGGER.warn("Insufficient permission to load native library", e);
 			libraryFound = false;
 		}
+		initialized = true;
+		return libraryFound;
 	}
 
 	// -- Constructor --

--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -138,7 +138,7 @@ public class SlideBook6Reader  extends FormatReader {
 	/* @see loci.formats.IFormatReader#isThisType(String, boolean) */
 	public boolean isThisType(String file, boolean open) {
 		// Check the first few bytes to determine if the file can be read by this reader.
-		return libraryFound && super.isThisType(file, open);
+		return super.isThisType(file, open) && isLibraryFound();
 	}
 
 	/**

--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -182,7 +182,7 @@ public class SlideBook6Reader  extends FormatReader {
 	// -- Internal FormatReader API methods --
 	public void close(boolean fileOnly) throws IOException {
 		super.close(fileOnly);
-		if (libraryFound) {
+		if (initialized && isLibraryFound()) {
 			closeFile();
 		}
 	}


### PR DESCRIPTION

This is the same as gh-2381 but rebased onto dev_5_1.

----

See https://trac.openmicroscopy.org/ome/ticket/13220 and https://github.com/openmicroscopy/bioformats/issues/2367

The [removal of the 3i Slidebook DLLs](https://github.com/openmicroscopy/bioformats/pull/2300) from the source code repository in Bio-Formats 5.1.9 caused warnings to be systematically printed for non-Fiji/ImageJ Windows users of Bio-Formats.In particular, when constructing an `ImageReader` and initializing the `SlideBook6Reader`, the [following line](https://github.com/scijava/native-lib-loader/blob/native-lib-loader-2.1.0/src/main/java/org/scijava/nativelib/NativeLibraryUtil.java#L275) in the native library loading library is now throwing an exception at the WARN level due to the DLL removal.

To mitigate this issue, an initial proposal was to use the logging to silence these warnings. The main caveat here is that `native-lib-loader` uses `java.util.logging`. While possible this approach would require the introduction of another logging dependency `jul-to-slf4j` in the middle of a stable release.

This PR proposes an alternative fix and modifies the `SlideBook6Reader` to perform the native library check at runtime rather than at creation time. The static `libraryFound` flag is initialized via a private method `isLibraryFound()` which should only be executed in `isThisType(String, boolean)` after the `FormatReader.isThisType(String, booolean)` call has returned true i.e. once it is established the id is a Slidebook file.

This PR should be primarily tested on Windows using both the ImageJ/Fiji plugin and at least another tool (command-line, MATLAB...). When opening a non-Slidebook file, no DLL warning should be thrown when calling the opening commands:

```
showinf.bat test.fake  % Command-line
bfopen('path\to\test.fake'); %MATLAB
```

When opening a Slidebook file without the [3i Slidebook DLLs](http://www.openmicroscopy.org/info/slidebook) included, the missing DLLs warnings should be printed:

```
showinf.bat \path\to\slidebook.sld % Command-line
bfopen('path\to\slidebook.sld'); % MATLAB
```

/cc @joshmoore @bramalingam @RichardMyers 

                