### PR TITLE
Move to develop .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ addons:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+  - openjdk7
 
 env:
   - BUILD=maven_findbugs
@@ -46,17 +45,13 @@ script:
 
 matrix:
   exclude:
-    - jdk: openjdk6
-      env: BUILD=sphinx_html
-    - jdk: oraclejdk7
+    - jdk: openjdk7
       env: BUILD=sphinx_html
     - jdk: oraclejdk8
       env: BUILD=cppwrap
-    - jdk: openjdk6
+    - jdk: openjdk7
       env: BUILD=cppwrap
-    - jdk: openjdk6
+    - jdk: openjdk7
       env: BUILD=maven_findbugs
-    - jdk: oraclejdk7
-      env: BUILD=maven
     - jdk: oraclejdk8
       env: BUILD=maven


### PR DESCRIPTION
@sbesson suggests that using the smaller Java7+ matrix from develop might fix the metadata branches builds.