### PR TITLE
Fix SVI Huygens link (rebased onto dev_5_1)

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2431,7 +2431,7 @@ notes = Bio-Formats uses the `MDB Tools Java port <http://mdbtools.sourceforge.n
 \n
 Commercial applications that support this format include: \n
 \n
-* `SVI Huygens <http://www2.svi.nl/>`_ \n
+* `SVI Huygens <https://svi.nl/HomePage>`_ \n
 * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
 * `Amira <http://www.amira.com/>`_ \n
 * `Image-Pro Plus <http://www.mediacy.com/>`_

--- a/docs/sphinx/formats/zeiss-lsm.txt
+++ b/docs/sphinx/formats/zeiss-lsm.txt
@@ -61,7 +61,7 @@ Bio-Formats uses the `MDB Tools Java port <http://mdbtools.sourceforge.net/>`_
 
 Commercial applications that support this format include: 
 
-* `SVI Huygens <http://www2.svi.nl/>`_ 
+* `SVI Huygens <https://svi.nl/HomePage>`_ 
 * `Bitplane Imaris <http://www.bitplane.com/>`_ 
 * `Amira <http://www.amira.com/>`_ 
 * `Image-Pro Plus <http://www.mediacy.com/>`_


### PR DESCRIPTION


This is the same as gh-2391 but rebased onto dev_5_1.

----

BF docs builds were unstable this morning because this link was broken. Replacement link is their homepage as found via google search. Should make the docs green again.

                    