### PR TITLE
Tests and logging

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -65,7 +65,7 @@ Type "ant -p" for a list of targets.
       <then>
         <junit haltonfailure="true" fork="true">
           <classpath>
-            <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+            <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
             <pathelement location="${artifact.dir}/junit-4.8.2.jar"/>
             <pathelement location="${test-classes.dir}"/>
             <pathelement location="${classes.dir}"/>
@@ -86,7 +86,7 @@ Type "ant -p" for a list of targets.
       <then>
         <testng haltonfailure="true" groups="all" testname="${component.name}">
           <classpath>
-            <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+            <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
             <pathelement path="${component.runtime-cp}"/>
             <pathelement location="${test-classes.dir}"/>
             <pathelement location="${classes.dir}"/>

--- a/ant/logback.xml
+++ b/ant/logback.xml
@@ -5,7 +5,6 @@
       <pattern>%d [%t] %-5p %c - %m%n</pattern>
     </encoder>
   </appender>
-  <logger name="loci.formats.ClassList" level="FATAL"/>
   <root level="WARN">
     <appender-ref ref="stdout"/>
   </root>

--- a/components/formats-api/build.xml
+++ b/components/formats-api/build.xml
@@ -18,7 +18,7 @@ Type "ant -p" for a list of targets.
       file="${testng.xml.template}" overwrite="true"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>

--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -20,7 +20,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng.xml"/>
     <testng haltonfailure="true" testname="${component.name}">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>
@@ -36,7 +36,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-lurawave.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-lurawave}"/>
@@ -53,7 +53,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-jai.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-jai}"/>
@@ -70,7 +70,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-ome-xml.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-xml}"/>
@@ -87,7 +87,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-exif.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-exif}"/>
@@ -104,7 +104,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-xerces.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-xerces}"/>
@@ -121,7 +121,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/spec/testng.xml"/>
     <testng haltonfailure="true" testname="${component.name}">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>

--- a/components/formats-common/build.xml
+++ b/components/formats-common/build.xml
@@ -18,7 +18,7 @@ Type "ant -p" for a list of targets.
       file="${testng.xml.template}" overwrite="true"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>
@@ -35,7 +35,7 @@ Type "ant -p" for a list of targets.
       file="${testng.xml.template}" overwrite="true"/>
     <testng failureProperty="failedTest" parallel="classes">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>

--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -20,7 +20,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng.xml"/>
     <testng haltonfailure="true" testname="${component.name}">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>
@@ -36,7 +36,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-mdb.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-mdb}"/>
@@ -53,7 +53,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-netcdf.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-netcdf}"/>
@@ -70,7 +70,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-poi.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-poi}"/>
@@ -87,7 +87,7 @@ Type "ant -p" for a list of targets.
       file="${tests.dir}/loci/formats/utests/testng-no-jhdf.xml"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.cp.no-jhdf}"/>
@@ -102,7 +102,7 @@ Type "ant -p" for a list of targets.
     description="test metadata level support for a single file" if="doTests">
     <testng sourcedir="${test.dir}" testname="Metadata tests" failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>

--- a/components/metakit/build.xml
+++ b/components/metakit/build.xml
@@ -18,7 +18,7 @@ Type "ant -p"  for a list of targets.
       file="${testng.xml.template}" overwrite="true"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>
@@ -33,7 +33,7 @@ Type "ant -p"  for a list of targets.
       file="${testng.xml.template}" overwrite="true"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>

--- a/components/ome-xml/build.xml
+++ b/components/ome-xml/build.xml
@@ -39,7 +39,7 @@ Type "ant -p" for a list of targets.
       file="${testng.xml}"/>
     <testng failureProperty="failedTest">
       <classpath>
-        <pathelement location="${root.dir}/tools/"/><!-- logback.xml -->
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
         <pathelement path="${component.runtime-cp}"/>


### PR DESCRIPTION
See https://trello.com/c/ISuLct1l/125-formats-bsd-unit-tests-take-too-long-to-run

This PR starts addressing test issues at the logging level with the following changes:
- the Ant test targets now use the `logback.xml` under `ant` (like the Maven test targets)
- the `FATAL` logging configuration in `ant/logback.xml` is removed.

The impact of this PR should be the following:
- Ant-based tests should have reduced logging (https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-build/ and https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-build-win) especially the Formats BSD tests should have no more logs due to the JPEG2000 tests
- Formats BSD Maven-based tests should now hide the stack trace due to the ClassList error. As a results the log  of the Maven components in the [Travis matrix build](http://travis-ci.org/openmicroscopy/bioformats) should not overflow the 10K lines.