### PR TITLE
Updating volocity links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2257,7 +2257,7 @@ mif = true
 
 [Volocity Library Clipping]
 extensions = .acff
-developer = `PerkinElmer <http://www.perkinelmer.com/pages/020/cellularimaging/products/volocity.xhtml>`_
+developer = `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
 bsd = no
 weHave = * several Volocity library clipping datasets
 weWant = * any datasets that do not open correctly \n
@@ -2272,7 +2272,7 @@ notes = RGB .acff files are not yet supported.  See :ticket:`6413`.
 
 [Volocity]
 extensions = .mvd2
-developer = `PerkinElmer <http://www.perkinelmer.com/pages/020/cellularimaging/products/volocity.xhtml>`_
+developer = `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
 bsd = no
 samples = `PerkinElmer Downloads <http://cellularimaging.perkinelmer.com/downloads/>`_
 weHave = * many example Volocity datasets

--- a/docs/sphinx/formats/volocity-library-clipping.txt
+++ b/docs/sphinx/formats/volocity-library-clipping.txt
@@ -6,7 +6,7 @@ Volocity Library Clipping
 
 Extensions: .acff
 
-Developer: `PerkinElmer <http://www.perkinelmer.com/pages/020/cellularimaging/products/volocity.xhtml>`_
+Developer: `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
 
 
 **Support**

--- a/docs/sphinx/formats/volocity.txt
+++ b/docs/sphinx/formats/volocity.txt
@@ -6,7 +6,7 @@ Volocity
 
 Extensions: .mvd2
 
-Developer: `PerkinElmer <http://www.perkinelmer.com/pages/020/cellularimaging/products/volocity.xhtml>`_
+Developer: `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
 
 
 **Support**


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-5.1-merge-docs/1245/warnings3Result/
Browsing around, it seems like PE are in the process of updating their website and some of their redirects are a bit shot! This is an older page but the new one (http://www.perkinelmer.com/category/cellular-imaging-software) has no mention of Volocity so it seemed like the best option. Hopefully it'll stick around!