### PR TITLE
Fix generateDS link (rebased onto dev_5_1)

### DIFF
--- a/docs/sphinx/developers/xsd-fu.txt
+++ b/docs/sphinx/developers/xsd-fu.txt
@@ -232,5 +232,5 @@ Special thanks
 
 A special thanks goes out to `Dave Kuhlman
 <http://www.davekuhlman.org/>`_ for his fabulous work on
-`http://www.davekuhlman.org/pages/generateds-generate-data-structures-from-xml-schema.html>`_
+`generateDS <http://www.davekuhlman.org/pages/generateds-generate-data-structures-from-xml-schema.html>`_
 which :program:`xsd-fu` makes heavy use of internally.

--- a/docs/sphinx/developers/xsd-fu.txt
+++ b/docs/sphinx/developers/xsd-fu.txt
@@ -232,5 +232,5 @@ Special thanks
 
 A special thanks goes out to `Dave Kuhlman
 <http://www.davekuhlman.org/>`_ for his fabulous work on
-`generateDS <http://www.davekuhlman.org/generateDS.html>`_ which
-:program:`xsd-fu` makes heavy use of internally.
+`http://www.davekuhlman.org/pages/generateds-generate-data-structures-from-xml-schema.html>`_
+which :program:`xsd-fu` makes heavy use of internally.


### PR DESCRIPTION

This is the same as gh-2404 but rebased onto dev_5_1.

----

Dave Kuhlman released an updated version yesterday and the URL has changed.

Should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-5.1-merge-docs/ green again.

Staged at http://www.openmicroscopy.org/site/support/bio-formats5.1-staging/developers/xsd-fu.html#special-thanks

                    