### PR TITLE
Add 5.1.10 version history (rebased onto develop)

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,20 @@
 Version history
 ===============
 
+5.1.10 (2016 May 9)
+-------------------
+
+Java bug fixes:
+
+* fixed warnings being thrown by Bio-Formats for ImageJ and other non-FIJI
+  users on Windows (these warning were triggered by the removal of the 3i
+  Slidebook DLLs from the source code repository in Bio-Formats 5.1.9 and
+  should now only be triggered when opening Slidebook files without the update
+  site enabled - http://www.openmicroscopy.org/info/slidebook).
+* a fix in the ImageJ plugin for files grouped using the "Dimensions" option
+* a fix for writing TIFF files in tiles
+
+
 5.1.9 (2016 April 14)
 ---------------------
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -7,7 +7,7 @@ Version history
 Java bug fixes:
 
 * fixed warnings being thrown for ImageJ and other non-FIJI users on Windows
-  (these warning were triggered by the removal of the 3i Slidebook DLLs from
+  (these warnings were triggered by the removal of the 3i Slidebook DLLs from
   the source code repository in Bio-Formats 5.1.9 and should now only be
   triggered when opening Slidebook files without the update site enabled -
   http://www.openmicroscopy.org/info/slidebook)

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -6,11 +6,11 @@ Version history
 
 Java bug fixes:
 
-* fixed warnings being thrown by Bio-Formats for ImageJ and other non-FIJI
-  users on Windows (these warning were triggered by the removal of the 3i
-  Slidebook DLLs from the source code repository in Bio-Formats 5.1.9 and
-  should now only be triggered when opening Slidebook files without the update
-  site enabled - http://www.openmicroscopy.org/info/slidebook).
+* fixed warnings being thrown for ImageJ and other non-FIJI users on Windows
+  (these warning were triggered by the removal of the 3i Slidebook DLLs from
+  the source code repository in Bio-Formats 5.1.9 and should now only be
+  triggered when opening Slidebook files without the update site enabled -
+  http://www.openmicroscopy.org/info/slidebook)
 * a fix in the ImageJ plugin for files grouped using the "Dimensions" option
 * a fix for writing TIFF files in tiles
 


### PR DESCRIPTION

This is the same as gh-2402 but rebased onto develop.

----

Adds version history for 5.1.10 release. Will be staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/about/whats-new.html

                    