### PR TITLE
Fix HCS variant of MetaMorph STK

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -95,6 +95,8 @@ public class MinimalTiffReader extends FormatReader {
 
   protected boolean noSubresolutions = false;
 
+  protected boolean seriesToIFD = false;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -282,7 +284,12 @@ public class MinimalTiffReader extends FormatReader {
 
     IFD firstIFD = ifds.get(0);
     lastPlane = no;
-    IFD ifd = ifds.get(no);
+    IFD ifd;
+    if (seriesToIFD) {
+      ifd = ifds.get(getSeries());
+    } else {
+      ifd = ifds.get(no);
+    }
     if ((firstIFD.getCompression() == TiffCompression.JPEG_2000
         || firstIFD.getCompression() == TiffCompression.JPEG_2000_LOSSY)
         && resolutionLevels != null) {

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -386,6 +386,7 @@ public class MinimalTiffReader extends FormatReader {
       tiffParser = null;
       resolutionLevels = null;
       j2kCodecOptions = null;
+      seriesToIFD = false;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -764,6 +764,7 @@ public class MetamorphReader extends BaseTiffReader {
         }
         core.add(toAdd);
       }
+      seriesToIFD = true;
     }
 
     Vector<String> timestamps = null;


### PR DESCRIPTION
Fixes a problem in HCS-style `.stk` datasets (see #2151) that was causing `MetamorphReader.openBytes` to always return the first plane regardless of the requested index.

#2151 introduced a convention where a `.stk` file whose UIC4 `StageLabel`s are `"Scan A01", "Scan A02", ...` is interpreted as a plate. In particular, image planes are mapped to different series. The problem is that #2151 does not change anything in `MinimalTiffReader.openBytes`, where TIFF IFDs are mapped to plane indices, not series indices.