### PR TITLE
log when using workaround for .cif issue from bad TIF tag

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FlowSightReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FlowSightReader.java
@@ -150,7 +150,12 @@ public class FlowSightReader extends FormatReader {
     if (channelNamesString != null) {
       channelNames = channelNamesString.split("\\|");
       if (channelNames.length != channelCount) {
-    	  channelCount = channelNames.length;
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Channel count (%d) does not match number of " +
+              "channel names (%d) in string \"%s\"",
+              channelCount, channelNames.length, channelNamesString);
+        }
+        channelCount = channelNames.length;
       }
       LOGGER.debug("Found {} channels: {}",
           channelCount, channelNamesString.replace('|', ','));


### PR DESCRIPTION
Satisfies https://github.com/openmicroscopy/bioformats/pull/2318#issuecomment-218255604 by logging the issue now handled by https://github.com/openmicroscopy/bioformats/pull/2318/commits/1187fe7ea98b715136819996a05a6e038fb5fed7. Unfortunately I am not aware that we have the original data that triggers the issue.