### PR TITLE
Memoizer.wrap: fix handling of MetadataOptions

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -555,24 +555,30 @@ public class Memoizer extends ReaderWrapper {
     }
     String k = Memoizer.class.getName();
     Object elapsed = options.getMetadataOption(k + ".minimumElapsed");
-    Object inplace = options.getMetadataOption(k + ".inPlace");
-    Object cachedir = options.getMetadataOption(k + ".cacheDirectory");
     if (!(elapsed instanceof Long)) {
+      if (null != elapsed) {
         LOGGER.warn("config: minimumElapsed wrong type: {}", elapsed);
-        return r;
-    } else if (!(inplace instanceof Boolean)) {
-        LOGGER.warn("config: inplace wrong type: {}", inplace);
-        return r;
-    } else if (cachedir != null && !(cachedir instanceof File)) {
-        LOGGER.warn("config: cachedir wrong type: {}", cachedir);
-        return r;
+      }
+      return r;
     }
-
+    Object inplace = options.getMetadataOption(k + ".inPlace");
+    if (!(inplace instanceof Boolean)) {
+      if (null != inplace) {
+        LOGGER.warn("config: inplace wrong type: {}", inplace);
+      }
+      return r;
+    }
     if (((Boolean) inplace).booleanValue()) {
       return new Memoizer(r, (Long) elapsed);
-    } else{
-      return new Memoizer(r, (Long) elapsed, (File) cachedir);
     }
+    Object cachedir = options.getMetadataOption(k + ".cacheDirectory");
+    if (!(cachedir instanceof File)) {
+      if (null != cachedir) {
+        LOGGER.warn("config: cachedir wrong type: {}", cachedir);
+      }
+      return r;
+    }
+    return new Memoizer(r, (Long) elapsed, (File) cachedir);
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -327,13 +327,14 @@ public class Memoizer extends ReaderWrapper {
 
   }
 
-  private static Object getMetadataOption(
-      MetadataOptions options, String name, Class type) {
-    Object opt = options.getMetadataOption(
-        String.format("%s.%s", Memoizer.class.getName(), name));
-    if (null != opt && !opt.getClass().isInstance(type)) {
-      LOGGER.warn("config: {} wrong type: {}", name, opt);
-      opt = null;
+  private static <T> T getMetadataOption(
+      MetadataOptions options, String name, Class<T> type) {
+    T opt = null;
+    String fullName = String.format("%s.%s", Memoizer.class.getName(), name);
+    try {
+      opt = type.cast(options.getMetadataOption(fullName));
+    } catch (ClassCastException e) {
+      LOGGER.warn("{}: wrong type (expected: {})", name, type.getName());
     }
     return opt;
   }
@@ -564,17 +565,17 @@ public class Memoizer extends ReaderWrapper {
     if (options == null) {
       return r;
     }
-    Object elapsed = getMetadataOption(options, "minimumElapsed", Long.class);
+    Long elapsed = getMetadataOption(options, "minimumElapsed", Long.class);
     if (null == elapsed) {
       return r;
     }
-    Object inplace = getMetadataOption(options, "inPlace", Boolean.class);
-    if (null != inplace && ((Boolean) inplace).booleanValue()) {
-      return new Memoizer(r, (Long) elapsed);
+    Boolean inplace = getMetadataOption(options, "inPlace", Boolean.class);
+    if (null != inplace && inplace.booleanValue()) {
+      return new Memoizer(r, elapsed);
     }
-    Object cachedir = getMetadataOption(options, "cacheDirectory", File.class);
+    File cachedir = getMetadataOption(options, "cacheDirectory", File.class);
     if (null != cachedir) {
-      return new Memoizer(r, (Long) elapsed, (File) cachedir);
+      return new Memoizer(r, elapsed, cachedir);
     }
     return r;
   }

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -562,7 +562,7 @@ public class Memoizer extends ReaderWrapper {
    */
   public static IFormatReader wrap(MetadataOptions options, IFormatReader r) {
     if (options == null) {
-      return null;
+      return r;
     }
     Object elapsed = getMetadataOption(options, "minimumElapsed", Long.class);
     if (null == elapsed) {

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -327,6 +327,17 @@ public class Memoizer extends ReaderWrapper {
 
   }
 
+  private static Object getMetadataOption(
+      MetadataOptions options, String name, Class type) {
+    Object opt = options.getMetadataOption(
+        String.format("%s.%s", Memoizer.class.getName(), name));
+    if (null != opt && !opt.getClass().isInstance(type)) {
+      LOGGER.warn("config: {} wrong type: {}", name, opt);
+      opt = null;
+    }
+    return opt;
+  }
+
   // -- Constants --
 
   /**
@@ -553,32 +564,19 @@ public class Memoizer extends ReaderWrapper {
     if (options == null) {
       return null;
     }
-    String k = Memoizer.class.getName();
-    Object elapsed = options.getMetadataOption(k + ".minimumElapsed");
-    if (!(elapsed instanceof Long)) {
-      if (null != elapsed) {
-        LOGGER.warn("config: minimumElapsed wrong type: {}", elapsed);
-      }
+    Object elapsed = getMetadataOption(options, "minimumElapsed", Long.class);
+    if (null == elapsed) {
       return r;
     }
-    Object inplace = options.getMetadataOption(k + ".inPlace");
-    if (!(inplace instanceof Boolean)) {
-      if (null != inplace) {
-        LOGGER.warn("config: inplace wrong type: {}", inplace);
-      }
-      return r;
-    }
-    if (((Boolean) inplace).booleanValue()) {
+    Object inplace = getMetadataOption(options, "inPlace", Boolean.class);
+    if (null != inplace && ((Boolean) inplace).booleanValue()) {
       return new Memoizer(r, (Long) elapsed);
     }
-    Object cachedir = options.getMetadataOption(k + ".cacheDirectory");
-    if (!(cachedir instanceof File)) {
-      if (null != cachedir) {
-        LOGGER.warn("config: cachedir wrong type: {}", cachedir);
-      }
-      return r;
+    Object cachedir = getMetadataOption(options, "cacheDirectory", File.class);
+    if (null != cachedir) {
+      return new Memoizer(r, (Long) elapsed, (File) cachedir);
     }
-    return new Memoizer(r, (Long) elapsed, (File) cachedir);
+    return r;
   }
 
   /**


### PR DESCRIPTION
Addresses a problem where `Memoizer.wrap` was issuing a warning if any of the relevant `MetadataOptions` was `null`. Since `MetadataOptions.getMetadataOption` returns `null` to signal that the requested option is not set, getting a `null` is not a sign that something went wrong, so I've changed `wrap` to silently return the unwrapped reader in this case.

**NOTE: this was breaking the Travis build by increasing the Maven test output from ~9K to ~75K lines.**

Other problems fixed here:

* If the whole `options` container was `null`, `wrap` returned `null`, while the docs state that the original reader would be returned unwrapped (which seems the sensible thing to do, so I've changed the code to match the docs and not the other way around)
* The code was giving up too early by returning the unwrapped reader after encountering an invalid value for `inplace`, while it can still return a `Memoizer` if it gets a valid `cachedir`