### PR TITLE
Update Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ addons:
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk6
 
 env:
   - BUILD=maven_findbugs
@@ -46,16 +45,10 @@ script:
 
 matrix:
   exclude:
-    - jdk: openjdk6
-      env: BUILD=sphinx_html
     - jdk: oraclejdk7
       env: BUILD=sphinx_html
     - jdk: oraclejdk8
       env: BUILD=cppwrap
-    - jdk: openjdk6
-      env: BUILD=cppwrap
-    - jdk: openjdk6
-      env: BUILD=maven_findbugs
     - jdk: oraclejdk7
       env: BUILD=maven
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7
 
 env:
   - BUILD=maven_findbugs
@@ -45,11 +45,13 @@ script:
 
 matrix:
   exclude:
-    - jdk: oraclejdk7
+    - jdk: openjdk7
       env: BUILD=sphinx_html
     - jdk: oraclejdk8
       env: BUILD=cppwrap
-    - jdk: oraclejdk7
-      env: BUILD=maven
+    - jdk: openjdk7
+      env: BUILD=cppwrap
+    - jdk: openjdk7
+      env: BUILD=maven_findbugs
     - jdk: oraclejdk8
       env: BUILD=maven


### PR DESCRIPTION
**Remove jdk6:** we have introduced Java 7 code with the recent rebases from `develop`, see for instance https://github.com/openmicroscopy/bioformats/pull/2373/files#diff-3e20012ef051456e6865dbdc9ae7f1ddR37, so the `metadata` branch now effectively requires Java 7+

**Replace oraclejdk7 with openjdk7:** this follows 1fe6c6dbbb1b8581cad7bfb33b227286cfcea4e1