### PR TITLE
Address slow loading of .sdt files beyond an arbitrary threshold.

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -44,7 +44,18 @@ import loci.formats.meta.MetadataStore;
  * Becker &amp; Hickl SPC-Image SDT files.
  *
  * @author Curtis Rueden ctrueden at wisc.edu
- */
+ *
+ * Please Note: This format holds FLIM data arranged so that each decay is stored contiguously.
+ * Therefore, as in other FLIM format readers e.g. SDTReader.java, on the first call to openBytes
+ * the whole data cube ( x,y,t) (NB actually t not real-time T) is loaded from the file and buffered
+ * On further calls to openBytes the appropriate 2D (x,y)plane (timebin) is returned from this buffer.
+ * This is in the interest of significantly improved  performance when all the planes are requested one after another.
+ * There will be a performance cost if a single plane is requested but this is highly unlikely for FLIM data.
+ * In order to limit the size of the buffer, beyond a certain size threshold only a subset of planes (a Block) are
+ * retained in the buffer.
+ *
+ **/
+
 public class SDTReader extends FormatReader {
 
   // -- Fields --
@@ -60,15 +71,7 @@ public class SDTReader extends FormatReader {
 
   /** Whether to combine lifetime bins into single intensity image planes. */
   protected boolean intensity = false;
-
-  /** Whether to pre-load all lifetime bins for faster loading. */
-  protected boolean preLoad = true;
-
-  /*
-   * Array to hold re-ordered data for all the timeBins in one channel
-   */
-  protected byte[] chanStore = null;
-
+  
   /*
    * Currently stored channel
    */
@@ -78,7 +81,22 @@ public class SDTReader extends FormatReader {
    * Currently stored series
    */
   protected int storedSeries = -1;
+  
+  /*
+   * Array to hold re-ordered data for all the timeBins
+   */
+  protected byte[] dataStore = null;
 
+  /**
+   * Block of time bins currently stored for faster loading.
+   */
+  protected int currentBlock;
+  
+  /**
+   * No of timeBins pre-loaded as a block
+  */
+  protected int blockLength ;  
+  
   // -- Constructor --
 
   /** Constructs a new SDT reader. */
@@ -98,14 +116,7 @@ public class SDTReader extends FormatReader {
     this.intensity = intensity;
   }
 
-  /**
-   * Toggles whether the reader should pre-load
-   * data for increased performance.
-   */
-  public void setPreLoad(boolean preLoad) {
-    this.preLoad = preLoad;
-  }
-
+  
   /**
    * Gets whether the reader is combining each lifetime
    * histogram into a summed intensity image plane.
@@ -168,14 +179,75 @@ public class SDTReader extends FormatReader {
       planeSize = sizeX * sizeY * times * bpp;
     }
 
-    if (preLoad  && !intensity) {
+    if ( !intensity) {
       int channel = no / times;
       int timeBin = no % times;
 
       byte[] rowBuf = new byte[bpp * times * paddedWidth];
 
       int binSize = paddedWidth * sizeY  * bpp;
+      
+      int preBlockSize = sizeX * sizeY * blockLength * bpp;
+      
+      // pre-load data for performance
+      if (dataStore == null) {
+        dataStore = new byte[preBlockSize];
+        currentBlock = -1;
+      }
 
+      if (timeBin / blockLength != currentBlock || storedChannel != channel ||
+        storedSeries != getSeries() ) {
+
+        currentBlock = timeBin / blockLength;
+
+        // A subset of whole timebins (a preBlock) is  copied into storage
+        // to allow different sub-plane sizes to be used for different timebin
+        in.seek(info.allBlockOffsets[getSeries()]);
+        ZipInputStream codec = null;
+        String check = in.readString(2);
+        in.seek(in.getFilePointer() - 2);
+        if (check.equals("PK")) {
+          codec = new ZipInputStream(in);
+          codec.getNextEntry();
+          codec.skip(channel * planeSize);
+        }
+        else {
+          in.skipBytes(channel * planeSize);
+        }
+
+        int endOfBlock = (currentBlock + 1) * blockLength;
+        int storeLength;
+        if (endOfBlock > timeBins) {
+          storeLength = timeBins - (currentBlock * blockLength);
+        } else {
+          storeLength = blockLength;
+        }
+
+        for (int row = 0; row < sizeY; row++) {
+          readPixels(rowBuf, in, codec, 0);
+          
+          for (int col = 0; col < paddedWidth; col++) {
+            // set output to first pixel of this row in 2D plane
+            // corresponding to zeroth timeBin
+            int output = (row * paddedWidth + col) * bpp;
+            int input = ((col * timeBins) + (currentBlock * blockLength)) * bpp;
+            // copy subset of decay into buffer.
+            
+            for (int t = 0; t < storeLength; t++) {
+              for (int bb = 0; bb < bpp; bb++) {
+                dataStore[output + bb] = rowBuf[input + bb];
+              }
+              output += binSize;
+              input += bpp;
+            }
+          }
+        }
+      }
+      storedChannel = channel;
+      storedSeries = getSeries();
+      // dataStore loaded
+
+      /**********************************************
       if (chanStore == null || storedChannel != channel ||
         storedSeries != getSeries() )
       {
@@ -218,17 +290,20 @@ public class SDTReader extends FormatReader {
         storedChannel = channel;
         storedSeries = getSeries();
       }  // chanStore loaded
+       ************************************************************************/
 
-      // copy 2D plane  from chanStore  into buf
+      // copy 2D plane  from dataStore  into buf
 
       int iLineSize = paddedWidth * bpp;
       int oLineSize = w * bpp;
       // offset to correct timebin yth line and xth pixel
-      int input = (binSize * timeBin) + (y * iLineSize) + (x * bpp);
+      int binInStore = timeBin - (currentBlock * blockLength);
+      
+      int input = (binSize * binInStore) + (y * iLineSize) + (x * bpp);
       int output = 0;
 
       for (int row = 0; row < h; row++) {
-        System.arraycopy(chanStore, input, buf, output , oLineSize);
+        System.arraycopy(dataStore, input, buf, output , oLineSize);
         input += iLineSize;
         output += oLineSize;
       }
@@ -258,7 +333,8 @@ public class SDTReader extends FormatReader {
 
       return buf;
     }
-    else {
+    else {   // intensity mode so no pre-loading
+      
       int channel = intensity ? no : no / times;
       int timeBin = intensity ? 0 : no % times;
 
@@ -329,11 +405,11 @@ public class SDTReader extends FormatReader {
     super.close(fileOnly);
     if (!fileOnly) {
       // init preLoading
-      preLoad = true;
-      chanStore = null;
+      dataStore = null;
       storedChannel = -1;
       storedSeries = -1;
       timeBins = channels = 0;
+      currentBlock = -1;
       info = null;
     }
   }
@@ -381,15 +457,7 @@ public class SDTReader extends FormatReader {
     m.indexed = false;
     m.falseColor = false;
     m.metadataComplete = true;
-
-    // disable pre-load mode for very large files
-    // threshold is set to the size of the largest test file currently available
-    if ( m.sizeX * m.sizeY * m.sizeT  >  (512 * 512 * 512))  {
-      preLoad = false;
-    }
-    else  {
-      preLoad = true;
-    }
+      
 
     if (intensity) {
       m.moduloT.parentType = FormatTools.SPECTRA;
@@ -420,6 +488,18 @@ public class SDTReader extends FormatReader {
         }
       }
     }
+      
+    int sizeThreshold = 512 * 512 * 512;  // Arbitrarily chosen size limit for buffer
+    blockLength = 2048;   //default No of bins in buffer
+
+    while (blockLength * m.sizeX * m.sizeY > sizeThreshold) {
+      blockLength = blockLength / 2;
+    }
+
+    if (blockLength > timeBins) {
+      blockLength = timeBins;
+    }
+
 
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this);

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -116,6 +116,12 @@ public class SDTReader extends FormatReader {
     this.intensity = intensity;
   }
 
+  /**
+   * Toggles whether the reader should pre-load data for increased performance.
+   */
+  public void setPreLoad(boolean preLoad) {
+    // Deprecated!! 
+  }
   
   /**
    * Gets whether the reader is combining each lifetime

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -71,10 +71,10 @@ public class SDTReader extends FormatReader {
 
   /** Whether to combine lifetime bins into single intensity image planes. */
   protected boolean intensity = false;
-  
+
   /** Whether to pre-load all lifetime bins for faster loading. */
   protected boolean preLoad = true;
-  
+
   /*
    * Currently stored channel
    */
@@ -84,7 +84,7 @@ public class SDTReader extends FormatReader {
    * Currently stored series
    */
   protected int storedSeries = -1;
-  
+
   /*
    * Array to hold re-ordered data for all the timeBins
    */
@@ -94,12 +94,12 @@ public class SDTReader extends FormatReader {
    * Block of time bins currently stored for faster loading.
    */
   protected int currentBlock;
-  
+
   /**
    * No of timeBins pre-loaded as a block
   */
-  protected int blockLength ;  
-  
+  protected int blockLength ;
+
   // -- Constructor --
 
   /** Constructs a new SDT reader. */
@@ -123,9 +123,9 @@ public class SDTReader extends FormatReader {
    * Toggles whether the reader should pre-load data for increased performance.
    */
   public void setPreLoad(boolean preLoad) {
-    this.preLoad = preLoad; 
+    this.preLoad = preLoad;
   }
-  
+
   /**
    * Gets whether the reader is combining each lifetime
    * histogram into a summed intensity image plane.
@@ -188,16 +188,16 @@ public class SDTReader extends FormatReader {
       planeSize = sizeX * sizeY * times * bpp;
     }
 
-    if ( preLoad && !intensity) {
+    if (preLoad && !intensity) {
       int channel = no / times;
       int timeBin = no % times;
 
       byte[] rowBuf = new byte[bpp * times * paddedWidth];
 
       int binSize = paddedWidth * sizeY  * bpp;
-      
-      int preBlockSize = sizeX * sizeY * blockLength * bpp;
-      
+
+      int preBlockSize = paddedWidth * sizeY * blockLength * bpp;
+
       // pre-load data for performance
       if (dataStore == null) {
         dataStore = new byte[preBlockSize];
@@ -234,14 +234,14 @@ public class SDTReader extends FormatReader {
 
         for (int row = 0; row < sizeY; row++) {
           readPixels(rowBuf, in, codec, 0);
-          
+
           for (int col = 0; col < paddedWidth; col++) {
             // set output to first pixel of this row in 2D plane
             // corresponding to zeroth timeBin
             int output = (row * paddedWidth + col) * bpp;
             int input = ((col * timeBins) + (currentBlock * blockLength)) * bpp;
             // copy subset of decay into buffer.
-            
+
             for (int t = 0; t < storeLength; t++) {
               for (int bb = 0; bb < bpp; bb++) {
                 dataStore[output + bb] = rowBuf[input + bb];
@@ -261,7 +261,7 @@ public class SDTReader extends FormatReader {
       int oLineSize = w * bpp;
       // offset to correct timebin yth line and xth pixel
       int binInStore = timeBin - (currentBlock * blockLength);
-      
+
       int input = (binSize * binInStore) + (y * iLineSize) + (x * bpp);
       int output = 0;
 
@@ -297,7 +297,7 @@ public class SDTReader extends FormatReader {
       return buf;
     }
     else {   // intensity mode so no pre-loading
-      
+
       int channel = intensity ? no : no / times;
       int timeBin = intensity ? 0 : no % times;
 
@@ -421,7 +421,7 @@ public class SDTReader extends FormatReader {
     m.indexed = false;
     m.falseColor = false;
     m.metadataComplete = true;
-      
+
 
     if (intensity) {
       m.moduloT.parentType = FormatTools.SPECTRA;
@@ -452,7 +452,7 @@ public class SDTReader extends FormatReader {
         }
       }
     }
-      
+
     int sizeThreshold = 512 * 512 * 512;  // Arbitrarily chosen size limit for buffer
     blockLength = 2048;   //default No of bins in buffer
 

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -72,6 +72,9 @@ public class SDTReader extends FormatReader {
   /** Whether to combine lifetime bins into single intensity image planes. */
   protected boolean intensity = false;
   
+  /** Whether to pre-load all lifetime bins for faster loading. */
+  protected boolean preLoad = true;
+  
   /*
    * Currently stored channel
    */
@@ -120,7 +123,7 @@ public class SDTReader extends FormatReader {
    * Toggles whether the reader should pre-load data for increased performance.
    */
   public void setPreLoad(boolean preLoad) {
-    // Deprecated!! 
+    this.preLoad = preLoad; 
   }
   
   /**
@@ -185,7 +188,7 @@ public class SDTReader extends FormatReader {
       planeSize = sizeX * sizeY * times * bpp;
     }
 
-    if ( !intensity) {
+    if ( preLoad && !intensity) {
       int channel = no / times;
       int timeBin = no % times;
 
@@ -365,6 +368,7 @@ public class SDTReader extends FormatReader {
     super.close(fileOnly);
     if (!fileOnly) {
       // init preLoading
+      preLoad = true;
       dataStore = null;
       storedChannel = -1;
       storedSeries = -1;

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -247,53 +247,7 @@ public class SDTReader extends FormatReader {
       storedSeries = getSeries();
       // dataStore loaded
 
-      /**********************************************
-      if (chanStore == null || storedChannel != channel ||
-        storedSeries != getSeries() )
-      {
-        // The whole plane (all timebins) is  copied into storage
-        // to allow different sub-plane sizes to be used for different timebins
-        chanStore = new byte[planeSize];
-        in.seek(info.allBlockOffsets[getSeries()]);
-
-        ZipInputStream codec = null;
-        String check = in.readString(2);
-        in.seek(in.getFilePointer() - 2);
-        if (check.equals("PK")) {
-          codec = new ZipInputStream(in);
-          codec.getNextEntry();
-          codec.skip(channel * planeSize);
-        }
-        else {
-          in.skipBytes(channel * planeSize);
-        }
-
-        for (int row = 0; row < sizeY; row++) {
-          readPixels(rowBuf, in, codec, 0);
-
-          int input = 0;
-          for (int col = 0; col < paddedWidth; col++) {
-            // set output to first pixel of this row in 2D plane
-            // corresponding to zeroth timeBin
-            int output = (row * paddedWidth + col) * bpp;
-
-            for (int t = 0; t < times; t++)  {
-              for (int bb = 0; bb < bpp; bb++) {
-                chanStore[output + bb] = rowBuf[input + bb];
-              }
-              output += binSize;
-              input += bpp;
-            }
-          }
-        }
-
-        storedChannel = channel;
-        storedSeries = getSeries();
-      }  // chanStore loaded
-       ************************************************************************/
-
       // copy 2D plane  from dataStore  into buf
-
       int iLineSize = paddedWidth * bpp;
       int oLineSize = w * bpp;
       // offset to correct timebin yth line and xth pixel

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -196,7 +196,7 @@ public class SDTReader extends FormatReader {
 
       int binSize = paddedWidth * sizeY  * bpp;
 
-      int preBlockSize = paddedWidth * sizeY * blockLength * bpp;
+      int preBlockSize = binSize * blockLength;
 
       // pre-load data for performance
       if (dataStore == null) {
@@ -226,8 +226,8 @@ public class SDTReader extends FormatReader {
 
         int endOfBlock = (currentBlock + 1) * blockLength;
         int storeLength;
-        if (endOfBlock > timeBins) {
-          storeLength = timeBins - (currentBlock * blockLength);
+        if (endOfBlock > times) {
+          storeLength = times - (currentBlock * blockLength);
         } else {
           storeLength = blockLength;
         }
@@ -239,7 +239,7 @@ public class SDTReader extends FormatReader {
             // set output to first pixel of this row in 2D plane
             // corresponding to zeroth timeBin
             int output = (row * paddedWidth + col) * bpp;
-            int input = ((col * timeBins) + (currentBlock * blockLength)) * bpp;
+            int input = ((col * times) + (currentBlock * blockLength)) * bpp;
             // copy subset of decay into buffer.
 
             for (int t = 0; t < storeLength; t++) {

--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -170,6 +170,7 @@ public class SDTReader extends FormatReader {
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     boolean little = isLittleEndian();
 
+    // This is the Becker Hickl block not the pre-loaded data block
     long blockSize = info.allBlockLengths[getSeries()];
 
     int paddedWidth = sizeX + ((4 - (sizeX % 4)) % 4);
@@ -199,13 +200,12 @@ public class SDTReader extends FormatReader {
       int preBlockSize = binSize * blockLength;
 
       // pre-load data for performance
-      if (dataStore == null) {
+      if (dataStore == null  || storedSeries != getSeries()) {
         dataStore = new byte[preBlockSize];
         currentBlock = -1;
       }
 
-      if (timeBin / blockLength != currentBlock || storedChannel != channel ||
-        storedSeries != getSeries() ) {
+      if (timeBin/blockLength != currentBlock || storedChannel != channel  ) {
 
         currentBlock = timeBin / blockLength;
 


### PR DESCRIPTION
To test should load all curated .sdt files but larger files (see QA17189 for sample file from Ninewells) should load in 10s of seconds rather than 10s of minutes.