### PR TITLE
Do not run upgrade check when passing -version

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -294,9 +294,9 @@ public final class ImageConverter {
     }
 
     if (printVersion) {
-      LOGGER.info("Version: {}", FormatTools.VERSION);
-      LOGGER.info("VCS revision: {}", FormatTools.VCS_REVISION);
-      LOGGER.info("Build date: {}", FormatTools.DATE);
+      System.out.println("Version: " + FormatTools.VERSION);
+      System.out.println("VCS revision: " + FormatTools.VCS_REVISION);
+      System.out.println("Build date: " + FormatTools.DATE);
       return true;
     }
 

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -129,9 +129,11 @@ public final class ImageConverter {
     }
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-") && args.length > 1) {
-        if (args[i].equals("-debug")) {
-          DebugTools.setRootLevel("DEBUG");
+        if (args[i].equals(VERSION)) {
+          printVersion = true;
+          return true;
         }
+        else if (args[i].equals("-debug")) DebugTools.setRootLevel("DEBUG");
         else if (args[i].equals("-stitch")) stitch = true;
         else if (args[i].equals("-separate")) separate = true;
         else if (args[i].equals("-merge")) merge = true;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -89,6 +89,7 @@ public final class ImageConverter {
     LoggerFactory.getLogger(ImageConverter.class);
 
   private static final String NO_UPGRADE_CHECK = "-no-upgrade";
+  private static final String VERSION = "-version";
 
   // -- Fields --
 
@@ -193,7 +194,7 @@ public final class ImageConverter {
         }
       }
       else {
-        if (args[i].equals("-version")) printVersion = true;
+        if (args[i].equals(VERSION)) printVersion = true;
         else if (in == null) in = args[i];
         else if (out == null) out = args[i];
         else {
@@ -860,7 +861,8 @@ public final class ImageConverter {
 
   public static void main(String[] args) throws FormatException, IOException {
     DebugTools.enableLogging("INFO");
-    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1) {
+    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1 &&
+        DataTools.indexOf(args, VERSION) == -1) {
       UpgradeChecker checker = new UpgradeChecker();
       boolean canUpgrade =
         checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -197,7 +197,6 @@ public class ImageInfo {
           return true;
         }
         else if (args[i].equals("-nopix")) pixels = false;
-        else if (args[i].equals(VERSION)) printVersion = true;
         else if (args[i].equals("-nocore")) doCore = false;
         else if (args[i].equals("-nometa")) doMeta = false;
         else if (args[i].equals("-nofilter")) filter = false;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -93,6 +93,7 @@ public class ImageInfo {
   private static final String NEWLINE = System.getProperty("line.separator");
 
   private static final String NO_UPGRADE_CHECK = "-no-upgrade";
+  private static final String VERSION = "-version";
 
   private static final ImmutableSet<String> HELP_ARGUMENTS =
       ImmutableSet.of("-h", "-help", "--help");
@@ -192,7 +193,7 @@ public class ImageInfo {
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-")) {
         if (args[i].equals("-nopix")) pixels = false;
-        else if (args[i].equals("-version")) printVersion = true;
+        else if (args[i].equals(VERSION)) printVersion = true;
         else if (args[i].equals("-nocore")) doCore = false;
         else if (args[i].equals("-nometa")) doMeta = false;
         else if (args[i].equals("-nofilter")) filter = false;
@@ -1110,7 +1111,8 @@ public class ImageInfo {
 
   public static void main(String[] args) throws Exception {
     DebugTools.enableLogging("INFO");
-    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1) {
+    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1 &&
+        DataTools.indexOf(args, VERSION) == -1) {
       UpgradeChecker checker = new UpgradeChecker();
       boolean canUpgrade =
         checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -192,7 +192,11 @@ public class ImageInfo {
     if (args == null) return false;
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-")) {
-        if (args[i].equals("-nopix")) pixels = false;
+        if (args[i].equals(VERSION)){
+          printVersion = true;
+          return true;
+        }
+        else if (args[i].equals("-nopix")) pixels = false;
         else if (args[i].equals(VERSION)) printVersion = true;
         else if (args[i].equals("-nocore")) doCore = false;
         else if (args[i].equals("-nometa")) doMeta = false;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -1017,9 +1017,9 @@ public class ImageInfo {
     boolean validArgs = parseArgs(args);
     if (!validArgs) return false;
     if (printVersion) {
-      LOGGER.info("Version: {}", FormatTools.VERSION);
-      LOGGER.info("VCS revision: {}", FormatTools.VCS_REVISION);
-      LOGGER.info("Build date: {}", FormatTools.DATE);
+      System.out.println("Version: " + FormatTools.VERSION);
+      System.out.println("VCS revision: " + FormatTools.VCS_REVISION);
+      System.out.println("Build date: " + FormatTools.DATE);
       return true;
     }
 


### PR DESCRIPTION
Fixes  https://trac.openmicroscopy.org/ome/ticket/13226

As indicated in the command help, this option should display the current library version and exit. This commit skips the initial upgrade check if the argument is passed.

To test this PR, run the command line tools *offline* and check:
- `showinf -version` and `bfconvert -version` do not throw a `java.net.UnknownHostException`
- `showinf test.fake` and `bfconvert test.fake` throw a `java.net.UnknownHostException`