### PR TITLE
FilePatternReader: fix openBytes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -134,7 +134,9 @@ public class FilePatternReader extends FormatReader {
     int planeIndex = fileIndexes[getSeries()][no][1];
     helper.setId(files[fileIndex]);
     helper.setSeries(getSeries());
-    return helper.openBytes(planeIndex, buf, x, y, w, h);
+    byte[] plane = helper.openBytes(planeIndex, buf, x, y, w, h);
+    helper.close();
+    return plane;
   }
 
   @Override

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -133,11 +133,8 @@ public class FilePatternReader extends FormatReader {
     int fileIndex = fileIndexes[getSeries()][no][0];
     int planeIndex = fileIndexes[getSeries()][no][1];
     helper.setId(files[fileIndex]);
-    int oldSeries = helper.getSeries();
     helper.setSeries(getSeries());
-    byte[] plane = helper.openBytes(planeIndex, buf, x, y, w, h);
-    helper.setSeries(oldSeries);
-    return plane;
+    return helper.openBytes(planeIndex, buf, x, y, w, h);
   }
 
   @Override

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -133,7 +133,11 @@ public class FilePatternReader extends FormatReader {
     int fileIndex = fileIndexes[getSeries()][no][0];
     int planeIndex = fileIndexes[getSeries()][no][1];
     helper.setId(files[fileIndex]);
-    return helper.openBytes(planeIndex, buf, x, y, w, h);
+    int oldSeries = helper.getSeries();
+    helper.setSeries(getSeries());
+    byte[] plane = helper.openBytes(planeIndex, buf, x, y, w, h);
+    helper.setSeries(oldSeries);
+    return plane;
   }
 
   @Override


### PR DESCRIPTION
Adds the following to `FilePatternReader.openBytes`:

* a `helper.setSeries` call to so that the correct planes are returned when stitching multi-series files
* a `helper.close` call to match `helper.setId` (avoids file leaks)