### PR TITLE
fix formatting for creating fakes with ROIs

### DIFF
--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -87,6 +87,8 @@ Regions
 
 To generate a fake file containing regions of interest:
 
+::
+
     touch "regions&points=10.fake"
     touch "regions&ellipses=20.fake"
     touch "regions&rectangles=5&lines=25.fake"


### PR DESCRIPTION
Fixes formatting of commands to type at shell prompt. Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/developers/generating-test-images.html#regions.