### PR TITLE
Fake images doc

### DIFF
--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -87,11 +87,15 @@ Regions
 
 To generate a fake file containing regions of interest:
 
+::
+
     touch "regions&points=10.fake"
     touch "regions&ellipses=20.fake"
     touch "regions&rectangles=5&lines=25.fake"
 
 Replace ``regions`` in the above examples with the desired image or plate which will contain the regions, e.g.
+
+::
 
     touch "HCSanalysis&plates=1&plateRows=16&plateCols=24&rectangles=100.fake"
 

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -91,6 +91,10 @@ To generate a fake file containing regions of interest:
     touch "regions&ellipses=20.fake"
     touch "regions&rectangles=5&lines=25.fake"
 
+Replace ``regions`` in the above example with the desired image or plate which will contain the regions, e.g.
+
+    touch "HCSanalysis&plates=1&plateRows=16&plateCols=24&rectangles=100.fake"
+
 For each shape type, the value will specify the number of regions of interest
 to create where each region of interest contains a single shape of the input
 type. By convention, all generated regions of interests are not associated to

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -91,7 +91,7 @@ To generate a fake file containing regions of interest:
     touch "regions&ellipses=20.fake"
     touch "regions&rectangles=5&lines=25.fake"
 
-Replace ``regions`` in the above example with the desired image or plate which will contain the regions, e.g.
+Replace ``regions`` in the above examples with the desired image or plate which will contain the regions, e.g.
 
     touch "HCSanalysis&plates=1&plateRows=16&plateCols=24&rectangles=100.fake"
 


### PR DESCRIPTION
This adds an example to the fake images workflow which clarifies how to connect the regions and plates (or images) when creating fakes.

To test, check https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/developers/generating-test-images.html

@sbesson 