### PR TITLE
Update axiovision link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2370,7 +2370,7 @@ mif = true
 pagename = zeiss-axiovision-zvi
 extensions = .zvi
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
-developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision-for-biology.html>`_
+developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision.html>`_
 bsd = no
 versions = 1.0, 2.0
 software = `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/en_de/downloads/axiovision.html>`_
@@ -2394,9 +2394,6 @@ using the Bio-Formats Importer plugin, you can just remove the \n
 ZVI_Reader.class from the plugins folder. \n
 \n
 Commercial applications that support ZVI include `Bitplane Imaris <http://www.bitplane.com/>`_. \n
-\n
-.. seealso:: \n
-  `Axiovision software overview <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision-for-biology.html>`_
 
 [Zeiss CZI]
 indexExtensions = .czi

--- a/docs/sphinx/formats/zeiss-axiovision-zvi.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-zvi.txt
@@ -6,7 +6,7 @@ Zeiss AxioVision ZVI (Zeiss Vision Image)
 
 Extensions: .zvi
 
-Developer: `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision-for-biology.html>`_
+Developer: `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision.html>`_
 
 Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 
@@ -63,7 +63,4 @@ both are installed. If you have a problem which is solved by opening the file
 using the Bio-Formats Importer plugin, you can just remove the 
 ZVI_Reader.class from the plugins folder. 
 
-Commercial applications that support ZVI include `Bitplane Imaris <http://www.bitplane.com/>`_. 
-
-.. seealso:: 
-  `Axiovision software overview <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision-for-biology.html>`_
+Commercial applications that support ZVI include `Bitplane Imaris <http://www.bitplane.com/>`_.


### PR DESCRIPTION
Previous link was broken - https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-docs/263/warnings3Result/ - poking around their website, this is the only Axiovision page now and is linked from their Microscopy software for biology & medicine section even though it's labelled as material science when you link through.

Should make the build green again.