### PR TITLE
Logging developer documentation 

### DIFF
--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -37,6 +37,7 @@ Using Bio-Formats as a Java library
     java-library
     export
     export2
+    logging
     conversion
     matlab-dev
     python-dev

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -5,7 +5,7 @@ If you wish to make use of Bio-Formats within your own software, you can
 :downloads:`download formats-gpl.jar <artifacts/formats-gpl.jar>` to use it as
 a library. Just add **formats-gpl.jar** to your CLASSPATH or build path. You
 will also need **common.jar** for common I/O functions, **ome-xml.jar** for
-metadata standardization, and `SLF4J <http://slf4j.org/>`_ for logging. 
+metadata standardization, and `SLF4J <http://slf4j.org/>`_ for :doc:`logging`.
 
 There are also certain packages that if present will be utilized to
 provide additional functionality. To include one, just place it in the

--- a/docs/sphinx/developers/logging.txt
+++ b/docs/sphinx/developers/logging.txt
@@ -8,7 +8,7 @@ Logging frameworks
 
 Bio-Formats uses `SLF4J <http://www.slf4j.org>`_ as a logging API. SLF4J is a
 facade and needs to be bound to a logging framework at deployment time. Two
-underlying logging framework are currently supported by Bio-Formats:
+underlying logging frameworks are currently supported by Bio-Formats:
 
 - `logback <http://logback.qos.ch/>`_ is the recommended framework and
   natively implements the SL4J API,

--- a/docs/sphinx/developers/logging.txt
+++ b/docs/sphinx/developers/logging.txt
@@ -14,7 +14,7 @@ underlying logging frameworks are currently supported by Bio-Formats:
   natively implements the SL4J API,
 - `log4j <http://logging.apache.org/log4j>`_ is the other logging framework
   supported by Bio-Formats and is mainly used in the
-  :ref:`MATLAB toolbox <matlab-dev>`.
+  :doc:`MATLAB toolbox <matlab-dev>`.
 
 Initialization
 --------------

--- a/docs/sphinx/developers/logging.txt
+++ b/docs/sphinx/developers/logging.txt
@@ -1,7 +1,7 @@
 Logging
 =======
 
-Logging is the process of writing log messages during the execution.
+Logging is the process of writing log messages during execution.
 
 Logging frameworks
 ------------------
@@ -41,7 +41,7 @@ The main methods are described below:
 - ``DebugTools.setRootLevel(level)`` will override the level of the root logger
   independently of how the logging system was initialized.
 
-- ``DebugTools.enableIJLogging()`` (logback-only) will add an ImageJ specific
+- ``DebugTools.enableIJLogging()`` (logback-only) will add an ImageJ-specific
   appender to the root logger.
 
 .. versionchanged:: 5.2.0

--- a/docs/sphinx/developers/logging.txt
+++ b/docs/sphinx/developers/logging.txt
@@ -1,8 +1,6 @@
 Logging
 =======
 
-Logging is the process of writing log messages during execution.
-
 Logging frameworks
 ------------------
 
@@ -29,8 +27,8 @@ framework and delegate the method calls to either
 The main methods are described below:
 
 - ``DebugTools.enableLogging()`` will initialize the underlying logging 
-  framework. This call will result in a no-op if the logging has been
-  initialized either via a binding-specific configuration file (see
+  framework. This call will result in a no-op if logging has been initialized
+  either via a binding-specific configuration file (see
   `logback configuration <http://logback.qos.ch/manual/configuration.html>`_)
   or via a prior call to ``DebugTools.enableLogging()``.
 

--- a/docs/sphinx/developers/logging.txt
+++ b/docs/sphinx/developers/logging.txt
@@ -1,34 +1,38 @@
 Logging
 =======
 
-Bio-Formats uses `SLF4J <http://www.slf4j.org>`_ as a logging API for 
-controlling the logger system.
+Logging is the process of writing log messages during the execution.
 
 Logging frameworks
 ------------------
 
-Two logging framework are currently supported in Bio-Formats:
+Bio-Formats uses `SLF4J <http://www.slf4j.org>`_ as a logging API. SLF4J is a
+facade and needs to be bound to a logging framework at deployment time. Two
+underlying logging framework are currently supported by Bio-Formats:
 
-- `logback <http://logback.qos.ch/>`_ is the recommended framework as it 
-  natively implements the SL4J API
+- `logback <http://logback.qos.ch/>`_ is the recommended framework and
+  natively implements the SL4J API,
 - `log4j <http://logging.apache.org/log4j>`_ is the other logging framework
-  supported by Bio-Formats used notably in the MATLAB toolbox.
+  supported by Bio-Formats and is mainly used in the
+  :ref:`MATLAB toolbox <matlab-dev>`.
 
 Initialization
 --------------
 
 The :javadoc:`DebugTools <loci/common/DebugTools.html>` class contains a 
-series of methods for the initialization and control of the logging system. 
-This class uses reflection to determine the underlying logging backend 
-implementation for the logging framework detected at runtime.
+series of framework-agnostic methods for the initialization and control of the
+logging system. This class uses reflection to detect the underlying logging
+framework and delegate the method calls to either
+:javadoc:`Log4jTools <loci/common/Log4jTools.html>` or
+:javadoc:`LogbackTools <loci/common/LogbackTools.html>`.
 
 The main methods are described below:
 
 - ``DebugTools.enableLogging()`` will initialize the underlying logging 
-  framework. This will result in a no-op if the logging has been initialized
-  either via a binding-specific configuration file (see
+  framework. This call will result in a no-op if the logging has been
+  initialized either via a binding-specific configuration file (see
   `logback configuration <http://logback.qos.ch/manual/configuration.html>`_)
-  or a prior call to ``DebugTools.enableLogging()``.
+  or via a prior call to ``DebugTools.enableLogging()``.
 
 - ``DebugTools.enableLogging(level)`` will initialize the logging framework
   under the same conditions as described above and set the root logger level if
@@ -42,6 +46,6 @@ The main methods are described below:
 
 .. versionchanged:: 5.2.0
 
-  Prioe to Bio-Formats 5.2.0, ``DebugTools.enableLogging(level)``
+  Prior to Bio-Formats 5.2.0, ``DebugTools.enableLogging(level)``
   unconditionally set the logging and root logger level. Use
   ``DebugTools.setRootLevel(level)`` to restore this behavior.

--- a/docs/sphinx/developers/logging.txt
+++ b/docs/sphinx/developers/logging.txt
@@ -1,0 +1,47 @@
+Logging
+=======
+
+Bio-Formats uses `SLF4J <http://www.slf4j.org>`_ as a logging API for 
+controlling the logger system.
+
+Logging frameworks
+------------------
+
+Two logging framework are currently supported in Bio-Formats:
+
+- `logback <http://logback.qos.ch/>`_ is the recommended framework as it 
+  natively implements the SL4J API
+- `log4j <http://logging.apache.org/log4j>`_ is the other logging framework
+  supported by Bio-Formats used notably in the MATLAB toolbox.
+
+Initialization
+--------------
+
+The :javadoc:`DebugTools <loci/common/DebugTools.html>` class contains a 
+series of methods for the initialization and control of the logging system. 
+This class uses reflection to determine the underlying logging backend 
+implementation for the logging framework detected at runtime.
+
+The main methods are described below:
+
+- ``DebugTools.enableLogging()`` will initialize the underlying logging 
+  framework. This will result in a no-op if the logging has been initialized
+  either via a binding-specific configuration file (see
+  `logback configuration <http://logback.qos.ch/manual/configuration.html>`_)
+  or a prior call to ``DebugTools.enableLogging()``.
+
+- ``DebugTools.enableLogging(level)`` will initialize the logging framework
+  under the same conditions as described above and set the root logger level if
+  the initialization was succesful.
+
+- ``DebugTools.setRootLevel(level)`` will override the level of the root logger
+  independently of how the logging system was initialized.
+
+- ``DebugTools.enableIJLogging()`` (logback-only) will add an ImageJ specific
+  appender to the root logger.
+
+.. versionchanged:: 5.2.0
+
+  Prioe to Bio-Formats 5.2.0, ``DebugTools.enableLogging(level)``
+  unconditionally set the logging and root logger level. Use
+  ``DebugTools.setRootLevel(level)`` to restore this behavior.

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -179,9 +179,10 @@ To convert the OME metadata into a string, use the ``dumpXML()`` method:
 Changing the logging level
 --------------------------
 
-By default, ``bfopen`` initializes the logging system at the `WARN` level. To
-set the logging level, use
-:javadoc:`loci.common.DebugTools.enableLogging(level) <loci/common/DebugTools.html#enableLogging(java.lang.String)>`:
+By default, ``bfopen`` uses ``bfInitLogging`` to initialize the logging system
+at the `WARN` level. To change the root logging level, use the
+:javadoc:`DebugTools <loci/common/DebugTools.html>` methods as described in
+the :doc:`logging` section.
 
 .. literalinclude:: examples/bftest.m
   :language: matlab


### PR DESCRIPTION
This PR adds a page to the Sphinx developer documentation to describe the logging framework (slf4j + log4j/logback) used by Bio-Formats and the methods of the `DebugTools` utility class.
It also includes some documentation of the breaking logging API changes in https://github.com/openmicroscopy/bioformats/pull/2372.


