### PR TITLE
Schema publication

### DIFF
--- a/components/specification/publish
+++ b/components/specification/publish
@@ -152,7 +152,7 @@ contains() {
     fi
 }
 
-devmarker="dev"
+devmarker="DEV"
 root=published
 
 

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -163,10 +163,6 @@ mkdir -p "$root"
 
 for dir in released-schema/20*
 do
-    # Don't copy legacy or other material
-    if [ "$dir" = "released-schema/additions" ]; then
-        continue
-    fi
 
     # Copy dev material, but don't make index
     if contains $dir $devmarker; then

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -217,7 +217,7 @@ do
 
         # Special case copying of legacy schemas
         if [ "$year" = "2003" ]; then
-            path="${root}/XMLschemas/${base}/${month}"
+            path="${root}/Schemas/${base}/${month}"
             path=$(echo "$path" | sed -e 's;/2003-\(.*\);/\1;')
             reldate="2003 ($month)"
         else
@@ -292,7 +292,6 @@ done
 # $3=filter (current or legacy)
 # $4=verbose (true or false)
 # $5=schema set (current or legacy)
-# $6=schema location (current=Schemas, legacy=XMLschemas)
 createlink() {
     name=$(basename "$1")
     release="$2"
@@ -319,27 +318,8 @@ createlink() {
     if [ "$4" = "false" ]; then
         reldesc=""
     fi
-    if [ "$5" = "current" ]; then
-        link=$(find published/Schemas -name "$name" | grep "$release" | head -n1)
-        link=$(echo "$link" | sed -e 's;published/Schemas/;;')
-        if [ "$6" = "legacy" ]; then
-            if [ -z "$2" ]; then
-                link="../Schemas/$link"
-            else
-                link="../../Schemas/$link"
-            fi
-        fi
-    else
-        link=$(find published/XMLschemas -name "$name" | grep "$release" | head -n1)
-        link=$(echo "$link" | sed -e 's;published/XMLschemas/;;')
-        if [ "$6" = "current" ]; then
-            if [ -z "$2" ]; then
-                link="../XMLschemas/$link"
-            else
-                link="../../XMLschemas/$link"
-            fi
-        fi
-    fi
+    link=$(find published/Schemas -name "$name" | grep "$release" | head -n1)
+    link=$(echo "$link" | sed -e 's;published/Schemas/;;')
     if [ -n "$2" ]; then
         link=$(echo "$link" | sed -e "s;^${shortname}/;;")
     fi
@@ -492,16 +472,14 @@ EOF
 <ul>
 EOF
 
-    for release in $(ls -1d "$root"/Schemas/$1/20* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
+    for release in $(ls -1d "$root"/Schemas/$1/20* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r ); do
         reldate=$(parsedate "$release")
         echo "<li>$reldate - namespace /$release/</li>"
     done
-    if [ -d "${root}/XMLschemas/$1" ]; then
-        for release in $(ls -1d "$root"/XMLschemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html  | sort -r | grep FC) $(ls -1d "$root"/XMLschemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
-            reldate="2003 ($release)"
-            echo "<li>$reldate - namespace /$release/$schema</li>"
-        done
-    fi
+    for release in $(ls -1d "$root"/Schemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html  | sort -r | grep FC) $(ls -1d "$root"/Schemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
+        reldate="2003 ($release)"
+        echo "<li>$reldate - namespace /$release/$schema</li>"
+    done
 
 
     cat <<EOF
@@ -518,11 +496,11 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
-        createlink "$schema" "$year" "current" "false" "current" "$2"
+    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | grep 20 | sort -r); do
+        createlink "$schema" "$year" "current" "false" "current"
     done
-    for year in $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
-        createlink "$schema" "$year" "current" "false" "legacy" "$2"
+    for year in $(find published/Schemas -name "$schema" | grep 2003 | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
+        createlink "$schema" "$year" "current" "false" "legacy"
     done
 
     cat <<EOF
@@ -531,11 +509,11 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
-        createlink "$schema" "$year" "legacy" "false" "current" "$2"
+    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | grep 20 | sort -r); do
+        createlink "$schema" "$year" "legacy" "false" "current"
     done
-    for year in $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
-        createlink "$schema" "$year" "legacy" "false" "legacy" "$2"
+    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
+        createlink "$schema" "$year" "legacy" "false" "legacy"
     done
 
     cat <<EOF
@@ -550,19 +528,10 @@ EOF
 for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/Schemas/;;'); do
     if [ $type != "Transforms" ]; then
         echo "HTML [2] -> $root/Schemas/${type}/index.html"
-        createintermediateindex "$type" "current" > "$root/Schemas/${type}/index.html"
+        createintermediateindex "$type" > "$root/Schemas/${type}/index.html"
     fi
 done
 
-for type in $(find "${root}/XMLschemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/XMLschemas/;;'); do
-    if [ $type != "Transforms" ]; then
-        echo "HTML [3] -> $root/XMLschemas/${type}/index.html"
-        createintermediateindex "$type" "legacy" > "$root/XMLschemas/${type}/index.html"
-    fi
-done
 
 echo "HTML [4] -> ${root}/Schemas/index.html"
 createmainindex "current" > "${root}/Schemas/index.html"
-echo "HTML [5] -> ${root}/XMLschemas/index.html"
-createmainindex "legacy" > "${root}/XMLschemas/index.html"
-

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -164,28 +164,8 @@ mkdir -p "$root"
 for dir in released-schema/20*
 do
 
-    # Copy dev material, but don't make index
     if contains $dir $devmarker; then
-        echo "DEV Folder Found"
-        for schema in "$dir"/*.xsd
-        do
-            rel=$(basename "$dir")
-            base=${schema%.xsd}
-            base=$(basename "$base")
-            name=$(basename "$schema")
-
-            # For some reason, the OME schema has always been lowercased
-            if [ "$base" = "ome" ]; then
-                base="OME"
-            fi
-
-            path="${root}/${base}/${rel}"
-
-            # Copy schema
-            mkdir -p "$path"
-            cp -v "$schema" "${path}/${name}"
-
-        done
+        echo "Skipping $dir folder"
         continue
     fi
 
@@ -281,6 +261,10 @@ dir="transforms"
 mkdir -p "$path"
 for transform in "$dir"/*.xsl
 do
+    if contains $transform $devmarker; then
+        echo "Skipping $transform"
+        continue
+    fi
     cp -v "$transform" "$path"
 done
 

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -179,7 +179,7 @@ do
                 base="OME"
             fi
 
-            path="${root}/Schemas/${base}/${rel}"
+            path="${root}/${base}/${rel}"
 
             # Copy schema
             mkdir -p "$path"
@@ -217,11 +217,11 @@ do
 
         # Special case copying of legacy schemas
         if [ "$year" = "2003" ]; then
-            path="${root}/Schemas/${base}/${month}"
+            path="${root}/${base}/${month}"
             path=$(echo "$path" | sed -e 's;/2003-\(.*\);/\1;')
             reldate="2003 ($month)"
         else
-            path="${root}/Schemas/${base}/${rel}"
+            path="${root}/${base}/${rel}"
             reldate=$(parsedate "$rel")
         fi
 
@@ -276,7 +276,7 @@ done
 # Special cases
 
 # Transforms folder
-path="${root}/Schemas/Transforms/"
+path="${root}/Transforms/"
 dir="transforms"
 mkdir -p "$path"
 for transform in "$dir"/*.xsl
@@ -318,8 +318,8 @@ createlink() {
     if [ "$4" = "false" ]; then
         reldesc=""
     fi
-    link=$(find published/Schemas -name "$name" | grep "$release" | head -n1)
-    link=$(echo "$link" | sed -e 's;published/Schemas/;;')
+    link=$(find published -name "$name" | grep "$release" | head -n1)
+    link=$(echo "$link" | sed -e 's;published/;;')
     if [ -n "$2" ]; then
         link=$(echo "$link" | sed -e "s;^${shortname}/;;")
     fi
@@ -405,7 +405,7 @@ EOF
 <ul>
 EOF
 
-    for schema in $(find published/Schemas -name '*xsd' | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
+    for schema in $(find published -name '*xsd' | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
         createlink "$schema" "" "current" "true" "current" "$1"
     done
 
@@ -415,7 +415,7 @@ EOF
 <ul>
 EOF
 
-    for schema in $(find published/Schemas -name '*xsd' | xargs $XARGSOPTS -n1 basename | sort | uniq); do
+    for schema in $(find published -name '*xsd' | xargs $XARGSOPTS -n1 basename | sort | uniq); do
         createlink "$schema" "" "legacy" "true" "current" "$1"
     done
     cat <<EOF
@@ -472,11 +472,11 @@ EOF
 <ul>
 EOF
 
-    for release in $(ls -1d "$root"/Schemas/$1/20* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r ); do
+    for release in $(ls -1d "$root"/$1/20* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r ); do
         reldate=$(parsedate "$release")
         echo "<li>$reldate - namespace /$release/</li>"
     done
-    for release in $(ls -1d "$root"/Schemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html  | sort -r | grep FC) $(ls -1d "$root"/Schemas/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
+    for release in $(ls -1d "$root"/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html  | sort -r | grep FC) $(ls -1d "$root"/$1/* | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
         reldate="2003 ($release)"
         echo "<li>$reldate - namespace /$release/$schema</li>"
     done
@@ -496,10 +496,10 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | grep 20 | sort -r); do
+    for year in $(find published -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | grep 20 | sort -r); do
         createlink "$schema" "$year" "current" "false" "current"
     done
-    for year in $(find published/Schemas -name "$schema" | grep 2003 | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
+    for year in $(find published -name "$schema" | grep 2003 | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
         createlink "$schema" "$year" "current" "false" "legacy"
     done
 
@@ -509,10 +509,10 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | grep 20 | sort -r); do
+    for year in $(find published -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | grep 20 | sort -r); do
         createlink "$schema" "$year" "legacy" "false" "current"
     done
-    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
+    for year in $(find published -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v 20 | grep -v FC); do
         createlink "$schema" "$year" "legacy" "false" "legacy"
     done
 
@@ -525,13 +525,13 @@ EOF
 EOF
 }
 
-for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/Schemas/;;'); do
+for type in $(find "${root}" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/;;'); do
     if [ $type != "Transforms" ]; then
-        echo "HTML [2] -> $root/Schemas/${type}/index.html"
-        createintermediateindex "$type" > "$root/Schemas/${type}/index.html"
+        echo "HTML [2] -> $root/${type}/index.html"
+        createintermediateindex "$type" > "$root/${type}/index.html"
     fi
 done
 
 
-echo "HTML [4] -> ${root}/Schemas/index.html"
-createmainindex "current" > "${root}/Schemas/index.html"
+echo "HTML [4] -> ${root}/index.html"
+createmainindex "current" > "${root}/index.html"

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -288,15 +288,6 @@ do
     cp -v "$transform" "$path"
 done
 
-# Samples folder
-path="${root}/Schemas/Samples/"
-dir="samples"
-mkdir -p "$path"
-for sample in "$dir"/*
-do
-    cp -vRL "$sample" "$path"
-done
-
 # Root index
 
 # Create an HTML link for a schema.
@@ -438,7 +429,7 @@ EOF
 <ul>
 EOF
 
-    for schema in $(find published/Schemas -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
+    for schema in $(find published/Schemas -name '*xsd' | xargs $XARGSOPTS -n1 basename | sort | uniq ); do
         createlink "$schema" "" "current" "true" "current" "$1"
     done
 
@@ -448,7 +439,7 @@ EOF
 <ul>
 EOF
 
-    for schema in $(find published/Schemas -name '*xsd' | grep -v "Samples" | xargs $XARGSOPTS -n1 basename | sort | uniq); do
+    for schema in $(find published/Schemas -name '*xsd' | xargs $XARGSOPTS -n1 basename | sort | uniq); do
         createlink "$schema" "" "legacy" "true" "current" "$1"
     done
     cat <<EOF
@@ -531,10 +522,10 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
+    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "current" "false" "current" "$2"
     done
-    for year in $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
+    for year in $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
         createlink "$schema" "$year" "current" "false" "legacy" "$2"
     done
 
@@ -544,10 +535,10 @@ EOF
 <ul>
 EOF
 
-    for year in $(find published/Schemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
+    for year in $(find published/Schemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r); do
         createlink "$schema" "$year" "legacy" "false" "current" "$2"
     done
-    for year in $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | grep -v "Samples" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
+    for year in $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep FC) $(find published/XMLschemas -name "$schema" | xargs $XARGSOPTS -n1 dirname | xargs $XARGSOPTS -n1 basename | grep -v $devmarker | grep -v html | sort -r | grep -v FC); do
         createlink "$schema" "$year" "legacy" "false" "legacy" "$2"
     done
 
@@ -561,14 +552,14 @@ EOF
 }
 
 for type in $(find "${root}/Schemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/Schemas/;;'); do
-    if [ $type != "Samples" ] && [ $type != "Transforms" ]; then
+    if [ $type != "Transforms" ]; then
         echo "HTML [2] -> $root/Schemas/${type}/index.html"
         createintermediateindex "$type" "current" > "$root/Schemas/${type}/index.html"
     fi
 done
 
 for type in $(find "${root}/XMLschemas" -mindepth 1 -maxdepth 1 -type d | sed -e 's;^published/XMLschemas/;;'); do
-    if [ $type != "Samples" ] && [ $type != "Transforms" ]; then
+    if [ $type != "Transforms" ]; then
         echo "HTML [3] -> $root/XMLschemas/${type}/index.html"
         createintermediateindex "$type" "legacy" > "$root/XMLschemas/${type}/index.html"
     fi

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -579,8 +579,3 @@ createmainindex "current" > "${root}/Schemas/index.html"
 echo "HTML [5] -> ${root}/XMLschemas/index.html"
 createmainindex "legacy" > "${root}/XMLschemas/index.html"
 
-echo "Add any web-extras"
-if [ -d "web-extra" ]; then
-    rsync --stats -r -t "web-extra/" "${root}"
-fi
-


### PR DESCRIPTION
See https://trello.com/c/zkbHhnNO/31-schema-release-process and https://github.com/openmicroscopy/bioformats/pull/1985 for an earlier version of this PR

This PR streamlines the XSD schema release workflow as follows:

- unifies the schemas generation under a single root to include both pre and post 2007 schemas including @rleigh-dundee's suggestion in https://github.com/openmicroscopy/bioformats/pull/1985#issuecomment-142570844
- removes deprecated `web-extras` and `Samples` which is managed and released independently under a different location
  
To test this PR

- run ``cd components/specification && ./publish`` and check no error is thrown
- review the diff between the `published` folder generated under specification and the live schemas. The pre-2007 schemas should be added to the the output folder and the relative links should no longer use `../XMLschemas/*`
- to help computing the difference, released schemas without the generation documentation have been synced to the `master` branch of https://github.com/sbesson/schemas. It should be possible to copy the content of the `published` folder and perform a `git diff`.

For deployment/URLs:
- all XSD schemas should be deployed under a single root location served at `http://www.openmicroscopy.org/Schemas` i.e. use `http://www.openmicroscopy.org/Schemas/OME/$release/ome.xsd`
- for the pre-2007 schemas currently served at `http://www.openmicroscopy.org/XMLSchemas`. there are 2 possibliities. Either leave them unmodified or also unify the URLs and let `http://www.openmicroscopy.org/XMLSchemas` be an alias of `http://www.openmicroscopy.org/Schemas`
- deployment can happen either by archiving the content of `./publish` via a job and deploying using `scc deploy`. If the Git repository/review process described above is sensible, we could also formalize the usage of https://github.com/ome/schemas which should allow to review diffs between releases and use a clone of this repository on the production server.

Follow-up efforts:
- the generated oXygen documentation needs review. Since the current workflow requires the xsd schemas to be published and live *before* the documentation is generated, the proposal is to generate them independently (and reproducibly) under a different root location. The generated documentation can still be served at `http://www.openmicroscopy.org/Schemas/Documentatation/Generated/OME-$release` or we can use the opportunity to move to a a different URL /cc @hflynn 