### PR TITLE
OME-TIFF: fix NPE when closing reader for partial multi-file filesets

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -1034,7 +1034,12 @@ public class ImageInfo {
 
     // initialize reader
     long s = System.currentTimeMillis();
-    reader.setId(id);
+    try {
+      reader.setId(id);
+    } catch (FormatException exc) {
+      reader.close();
+      throw(exc);
+    }
     long e = System.currentTimeMillis();
     float sec = (e - s) / 1000f;
     LOGGER.info("Initialization took {}s", sec);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -1038,7 +1038,9 @@ public class ImageInfo {
       reader.setId(id);
     } catch (FormatException exc) {
       reader.close();
-      throw(exc);
+      LOGGER.error("Failure during the reader initialization");
+      LOGGER.debug("", exc);
+      return false;
     }
     long e = System.currentTimeMillis();
     float sec = (e - s) / 1000f;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -404,6 +404,7 @@ public class OMETiffReader extends FormatReader {
     super.close(fileOnly);
     if (info != null) {
       for (OMETiffPlane[] dimension : info) {
+        if (dimension == null) continue;
         for (OMETiffPlane plane : dimension) {
           if (plane.reader != null) {
             try {


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/13107

At the Bio-Formats command-line tools level, this PR adds a `reader.close()` call if a `FormatException` is thrown by `reader.setId()` reproducing the NPE described in the ticket. In addition these exceptions are not handled more gracefully using logging and should return a non-zero return code.

This PR should be tested at using either one of the QA files linked to the ticket or any of the [multi-file OME-TIFF filesets](https://www.openmicroscopy.org/site/support/ome-model/ome-tiff/data.html#multi-file-ome-tiff-filesets) after deleting one of the TIFF files:
- at the Bio-Formats level, `showinf /path/to/broken_image.ome.tiff` should print an error statement and the full stack trace should be shown when using `showinf -debug /path/to/broken_image.ome.tiff`
- at the OMERO level, importing the partial fileset should still fail but the error should not longer be a NPE but instead a message about the nature of the error.
