### PR TITLE
Support for more native libraries

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlideBook6Reader.java
@@ -52,8 +52,8 @@ import org.scijava.nativelib.NativeLibraryUtil;
 
 /**
  * SlideBook6Reader is a file format reader for 3i SlideBook SLD files that uses
- * the SlideBook SBReadFile SDK via the (Windows only) dlls: 
- *   SBReadFile.dll and SlideBook6Reader.dll
+ * the SlideBook SBReadFile SDK via the native libraries:
+ *   [lib]SlideBook6Reader.[dll,so,dylib]
  *
  * @author Richard Myers, richard at intelligent-imaging.com
  *
@@ -71,7 +71,7 @@ public class SlideBook6Reader  extends FormatReader {
 	public static final long SLD_MAGIC_BYTES_3 = 0xf6010101L;
 
 	private static final String URL_3I_SLD =
-			"http://www.openmicroscopy.org/site/support/bio-formats/formats/3i-slidebook.html";
+			"http://www.intelligent-imaging.com/bioformats";
 	private static final String NO_3I_MSG = "3i SlideBook SlideBook6Reader library not found. " +
 			"Please see " + URL_3I_SLD + " for details.";
 	private static final String GENERAL_3I_MSG = "3i SlideBook SlideBook6Reader library problem. " +
@@ -85,15 +85,8 @@ public class SlideBook6Reader  extends FormatReader {
 	private static boolean isLibraryFound() {
 		if (initialized) return libraryFound;
 		try {
-			// load JNI wrapper of SBReadFile.dll
-			NativeLibraryUtil.Architecture arch = NativeLibraryUtil.getArchitecture();
-			if (arch != NativeLibraryUtil.Architecture.WINDOWS_64 && arch != NativeLibraryUtil.Architecture.WINDOWS_32) {
-				// TODO: add compiled linux and OS X architecture libraries to class
-				throw new UnsatisfiedLinkError();
-			}
-			if (!libraryFound) {
-				libraryFound = NativeLibraryUtil.loadNativeLibrary(SlideBook6Reader.class, "SlideBook6Reader");
-			}
+			// load JNI wrapper of [lib]SlideBook6Reader.[dll, dylib, so]
+			libraryFound = NativeLibraryUtil.loadNativeLibrary(SlideBook6Reader.class, "SlideBook6Reader");
 		}
 		catch (UnsatisfiedLinkError e) {
 			// log level debug, otherwise a warning will be printed every time a file is initialized without the .dll present


### PR DESCRIPTION
Remove static check for windows x32/x64 architecture; now checks at
runtime if correct dynamic library exists.  SlideBook ImageJ update site
also now has OS X x32, x64 and Linux x64 libraries.