### PR TITLE
Zeiss CZI: fix timestamp indexing when multiple separate channels are present

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -913,10 +913,18 @@ public class ZeissCZIReader extends FormatReader {
         if (p.timestamp != null) {
           store.setPlaneDeltaT(new Time(p.timestamp - startTime, UNITS.SECOND), i, plane);
         }
-        else if (plane < timestamps.size()) {
+        else if (plane < timestamps.size() && timestamps.size() == getImageCount()) {
+          // only use the plane index if there is one timestamp per plane
            if (timestamps.get(plane) != null) {
              store.setPlaneDeltaT(new Time(timestamps.get(plane), UNITS.SECOND), i, plane);
            }
+        }
+        else if (getZCTCoords(plane)[2] < timestamps.size()) {
+          // otherwise use the timepoint index, to prevent incorrect timestamping of channels
+          int t = getZCTCoords(plane)[2];
+          if (timestamps.get(t) != null) {
+            store.setPlaneDeltaT(new Time(timestamps.get(t), UNITS.S), i, plane);
+          }
         }
         if (p.exposureTime != null) {
           store.setPlaneExposureTime(new Time(p.exposureTime, UNITS.SECOND), i, plane);


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-May/006046.html

To test, verify that ```showinf -nopix -omexml``` without this change only shows timestamps for the first two planes (c == 0 t == 0 and c == 1 t== 0).  With this change, timestamps should be shown for all planes, and the timestamps for all channels of the same timepoint should be the same.