### PR TITLE
SVS: fix FormatNumberException by using the DataTools parsing API

### DIFF
--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -35,6 +35,10 @@ package loci.common;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.Locale;
 
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
@@ -54,17 +58,10 @@ public final class DataTools {
   // -- Static fields --
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTools.class);
 
-  // Character used for the decimal sign in the current locale
-  private static char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
-
+  private static NumberFormat nf = DecimalFormat.getInstance(Locale.ENGLISH);
   // -- Constructor --
 
   private DataTools() { }
-
-  // -- Data reading --
-  public static void reset() {
-    decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
-  }
 
   /** Reads the contents of the given file into a string. */
   public static String readFile(String id) throws IOException {
@@ -479,8 +476,8 @@ public final class DataTools {
   public static Float parseFloat(String value) {
     if (value == null) return null;
     try {
-      return Float.valueOf(sanitizeDecimalString(value));
-    } catch (NumberFormatException e) {
+      return nf.parse(value.replaceAll(",", ".")).floatValue();
+    } catch (ParseException e) {
       LOGGER.debug("Could not parse float value", e);
     }
     return null;
@@ -494,18 +491,11 @@ public final class DataTools {
   public static Double parseDouble(String value) {
     if (value == null) return null;
     try {
-      return Double.valueOf(sanitizeDecimalString(value));
-    } catch (NumberFormatException e) {
+      return nf.parse(value.replaceAll(",", ".")).doubleValue();
+    } catch (ParseException e) {
       LOGGER.debug("Could not parse double value", e);
     }
     return null;
-  }
-
-  /** Normalizes the decimal separator of a string for the user's locale. */
-  private static String sanitizeDecimalString(String value) {
-    value = value.replaceAll("[^0-9,\\.]", "");
-    char usedSeparator = decimalSeparator == '.' ? ',' : '.';
-    return value.replace(usedSeparator, decimalSeparator);
   }
 
   /**

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -55,13 +55,16 @@ public final class DataTools {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTools.class);
 
   // Character used for the decimal sign in the current locale
-  private static final char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+  private static char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
 
   // -- Constructor --
 
   private DataTools() { }
 
   // -- Data reading --
+  public static void reset() {
+    decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+  }
 
   /** Reads the contents of the given file into a string. */
   public static String readFile(String id) throws IOException {

--- a/components/formats-common/test/loci/common/utests/DataToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DataToolsTest.java
@@ -32,10 +32,12 @@
 
 package loci.common.utests;
 
+import loci.common.DataTools;
+import java.util.Locale;
+
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.fail;
-import loci.common.DataTools;
-
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -43,8 +45,12 @@ import org.testng.annotations.Test;
  */
 public class DataToolsTest {
 
-  // -- Tests --
+  @DataProvider(name = "locales")
+  public Object[][] createData() {
+    return new Object[][] {{"FR"}, {"DE"}, {"US"}, {"GB"}};
+  }
 
+  // -- Tests --
   @Test
   public void testSafeMultiply32() {
     // test vacuous edge cases
@@ -198,8 +204,10 @@ public class DataToolsTest {
     assertEquals(DataTools.parseLong("not a number"), null);
   }
 
-  @Test
-  public void testParseFloat() {
+  @Test(dataProvider="locales")
+  public void testParseFloat(String locale) {
+    Locale.setDefault(new Locale(locale));
+    DataTools.reset();
     assertEquals(DataTools.parseFloat(null), null);
     assertEquals(DataTools.parseFloat(""), null);
     assertEquals(DataTools.parseFloat("0"), 0.0f);
@@ -210,8 +218,10 @@ public class DataToolsTest {
     assertEquals(DataTools.parseFloat("not a number"), null);
   }
 
-  @Test
-  public void testParseDouble() {
+  @Test(dataProvider="locales")
+  public void testParseDouble(String locale) {
+    Locale.setDefault(new Locale(locale));
+    DataTools.reset();
     assertEquals(DataTools.parseDouble(null), null);
     assertEquals(DataTools.parseDouble(""), null);
     assertEquals(DataTools.parseDouble("0"), 0.0d);

--- a/components/formats-common/test/loci/common/utests/DataToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DataToolsTest.java
@@ -207,7 +207,6 @@ public class DataToolsTest {
   @Test(dataProvider="locales")
   public void testParseFloat(String locale) {
     Locale.setDefault(new Locale(locale));
-    DataTools.reset();
     assertEquals(DataTools.parseFloat(null), null);
     assertEquals(DataTools.parseFloat(""), null);
     assertEquals(DataTools.parseFloat("0"), 0.0f);
@@ -221,7 +220,6 @@ public class DataToolsTest {
   @Test(dataProvider="locales")
   public void testParseDouble(String locale) {
     Locale.setDefault(new Locale(locale));
-    DataTools.reset();
     assertEquals(DataTools.parseDouble(null), null);
     assertEquals(DataTools.parseDouble(""), null);
     assertEquals(DataTools.parseDouble("0"), 0.0d);

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import loci.common.Constants;
+import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
@@ -289,7 +290,7 @@ public class SVSReader extends BaseTiffReader {
               value = t.substring(t.indexOf("=") + 1).trim();
               addSeriesMeta(key, value);
               if (key.equals("MPP")) {
-                pixelSize[i] = FormatTools.getPhysicalSizeX(Double.parseDouble(value));
+                pixelSize[i] = FormatTools.getPhysicalSizeX(DataTools.parseDouble(value));
               }
               else if (key.equals("Date")) {
                 date = value;
@@ -298,19 +299,19 @@ public class SVSReader extends BaseTiffReader {
                 time = value;
               }
               else if (key.equals("Emission Wavelength")) {
-                emissionWavelength = new Double(value);
+                emissionWavelength = DataTools.parseDouble(value);
               }
               else if (key.equals("Excitation Wavelength")) {
-                excitationWavelength = new Double(value);
+                excitationWavelength = DataTools.parseDouble(value);
               }
               else if (key.equals("Exposure Time")) {
-                exposureTime = new Double(value);
+                exposureTime = DataTools.parseDouble(value);
               }
               else if (key.equals("Exposure Scale")) {
-                exposureScale = new Double(value);
+                exposureScale = DataTools.parseDouble(value);
               }
               else if (key.equals("AppMag")) {
-                magnification = new Double(value);
+                magnification = DataTools.parseDouble(value);
               }
             }
           }


### PR DESCRIPTION
See https://trello.com/c/ErnjO26c/113-review-number-parsing-across-readers and the file uploaded as QA 17150.

To test this PR,
- check opening the SVS file from the QA above without this PR throws a `FormatNumberException`
- check the same file can be opened with this PR