### PR TITLE
Formats-bsd: unit tests performance

### DIFF
--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -12,8 +12,9 @@ Type "ant -p" for a list of targets.
   <import file="${root.dir}/ant/java.xml"/>
   <property file="build.properties"/>
 
-  <target name="test" depends="jar,compile-tests,test-no-ome-xml,
-    test-no-lurawave, test-no-jai, test-no-exif, test-no-xerces, test-spec"
+  <target name="test" depends="jar,compile-tests,test-long-running,
+      test-no-ome-xml,test-no-lurawave,test-no-jai,test-no-exif,
+      test-no-xerces,test-spec"
     description="run tests">
     <!-- NOTE: Overrides default "test" target from java.xml -->
     <copy tofile="${build.dir}/testng.xml" overwrite="true"
@@ -128,6 +129,23 @@ Type "ant -p" for a list of targets.
       </classpath>
       <xmlfileset file="${build.dir}/testng.xml"/>
     </testng>
+  </target>
+
+  <target name="test-long-running" depends="compile-tests"
+    description="run long-running test " if="doTests">
+    <copy tofile="${build.dir}/testng.xml" overwrite="true"
+      file="${tests.dir}/loci/formats/utests/testng-long-running.xml"/>
+    <testng failureProperty="failedTest">
+      <classpath>
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
+        <pathelement location="${test-classes.dir}"/>
+        <pathelement location="${classes.dir}"/>
+        <pathelement path="${component.runtime-cp}"/>
+      </classpath>
+      <xmlfileset file="${build.dir}/testng.xml"/>
+      <jvmarg value="-mx${testng.memory}"/>
+    </testng>
+    <fail if="failedTest"/>
   </target>
 
   <target name="jar-formats-bsd-tests" depends="compile, compile-tests, copy-test-source"

--- a/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000LongRunningTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000LongRunningTest.java
@@ -42,7 +42,7 @@ public class SixteenBitLosslessJPEG2000LongRunningTest {
 
   @Factory
   public Object[] factoryMethod() {
-    return new Object[] { new SixteenBitLosslessJPEG2000Test(1)};
+    return new Object[] {new SixteenBitLosslessJPEG2000Test(1)};
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000LongRunningTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000LongRunningTest.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import org.testng.annotations.Factory;
+
+/**
+ * Long-running test case which outlines the problems seen in    
+ * trac.openmicroscopy.org/ome/ticket/6278.
+ */
+public class SixteenBitLosslessJPEG2000LongRunningTest {
+
+  @Factory
+  public Object[] factoryMethod() {
+    return new Object[] { new SixteenBitLosslessJPEG2000Test(1)};
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
@@ -66,13 +66,14 @@ public class SixteenBitLosslessJPEG2000Test {
   private static final Logger LOGGER =
     LoggerFactory.getLogger(SixteenBitLosslessJPEG2000Test.class);
 
-  private int increment = 1024;
+  private final int increment;
 
   public SixteenBitLosslessJPEG2000Test() {
+    this(1024);
   }
 
   public SixteenBitLosslessJPEG2000Test(int increment) {
-      this.increment=increment;
+      this.increment = increment;
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
+++ b/components/formats-bsd/test/loci/formats/utests/SixteenBitLosslessJPEG2000Test.java
@@ -66,12 +66,21 @@ public class SixteenBitLosslessJPEG2000Test {
   private static final Logger LOGGER =
     LoggerFactory.getLogger(SixteenBitLosslessJPEG2000Test.class);
 
+  private int increment = 1024;
+
+  public SixteenBitLosslessJPEG2000Test() {
+  }
+
+  public SixteenBitLosslessJPEG2000Test(int increment) {
+      this.increment=increment;
+  }
+
   @Test
   public void testLosslessPixels() throws Exception {
     int failureCount = 0;
-    for (short v=Short.MIN_VALUE; v<Short.MAX_VALUE; v++) {
+    for (int v=Short.MIN_VALUE; v<Short.MAX_VALUE; v+=increment) {
       int index = v + Short.MAX_VALUE + 1;
-      byte[] pixels = DataTools.shortToBytes(v, false);
+      byte[] pixels = DataTools.shortToBytes((short) v, false);
 
       String file = index + ".jp2";
       ByteArrayHandle tmpFile = new ByteArrayHandle(1);

--- a/components/formats-bsd/test/loci/formats/utests/testng-long-running.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng-long-running.xml
@@ -1,0 +1,40 @@
+<!--
+  #%L
+  BSD implementations of Bio-Formats readers and writers
+  %%
+  Copyright (C) 2015 - 2016 Open Microscopy Environment:
+    - Board of Regents of the University of Wisconsin-Madison
+    - Glencoe Software, Inc.
+    - University of Dundee
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+<suite name="Long Running Tests">
+    <test name="SixteenBitLosslessJPEG2000LongRunningTest">
+        <groups/>
+        <classes>
+            <class name="loci.formats.utests.SixteenBitLosslessJPEG2000LongRunningTest"/>
+        </classes>
+        <packages/>
+    </test>
+</suite>


### PR DESCRIPTION
See https://trello.com/c/ISuLct1l/125-formats-bsd-unit-tests-take-too-long-to-run

This PR proposes to reduce the time spent in the default Formats BSD unit tests with the main bottleneck being the `SixteenBitLosslessJPEG2000Test` class which loops over every short value from -32,768 to +32,767.

#### Test classes

- add an increment field in `SixteenBitLosslessJPEG2000Test` controlling the loop of `testLosslessPixels`
- set this increment to `1024` by default
- define another test class and use the TestNG Factory annotation to set the increment to `1` and test all short values

#### Build infrastructure

- leave `testng.xml` consumed by the default Maven `test` target unchanged
- define a new `testng-long-running.xml` configuration file and `test-long-running` Ant target allowing to run the full test using the entire Short range.

### Testing instructions
- check Travis is green with this PR included and the time spent in the Maven matrix component is reduced and/or check that `mvn test` completes faster
- check that `ant test` runs the `SixteenBitLosslessJPEG2000LongRunningTest` and tests all short values