### PR TITLE
Add helper methods to FormatTools for creating stage position lengths

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1437,7 +1437,57 @@ public final class FormatTools {
     }
     return new Time(value, UNITS.SECOND);
   }
-  
+
+  /**
+   * Formats the input value for the position into a length.
+   *
+   * @param value  the value of the position
+   * @param unit   the unit of the position. If {@code null} or invalid,
+   *               default to reference frame.
+   *
+   * @return       the physical size formatted as a {@link Length}
+   */
+  public static Length getPosition(Double value, String unit) {
+    if (value == null || value == Double.POSITIVE_INFINITY ||
+        value == -Double.POSITIVE_INFINITY) {
+      LOGGER.debug("Expected float value for position; got {}", value);
+      return null;
+    }
+
+    if (unit == null) return new Length(value, UNITS.REFERENCEFRAME);
+
+    try {
+      return UnitsLength.create(value, UnitsLength.fromString(unit));
+    } catch (EnumerationException e) {
+      LOGGER.debug(e.getMessage());
+      return new Length(value, UNITS.REFERENCEFRAME);
+    }
+  }
+
+  /**
+   * Formats the input value for the position into a length.
+   *
+   * @param value  the value of the position
+   *
+   * @return       the physical size formatted as a {@link Length}
+   */
+  public static Length getPosition(Double value) {
+   return getPosition(value, UNITS.REFERENCEFRAME);
+  }
+
+  /**
+   * Formats the input value for the position into a length of the given unit.
+   *
+   * @param value  the value of the position
+   * @param unit   the unit of the position. If {@code null} or invalid,
+   *               default to reference frame.
+   *
+   * @return       the position formatted as a {@link Length}
+   */
+  public static Length getPosition(Double value, Unit<Length> unit) {
+      return getPosition(value, unit.getSymbol());
+  }
+
   public static Length getPhysicalSize(Double value, String unit) {
     if (value != null && value != 0 && value < Double.POSITIVE_INFINITY) {
       if (unit != null) {
@@ -1554,7 +1604,7 @@ public final class FormatTools {
 
   /**
    * Formats the input value for the physical size in Z into a length in
-   * microns
+   * microns.
    *
    * @param value  the value of the physical size in Z in microns
    *
@@ -1586,7 +1636,6 @@ public final class FormatTools {
    * @param unit   the unit of the physical size in Z
    *
    * @return       the physical size formatted as a {@link Length}
-
    */
   public static Length getPhysicalSizeZ(Double value, Unit<Length> unit) {
       return getPhysicalSize(value, unit.getSymbol());

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1441,12 +1441,15 @@ public final class FormatTools {
 
 
   /**
-   * Formats the input value for the position into a length of the given unit.
+   * Formats the input value for the stage position into a length of the given
+   * unit.
    *
-   * @param value  the value of the position
-   * @param unit   the unit of the position
+   * @param value  the value of the stage position
+   * @param unit   the unit of the stage position
    *
-   * @return       the position formatted as a {@link Length}
+   * @return       the stage position formatted as a {@link Length}. Returns
+   *               {@code null} if {@code value} is {@code null} or infinite
+   *               or {@code unit} is {@code null}.
    */
   public static Length getStagePosition(Double value, Unit<Length> unit) {
     if (value == null || value.isInfinite()) {
@@ -1466,10 +1469,14 @@ public final class FormatTools {
    * Formats the input value for the stage position into a length of the given
    * unit.
    *
-   * @param value  the value of the position
-   * @param unit   the unit of the position
+   * @param value  the value of the stage position
+   * @param unit   the unit of the stage position. If the string cannot be
+   *               converted into a base length unit, the stage position length
+   *               will be constructure using the default reference frame unit.
    *
-   * @return       the physical size formatted as a {@link Length}
+   * @return       the stage position formatted as a {@link Length}. Returns
+   *               {@code null} under the same conditions as
+   *               {@link #getStagePosition(Double, String)}.
    */
   public static Length getStagePosition(Double value, String unit) {
       Unit<Length> baseunit = null;

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1444,52 +1444,42 @@ public final class FormatTools {
    * Formats the input value for the position into a length of the given unit.
    *
    * @param value  the value of the position
-   * @param unit   the unit of the position. If {@code null} or invalid,
-   *               default to reference frame.
+   * @param unit   the unit of the position
    *
    * @return       the position formatted as a {@link Length}
    */
-  public static Length getPosition(Double value, Unit<Length> unit) {
+  public static Length getStagePosition(Double value, Unit<Length> unit) {
     if (value == null || value.isInfinite()) {
-      LOGGER.debug("Expected float value for position; got {}", value);
+      LOGGER.debug("Expected float value for stage position; got {}", value);
       return null;
     }
 
-    if (unit == null) unit = UNITS.REFERENCEFRAME;
+    if (unit == null) {
+      LOGGER.debug("Expected valid unit for stage position; got {}", unit);
+      return null;
+    }
 
     return new Length(value, unit);
   }
 
-
   /**
-   * Formats the input value for the position into a length of the given unit
+   * Formats the input value for the stage position into a length of the given
+   * unit.
    *
    * @param value  the value of the position
-   * @param unit   the unit of the position. If {@code null} or invalid,
-   *               default to reference frame.
+   * @param unit   the unit of the position
    *
    * @return       the physical size formatted as a {@link Length}
    */
-  public static Length getPosition(Double value, String unit) {
+  public static Length getStagePosition(Double value, String unit) {
+      Unit<Length> baseunit = null;
       try {
-        Unit<Length> baseunit =  UnitsLengthEnumHandler.getBaseUnit(
+        baseunit = UnitsLengthEnumHandler.getBaseUnit(
           UnitsLength.fromString(unit));
-        return getPosition(value, baseunit);
       } catch (EnumerationException e) {
         LOGGER.debug(e.getMessage());
       }
-      return getPosition(value, UNITS.REFERENCEFRAME);
-  }
-
-  /**
-   * Formats the input value for the position into a length.
-   *
-   * @param value  the value of the position
-   *
-   * @return       the physical size formatted as a {@link Length}
-   */
-  public static Length getPosition(Double value) {
-   return getPosition(value, UNITS.REFERENCEFRAME);
+      return getStagePosition(value, baseunit);
   }
 
   public static Length getPhysicalSize(Double value, String unit) {

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1477,7 +1477,9 @@ public final class FormatTools {
         baseunit = UnitsLengthEnumHandler.getBaseUnit(
           UnitsLength.fromString(unit));
       } catch (EnumerationException e) {
+        LOGGER.warn("Invalid base unit: using default reference frame unit");
         LOGGER.debug(e.getMessage());
+        baseunit = UNITS.REFERENCEFRAME;
       }
       return getStagePosition(value, baseunit);
   }

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -54,6 +54,7 @@ import loci.formats.services.OMEXMLServiceImpl;
 
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.UnitsLength;
+import ome.xml.model.enums.handlers.UnitsLengthEnumHandler;
 import ome.xml.model.enums.UnitsTime;
 import ome.xml.model.primitives.PrimitiveNumber;
 import ome.xml.model.primitives.PositiveFloat;
@@ -1438,42 +1439,6 @@ public final class FormatTools {
     return new Time(value, UNITS.SECOND);
   }
 
-  /**
-   * Formats the input value for the position into a length.
-   *
-   * @param value  the value of the position
-   * @param unit   the unit of the position. If {@code null} or invalid,
-   *               default to reference frame.
-   *
-   * @return       the physical size formatted as a {@link Length}
-   */
-  public static Length getPosition(Double value, String unit) {
-    if (value == null || value == Double.POSITIVE_INFINITY ||
-        value == -Double.POSITIVE_INFINITY) {
-      LOGGER.debug("Expected float value for position; got {}", value);
-      return null;
-    }
-
-    if (unit == null) return new Length(value, UNITS.REFERENCEFRAME);
-
-    try {
-      return UnitsLength.create(value, UnitsLength.fromString(unit));
-    } catch (EnumerationException e) {
-      LOGGER.debug(e.getMessage());
-      return new Length(value, UNITS.REFERENCEFRAME);
-    }
-  }
-
-  /**
-   * Formats the input value for the position into a length.
-   *
-   * @param value  the value of the position
-   *
-   * @return       the physical size formatted as a {@link Length}
-   */
-  public static Length getPosition(Double value) {
-   return getPosition(value, UNITS.REFERENCEFRAME);
-  }
 
   /**
    * Formats the input value for the position into a length of the given unit.
@@ -1485,7 +1450,47 @@ public final class FormatTools {
    * @return       the position formatted as a {@link Length}
    */
   public static Length getPosition(Double value, Unit<Length> unit) {
-      return getPosition(value, unit.getSymbol());
+    if (value == null || value == Double.POSITIVE_INFINITY ||
+        value == -Double.POSITIVE_INFINITY) {
+      LOGGER.debug("Expected float value for position; got {}", value);
+      return null;
+    }
+
+    if (unit == null) unit = UNITS.REFERENCEFRAME;
+
+    return new Length(value, unit);
+  }
+
+
+  /**
+   * Formats the input value for the position into a length of the given unit
+   *
+   * @param value  the value of the position
+   * @param unit   the unit of the position. If {@code null} or invalid,
+   *               default to reference frame.
+   *
+   * @return       the physical size formatted as a {@link Length}
+   */
+  public static Length getPosition(Double value, String unit) {
+      try {
+        Unit<Length> baseunit =  UnitsLengthEnumHandler.getBaseUnit(
+          UnitsLength.fromString(unit));
+        return getPosition(value, baseunit);
+      } catch (EnumerationException e) {
+        LOGGER.debug(e.getMessage());
+      }
+      return getPosition(value, UNITS.REFERENCEFRAME);
+  }
+
+  /**
+   * Formats the input value for the position into a length.
+   *
+   * @param value  the value of the position
+   *
+   * @return       the physical size formatted as a {@link Length}
+   */
+  public static Length getPosition(Double value) {
+   return getPosition(value, UNITS.REFERENCEFRAME);
   }
 
   public static Length getPhysicalSize(Double value, String unit) {

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1450,8 +1450,7 @@ public final class FormatTools {
    * @return       the position formatted as a {@link Length}
    */
   public static Length getPosition(Double value, Unit<Length> unit) {
-    if (value == null || value == Double.POSITIVE_INFINITY ||
-        value == -Double.POSITIVE_INFINITY) {
+    if (value == null || value.isInfinite()) {
       LOGGER.debug("Expected float value for position; got {}", value);
       return null;
     }

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -185,9 +185,10 @@ public class FormatToolsTest {
       {-Constants.EPSILON, "mm", new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, "mm", null},
       // Invalid length string units
-      {1.0, null, null},
-      {1.0, "foo", null},
-      {1.0, "s", null},
+      {1.0, null, new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, "", new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, "foo", new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, "s", new Length(1.0, UNITS.REFERENCEFRAME)},
     };
   }
 
@@ -209,7 +210,6 @@ public class FormatToolsTest {
   @Test(dataProvider = "stagePositionStringUnit")
   public void testGetStagePositionStringUnit(Double value, String unit, Length length) {
     assertEquals(length, FormatTools.getStagePosition(value, unit));
-    assertEquals(null, FormatTools.getStagePosition(value, ""));
   }
 
 

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -131,12 +131,7 @@ public class FormatToolsTest {
       {1.0, "mm", new Length(1.0, UNITS.MILLIMETER)},
       {.1, "microns", new Length(.1, UNITS.MICROMETER)},
       {.1, "mm", new Length(.1, UNITS.MILLIMETER)},
-    };
-  }
-
-  @DataProvider(name = "physicalSizeInvalidStringUnit")
-  public Object[][] createValueInvalidStringLengths() {
-    return new Object[][] {
+      // Invalid length units
       {1.0, null, new Length(1.0, UNITS.MICROMETER)},
       {1.0, "foo", new Length(1.0, UNITS.MICROMETER)},
       {1.0, "s", new Length(1.0, UNITS.MICROMETER)},
@@ -169,10 +164,6 @@ public class FormatToolsTest {
     assertEquals(length, FormatTools.getPhysicalSizeX(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeY(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeZ(value, unit));
-  }
-
-  @Test(dataProvider = "physicalSizeInvalidStringUnit")
-  public void testGetPhysicalSizeInvalidStringUnit(Double value, String unit, Length length) {
     assertEquals(length, FormatTools.getPhysicalSizeX(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeY(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeZ(value, unit));

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -197,7 +197,10 @@ public class FormatToolsTest {
       {Constants.EPSILON, "mm", new Length(Constants.EPSILON, UNITS.MILLIMETER)},
       {-Constants.EPSILON, "mm", new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, "mm", null},
-      {-Double.POSITIVE_INFINITY, "mm", null},
+      // Invalid length string units
+      {1.0, null, new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, "foo", new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, "s", new Length(1.0, UNITS.REFERENCEFRAME)},
     };
   }
 
@@ -212,6 +215,7 @@ public class FormatToolsTest {
       {-Constants.EPSILON, UNITS.MILLIMETER, new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
       {-Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
+      {1.0, null, new Length(1.0, UNITS.REFERENCEFRAME)},
     };
   }
 

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -173,22 +173,9 @@ public class FormatToolsTest {
     assertEquals(length, FormatTools.getPhysicalSizeZ(value, unit));
   }
 
-  @DataProvider(name = "positionNoUnit")
-  public Object[][] createPositionNoUnit() {
-    return new Object[][] {
-      {null, null},
-      {0.0, new Length(0.0, UNITS.REFERENCEFRAME)},
-      {1.0, new Length(1.0, UNITS.REFERENCEFRAME)},
-      {.1, new Length(.1, UNITS.REFERENCEFRAME)},
-      {Constants.EPSILON, new Length(Constants.EPSILON, UNITS.REFERENCEFRAME)},
-      {-Constants.EPSILON, new Length(-Constants.EPSILON, UNITS.REFERENCEFRAME)},
-      {Double.POSITIVE_INFINITY, null},
-      {-Double.POSITIVE_INFINITY, null},
-    };
-  }
 
-  @DataProvider(name = "positionStringUnit")
-  public Object[][] createPositionStringUnit() {
+  @DataProvider(name = "stagePositionStringUnit")
+  public Object[][] createStagePositionStringUnit() {
     return new Object[][] {
       {null, "mm", null},
       {0.0, "mm", new Length(0.0, UNITS.MILLIMETER)},
@@ -198,14 +185,14 @@ public class FormatToolsTest {
       {-Constants.EPSILON, "mm", new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, "mm", null},
       // Invalid length string units
-      {1.0, null, new Length(1.0, UNITS.REFERENCEFRAME)},
-      {1.0, "foo", new Length(1.0, UNITS.REFERENCEFRAME)},
-      {1.0, "s", new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, null, null},
+      {1.0, "foo", null},
+      {1.0, "s", null},
     };
   }
 
-  @DataProvider(name = "positionUnit")
-  public Object[][] createPositionUnit() {
+  @DataProvider(name = "stagePositionUnit")
+  public Object[][] createStagePositionUnit() {
     return new Object[][] {
       {null, UNITS.MILLIMETER, null},
       {0.0, UNITS.MILLIMETER, new Length(0.0, UNITS.MILLIMETER)},
@@ -215,24 +202,19 @@ public class FormatToolsTest {
       {-Constants.EPSILON, UNITS.MILLIMETER, new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
       {-Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
-      {1.0, null, new Length(1.0, UNITS.REFERENCEFRAME)},
+      {1.0, null, null},
     };
   }
 
-  @Test(dataProvider = "positionNoUnit")
-  public void testGetPositionNoUnit(Double value, Length length) {
-    assertEquals(length, FormatTools.getPosition(value));
-    assertEquals(length, FormatTools.getPosition(value, ""));
-  }
-
-  @Test(dataProvider = "positionStringUnit")
-  public void testGetPositionStringUnit(Double value, String unit, Length length) {
-    assertEquals(length, FormatTools.getPosition(value, unit));
+  @Test(dataProvider = "stagePositionStringUnit")
+  public void testGetStagePositionStringUnit(Double value, String unit, Length length) {
+    assertEquals(length, FormatTools.getStagePosition(value, unit));
+    assertEquals(null, FormatTools.getStagePosition(value, ""));
   }
 
 
-  @Test(dataProvider = "positionUnit")
-  public void testGetPositionUnit(Double value, Unit<Length> unit, Length length) {
-    assertEquals(length, FormatTools.getPosition(value, unit));
+  @Test(dataProvider = "stagePositionUnit")
+  public void testGetStagePositionUnit(Double value, Unit<Length> unit, Length length) {
+    assertEquals(length, FormatTools.getStagePosition(value, unit));
   }
 }

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -164,9 +164,6 @@ public class FormatToolsTest {
     assertEquals(length, FormatTools.getPhysicalSizeX(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeY(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeZ(value, unit));
-    assertEquals(length, FormatTools.getPhysicalSizeX(value, unit));
-    assertEquals(length, FormatTools.getPhysicalSizeY(value, unit));
-    assertEquals(length, FormatTools.getPhysicalSizeZ(value, unit));
   }
 
   @Test(dataProvider = "physicalSizeUnit")
@@ -174,5 +171,64 @@ public class FormatToolsTest {
     assertEquals(length, FormatTools.getPhysicalSizeX(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeY(value, unit));
     assertEquals(length, FormatTools.getPhysicalSizeZ(value, unit));
+  }
+
+  @DataProvider(name = "positionNoUnit")
+  public Object[][] createPositionNoUnit() {
+    return new Object[][] {
+      {null, null},
+      {0.0, new Length(0.0, UNITS.REFERENCEFRAME)},
+      {1.0, new Length(1.0, UNITS.REFERENCEFRAME)},
+      {.1, new Length(.1, UNITS.REFERENCEFRAME)},
+      {Constants.EPSILON, new Length(Constants.EPSILON, UNITS.REFERENCEFRAME)},
+      {-Constants.EPSILON, new Length(-Constants.EPSILON, UNITS.REFERENCEFRAME)},
+      {Double.POSITIVE_INFINITY, null},
+      {-Double.POSITIVE_INFINITY, null},
+    };
+  }
+
+  @DataProvider(name = "positionStringUnit")
+  public Object[][] createPositionStringUnit() {
+    return new Object[][] {
+      {null, "mm", null},
+      {0.0, "mm", new Length(0.0, UNITS.MILLIMETER)},
+      {1.0, "mm", new Length(1.0, UNITS.MILLIMETER)},
+      {.1, "mm", new Length(.1, UNITS.MILLIMETER)},
+      {Constants.EPSILON, "mm", new Length(Constants.EPSILON, UNITS.MILLIMETER)},
+      {-Constants.EPSILON, "mm", new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
+      {Double.POSITIVE_INFINITY, "mm", null},
+      {-Double.POSITIVE_INFINITY, "mm", null},
+    };
+  }
+
+  @DataProvider(name = "positionUnit")
+  public Object[][] createPositionUnit() {
+    return new Object[][] {
+      {null, UNITS.MILLIMETER, null},
+      {0.0, UNITS.MILLIMETER, new Length(0.0, UNITS.MILLIMETER)},
+      {1.0, UNITS.MILLIMETER, new Length(1.0, UNITS.MILLIMETER)},
+      {.1, UNITS.MILLIMETER, new Length(.1, UNITS.MILLIMETER)},
+      {Constants.EPSILON, UNITS.MILLIMETER, new Length(Constants.EPSILON, UNITS.MILLIMETER)},
+      {-Constants.EPSILON, UNITS.MILLIMETER, new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
+      {Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
+      {-Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
+    };
+  }
+
+  @Test(dataProvider = "positionNoUnit")
+  public void testGetPositionNoUnit(Double value, Length length) {
+    assertEquals(length, FormatTools.getPosition(value));
+    assertEquals(length, FormatTools.getPosition(value, ""));
+  }
+
+  @Test(dataProvider = "positionStringUnit")
+  public void testGetPositionStringUnit(Double value, String unit, Length length) {
+    assertEquals(length, FormatTools.getPosition(value, unit));
+  }
+
+
+  @Test(dataProvider = "positionUnit")
+  public void testGetPositionUnit(Double value, Unit<Length> unit, Length length) {
+    assertEquals(length, FormatTools.getPosition(value, unit));
   }
 }


### PR DESCRIPTION
See discussion in https://github.com/openmicroscopy/bioformats/pull/2437 for more context. Similarly to the existing `FormatTools.getPhysicalSize()` methods, this PR adds a set of three methods to the `FormatTools` class allowing to format a stage position from an input `Double` and an input unit:
- `FormatTools.getStagePosition(Double, String)`
- `FormatTools.getStagePosition(Double, Unit<Length>)`

The use case for these methods is the parsing of string values across the readers in a safe manner. In particular, combined with `DataTools` utility methods, the following forms:

```
Length pos = FormatTools.getStagePosition(DataTools.parseDouble(value), unit);
```

should allow to handle most invalid cases and prevent the usage of `try/catch` statement.

Unit tests have been added to `FormatToolsTest` to cover the semantics of the new methods. In particular it should be tested that the array of objects in the data providers cover most use cases.
