### PR TITLE
Command-line tools: common methods refactoring

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -60,7 +60,6 @@ import loci.formats.ImageWriter;
 import loci.formats.MetadataTools;
 import loci.formats.MinMaxCalculator;
 import loci.formats.MissingLibraryException;
-import loci.formats.UpgradeChecker;
 import loci.formats.gui.Index16ColorModel;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataRetrieve;
@@ -87,8 +86,6 @@ public final class ImageConverter {
 
   private static final Logger LOGGER =
     LoggerFactory.getLogger(ImageConverter.class);
-
-  private static final String NO_UPGRADE_CHECK = "-no-upgrade";
 
   // -- Fields --
 
@@ -189,7 +186,7 @@ public final class ImageConverter {
           }
           catch (NumberFormatException e) { }
         }
-        else if (!args[i].equals(NO_UPGRADE_CHECK)) {
+        else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
           LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;
         }
@@ -860,17 +857,7 @@ public final class ImageConverter {
 
   public static void main(String[] args) throws FormatException, IOException {
     DebugTools.enableLogging("INFO");
-    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1 &&
-        DataTools.indexOf(args, CommandLineTools.VERSION) == -1) {
-      UpgradeChecker checker = new UpgradeChecker();
-      boolean canUpgrade =
-        checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);
-      if (canUpgrade) {
-        LOGGER.info("*** A new stable version is available. ***");
-        LOGGER.info("*** Install the new version using:     ***");
-        LOGGER.info("***   'upgradechecker -install'        ***");
-      }
-    }
+    CommandLineTools.runUpgradeCheck(args);
     ImageConverter converter = new ImageConverter();
     if (!converter.testConvert(new ImageWriter(), args)) System.exit(1);
     System.exit(0);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -89,7 +89,6 @@ public final class ImageConverter {
     LoggerFactory.getLogger(ImageConverter.class);
 
   private static final String NO_UPGRADE_CHECK = "-no-upgrade";
-  private static final String VERSION = "-version";
 
   // -- Fields --
 
@@ -129,7 +128,7 @@ public final class ImageConverter {
     }
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-") && args.length > 1) {
-        if (args[i].equals(VERSION)) {
+        if (args[i].equals(CommandLineTools.VERSION)) {
           printVersion = true;
           return true;
         }
@@ -196,7 +195,7 @@ public final class ImageConverter {
         }
       }
       else {
-        if (args[i].equals(VERSION)) printVersion = true;
+        if (args[i].equals(CommandLineTools.VERSION)) printVersion = true;
         else if (in == null) in = args[i];
         else if (out == null) out = args[i];
         else {
@@ -294,9 +293,7 @@ public final class ImageConverter {
     }
 
     if (printVersion) {
-      System.out.println("Version: " + FormatTools.VERSION);
-      System.out.println("VCS revision: " + FormatTools.VCS_REVISION);
-      System.out.println("Build date: " + FormatTools.DATE);
+      CommandLineTools.printVersion();
       return true;
     }
 
@@ -864,7 +861,7 @@ public final class ImageConverter {
   public static void main(String[] args) throws FormatException, IOException {
     DebugTools.enableLogging("INFO");
     if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1 &&
-        DataTools.indexOf(args, VERSION) == -1) {
+        DataTools.indexOf(args, CommandLineTools.VERSION) == -1) {
       UpgradeChecker checker = new UpgradeChecker();
       boolean canUpgrade =
         checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -294,6 +294,8 @@ public final class ImageConverter {
       return true;
     }
 
+    CommandLineTools.runUpgradeCheck(args);
+
     if (in == null || out == null) {
       printUsage();
       return false;
@@ -857,7 +859,6 @@ public final class ImageConverter {
 
   public static void main(String[] args) throws FormatException, IOException {
     DebugTools.enableLogging("INFO");
-    CommandLineTools.runUpgradeCheck(args);
     ImageConverter converter = new ImageConverter();
     if (!converter.testConvert(new ImageWriter(), args)) System.exit(1);
     System.exit(0);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -91,8 +91,6 @@ public class ImageInfo {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImageInfo.class);
   private static final String NEWLINE = System.getProperty("line.separator");
 
-  private static final String NO_UPGRADE_CHECK = "-no-upgrade";
-
   private static final ImmutableSet<String> HELP_ARGUMENTS =
       ImmutableSet.of("-h", "-help", "--help");
 
@@ -272,7 +270,7 @@ public class ImageInfo {
             cache = true;
             cachedir = args[++i];
         }
-        else if (!args[i].equals(NO_UPGRADE_CHECK)) {
+        else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
           LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;
         }
@@ -1017,6 +1015,7 @@ public class ImageInfo {
       CommandLineTools.printVersion();
       return true;
     }
+    CommandLineTools.runUpgradeCheck(args);
 
     createReader();
 
@@ -1110,7 +1109,6 @@ public class ImageInfo {
 
   public static void main(String[] args) throws Exception {
     DebugTools.enableLogging("INFO");
-    CommandLineTools.runUpgradeCheck(args);
     if (!new ImageInfo().testRead(args)) System.exit(1);
   }
 

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -93,7 +93,6 @@ public class ImageInfo {
   private static final String NEWLINE = System.getProperty("line.separator");
 
   private static final String NO_UPGRADE_CHECK = "-no-upgrade";
-  private static final String VERSION = "-version";
 
   private static final ImmutableSet<String> HELP_ARGUMENTS =
       ImmutableSet.of("-h", "-help", "--help");
@@ -192,7 +191,7 @@ public class ImageInfo {
     if (args == null) return false;
     for (int i=0; i<args.length; i++) {
       if (args[i].startsWith("-")) {
-        if (args[i].equals(VERSION)){
+        if (args[i].equals(CommandLineTools.VERSION)){
           printVersion = true;
           return true;
         }
@@ -1016,9 +1015,7 @@ public class ImageInfo {
     boolean validArgs = parseArgs(args);
     if (!validArgs) return false;
     if (printVersion) {
-      System.out.println("Version: " + FormatTools.VERSION);
-      System.out.println("VCS revision: " + FormatTools.VCS_REVISION);
-      System.out.println("Build date: " + FormatTools.DATE);
+      CommandLineTools.printVersion();
       return true;
     }
 
@@ -1115,7 +1112,7 @@ public class ImageInfo {
   public static void main(String[] args) throws Exception {
     DebugTools.enableLogging("INFO");
     if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1 &&
-        DataTools.indexOf(args, VERSION) == -1) {
+        DataTools.indexOf(args, CommandLineTools.VERSION) == -1) {
       UpgradeChecker checker = new UpgradeChecker();
       boolean canUpgrade =
         checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -63,7 +63,6 @@ import loci.formats.MetadataTools;
 import loci.formats.MinMaxCalculator;
 import loci.formats.MissingLibraryException;
 import loci.formats.Modulo;
-import loci.formats.UpgradeChecker;
 import loci.formats.gui.AWTImageTools;
 import loci.formats.gui.BufferedImageReader;
 import loci.formats.gui.ImageViewer;
@@ -1111,17 +1110,7 @@ public class ImageInfo {
 
   public static void main(String[] args) throws Exception {
     DebugTools.enableLogging("INFO");
-    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) == -1 &&
-        DataTools.indexOf(args, CommandLineTools.VERSION) == -1) {
-      UpgradeChecker checker = new UpgradeChecker();
-      boolean canUpgrade =
-        checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);
-      if (canUpgrade) {
-        LOGGER.info("*** A new stable version is available. ***");
-        LOGGER.info("*** Install the new version using:     ***");
-        LOGGER.info("***   'upgradechecker -install'        ***");
-      }
-    }
+    CommandLineTools.runUpgradeCheck(args);
     if (!new ImageInfo().testRead(args)) System.exit(1);
   }
 

--- a/components/formats-bsd/src/loci/formats/UpgradeChecker.java
+++ b/components/formats-bsd/src/loci/formats/UpgradeChecker.java
@@ -42,6 +42,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -247,6 +248,9 @@ public class UpgradeChecker {
         LOGGER.debug("UPGRADE AVAILABLE:" + result);
         return true;
       }
+    }
+    catch (UnknownHostException e) {
+      LOGGER.warn("Failed to reach the update site");
     }
     catch (IOException e) {
       LOGGER.warn("Failed to compare version numbers", e);

--- a/components/formats-bsd/src/loci/formats/tools/CommandLineTools.java
+++ b/components/formats-bsd/src/loci/formats/tools/CommandLineTools.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.tools;
+
+import loci.formats.FormatTools;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An utility class for various methods used in command-line tools
+ */
+public final class CommandLineTools {
+
+  // -- Constants --
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommandLineTools.class);
+  public static final String VERSION = "-version";
+
+  public static void printVersion() {
+    System.out.println("Version: " + FormatTools.VERSION);
+    System.out.println("VCS revision: " + FormatTools.VCS_REVISION);
+    System.out.println("Build date: " + FormatTools.DATE);
+  }
+}

--- a/components/formats-bsd/src/loci/formats/tools/CommandLineTools.java
+++ b/components/formats-bsd/src/loci/formats/tools/CommandLineTools.java
@@ -58,7 +58,10 @@ public final class CommandLineTools {
   }
 
   public static void runUpgradeCheck(String[] args) {
-    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) != -1) return;
+    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) != -1) {
+      LOGGER.debug("Skipping upgrade check");
+      return;
+    }
     UpgradeChecker checker = new UpgradeChecker();
     boolean canUpgrade =
       checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);

--- a/components/formats-bsd/src/loci/formats/tools/CommandLineTools.java
+++ b/components/formats-bsd/src/loci/formats/tools/CommandLineTools.java
@@ -32,7 +32,9 @@
 
 package loci.formats.tools;
 
+import loci.common.DataTools;
 import loci.formats.FormatTools;
+import loci.formats.UpgradeChecker;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,9 +49,23 @@ public final class CommandLineTools {
   private static final Logger LOGGER = LoggerFactory.getLogger(CommandLineTools.class);
   public static final String VERSION = "-version";
 
+  public static final String NO_UPGRADE_CHECK = "-no-upgrade";
+
   public static void printVersion() {
     System.out.println("Version: " + FormatTools.VERSION);
     System.out.println("VCS revision: " + FormatTools.VCS_REVISION);
     System.out.println("Build date: " + FormatTools.DATE);
+  }
+
+  public static void runUpgradeCheck(String[] args) {
+    if (DataTools.indexOf(args, NO_UPGRADE_CHECK) != -1) return;
+    UpgradeChecker checker = new UpgradeChecker();
+    boolean canUpgrade =
+      checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);
+    if (canUpgrade) {
+      LOGGER.info("*** A new stable version is available. ***");
+      LOGGER.info("*** Install the new version using:     ***");
+      LOGGER.info("***   'upgradechecker -install'        ***");
+    }
   }
 }

--- a/components/formats-bsd/src/loci/formats/tools/TiffComment.java
+++ b/components/formats-bsd/src/loci/formats/tools/TiffComment.java
@@ -43,7 +43,6 @@ import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
 import loci.formats.FormatException;
-import loci.formats.UpgradeChecker;
 import loci.formats.tiff.TiffParser;
 import loci.formats.tiff.TiffSaver;
 
@@ -53,14 +52,7 @@ import loci.formats.tiff.TiffSaver;
 public class TiffComment {
 
   public static void main(String[] args) throws FormatException, IOException {
-    UpgradeChecker checker = new UpgradeChecker();
-    boolean canUpgrade =
-      checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);
-    if (canUpgrade) {
-      System.out.println("*** A new stable version is available. ***");
-      System.out.println("*** Install the new version using:     ***");
-      System.out.println("***   'upgradechecker -install'        ***");
-    }
+    CommandLineTools.runUpgradeCheck(args);
 
     if (args.length == 0) {
       System.out.println("Usage:");

--- a/components/formats-bsd/src/loci/formats/tools/XMLValidate.java
+++ b/components/formats-bsd/src/loci/formats/tools/XMLValidate.java
@@ -40,7 +40,6 @@ import java.io.StringReader;
 
 import loci.common.Constants;
 import loci.common.xml.XMLTools;
-import loci.formats.UpgradeChecker;
 import loci.formats.tiff.TiffParser;
 
 /**
@@ -62,14 +61,7 @@ public class XMLValidate {
   }
 
   public static void main(String[] args) throws Exception {
-    UpgradeChecker checker = new UpgradeChecker();
-    boolean canUpgrade =
-      checker.newVersionAvailable(UpgradeChecker.DEFAULT_CALLER);
-    if (canUpgrade) {
-      System.out.println("*** A new stable version is available. ***");
-      System.out.println("*** Install the new version using:     ***");
-      System.out.println("***   'upgradechecker -install'        ***");
-    }
+    CommandLineTools.runUpgradeCheck(args);
 
     if (args.length == 0) {
       // read from stdin


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/8260 and https://trac.openmicroscopy.org/ome/ticket/13226 


This PR initiates the refactoring of the common functions used across the various command-line interfaces into a central class under `formats-bsd`. Currently this refactoring is limited to the version printing and the upgrade checking but more could be migrated there in the future.

Summary of changes:
- add a `loci.formats.tools.CommandLineTools` class defining both command-line arguments and methods
- migrates arguments and code used in `showinf`, `bfconvert`, `tiffcomment` and `xmlvalid`
- decouples the version and upgrade check  logic by running the upgrade check *after* the version handling
- gracefully handles `UnknowHostException` in the `UpgradeChecker` allowing to prevent stack traces when using the tools offline - see https://trac.openmicroscopy.org/ome/ticket/13226

To test this PR:
- test the `showinf/bfconvert` functionalities are unchanged with a mixture of `-version/-no-upgrade` is unmodified
- test `showinf/bfconvert/tiffcomment/xmlvalid` offline and check a log message is sent at the `WARN` level instead of a stack trace during the upgrade check.