### PR TITLE
Unify Java templates indentation to 2 spaces

### DIFF
--- a/components/xsd-fu/templates-java/AggregateMetadata.template
+++ b/components/xsd-fu/templates-java/AggregateMetadata.template
@@ -12,71 +12,71 @@
 {% def index_string(name) %}int ${index_name_string(name)}{% end %}\
 \
 {% def counter(parent, obj, indexes) %}\
-        public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                int result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
-                                if (result >= 0) return result;
-                        }
-                }
-                return -1;
-        }
+  public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        int result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
+        if (result >= 0) return result;
+      }
+    }
+    return -1;
+  }
 {% end %}\
 \
 {% def getter(parent, obj, prop, indexes) %}\
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                ${prop.metadataStoreRetType} result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        ${prop.metadataStoreRetType} result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 {% end %}\
 {% when len(indexes) > 0 %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                ${prop.metadataStoreRetType} result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)});
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        ${prop.metadataStoreRetType} result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)});
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 {% end %}\
 {% otherwise %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}()
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                ${prop.metadataStoreRetType} result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}();
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}()
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        ${prop.metadataStoreRetType} result = retrieve.get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}();
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 {% end %}\
 {% end %}\
 {% end %}\
@@ -85,54 +85,54 @@
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
 {% if debug %}\
-        // MARKER [A-GET]
+  // MARKER [A-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                MetadataStore store = (MetadataStore) o;
-                                store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
-                        }
-                }
-        }
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        MetadataStore store = (MetadataStore) o;
+        store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
+      }
+    }
+  }
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
-        // MARKER [B-GET]
+  // MARKER [B-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                MetadataStore store = (MetadataStore) o;
-                                store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)});
-                        }
-                }
-        }
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        MetadataStore store = (MetadataStore) o;
+        store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)});
+      }
+    }
+  }
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-        // MARKER [C-GET]
+  // MARKER [C-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                MetadataStore store = (MetadataStore) o;
-                                store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName});
-                        }
-                }
-        }
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        MetadataStore store = (MetadataStore) o;
+        store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName});
+      }
+    }
+  }
 {% end %}\
 {% end %}\
 {% end %}\
@@ -253,60 +253,60 @@ import org.slf4j.LoggerFactory;
  */
 public class AggregateMetadata implements IMetadata
 {
-        // -- Fields --
+  // -- Fields --
 
-        /** The active metadata store delegates. */
-        private List<BaseMetadata> delegates;
+  /** The active metadata store delegates. */
+  private List<BaseMetadata> delegates;
 
-        // -- Constructor --
+  // -- Constructor --
 
-        /**
-         * Creates a new instance.
-         * @param delegates of type {@link MetadataRetrieve}
-         *   and/or {@link MetadataStore}.
-         */
-        public AggregateMetadata(List<BaseMetadata> delegates)
-        {
-                this.delegates = delegates;
-        }
+  /**
+  * Creates a new instance.
+  * @param delegates of type {@link MetadataRetrieve}
+  *   and/or {@link MetadataStore}.
+  */
+  public AggregateMetadata(List<BaseMetadata> delegates)
+  {
+    this.delegates = delegates;
+  }
 
-        // -- MetadataStore API methods --
+  // -- MetadataStore API methods --
 
-        /* @see MetadataStore#createRoot() */
-        public void createRoot()
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                ((MetadataStore) o).createRoot();
-                        }
-                }
-        }
+  /* @see MetadataStore#createRoot() */
+  public void createRoot()
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        ((MetadataStore) o).createRoot();
+      }
+    }
+  }
 
-        /**
-         * Unsupported with an AggregateMetadata.
-         * @throws RuntimeException Always.
-         */
-        public MetadataRoot getRoot()
-        {
-                throw new RuntimeException("Unsupported by AggregateMetadata");
-        }
+  /**
+   * Unsupported with an AggregateMetadata.
+   * @throws RuntimeException Always.
+   */
+  public MetadataRoot getRoot()
+  {
+    throw new RuntimeException("Unsupported by AggregateMetadata");
+  }
 
-        /**
-         * Unsupported with an AggregateMetadata.
-         * @throws RuntimeException Always.
-         */
-        public void setRoot(MetadataRoot root)
-        {
-                throw new RuntimeException("Unsupported by AggregateMetadata");
-        }
+  /**
+   * Unsupported with an AggregateMetadata.
+   * @throws RuntimeException Always.
+   */
+  public void setRoot(MetadataRoot root)
+  {
+    throw new RuntimeException("Unsupported by AggregateMetadata");
+  }
 
-        // -- AggregateMetadata API methods --
+  // -- AggregateMetadata API methods --
 
 
-        // -- Entity counting (manual definitions) --
+  // -- Entity counting (manual definitions) --
 
   public int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex) {
     for (Iterator iter = delegates.iterator(); iter.hasNext();) {
@@ -453,7 +453,7 @@ public class AggregateMetadata implements IMetadata
   }
 
 
-        // -- Entity counting (code generated definitions) --
+  // -- Entity counting (code generated definitions) --
 
 {% for abstractClass in model.opts.lang.getSubstitutionTypes() %}\
 {% for k, v in indexes[abstractClass].items() %}\
@@ -492,40 +492,40 @@ public class AggregateMetadata implements IMetadata
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
-        // Element's text data
-        // ${repr(indexes[o.name])}
-        public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                ((MetadataStore) o).set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
-                        }
-                }
-        }
+  // Element's text data
+  // ${repr(indexes[o.name])}
+  public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        ((MetadataStore) o).set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
+      }
+    }
+  }
 
-        public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
+  public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        ${o.langBaseType} result = ((MetadataRetrieve) o).get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
+        if (result != null)
         {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                ${o.langBaseType} result = ((MetadataRetrieve) o).get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
-                                if (result != null)
-                                {
-                                        return result;
-                                }
-                        }
-                }
-                return null;
+          return result;
         }
+      }
+    }
+    return null;
+  }
 
 {% end %}\
 {% if parents[o.name] is not None and not o.isAbstract %}\
-        // ${o.name} entity counting
+  // ${o.name} entity counting
 {% for k, v in indexes[o.name].items() %}\
 {% if fu.max_occurs_under_parent(model, k, o.name) > 1 and (k not in fu.METADATA_COUNT_IGNORE or o.type not in fu.METADATA_COUNT_IGNORE[k]) %}\
 ${counter(k, o, v)}\
@@ -536,90 +536,90 @@ ${counter(k, o, v)}\
 {% end %}\
 {% end %}\
 
-        // -- Entity retrieval (manual definitions) --
-        /** Gets the UUID associated with this collection of metadata. */
-        public String getUUID()
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                String result = retrieve.getUUID();
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  // -- Entity retrieval (manual definitions) --
+  /** Gets the UUID associated with this collection of metadata. */
+  public String getUUID()
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        String result = retrieve.getUUID();
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 
-        /** Gets the Map value associated with this annotation */
-        public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                List<MapPair> result = retrieve.getMapAnnotationValue(mapAnnotationIndex);
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  /** Gets the Map value associated with this annotation */
+  public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        List<MapPair> result = retrieve.getMapAnnotationValue(mapAnnotationIndex);
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 
-        /** Gets the Map value associated with this generic light source */
-        public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                List<MapPair> result = retrieve.getGenericExcitationSourceMap(instrumentIndex, lightSourceIndex);
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  /** Gets the Map value associated with this generic light source */
+  public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        List<MapPair> result = retrieve.getGenericExcitationSourceMap(instrumentIndex, lightSourceIndex);
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 
-        /** Gets the Map value associated with this imaging environment */
-        public List<MapPair> getImagingEnvironmentMap(int imageIndex)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataRetrieve)
-                        {
-                                MetadataRetrieve retrieve = (MetadataRetrieve) o;
-                                List<MapPair> result = retrieve.getImagingEnvironmentMap(imageIndex);
-                                if (result != null) return result;
-                        }
-                }
-                return null;
-        }
+  /** Gets the Map value associated with this imaging environment */
+  public List<MapPair> getImagingEnvironmentMap(int imageIndex)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        List<MapPair> result = retrieve.getImagingEnvironmentMap(imageIndex);
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
 
-        // -- Entity retrieval (code generated definitions) --
+  // -- Entity retrieval (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
-        //
-        // ${o.name} property storage
-        //
-        // Indexes: ${repr(indexes[o.name])}
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // Indexes: ${repr(indexes[o.name])}
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -632,14 +632,14 @@ ${counter(k, o, v)}\
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for parent_k, parent_v in indexes[k].items() %}\
 {% if not prop.isBackReference and not prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [AAA-AGG]
+  // MARKER [AAA-AGG]
 {% end debug %}\
   // ${prop.name} accessor from parent ${k}
 ${getter(k, o, prop, v)}\
@@ -656,23 +656,23 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [FFF-AGG]
+  // MARKER [FFF-AGG]
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if debug %}\
-        // MARKER [HHH-AGG]
+  // MARKER [HHH-AGG]
 {% end debug %}\
 ${getter(k, o, prop, v)}\
 
@@ -686,81 +686,81 @@ ${getter(k, o, prop, v)}\
 {% end %}\
 {% end %}\
 
-        // -- Entity storage (manual definitions) --
+  // -- Entity storage (manual definitions) --
 
-        /** Sets the UUID associated with this collection of metadata. */
-        public void setUUID(String uuid)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                ((MetadataStore) o).setUUID(uuid);
-                        }
-                }
-        }
+  /** Sets the UUID associated with this collection of metadata. */
+  public void setUUID(String uuid)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        ((MetadataStore) o).setUUID(uuid);
+      }
+    }
+  }
 
-        /** Sets the Map value associated with this annotation */
-        public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                MetadataStore store = (MetadataStore) o;
-                                store.setMapAnnotationValue(value, mapAnnotationIndex);
-                        }
-                }
-        }
+  /** Sets the Map value associated with this annotation */
+  public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        MetadataStore store = (MetadataStore) o;
+        store.setMapAnnotationValue(value, mapAnnotationIndex);
+      }
+    }
+  }
 
-        /** Sets the Map value associated with this generic light source */
-        public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                MetadataStore store = (MetadataStore) o;
-                                store.setGenericExcitationSourceMap(map, instrumentIndex, lightSourceIndex);
-                        }
-                }
-        }
+  /** Sets the Map value associated with this generic light source */
+  public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        MetadataStore store = (MetadataStore) o;
+        store.setGenericExcitationSourceMap(map, instrumentIndex, lightSourceIndex);
+      }
+    }
+  }
 
-        /** Sets the Map value associated with this imaging environment */
-        public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
-        {
-                for (Iterator iter = delegates.iterator(); iter.hasNext();)
-                {
-                        Object o = iter.next();
-                        if (o instanceof MetadataStore)
-                        {
-                                MetadataStore store = (MetadataStore) o;
-                                store.setImagingEnvironmentMap(map, imageIndex);
-                        }
-                }
-        }
+  /** Sets the Map value associated with this imaging environment */
+  public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        MetadataStore store = (MetadataStore) o;
+        store.setImagingEnvironmentMap(map, imageIndex);
+      }
+    }
+  }
 
-        // -- Entity storage (code generated definitions) --
+  // -- Entity storage (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
-        //
-        // ${o.name} property storage
-        //
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -773,7 +773,7 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
@@ -794,17 +794,17 @@ ${setter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [GGG-AGG]
+  // MARKER [GGG-AGG]
 {% end debug %}\
 {% end %}\
 {% otherwise %}\

--- a/components/xsd-fu/templates-java/DummyMetadata.template
+++ b/components/xsd-fu/templates-java/DummyMetadata.template
@@ -12,52 +12,52 @@
 {% def index_string(name) %}int ${index_name_string(name)}{% end %}\
 \
 {% def counter(parent, obj, indexes) %}\
-        public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
-        {
-                return -1;
-        }
+  public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
+  {
+    return -1;
+  }
 {% end %}\
 \
 {% def getter(parent, obj, prop, indexes) %}\
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
 {% end %}\
 {% when len(indexes) > 0 %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
 {% end %}\
 {% otherwise %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}()
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}()
 {% end %}\
 {% end %}\
-        {
-                return null;
-        }
+  {
+    return null;
+  }
 {% end %}\
 \
 {% def setter(parent, obj, prop, indexes) %}\
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
 {% if debug %}\
-        // MARKER [A-GET]
+  // MARKER [A-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
-        // MARKER [B-GET]
+  // MARKER [B-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-        // MARKER [C-GET]
+  // MARKER [C-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
 {% end %}\
 {% end %}\
-        {
-        }
+  {
+  }
 {% end %}\
 \
 {% python
@@ -173,22 +173,22 @@ import ${lang.units_package}.unit.Unit;
  */
 public class DummyMetadata implements IMetadata
 {
-        // -- MetadataStore API methods --
+  // -- MetadataStore API methods --
 
-        public void createRoot()
-        {
-        }
+  public void createRoot()
+  {
+  }
 
-        public MetadataRoot getRoot()
-        {
-                return null;
-        }
+  public MetadataRoot getRoot()
+  {
+    return null;
+  }
 
-        public void setRoot(MetadataRoot root)
-        {
-        }
+  public void setRoot(MetadataRoot root)
+  {
+  }
 
-        // -- Entity counting (manual definitions) --
+  // -- Entity counting (manual definitions) --
 
   public int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex) {
     return -1;
@@ -236,7 +236,7 @@ public class DummyMetadata implements IMetadata
   }
 
 
-        // -- Entity counting (code generated definitions) --
+  // -- Entity counting (code generated definitions) --
 
 {% for abstractClass in model.opts.lang.getSubstitutionTypes() %}\
 {% for k, v in indexes[abstractClass].items() %}\
@@ -256,20 +256,20 @@ public class DummyMetadata implements IMetadata
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
-        // Element's text data
-        // ${repr(indexes[o.name])}
-        public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
-        {
-        }
+  // Element's text data
+  // ${repr(indexes[o.name])}
+  public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
+  {
+  }
 
-        public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
-        {
-                return null;
-        }
+  public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
+  {
+    return null;
+  }
 
 {% end %}\
 {% if parents[o.topLevelName] is not None and not o.isAbstract %}\
-        // ${o.name} entity counting
+  // ${o.name} entity counting
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if fu.max_occurs_under_parent(model, k, o.name) > 1 and (k not in fu.METADATA_COUNT_IGNORE or o.type not in fu.METADATA_COUNT_IGNORE[k]) %}\
 ${counter(k, o, v)}\
@@ -280,54 +280,54 @@ ${counter(k, o, v)}\
 {% end %}\
 {% end %}\
 
-        // -- Entity retrieval (manual definitions) --
+  // -- Entity retrieval (manual definitions) --
 
-        /** Gets the UUID associated with this collection of metadata. */
-        public String getUUID()
-        {
-                return null;
-        }
+  /** Gets the UUID associated with this collection of metadata. */
+  public String getUUID()
+  {
+    return null;
+  }
 
-        /** Gets the Map value associated with this annotation */
-        public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
-        {
-                return null;
-        }
+  /** Gets the Map value associated with this annotation */
+  public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
+  {
+    return null;
+  }
 
-        /** Gets the Map value associated with this generic light source */
-        public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
-        {
-                return null;
-        }
+  /** Gets the Map value associated with this generic light source */
+  public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
+  {
+    return null;
+  }
 
-        /** Gets the Map value associated with this imaging environment */
-        public List<MapPair> getImagingEnvironmentMap(int imageIndex)
-        {
-                return null;
-        }
+  /** Gets the Map value associated with this imaging environment */
+  public List<MapPair> getImagingEnvironmentMap(int imageIndex)
+  {
+    return null;
+  }
 
-        // -- Entity retrieval (code generated definitions) --
+  // -- Entity retrieval (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
 {% if debug %}\
-        // MARKER [EEE]
+  // MARKER [EEE]
 {% end debug %}\
-        //
-        // ${o.name} property storage
-        //
-        // Indexes: ${repr(indexes[o.name])}
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // Indexes: ${repr(indexes[o.name])}
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -340,20 +340,20 @@ ${counter(k, o, v)}\
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // MARKER [CCC]
+  // MARKER [CCC]
 {% end debug %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for parent_k, parent_v in indexes[k].items() %}\
 {% if debug %}\
-        // MARKER [DDD]
+  // MARKER [DDD]
 {% end debug %}\
 {% if not prop.isBackReference and not prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [AAA]
+  // MARKER [AAA]
 {% end debug %}\
   // ${prop.name} accessor from parent ${k}
 ${getter(k, o, prop, v)}\
@@ -370,23 +370,23 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [FFF-AGG]
+  // MARKER [FFF-AGG]
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if debug %}\
-        // MARKER [HHH-AGG]
+  // MARKER [HHH-AGG]
 {% end debug %}\
 ${getter(k, o, prop, v)}\
 
@@ -400,46 +400,46 @@ ${getter(k, o, prop, v)}\
 {% end %}\
 {% end %}\
 
-        // -- Entity storage (manual definitions) --
+  // -- Entity storage (manual definitions) --
 
-        /** Sets the UUID associated with this collection of metadata. */
-        public void setUUID(String uuid)
-        {
-        }
+  /** Sets the UUID associated with this collection of metadata. */
+  public void setUUID(String uuid)
+  {
+  }
 
-        /** Sets the Map value associated with this annotation */
-        public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
-        {
-        }
+  /** Sets the Map value associated with this annotation */
+  public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
+  {
+  }
 
-        /** Sets the Map value associated with this generic light source */
-        public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
-        {
-        }
+  /** Sets the Map value associated with this generic light source */
+  public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
+  {
+  }
 
-        /** Sets the Map value associated with this imaging environment */
-        public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
-        {
-        }
+  /** Sets the Map value associated with this imaging environment */
+  public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
+  {
+  }
 
-        // -- Entity storage (code generated definitions) --
+  // -- Entity storage (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
-        //
-        // ${o.name} property storage
-        //
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -452,7 +452,7 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
@@ -471,17 +471,17 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [GGG-AGG]
+  // MARKER [GGG-AGG]
 {% end debug %}\
 {% end %}\
 {% otherwise %}\

--- a/components/xsd-fu/templates-java/FilterMetadata.template
+++ b/components/xsd-fu/templates-java/FilterMetadata.template
@@ -15,39 +15,39 @@
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
 {% if debug %}\
-        // MARKER [A-GET]
+  // MARKER [A-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
-        {
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
+  {
 {% if prop.langType == "String" %}\
-                ${prop.argumentName} = filter? DataTools.sanitize(${prop.argumentName}) : ${prop.argumentName};
+    ${prop.argumentName} = filter? DataTools.sanitize(${prop.argumentName}) : ${prop.argumentName};
 {% end %}\
-                store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
-        }
+    store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
+  }
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
-        // MARKER [B-GET]
+  // MARKER [B-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
-        {
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
+  {
 {% if prop.langType == "String" %}\
-                ${prop.argumentName} = filter? DataTools.sanitize(${prop.argumentName}) : ${prop.argumentName};
+    ${prop.argumentName} = filter? DataTools.sanitize(${prop.argumentName}) : ${prop.argumentName};
 {% end %}\
-                store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)});
-        }
+    store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)});
+  }
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-        // MARKER [C-GET]
+  // MARKER [C-GET]
 {% end debug %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
-        {
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
+  {
 {% if prop.langType == "String" %}\
-                ${prop.argumentName} = filter? DataTools.sanitize(${prop.argumentName}) : ${prop.argumentName};
+    ${prop.argumentName} = filter? DataTools.sanitize(${prop.argumentName}) : ${prop.argumentName};
 {% end %}\
-                store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName});
-        }
+    store.set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName});
+  }
 {% end %}\
 {% end %}\
 {% end %}\
@@ -167,108 +167,108 @@ import ${lang.units_package}.unit.Unit;
  */
 public class FilterMetadata implements MetadataStore
 {
-        // -- Fields --
+  // -- Fields --
 
-        /** The wrapped metadata store. */
-        private MetadataStore store;
-        /** Is filtering enabled? */
-        private boolean filter;
+  /** The wrapped metadata store. */
+  private MetadataStore store;
+  /** Is filtering enabled? */
+  private boolean filter;
 
-        // -- Constructor --
+  // -- Constructor --
 
-        /**
-         * Creates a new instance.
-         * @param store the metadata store to wrap.
-         * @param filter true to enable filtering, false to
-         * disable.
-         */
-        public FilterMetadata(MetadataStore store, boolean filter)
-        {
-                this.store = store;
-                this.filter = filter;
-        }
+  /**
+   * Creates a new instance.
+   * @param store the metadata store to wrap.
+   * @param filter true to enable filtering, false to
+   * disable.
+   */
+  public FilterMetadata(MetadataStore store, boolean filter)
+  {
+    this.store = store;
+    this.filter = filter;
+  }
 
-        // -- MetadataStore API methods --
+  // -- MetadataStore API methods --
 
-        /* @see MetadataStore#createRoot() */
-        public void createRoot()
-        {
-                store.createRoot();
-        }
+  /* @see MetadataStore#createRoot() */
+  public void createRoot()
+  {
+    store.createRoot();
+  }
 
-        /* @see MetadataStore#getRoot() */
-        public MetadataRoot getRoot()
-        {
-                return store.getRoot();
-        }
+  /* @see MetadataStore#getRoot() */
+  public MetadataRoot getRoot()
+  {
+    return store.getRoot();
+  }
 
-        /* @see MetadataStore#setRoot(MetadataRoot) */
-        public void setRoot(MetadataRoot root)
-        {
-                store.setRoot(root);
-        }
+  /* @see MetadataStore#setRoot(MetadataRoot) */
+  public void setRoot(MetadataRoot root)
+  {
+    store.setRoot(root);
+  }
 
-        /* @see MetadataStore#setUUID(String) */
-        public void setUUID(String uuid)
-        {
-                store.setUUID(uuid);
-        }
+  /* @see MetadataStore#setUUID(String) */
+  public void setUUID(String uuid)
+  {
+    store.setUUID(uuid);
+  }
 
-        // -- AggregateMetadata API methods --
+  // -- AggregateMetadata API methods --
 
-        // -- Entity storage (manual definitions) --
+  // -- Entity storage (manual definitions) --
 
-        /** Sets the Map value associated with this annotation */
-        public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
-        {
-                store.setMapAnnotationValue(value, mapAnnotationIndex);
-        }
+  /** Sets the Map value associated with this annotation */
+  public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
+  {
+    store.setMapAnnotationValue(value, mapAnnotationIndex);
+  }
 
-        /** Sets the Map value associated with this generic light source */
-        public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
-        {
-                store.setGenericExcitationSourceMap(map, instrumentIndex, lightSourceIndex);
-        }
+  /** Sets the Map value associated with this generic light source */
+  public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
+  {
+    store.setGenericExcitationSourceMap(map, instrumentIndex, lightSourceIndex);
+  }
 
-        /** Sets the Map value associated with this imaging environment */
-        public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
-        {
-                store.setImagingEnvironmentMap(map, imageIndex);
-        }
+  /** Sets the Map value associated with this imaging environment */
+  public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
+  {
+    store.setImagingEnvironmentMap(map, imageIndex);
+  }
 
-        // -- Entity storage (code generated definitions) --
+  // -- Entity storage (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
-        // Element's text data
-        // ${repr(indexes[o.name])}
-        public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
-        {
+  // Element's text data
+  // ${repr(indexes[o.name])}
+  public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
+  {
 {% if o.langBaseType == "String" %}\
-                value = filter? DataTools.sanitize(value) : value;
+    value = filter? DataTools.sanitize(value) : value;
 {% end %}\
-                store.set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
-        }
+    store.set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
+  }
 
 {% end %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
 {% if debug %}\
-        // MARKER [EEE]
+  // MARKER [EEE]
 {% end debug %}\
-        //
-        // ${o.name} property storage
-        //
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -281,20 +281,20 @@ public class FilterMetadata implements MetadataStore
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // MARKER [CCC]
+  // MARKER [CCC]
 {% end debug %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for parent_k, parent_v in indexes[k].items() %}\
 {% if debug %}\
-        // MARKER [DDD]
+  // MARKER [DDD]
 {% end debug %}\
 {% if not prop.isBackReference and not prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [AAA] - isUnitsEnumeration ${prop.isUnitsEnumeration}
+  // MARKER [AAA] - isUnitsEnumeration ${prop.isUnitsEnumeration}
 {% end debug %}\
   // ${prop.name} accessor from parent ${k}
 ${setter(k, o, prop, v)}\
@@ -311,26 +311,26 @@ ${setter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [FFF]
+  // MARKER [FFF]
 {% end debug %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, unit enumeration property
+  // Ignoring ${prop.name} element, unit enumeration property
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if debug %}\
-        // MARKER [BBB]
+  // MARKER [BBB]
 {% end debug %}\
 ${setter(k, o, prop, v)}\
 

--- a/components/xsd-fu/templates-java/MetadataRetrieve.template
+++ b/components/xsd-fu/templates-java/MetadataRetrieve.template
@@ -11,43 +11,43 @@
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
 {% if debug %}\
-        // MARKER [A-GET]
+  // MARKER [A-GET]
 {% end debug %}\
-        /**
-         * Get the ${prop.name} property of ${o.name}.
-         *
+  /**
+   * Get the ${prop.name} property of ${o.name}.
+   *
 {% for param in indexes %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index.
-         * @return the ${prop.name} property.
-         */
-        ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)});\
+   * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index.
+   * @return the ${prop.name} property.
+   */
+  ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)});\
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
-        // MARKER [B-GET]
+  // MARKER [B-GET]
 {% end debug %}\
-        /**
-         * Get the ${prop.name} property of ${o.name}.
-         *
+  /**
+   * Get the ${prop.name} property of ${o.name}.
+   *
 {% for param in indexes %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @return the ${prop.name} property.
-         */
-        ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)});\
+   * @return the ${prop.name} property.
+   */
+  ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)});\
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-        // MARKER [C-GET]
+  // MARKER [C-GET]
 {% end debug %}\
-        /**
-         * Get the ${prop.name} property of ${o.name}.
-         *
-         * @return the ${prop.name} property.
-         */
-        ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}();\
+  /**
+   * Get the ${prop.name} property of ${o.name}.
+   *
+   * @return the ${prop.name} property.
+   */
+  ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}();\
 {% end %}\
 {% end %}\
 {% end %}\
@@ -306,18 +306,18 @@ public interface MetadataRetrieve extends BaseMetadata {
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
 {% if debug %}\
-        // Element's text data
-        // ${repr(indexes[o.name])}
+  // Element's text data
+  // ${repr(indexes[o.name])}
 {% end debug %}\
-        /**
-         * Get the text value of ${o.name}.
-         *
+  /**
+   * Get the text value of ${o.name}.
+   *
 {% for param in indexes[o.topLevelName].items()[0][1] %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @return the text value.
-         */
-        ${o.langBaseType} get${o.topLevelName}Value(${indexes_string(indexes[o.topLevelName].items()[0][1])});
+   * @return the text value.
+   */
+  ${o.langBaseType} get${o.topLevelName}Value(${indexes_string(indexes[o.topLevelName].items()[0][1])});
 
 {% end %}\
 
@@ -325,19 +325,19 @@ public interface MetadataRetrieve extends BaseMetadata {
 
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
 {% if debug %}\
-        // ${o.name} entity counting
+  // ${o.name} entity counting
 {% end debug %}\
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if fu.max_occurs_under_parent(model, k, o.name) > 1 and (k not in fu.METADATA_COUNT_IGNORE or o.type not in fu.METADATA_COUNT_IGNORE[k]) %}\
-        /**
-         * Get the number of ${o.name} elements{% if is_multi_path[o.name] %} in ${k}{% end %}.
-         *
+  /**
+   * Get the number of ${o.name} elements{% if is_multi_path[o.name] %} in ${k}{% end %}.
+   *
 {% for param in v[:-1] %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @return the number of ${o.name} elements.
-         */
-        int get{% if is_multi_path[o.name] %}${k}{% end %}${o.name}Count(${indexes_string(v[:-1])});
+   * @return the number of ${o.name} elements.
+   */
+  int get{% if is_multi_path[o.name] %}${k}{% end %}${o.name}Count(${indexes_string(v[:-1])});
 
 {% end %}\
 {% end %}\
@@ -345,62 +345,62 @@ public interface MetadataRetrieve extends BaseMetadata {
 {% end %}\
 {% end %}\
 
-        // -- Entity retrieval (manual definitions) --
+  // -- Entity retrieval (manual definitions) --
 
-        /**
-         * Get the values from a MapAnnotation.
-         *
-         * @param mapAnnotationIndex the MapAnnotation index.
-         * @return the MapAnnotation values.
-         */
-        List<MapPair> getMapAnnotationValue(int mapAnnotationIndex);
+  /**
+   * Get the values from a MapAnnotation.
+   *
+   * @param mapAnnotationIndex the MapAnnotation index.
+   * @return the MapAnnotation values.
+   */
+  List<MapPair> getMapAnnotationValue(int mapAnnotationIndex);
 
-        /**
-         * Get the MapAnnotation values from a GenericExcitationSource.
-         *
-         * @param instrumentIndex the Instrument index.
-         * @param lightSourceIndex the LightSource index.
-         * @return the MapAnnotation values.
-         */
-        List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex);
+  /**
+   * Get the MapAnnotation values from a GenericExcitationSource.
+   *
+   * @param instrumentIndex the Instrument index.
+   * @param lightSourceIndex the LightSource index.
+   * @return the MapAnnotation values.
+   */
+  List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex);
 
-        /**
-         * Get the MapAnnotation values from a ImagingEnvironment.
-         *
-         * @param imageIndex the Image index.
-         * @return the MapAnnotation values.
-         */
-        List<MapPair> getImagingEnvironmentMap(int imageIndex);
+  /**
+   * Get the MapAnnotation values from a ImagingEnvironment.
+   *
+   * @param imageIndex the Image index.
+   * @return the MapAnnotation values.
+   */
+  List<MapPair> getImagingEnvironmentMap(int imageIndex);
 
-        /**
-         * Get the UUID associated with this collection of metadata.
-         *
-         * @return the UUID.
-         */
-        /** Gets the UUID associated with this collection of metadata. */
-        String getUUID();
+  /**
+   * Get the UUID associated with this collection of metadata.
+   *
+   * @return the UUID.
+   */
+  /** Gets the UUID associated with this collection of metadata. */
+  String getUUID();
 
-        // -- Entity retrieval (code generated definitions) --
+  // -- Entity retrieval (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
 {% if debug %}\
-        // MARKER [EEE]
-        //
-        // ${o.name} property storage
-        //
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  // MARKER [EEE]
+  //
+  // ${o.name} property storage
+  //
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 {% end debug %}\
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -413,20 +413,20 @@ public interface MetadataRetrieve extends BaseMetadata {
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // MARKER [CCC]
-        // Ignoring ${prop.name} of parent abstract type
+  // MARKER [CCC]
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for parent_k, parent_v in indexes[k].items() %}\
 {% if debug %}\
-        // MARKER [DDD]
+  // MARKER [DDD]
 {% end debug %}\
 {% if not prop.isBackReference and not prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [AAA] - isUnitsEnumeration ${prop.isUnitsEnumeration}
+  // MARKER [AAA] - isUnitsEnumeration ${prop.isUnitsEnumeration}
 {% end debug %}\
-        // ${prop.name} accessor from parent ${k}
+  // ${prop.name} accessor from parent ${k}
 ${getter(k, o, prop, v)}
 
 {% end %}\
@@ -441,24 +441,24 @@ ${getter(k, o, prop, v)}
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [FFF]
-        // Ignoring ${prop.name} element, unit enumeration property
+  // MARKER [FFF]
+  // Ignoring ${prop.name} element, unit enumeration property
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if debug %}\
-        // MARKER [BBB]
+  // MARKER [BBB]
 {% end debug %}\
 ${getter(k, o, prop, v)}
 

--- a/components/xsd-fu/templates-java/MetadataStore.template
+++ b/components/xsd-fu/templates-java/MetadataStore.template
@@ -11,43 +11,43 @@
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
 {% if debug %}\
-        // MARKER [A-GET]
+  // MARKER [A-GET]
 {% end debug %}\
-        /**
-         * Set the ${prop.name} property of ${o.name}.
-         *
-         * @param ${prop.argumentName} ${prop.name} to set.
+  /**
+   * Set the ${prop.name} property of ${o.name}.
+   *
+   * @param ${prop.argumentName} ${prop.name} to set.
 {% for param in indexes %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
-         */
-        void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)});\
+   * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
+   */
+  void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)});\
 {% end %}\
 {% when len(indexes) > 0 %}\
 {% if debug %}\
-        // MARKER [B-GET]
+  // MARKER [B-GET]
 {% end debug %}\
-        /**
-         * Set the ${prop.name} property of ${o.name}.
-         *
-         * @param ${prop.argumentName} ${prop.name} to set.
+  /**
+   * Set the ${prop.name} property of ${o.name}.
+   *
+   * @param ${prop.argumentName} ${prop.name} to set.
 {% for param in indexes %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         */
-        void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)});\
+   */
+  void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)});\
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-        // MARKER [C-GET]
+  // MARKER [C-GET]
 {% end debug %}\
-        /**
-         * Set the ${prop.name} property of ${o.name}.
-         *
-         * @param ${prop.argumentName} ${prop.name} to set.
-         */
-        void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName});\
+  /**
+   * Set the ${prop.name} property of ${o.name}.
+   *
+   * @param ${prop.argumentName} ${prop.name} to set.
+   */
+  void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName});\
 {% end %}\
 {% end %}\
 {% end %}\
@@ -166,101 +166,101 @@ import ${lang.units_package}.unit.Unit;
  */
 public interface MetadataStore extends BaseMetadata
 {
-        /**
-         * Create root node.  The action taken here is specific to the
-         * concrete metadata implementation.
-         */
-        void createRoot();
+  /**
+   * Create root node.  The action taken here is specific to the
+   * concrete metadata implementation.
+   */
+  void createRoot();
 
-        /**
-         * Get the root node of the metadata.  Note that the root node
-         * type will be specific to the concrete metadata
-         * implementation.
-         *
-         * @return the root node.
-         */
-        MetadataRoot getRoot();
+  /**
+   * Get the root node of the metadata.  Note that the root node
+   * type will be specific to the concrete metadata
+   * implementation.
+   *
+   * @return the root node.
+   */
+  MetadataRoot getRoot();
 
-        /**
-         * Set the root node of the metadata.  Note that the root node
-         * type will be specific to the concrete metadata
-         * implementation.  An exception will be thrown if the root
-         * node is of an incompatible type.
-         *
-         * @param root the root node.
-         */
-        void setRoot(MetadataRoot root);
+  /**
+   * Set the root node of the metadata.  Note that the root node
+   * type will be specific to the concrete metadata
+   * implementation.  An exception will be thrown if the root
+   * node is of an incompatible type.
+   *
+   * @param root the root node.
+   */
+  void setRoot(MetadataRoot root);
 
-        // -- Entity storage (manual definitions) --
+  // -- Entity storage (manual definitions) --
 
-        /**
-         * Set the values of a MapAnnotation.
-         *
-         * @param value the MapAnnotation values to set.
-         * @param mapAnnotationIndex the MapAnnotation index.
-         */
-        void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex);
+  /**
+   * Set the values of a MapAnnotation.
+   *
+   * @param value the MapAnnotation values to set.
+   * @param mapAnnotationIndex the MapAnnotation index.
+   */
+  void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex);
 
-        /**
-         * Set the MapAnnotation values of a GenericExcitationSource.
-         *
-         * @param map the MapAnnotation values to set.
-         * @param instrumentIndex the Instrument index.
-         */
-        void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex);
+  /**
+   * Set the MapAnnotation values of a GenericExcitationSource.
+   *
+   * @param map the MapAnnotation values to set.
+   * @param instrumentIndex the Instrument index.
+   */
+  void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex);
 
-        /**
-         * Set the MapAnnotation values of an ImagingEnvironment.
-         *
-         * @param map the MapAnnotation values to set.
-         * @param imageIndex the Image index.
-         */
-        void setImagingEnvironmentMap(List<MapPair> map, int imageIndex);
+  /**
+   * Set the MapAnnotation values of an ImagingEnvironment.
+   *
+   * @param map the MapAnnotation values to set.
+   * @param imageIndex the Image index.
+   */
+  void setImagingEnvironmentMap(List<MapPair> map, int imageIndex);
 
-        // -- Entity storage (code generated definitions) --
+  // -- Entity storage (code generated definitions) --
 
-        /**
-         * Set the UUID associated with this collection of metadata.
-         *
-         * @param uuid the UUID to set.
-         */
-        void setUUID(String uuid);
+  /**
+   * Set the UUID associated with this collection of metadata.
+   *
+   * @param uuid the UUID to set.
+   */
+  void setUUID(String uuid);
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
 {% if debug %}\
-        // Element's text data
-        // ${repr(indexes[o.name])}
+  // Element's text data
+  // ${repr(indexes[o.name])}
 {% end debug %}\
-        /**
-         * Set the text value of ${o.name}.
-         *
-         * @param value text value.
+  /**
+   * Set the text value of ${o.name}.
+   *
+   * @param value text value.
 {% for param in indexes[o.name].items()[0][1] %}\
-         * @param ${param['argname']} the ${param['type']} index.
+   * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-         */
-        void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])});
+   */
+  void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])});
 
 {% end %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}\
 {% if debug %}\
-        // MARKER [EEE]
-        //
-        // ${o.name} property storage
-        //
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  // MARKER [EEE]
+  //
+  // ${o.name} property storage
+  //
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 {% end debug %}\
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
 {% if debug %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end debug %}\
 {% end %}\
@@ -273,20 +273,20 @@ public interface MetadataStore extends BaseMetadata
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // MARKER [CCC]
+  // MARKER [CCC]
 {% end debug %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for parent_k, parent_v in indexes[k].items() %}\
 {% if debug %}\
-        // MARKER [DDD]
+  // MARKER [DDD]
 {% end debug %}\
 {% if not prop.isBackReference and not prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [AAA] - isUnitsEnumeration ${prop.isUnitsEnumeration}
+  // MARKER [AAA] - isUnitsEnumeration ${prop.isUnitsEnumeration}
 {% end debug %}\
   // ${prop.name} accessor from parent ${k}
 ${setter(k, o, prop, v)}
@@ -302,26 +302,26 @@ ${setter(k, o, prop, v)}
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE)%}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // MARKER [FFF]
+  // MARKER [FFF]
 {% end debug %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, unit enumeration property
+  // Ignoring ${prop.name} element, unit enumeration property
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for k, v in indexes[o.topLevelName].items() %}\
 {% if debug %}\
-        // MARKER [BBB]
+  // MARKER [BBB]
 {% end debug %}\
 ${setter(k, o, prop, v)}
 

--- a/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
+++ b/components/xsd-fu/templates-java/OMEXMLMetadataImpl.template
@@ -10,177 +10,177 @@
 {% def index_string(name) %}int ${index_name_string(name)}{% end %}\
 \
 {% def counter(parent, obj, indexes) %}\
-        public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
-        {
+  public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
+  {
 {% if debug %}\
-                // MARKER [A-IMP]
+    // MARKER [A-IMP]
 {% end debug %}\
-                // Parents: ${repr(parents[obj.name])}
+    // Parents: ${repr(parents[obj.name])}
 {% if obj.isReference %}\
-                // ${obj.name} is a reference
-                return ${join_accessors(obj.name, parent, obj.name, -1, ["sizeOfLinked%sList()" % obj.name.replace('Ref', '')])};
+    // ${obj.name} is a reference
+    return ${join_accessors(obj.name, parent, obj.name, -1, ["sizeOfLinked%sList()" % obj.name.replace('Ref', '')])};
 {% end %}\
 {% if not obj.isReference %}\
-                // ${obj.name} is not a reference
-                return ${join_accessors(obj.name, parent, obj.name, -1, ["sizeOf%sList()" % obj.name.replace('Ref', '')])};
+    // ${obj.name} is not a reference
+    return ${join_accessors(obj.name, parent, obj.name, -1, ["sizeOf%sList()" % obj.name.replace('Ref', '')])};
 {% end %}\
-        }
+  }
 {% end %}\
 \
 {% def getter(parent, obj, prop, indexes) %}\
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
 {% end %}\
 {% when len(indexes) > 0 %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
 {% end %}\
 {% otherwise %}\
-        public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}()
+  public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}()
 {% end %}\
 {% end %}\
-        {
+  {
 {% if debug %}\
-                // MARKER [B-IMP]
+    // MARKER [B-IMP]
 {% end debug %}\
-                // Parents: ${repr(parents[obj.name])}
+    // Parents: ${repr(parents[obj.name])}
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference and prop.maxOccurs > 1 %}\
-                // ${parent} is abstract proprietary, is reference and occurs more than once
-                return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
+    // ${parent} is abstract proprietary, is reference and occurs more than once
+    return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
-                // ${parent} is abstract proprietary
-                return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}().getID();
+    // ${parent} is abstract proprietary
+    return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}().getID();
 {% end %}\
 {% when is_abstract(parent) %}\
-                // ${parent} is abstract proprietary and not a reference
-                return ${join_accessors(obj.name, parent, prop)}.get${prop.methodName}();
+    // ${parent} is abstract proprietary and not a reference
+    return ${join_accessors(obj.name, parent, prop)}.get${prop.methodName}();
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
-                // ${prop.name} is reference and occurs more than once
-                return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
+    // ${prop.name} is reference and occurs more than once
+    return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
 {% end %}\
 {% when prop.isReference %}\
-                // ${prop.name} is reference and occurs only once
-                return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}().getID();
+    // ${prop.name} is reference and occurs only once
+    return ${join_accessors(obj.name, parent, prop)}.getLinked${prop.methodName}().getID();
 {% end %}\
 {% otherwise %}\
-                // ${prop.name} is not a reference
-                return ${join_accessors(obj.name, parent, prop)}.get${prop.methodName}();
+    // ${prop.name} is not a reference
+    return ${join_accessors(obj.name, parent, prop)}.get${prop.methodName}();
 {% end %}\
 {% end %}\
-        }
+  }
 {% end %}\
 \
 {% def setter(parent, obj, prop, indexes) %}\
 {% choose %}\
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
 {% end %}\
 {% when len(indexes) > 0 %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
 {% end %}\
 {% otherwise %}\
-        public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
+  public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
 {% end %}\
 {% end %}\
-        {
+  {
 {% if debug %}\
-                // MARKER [C-IMP]
+    // MARKER [C-IMP]
 {% end debug %}\
-                // Parents: ${repr(parents[obj.name])}
+    // Parents: ${repr(parents[obj.name])}
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
-                // ${prop.name} is abstract and is a reference
-                ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
-                ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
-                model.addReference(
-                                root.${".".join(accessor(obj.name, parent, prop)[:-1])},
-                                ${prop.instanceVariableName}_reference);
-                // ${parent} is abstract
+    // ${prop.name} is abstract and is a reference
+    ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
+    ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
+    model.addReference(
+      root.${".".join(accessor(obj.name, parent, prop)[:-1])},
+      ${prop.instanceVariableName}_reference);
+    // ${parent} is abstract
 {% end %}\
 {% when is_abstract(parent) %}\
-                // ${parent} is abstract and not a reference
-                OME o0 = root;
+    // ${parent} is abstract and not a reference
+    OME o0 = root;
 {% for i, v in enumerate(accessor(obj.name, parent, prop, accessor_string_complex)[:-1]) %}\
 {% choose %}\
 {% when v['level'] == 2 %}\
-                if (o${i}.sizeOf${v['name']}List() == ${index_name_string(v['name'])})
-                {
-                        o${i}.add${v['name']}(new ${obj.name}());
-                }
+    if (o${i}.sizeOf${v['name']}List() == ${index_name_string(v['name'])})
+    {
+      o${i}.add${v['name']}(new ${obj.name}());
+    }
 {% end %}\
 {% when v['max_occurs'] > 1 %}\
-                if (o${i}.sizeOf${v['name']}List() == ${index_name_string(v['name'])})
-                {
-                        o${i}.add${v['name']}(new ${v['name']}());
-                }
+    if (o${i}.sizeOf${v['name']}List() == ${index_name_string(v['name'])})
+    {
+      o${i}.add${v['name']}(new ${v['name']}());
+    }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
-                if (o${i}.${v['accessor']} == null)
-                {
-                        o${i}.set${v['name']}(new ${v['name']}());
-                }
+    if (o${i}.${v['accessor']} == null)
+    {
+      o${i}.set${v['name']}(new ${v['name']}());
+    }
 {% end %}\
 {% end %}\
-                ${v['name']} o${i + 1} = o${i}.${v['accessor']};
+    ${v['name']} o${i + 1} = o${i}.${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-                model.addModelObject(${prop.argumentName}, o${i + 1});
+    model.addModelObject(${prop.argumentName}, o${i + 1});
 {% end %}\
-                ((${obj.name})o${i + 1}).set${prop.methodName}(${prop.argumentName});
+    ((${obj.name})o${i + 1}).set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% end %}\
 {% end %}\
 {% when prop.isReference %}\
-                // ${prop.name} is reference and occurs more than once
-                ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
-                ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
-                model.addReference(
-                                ${join_accessors(obj.name, parent, prop)},
-                                ${prop.instanceVariableName}_reference);
+    // ${prop.name} is reference and occurs more than once
+    ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
+    ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
+    model.addReference(
+      ${join_accessors(obj.name, parent, prop)},
+      ${prop.instanceVariableName}_reference);
 {% end %}\
 {% otherwise %}\
-                // ${prop.name} is not a reference
-                OME o0 = root;
+    // ${prop.name} is not a reference
+    OME o0 = root;
 {% for i, v in enumerate(accessor(obj.name, parent, prop, accessor_string_complex)) %}\
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
-                if (o${i}.sizeOf${v['name']}List() == ${index_name_string(v['name'])})
-                {
-                        o${i}.add${v['name']}(new ${v['concreteName']}());
-                }
+    if (o${i}.sizeOf${v['name']}List() == ${index_name_string(v['name'])})
+    {
+      o${i}.add${v['name']}(new ${v['concreteName']}());
+    }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
-                if (o${i}.${v['accessor']} == null)
-                {
-                        o${i}.set${v['name']}(new ${v['concreteName']}());
-                }
+    if (o${i}.${v['accessor']} == null)
+    {
+      o${i}.set${v['name']}(new ${v['concreteName']}());
+    }
 {% end %}\
 {% end %}\
 {% if not v['isAbstractSub'] %}\
-                ${v['name']} o${i + 1} = o${i}.${v['accessor']};
+    ${v['name']} o${i + 1} = o${i}.${v['accessor']};
 {% end %}\
 {% if v['isAbstractSub'] %}\
-                ${v['concreteName']} o${i + 1} = (${v['concreteName']}) o${i}.${v['accessor']};
+    ${v['concreteName']} o${i + 1} = (${v['concreteName']}) o${i}.${v['accessor']};
 {% end %}\
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-                model.addModelObject(${prop.argumentName}, o${i + 1});
+    model.addModelObject(${prop.argumentName}, o${i + 1});
 {% end %}\
-                o${i + 1}.set${prop.methodName}(${prop.argumentName});
+    o${i + 1}.set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% end %}\
 {% end %}\
 {% end %}\
 {% if obj.name in customContent and prop.name in customContent[obj.name] %}\
 {% if debug %}\
-                // Custom content from ${obj.name} ${prop.name} template
+    // Custom content from ${obj.name} ${prop.name} template
 {% end debug %}\
 ${customContent[obj.name][prop.name]}
 {% end %}\
-        }
+  }
 {% end %}\
 \
 {% python
@@ -324,47 +324,47 @@ import ${lang.units_package}.unit.Unit;
  */
 public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 {
-        private OMEXMLMetadataRoot root; // OME
+  private OMEXMLMetadataRoot root; // OME
 
-        private OMEModel model;
+  private OMEModel model;
 
-        public OMEXMLMetadataImpl()
-        {
-                createRoot();
-        }
+  public OMEXMLMetadataImpl()
+  {
+    createRoot();
+  }
 
-        public void createRoot()
-        {
-                root = new OMEXMLMetadataRoot();
-                model = new OMEModelImpl();
-        }
+  public void createRoot()
+  {
+    root = new OMEXMLMetadataRoot();
+    model = new OMEModelImpl();
+  }
 
-        public MetadataRoot getRoot()
-        {
-                return root;
-        }
+  public MetadataRoot getRoot()
+  {
+    return root;
+  }
 
-        public void setRoot(MetadataRoot root)
-        {
-                if (root instanceof OMEXMLMetadataRoot)
-                        this.root = (OMEXMLMetadataRoot) root;
-                else
-                        throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
-                model = new OMEModelImpl();
-        }
+  public void setRoot(MetadataRoot root)
+  {
+    if (root instanceof OMEXMLMetadataRoot)
+      this.root = (OMEXMLMetadataRoot) root;
+    else
+      throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
+    model = new OMEModelImpl();
+  }
 
-        public String dumpXML()
-        {
-                resolveReferences();
-                return super.dumpXML();
-        }
+  public String dumpXML()
+  {
+    resolveReferences();
+    return super.dumpXML();
+  }
 
-        public int resolveReferences()
-        {
-                return model.resolveReferences();
-        }
+  public int resolveReferences()
+  {
+    return model.resolveReferences();
+  }
 
-        // -- Entity counting (manual definitions) --
+  // -- Entity counting (manual definitions) --
 
   public int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex) {
     return root.getStructuredAnnotations().getBooleanAnnotation(booleanAnnotationIndex).sizeOfLinkedAnnotationList();
@@ -428,42 +428,42 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\
-        // Element's text data
-        // ${repr(indexes[o.name])}
-        public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
-        {
-                OME o0 = root;
-                if (o0.sizeOfImageList() == imageIndex)
-                {
-                        o0.addImage(new Image());
-                }
-                Image o1 = o0.getImage(imageIndex);
-                if (o1.getPixels() == null)
-                {
-                        o1.setPixels(new Pixels());
-                }
-                Pixels o2 = o1.getPixels();
-                if (o2.sizeOfTiffDataList() == tiffDataIndex)
-                {
-                        o2.addTiffData(new TiffData());
-                }
-                TiffData o3 = o2.getTiffData(tiffDataIndex);
-                if (o3.getUUID() == null)
-                {
-                        o3.setUUID(new UUID());
-                }
-                UUID o4 = o3.getUUID();
-                o4.setValue(value);
-        }
+  // Element's text data
+  // ${repr(indexes[o.name])}
+  public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
+  {
+    OME o0 = root;
+    if (o0.sizeOfImageList() == imageIndex)
+    {
+      o0.addImage(new Image());
+    }
+    Image o1 = o0.getImage(imageIndex);
+    if (o1.getPixels() == null)
+    {
+      o1.setPixels(new Pixels());
+    }
+    Pixels o2 = o1.getPixels();
+    if (o2.sizeOfTiffDataList() == tiffDataIndex)
+    {
+      o2.addTiffData(new TiffData());
+    }
+    TiffData o3 = o2.getTiffData(tiffDataIndex);
+    if (o3.getUUID() == null)
+    {
+      o3.setUUID(new UUID());
+    }
+    UUID o4 = o3.getUUID();
+    o4.setValue(value);
+  }
 
-        public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
-        {
-                return root.getImage(imageIndex).getPixels().getTiffData(tiffDataIndex).getUUID().getValue();
-        }
+  public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
+  {
+    return root.getImage(imageIndex).getPixels().getTiffData(tiffDataIndex).getUUID().getValue();
+  }
 
 {% end %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isAbstractSubstitution %}\
-        // ${o.name} entity counting
+  // ${o.name} entity counting
 {% for k, v in indexes[o.name].items() %}\
 {% if fu.max_occurs_under_parent(model, k, o.name) > 1 and (k not in fu.METADATA_COUNT_IGNORE or o.type not in fu.METADATA_COUNT_IGNORE[k]) %}\
 ${counter(k, o, v)}\
@@ -474,51 +474,51 @@ ${counter(k, o, v)}\
 {% end %}\
 {% end %}\
 
-        // -- Entity retrieval (manual definitions) --
+  // -- Entity retrieval (manual definitions) --
 
-        /** Gets the UUID associated with this collection of metadata. */
-        public String getUUID()
-        {
-                return root.getUUID();
-        }
+  /** Gets the UUID associated with this collection of metadata. */
+  public String getUUID()
+  {
+    return root.getUUID();
+  }
 
-        /** Gets the Map value associated with this annotation */
-        public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
-        {
-                return root.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).getValue();
-        }
+  /** Gets the Map value associated with this annotation */
+  public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
+  {
+    return root.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).getValue();
+  }
 
-        /** Gets the Map value associated with this generic light source */
-        public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
-        {
+  /** Gets the Map value associated with this generic light source */
+  public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
+  {
     GenericExcitationSource o = (GenericExcitationSource) root.getInstrument(instrumentIndex).getLightSource(lightSourceIndex);
     return o.getMap();
-        }
+  }
 
-        /** Gets the Map value associated with this imaging environment */
-        public List<MapPair> getImagingEnvironmentMap(int imageIndex)
-        {
-                return root.getImage(imageIndex).getImagingEnvironment().getMap();
-        }
+  /** Gets the Map value associated with this imaging environment */
+  public List<MapPair> getImagingEnvironmentMap(int imageIndex)
+  {
+    return root.getImage(imageIndex).getImagingEnvironment().getMap();
+  }
 
-        // -- Entity retrieval (code generated definitions) --
+  // -- Entity retrieval (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
-        //
-        // ${o.name} property storage
-        //
-        // Indexes: ${repr(indexes[o.name])}
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // Indexes: ${repr(indexes[o.name])}
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end %}\
 {% end %}\
@@ -530,13 +530,13 @@ ${counter(k, o, v)}\
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% for parent_k, parent_v in indexes[k].items() %}\
 {% if not prop.isBackReference and not prop.isUnitsEnumeration %}\
- // ${prop.name} accessor from parent ${k}
+  // ${prop.name} accessor from parent ${k}
 ${getter(k, o, prop, v)}\
 
 {% end %}\
@@ -551,17 +551,17 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, units enumeration
+  // Ignoring ${prop.name} element, units enumeration
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
@@ -578,82 +578,82 @@ ${getter(k, o, prop, v)}\
 {% end %}\
 {% end %}\
 
-        // -- Entity storage (manual definitions) --
+  // -- Entity storage (manual definitions) --
 
-        /** Sets the UUID associated with this collection of metadata. */
-        public void setUUID(String uuid)
-        {
-                root.setUUID(uuid);
-        }
+  /** Sets the UUID associated with this collection of metadata. */
+  public void setUUID(String uuid)
+  {
+    root.setUUID(uuid);
+  }
 
-        /** Sets the Map value associated with this annotation */
-        public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
-        {
-                OME o0 = root;
-                if (o0.getStructuredAnnotations() == null)
-                {
-                        o0.setStructuredAnnotations(new StructuredAnnotations());
-                }
-                StructuredAnnotations o1 = o0.getStructuredAnnotations();
-                if (o1.sizeOfMapAnnotationList() == mapAnnotationIndex)
-                {
-                        o1.addMapAnnotation(new MapAnnotation());
-                }
-                MapAnnotation o2 = o1.getMapAnnotation(mapAnnotationIndex);
-                o2.setValue(value);
-        }
+  /** Sets the Map value associated with this annotation */
+  public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
+  {
+    OME o0 = root;
+    if (o0.getStructuredAnnotations() == null)
+    {
+      o0.setStructuredAnnotations(new StructuredAnnotations());
+    }
+    StructuredAnnotations o1 = o0.getStructuredAnnotations();
+    if (o1.sizeOfMapAnnotationList() == mapAnnotationIndex)
+    {
+      o1.addMapAnnotation(new MapAnnotation());
+    }
+    MapAnnotation o2 = o1.getMapAnnotation(mapAnnotationIndex);
+    o2.setValue(value);
+  }
 
-        /** Sets the Map value associated with this generic light source */
-        public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
-        {
-                OME o0 = root;
-                if (o0.sizeOfInstrumentList() == instrumentIndex)
-                {
-                        o0.addInstrument(new Instrument());
-                }
-                Instrument o1 = o0.getInstrument(instrumentIndex);
-                if (o1.sizeOfLightSourceList() == lightSourceIndex)
-                {
-                        o1.addLightSource(new GenericExcitationSource());
-                }
-                LightSource o2 = o1.getLightSource(lightSourceIndex);
-                ((GenericExcitationSource)o2).setMap(map);
-        }
+  /** Sets the Map value associated with this generic light source */
+  public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
+  {
+    OME o0 = root;
+    if (o0.sizeOfInstrumentList() == instrumentIndex)
+    {
+      o0.addInstrument(new Instrument());
+    }
+    Instrument o1 = o0.getInstrument(instrumentIndex);
+    if (o1.sizeOfLightSourceList() == lightSourceIndex)
+    {
+      o1.addLightSource(new GenericExcitationSource());
+    }
+    LightSource o2 = o1.getLightSource(lightSourceIndex);
+    ((GenericExcitationSource)o2).setMap(map);
+  }
 
-        /** Sets the Map value associated with this imaging environment */
-        public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
-        {
-                OME o0 = root;
-                if (o0.sizeOfImageList() == imageIndex)
-                {
-                        o0.addImage(new Image());
-                }
-                Image o1 = o0.getImage(imageIndex);
-                if (o1.getImagingEnvironment() == null)
-                {
-                        o1.setImagingEnvironment(new ImagingEnvironment());
-                }
-                ImagingEnvironment o2 = o1.getImagingEnvironment();
-                o2.setMap(map);
-        }
+  /** Sets the Map value associated with this imaging environment */
+  public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
+  {
+    OME o0 = root;
+    if (o0.sizeOfImageList() == imageIndex)
+    {
+      o0.addImage(new Image());
+    }
+    Image o1 = o0.getImage(imageIndex);
+    if (o1.getImagingEnvironment() == null)
+    {
+      o1.setImagingEnvironment(new ImagingEnvironment());
+    }
+    ImagingEnvironment o2 = o1.getImagingEnvironment();
+    o2.setMap(map);
+  }
 
-        // -- Entity storage (code generated definitions) --
+  // -- Entity storage (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), lambda x, y: cmp(x.name, y.name)) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if (parents[o.name] is not None and not o.isAbstract) or o.isConcreteSubstitution %}
-        //
-        // ${o.name} property storage
-        //
-        // ${repr(parents[o.name])}
-        // Is multi path? ${is_multi_path[o.name]}
+  //
+  // ${o.name} property storage
+  //
+  // ${repr(parents[o.name])}
+  // Is multi path? ${is_multi_path[o.name]}
 
 {% choose %}\
 {% when o.isReference %}\
 {% for prop in sorted(o.properties.values() + o.baseObjectProperties, lambda x, y: cmp(x.name, y.name)) %}\
-        // ${prop.minOccurs}:${prop.maxOccurs}
-        // Is multi path? ${is_multi_path[o.name]}
-        // Ignoring ${prop.name} property of reference ${o.name}
+  // ${prop.minOccurs}:${prop.maxOccurs}
+  // Is multi path? ${is_multi_path[o.name]}
+  // Ignoring ${prop.name} property of reference ${o.name}
 
 {% end %}\
 {% end %}\
@@ -665,7 +665,7 @@ ${getter(k, o, prop, v)}\
 {% choose %}\
 {% when not prop.isPrimitive and prop.isChoice %}\
 {% if debug %}\
-        // Ignoring ${prop.name} of parent abstract type
+  // Ignoring ${prop.name} of parent abstract type
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
@@ -686,17 +686,17 @@ ${setter(k, o, prop, v)}\
 {% choose %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-        // Ignoring ${prop.name} back reference
+  // Ignoring ${prop.name} back reference
 {% end debug %}\
 {% end %}\
 {% when not prop.isReference and not prop.isAttribute and prop.isComplex() and (not prop.name in fu.COMPLEX_OVERRIDE) %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, complex property
+  // Ignoring ${prop.name} element, complex property
 {% end debug %}\
 {% end %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-        // Ignoring ${prop.name} element, units enumeration
+  // Ignoring ${prop.name} element, units enumeration
 {% end debug %}\
 {% end %}\
 {% otherwise %}\

--- a/components/xsd-fu/templates-java/OMEXMLMetadataImpl_Channel_ID.template
+++ b/components/xsd-fu/templates-java/OMEXMLMetadataImpl_Channel_ID.template
@@ -1,4 +1,4 @@
-                if (o3.getLightPath() == null)
-                {
-                        o3.setLightPath(new LightPath());
-                }
+    if (o3.getLightPath() == null)
+    {
+      o3.setLightPath(new LightPath());
+    }

--- a/components/xsd-fu/templates-java/OMEXMLModelEnumHandler.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelEnumHandler.template
@@ -131,7 +131,7 @@ public class ${klass.langType}EnumHandler implements IEnumerationHandler {
 {% end %}\
 {% if 'Other' not in klass.possibleValues %}\
     throw new EnumerationException(this.getClass().getName() +
-     " could not find enumeration for " + value);
+      " could not find enumeration for " + value);
 {% end %}\
   }
 
@@ -169,32 +169,32 @@ public class ${klass.langType}EnumHandler implements IEnumerationHandler {
     throws EnumerationException
   {
     if (inValue instanceof NonNegativeFloat) {
-        NonNegativeFloat typedValue = (NonNegativeFloat) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      NonNegativeFloat typedValue = (NonNegativeFloat) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     if (inValue instanceof NonNegativeInteger) {
-        NonNegativeInteger typedValue = (NonNegativeInteger) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      NonNegativeInteger typedValue = (NonNegativeInteger) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     if (inValue instanceof NonNegativeLong) {
-        NonNegativeLong typedValue = (NonNegativeLong) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      NonNegativeLong typedValue = (NonNegativeLong) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     if (inValue instanceof PercentFraction) {
-        PercentFraction typedValue = (PercentFraction) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      PercentFraction typedValue = (PercentFraction) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     if (inValue instanceof PositiveFloat) {
-        PositiveFloat typedValue = (PositiveFloat) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      PositiveFloat typedValue = (PositiveFloat) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     if (inValue instanceof PositiveInteger) {
-        PositiveInteger typedValue = (PositiveInteger) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      PositiveInteger typedValue = (PositiveInteger) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     if (inValue instanceof PositiveLong) {
-        PositiveLong typedValue = (PositiveLong) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
+      PositiveLong typedValue = (PositiveLong) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(typedValue.getValue(), getBaseUnit(inModelUnit));
     }
     LOGGER.warn("Unknown type '{}' cannot be used to create a '${klass.model.opts.lang.typeToUnitsType(klass.langType)}' quantity",
       inValue.getClass().getName());
@@ -206,12 +206,12 @@ public class ${klass.langType}EnumHandler implements IEnumerationHandler {
     throws EnumerationException
   {
     if (inValue instanceof Double) {
-        Double doubleValue = (Double) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(doubleValue, getBaseUnit(inModelUnit));
+      Double doubleValue = (Double) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(doubleValue, getBaseUnit(inModelUnit));
     }
     if (inValue instanceof Integer) {
-        Integer intValue = (Integer) inValue;
-        return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(intValue, getBaseUnit(inModelUnit));
+      Integer intValue = (Integer) inValue;
+      return new ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)}(intValue, getBaseUnit(inModelUnit));
     }
     LOGGER.warn("Unknown type '{}' cannot be used to create a '${klass.model.opts.lang.typeToUnitsType(klass.langType)}' quantity",
       inValue.getClass().getName());

--- a/components/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -92,293 +92,293 @@ public class ${klass.name} extends ${klass.parentName}
 {% end %}\
 {% end %}\
 {
-        // Base: ${klass.base} -- Name: ${klass.name} -- Type: ${klass.type} -- modelBaseType: ${klass.modelBaseType} -- langBaseType: ${klass.langBaseType}
+  // Base: ${klass.base} -- Name: ${klass.name} -- Type: ${klass.type} -- modelBaseType: ${klass.modelBaseType} -- langBaseType: ${klass.langBaseType}
 
-        // -- Constants --
+  // -- Constants --
 
-        public static final String NAMESPACE = "${klass.namespace}";
+  public static final String NAMESPACE = "${klass.namespace}";
 
-        /** Logger for this class. */
-        private static final Logger LOGGER =
-                LoggerFactory.getLogger(${klass.name}.class);
+  /** Logger for this class. */
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(${klass.name}.class);
 
-        // -- Instance variables --
+  // -- Instance variables --
 {% for prop in klass.instanceVariables %}\
 {% if not prop[4] %}\
 
 {% if prop[3] is not None %}\
-        // ${prop[3]}
+  // ${prop[3]}
 {% end %}\
 {% if prop[0] is not None %}\
 {% if prop[2] is not None %}\
-        private ${prop[0]} ${prop[1]} = new ${prop[2]}();
+  private ${prop[0]} ${prop[1]} = new ${prop[2]}();
 {% end %}\
 {% if prop[2] is None %}\
-        private ${prop[0]} ${prop[1]};
+  private ${prop[0]} ${prop[1]};
 {% end %}\
 {% end %}\
 {% end %}\
 {% end %}\
 
-        // -- Constructors --
+  // -- Constructors --
 
-        /** Default constructor. */
-        public ${klass.name}()
-        {
+  /** Default constructor. */
+  public ${klass.name}()
+  {
 {% if klass.parentName is not None and klass.parentName != 'AbstractOMEModelObject' %}\
-                super();
+    super();
 {% end %}\
-        }
+  }
 
-        /**
-         * Constructs ${klass.name} recursively from an XML DOM tree.
-         * @param element Root of the XML DOM tree to construct a model object
-         * graph from.
-         * @param model Handler for the OME model which keeps track of instances
-         * and references seen during object population.
-         * @throws EnumerationException If there is an error instantiating an
-         * enumeration during model object creation.
-         */
-        public ${klass.name}(Element element, OMEModel model)
-            throws EnumerationException
-        {
-                update(element, model);
-        }
+  /**
+   * Constructs ${klass.name} recursively from an XML DOM tree.
+   * @param element Root of the XML DOM tree to construct a model object
+   * graph from.
+   * @param model Handler for the OME model which keeps track of instances
+   * and references seen during object population.
+   * @throws EnumerationException If there is an error instantiating an
+   * enumeration during model object creation.
+   */
+  public ${klass.name}(Element element, OMEModel model)
+    throws EnumerationException
+  {
+    update(element, model);
+  }
 
-        /** Copy constructor. */
-        public ${klass.name}(${klass.name} orig)
-        {
+  /** Copy constructor. */
+  public ${klass.name}(${klass.name} orig)
+  {
 {% if klass.parentName is not None and klass.parentName != 'AbstractOMEModelObject' %}\
-                super(orig);
+    super(orig);
 {% end %}\
 {% for prop in klass.instanceVariables %}\
 {% choose %}\
 {% when prop[0] is not None and prop[4] %}\
 {% if debug %}\
-                // Unit property ${prop[1]}, copied with it's value property
+    // Unit property ${prop[1]}, copied with it's value property
 {% end debug %}\
 {% end %}\
 {% when prop[0] is not None %}\
-                ${prop[1]} = orig.${prop[1]};
+    ${prop[1]} = orig.${prop[1]};
 {% end %}\
 {% when prop[0] is None %}\
 {% if debug %}\
-                // *** WARNING *** Unhandled or skipped property ${prop[1]}
+    // *** WARNING *** Unhandled or skipped property ${prop[1]}
 {% end debug %}\
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-                // *** WARNING *** Unhandled or skipped non-unit property ${prop[1]}
+    // *** WARNING *** Unhandled or skipped non-unit property ${prop[1]}
 {% end debug %}\
 {% end %}\
 {% end %}\
 {% end %}\
-        }
+  }
 
-        // -- Custom content from ${klass.name} specific template --
+  // -- Custom content from ${klass.name} specific template --
 
 ${customContent}\
 
-        // -- OMEModelObject API methods --
+  // -- OMEModelObject API methods --
 
-        /**
-         * Updates ${klass.name} recursively from an XML DOM tree. <b>NOTE:</b> No
-         * properties are removed, only added or updated.
-         * @param element Root of the XML DOM tree to construct a model object
-         * graph from.
-         * @param model Handler for the OME model which keeps track of instances
-         * and references seen during object population.
-         * @throws EnumerationException If there is an error instantiating an
-         * enumeration during model object creation.
-         */
-        public void update(Element element, OMEModel model)
-            throws EnumerationException
-        {
-                super.update(element, model);
+  /**
+   * Updates ${klass.name} recursively from an XML DOM tree. <b>NOTE:</b> No
+   * properties are removed, only added or updated.
+   * @param element Root of the XML DOM tree to construct a model object
+   * graph from.
+   * @param model Handler for the OME model which keeps track of instances
+   * and references seen during object population.
+   * @throws EnumerationException If there is an error instantiating an
+   * enumeration during model object creation.
+   */
+  public void update(Element element, OMEModel model)
+    throws EnumerationException
+  {
+    super.update(element, model);
 {% if klass.langBaseType != 'Object' %}\
-                // Element's text data
-                String value_textContent = element.getTextContent();
-                if (value_textContent.trim().length() > 0) {
-                        value = ${klass.langBaseType}.valueOf(value_textContent);
-                }
+    // Element's text data
+    String value_textContent = element.getTextContent();
+    if (value_textContent.trim().length() > 0) {
+      value = ${klass.langBaseType}.valueOf(value_textContent);
+    }
 {% end %}\
-                String tagName = element.getTagName();
-                if (!"${klass.name}".equals(tagName))
-                {
-                        LOGGER.debug("Expecting node name of ${klass.name} got {}", tagName);
-                }
+    String tagName = element.getTagName();
+    if (!"${klass.name}".equals(tagName))
+    {
+      LOGGER.debug("Expecting node name of ${klass.name} got {}", tagName);
+    }
 {% for prop in klass.properties.values() %}\
 {% choose %}\
 {% when prop.name in customUpdatePropertyContent %}\
 {% if debug %}\
-                // -- BEGIN custom content from ${prop.name} property template --
+    // -- BEGIN custom content from ${prop.name} property template --
 {% end debug %}\
 ${customUpdatePropertyContent[prop.name]}
 {% if debug %}\
-                // -- END custom content from ${prop.name} property template --
+    // -- END custom content from ${prop.name} property template --
 {% end debug %}\
 {% end %}\
 {% when prop.hasBaseAttribute %}\
-                // Element's text data
-                String value_textContent = element.getTextContent();
-                if (value_textContent.trim().length() > 0) {
+    // Element's text data
+    String value_textContent = element.getTextContent();
+    if (value_textContent.trim().length() > 0) {
 {% if prop.type == 'base64Binary' %}\
-                        byte[] rawBytes = DatatypeConverter.parseBase64Binary(value_textContent);
-                        set${prop.methodName}(rawBytes);
+      byte[] rawBytes = DatatypeConverter.parseBase64Binary(value_textContent);
+      set${prop.methodName}(rawBytes);
 {% end if prop.type %}\
 {% if not prop.type == 'base64Binary' %}\
-                        set${prop.methodName}(${prop.type}.valueOf(value_textContent));
+      set${prop.methodName}(${prop.type}.valueOf(value_textContent));
 {% end if not prop.type %}\
-                }
+    }
 {% end when %}\
 {% when prop.isReference %}\
-                // Element reference ${prop.name}
-                List<Element> ${prop.name}_nodeList =
-                                getChildrenByTagName(element, "${prop.name}");
-                for (Element ${prop.name}_element : ${prop.name}_nodeList)
-                {
-                        ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
-                        ${prop.instanceVariableName}_reference.setID(${prop.name}_element.getAttribute("ID"));
-                        model.addReference(this, ${prop.instanceVariableName}_reference);
-                }
+    // Element reference ${prop.name}
+    List<Element> ${prop.name}_nodeList =
+      getChildrenByTagName(element, "${prop.name}");
+    for (Element ${prop.name}_element : ${prop.name}_nodeList)
+    {
+      ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
+      ${prop.instanceVariableName}_reference.setID(${prop.name}_element.getAttribute("ID"));
+      model.addReference(this, ${prop.instanceVariableName}_reference);
+    }
 {% end %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-                // *** IGNORING *** Skipped back reference ${prop.name}
+    // *** IGNORING *** Skipped back reference ${prop.name}
 {% end debug %}\
 {% end %}\
 {% when prop.isAttribute and prop.name == "ID" %}\
-                if (!element.hasAttribute("ID") && getID() == null)
-                {
-                        // TODO: Should be its own exception
-                        throw new RuntimeException(String.format(
-                                        "${klass.name} missing required ID property."));
-                }
-                if (element.hasAttribute("ID"))
-                {
-                        // ID property
-                        set${prop.methodName}(${prop.langType}.valueOf(
-                                                element.getAttribute("${prop.name}")));
-                        // Adding this model object to the model handler
-                        model.addModelObject(getID(), this);
-                }
+    if (!element.hasAttribute("ID") && getID() == null)
+    {
+      // TODO: Should be its own exception
+      throw new RuntimeException(String.format(
+        "${klass.name} missing required ID property."));
+    }
+    if (element.hasAttribute("ID"))
+    {
+      // ID property
+      set${prop.methodName}(${prop.langType}.valueOf(
+        element.getAttribute("${prop.name}")));
+      // Adding this model object to the model handler
+      model.addModelObject(getID(), this);
+    }
 {% end %}\
 {% when prop.isAttribute %}\
 {% choose %}\
 {% when prop.isUnitsEnumeration %}\
 {% if debug %}\
-                        // MARKER [JJJ]
-                        // Attribute property which is Units enumeration ${prop.name}
+    // MARKER [JJJ]
+    // Attribute property which is Units enumeration ${prop.name}
 {% end debug %}\
 {% end %}\
 {% when prop.isEnumeration and not prop.isUnitsEnumeration%}\
 {% if debug %}\
-                        // MARKER [KKK]
+    // MARKER [KKK]
 {% end debug %}\
-                if (element.hasAttribute("${prop.name}"))
-                {
-                        // Attribute property which is an enumeration ${prop.name}
-                        set${prop.methodName}(${prop.langType}.fromString(
-                                        element.getAttribute("${prop.name}")));
-                }
+    if (element.hasAttribute("${prop.name}"))
+    {
+      // Attribute property which is an enumeration ${prop.name}
+      set${prop.methodName}(${prop.langType}.fromString(
+        element.getAttribute("${prop.name}")));
+    }
 {% end %}\
 {% when prop.hasUnitsCompanion %}\
 {% if debug %}\
-                        // MARKER [UUU]
+    // MARKER [UUU]
 {% end debug %}\
-                if (element.hasAttribute("${prop.name}"))
-                {
-                        // Attribute property ${prop.name} with unit companion ${prop.unitsCompanion.name}
-                        String unitSymbol = element.getAttribute("${prop.unitsCompanion.name}");
-                        if ((unitSymbol == null) || (unitSymbol.isEmpty()))
-                        {
-                                // Use default value specified in the xsd model
-                                unitSymbol = get${prop.unitsCompanion.name}XsdDefault();
-                        }
-                        ${prop.unitsCompanion.langType} modelUnit =
-                                ${prop.unitsCompanion.langType}.fromString(unitSymbol);
-                        ${prop.langType} baseValue = ${prop.langType}.valueOf(
-                                        element.getAttribute("${prop.name}"));
-                        if (baseValue != null)
-                        {
-                                set${prop.methodName}(${prop.unitsCompanion.langType}EnumHandler.getQuantity(baseValue, modelUnit));
-                        }
-                }
+    if (element.hasAttribute("${prop.name}"))
+    {
+      // Attribute property ${prop.name} with unit companion ${prop.unitsCompanion.name}
+      String unitSymbol = element.getAttribute("${prop.unitsCompanion.name}");
+      if ((unitSymbol == null) || (unitSymbol.isEmpty()))
+      {
+        // Use default value specified in the xsd model
+        unitSymbol = get${prop.unitsCompanion.name}XsdDefault();
+      }
+      ${prop.unitsCompanion.langType} modelUnit =
+        ${prop.unitsCompanion.langType}.fromString(unitSymbol);
+      ${prop.langType} baseValue = ${prop.langType}.valueOf(
+        element.getAttribute("${prop.name}"));
+      if (baseValue != null)
+      {
+        set${prop.methodName}(${prop.unitsCompanion.langType}EnumHandler.getQuantity(baseValue, modelUnit));
+      }
+    }
 {% end %}\
 {% when not prop.isEnumeration %}\
 {% if debug %}\
-                        // MARKER [LLL]
+    // MARKER [LLL]
 {% end debug %}\
-                if (element.hasAttribute("${prop.name}"))
-                {
-                        // Attribute property ${prop.name}
-                        set${prop.methodName}(${prop.langType}.valueOf(
-                                        element.getAttribute("${prop.name}")));
-                }
+    if (element.hasAttribute("${prop.name}"))
+    {
+      // Attribute property ${prop.name}
+      set${prop.methodName}(${prop.langType}.valueOf(
+        element.getAttribute("${prop.name}")));
+    }
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-                // MARKER [MMM]
-                // *** WARNING *** Unhandled or skipped attribute ${prop.name}
+    // MARKER [MMM]
+    // *** WARNING *** Unhandled or skipped attribute ${prop.name}
 {% end debug %}\
 {% end %}\
 {% end %}\
 {% end %}\
 {% when prop.maxOccurs == 1 and (not klass.isAbstract or not prop.isAttribute) %}\
-                List<Element> ${prop.name}_nodeList =
-                                getChildrenByTagName(element, "${prop.name}");
-                if (${prop.name}_nodeList.size() > 1)
-                {
-                        // TODO: Should be its own Exception
-                        throw new RuntimeException(String.format(
-                                        "${prop.name} node list size %d != 1",
-                                        ${prop.name}_nodeList.size()));
-                }
-                else if (${prop.name}_nodeList.size() != 0)
-                {
+    List<Element> ${prop.name}_nodeList =
+      getChildrenByTagName(element, "${prop.name}");
+    if (${prop.name}_nodeList.size() > 1)
+    {
+      // TODO: Should be its own Exception
+      throw new RuntimeException(String.format(
+        "${prop.name} node list size %d != 1",
+        ${prop.name}_nodeList.size()));
+    }
+    else if (${prop.name}_nodeList.size() != 0)
+    {
 {% if prop.isComplex() and not klass.isAbstract %}\
-                        // Element property ${prop.name} which is complex (has
-                        // sub-elements)
+      // Element property ${prop.name} which is complex (has
+      // sub-elements)
 {% if prop.langTypeNS != 'List<MapPair>' %}\
-                        set${prop.methodName}(new ${prop.langType}(
-                                        (Element) ${prop.name}_nodeList.get(0), model));
+      set${prop.methodName}(new ${prop.langType}(
+        (Element) ${prop.name}_nodeList.get(0), model));
 {% end %}\
 {% if prop.langTypeNS == 'List<MapPair>' %}\
-                        List<MapPair> p = new java.util.ArrayList<MapPair>();
-                        NodeList children = ${prop.name}_nodeList.get(0).getChildNodes();
+      List<MapPair> p = new java.util.ArrayList<MapPair>();
+      NodeList children = ${prop.name}_nodeList.get(0).getChildNodes();
 
-                        for (int i=0; i<children.getLength(); i++) {
-                                Node child = children.item(i);
-                                if (child.getNodeType() == Node.ELEMENT_NODE) {
-                                        p.add(new MapPair(((Element) child).getAttribute("K"), child.getTextContent()));
-                                }
-                        }
-                        set${prop.methodName}(p);
+      for (int i=0; i<children.getLength(); i++) {
+        Node child = children.item(i);
+        if (child.getNodeType() == Node.ELEMENT_NODE) {
+          p.add(new MapPair(((Element) child).getAttribute("K"), child.getTextContent()));
+        }
+      }
+      set${prop.methodName}(p);
 {% end %}\
 {% end %}\
 {% if not prop.isComplex() %}\
-                        // Element property ${prop.name} which is not complex (has no
-                        // sub-elements)
-                        set${prop.methodName}(
-                                        ${prop.langType}.valueOf(${prop.name}_nodeList.get(0).getTextContent()));
+      // Element property ${prop.name} which is not complex (has no
+      // sub-elements)
+      set${prop.methodName}(
+        ${prop.langType}.valueOf(${prop.name}_nodeList.get(0).getTextContent()));
 {% end %}\
-                }
+    }
 {% end %}\
 {% when prop.maxOccurs > 1 and prop.isComplex() and not klass.isAbstract %}\
 {% if prop.isAbstract %}\
 {% if prop.isAbstractSubstitution %}\
-                // Element property ${prop.name} which is complex (has
-                // sub-elements) and occurs more than once. The element's model
-                // object type is also abstract so we need to have a handler for
-                // each "subclass".
+    // Element property ${prop.name} which is complex (has
+    // sub-elements) and occurs more than once. The element's model
+    // object type is also abstract so we need to have a handler for
+    // each "subclass".
 {% for subClass in getConcreteClasses(prop.name) %}\
-                List<Element> ${subClass}_nodeList =
-                                getChildrenByTagName(element, "${subClass}");
-                for (Element ${subClass}_element : ${subClass}_nodeList)
-                {
+    List<Element> ${subClass}_nodeList =
+      getChildrenByTagName(element, "${subClass}");
+    for (Element ${subClass}_element : ${subClass}_nodeList)
+    {
       add${prop.methodName}(
-          new ${subClass}(${subClass}_element, model));
-     }
+      new ${subClass}(${subClass}_element, model));
+    }
 {% end %}\
 {% end %}\
 {% if not prop.isAbstractSubstitution %}\
@@ -393,7 +393,7 @@ ${customUpdatePropertyContent[prop.name]}
 {% for inner_prop in model.getObjectByName(prop.name).properties.values() %}\
 {% if not inner_prop.isAttribute and inner_prop.isComplex() and not inner_prop.isReference and inner_prop.isChoice %}\
       List<Element> ${inner_prop.name}_nodeList =
-          getChildrenByTagName(${prop.name}_element, "${inner_prop.name}");
+        getChildrenByTagName(${prop.name}_element, "${inner_prop.name}");
       for (Element ${inner_prop.name}_element : ${inner_prop.name}_nodeList)
       {
         ${inner_prop.langType} o = new ${inner_prop.langType}(${prop.name}_element, model);
@@ -406,403 +406,403 @@ ${customUpdatePropertyContent[prop.name]}
 {% end %}\
 {% end %}\
 {% if not prop.isAbstract %}\
-                // Element property ${prop.name} which is complex (has
-                // sub-elements) and occurs more than once
-                List<Element> ${prop.name}_nodeList =
-                                getChildrenByTagName(element, "${prop.name}");
-                for (Element ${prop.name}_element : ${prop.name}_nodeList)
-                {
-                        add${prop.methodName}(
-                                        new ${prop.langType}(${prop.name}_element, model));
-                }
+    // Element property ${prop.name} which is complex (has
+    // sub-elements) and occurs more than once
+    List<Element> ${prop.name}_nodeList =
+      getChildrenByTagName(element, "${prop.name}");
+    for (Element ${prop.name}_element : ${prop.name}_nodeList)
+    {
+      add${prop.methodName}(
+        new ${prop.langType}(${prop.name}_element, model));
+    }
 {% end %}\
 {% end %}\
 {% when prop.maxOccurs > 1 %}\
-                // Element property ${prop.name} which is not complex (has no
-                // sub-elements) which occurs more than once
-                List<Element> ${prop.name}_nodeList =
-                                getChildrenByTagName("${prop.name}");
-                for (Element ${prop.name}_element : ${prop.name}_nodeList)
-                {
-                        add${prop.methodName}(new ${prop.langType}(
-                                        ${prop.name}_element.getTextContent(), model));
-                }
+    // Element property ${prop.name} which is not complex (has no
+    // sub-elements) which occurs more than once
+    List<Element> ${prop.name}_nodeList =
+      getChildrenByTagName("${prop.name}");
+    for (Element ${prop.name}_element : ${prop.name}_nodeList)
+    {
+      add${prop.methodName}(new ${prop.langType}(
+        ${prop.name}_element.getTextContent(), model));
+    }
 {% end %}\
 {% otherwise %}\
 {% if debug %}\
-                // *** WARNING *** Unhandled or skipped property ${prop.name}
+    // *** WARNING *** Unhandled or skipped property ${prop.name}
 {% end debug %}\
 {% end %}\
 {% end %}\
 {% end %}\
-        }
+  }
 
-        // -- ${klass.name} API methods --
+  // -- ${klass.name} API methods --
 
-        public boolean link(Reference reference, OMEModelObject o)
-        {
-                boolean wasHandledBySuperClass = super.link(reference, o);
-                if (wasHandledBySuperClass)
-                {
-                        return true;
-                }
+  public boolean link(Reference reference, OMEModelObject o)
+  {
+    boolean wasHandledBySuperClass = super.link(reference, o);
+    if (wasHandledBySuperClass)
+    {
+      return true;
+    }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
-                if (reference instanceof ${prop.name})
-                {
-                        ${prop.langType} o_casted = (${prop.langType}) o;
+    if (reference instanceof ${prop.name})
+    {
+      ${prop.langType} o_casted = (${prop.langType}) o;
 {% if not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-                        o_casted.link${klass.type}(this);
+      o_casted.link${klass.type}(this);
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
       o_casted.link${klass.name}${prop.methodName}(this);
 {% end %}\
 {% end %}\
 {% if prop.maxOccurs > 1 %}\
-                        ${prop.instanceVariableName}.add(o_casted);
+      ${prop.instanceVariableName}.add(o_casted);
 {% end %}\
 {% if prop.maxOccurs == 1 %}\
-                        ${prop.instanceVariableName} = o_casted;
+      ${prop.instanceVariableName} = o_casted;
 {% end %}\
-                        return true;
-                }
+      return true;
+    }
 {% end %}\
 {% end %}\
-                LOGGER.debug("Unable to handle reference of type: {}", reference.getClass());
-                return false;
-        }
+    LOGGER.debug("Unable to handle reference of type: {}", reference.getClass());
+    return false;
+  }
 {% if klass.langBaseType != 'Object' %}\
-        // Element's text data getter
-        public ${klass.langBaseType} getValue()
-        {
-                return this.value;
-        }
+  // Element's text data getter
+  public ${klass.langBaseType} getValue()
+  {
+    return this.value;
+  }
 
-        // Element's text data setter
-        public void setValue(${klass.langBaseType} value)
-        {
-                this.value = value;
-        }
+  // Element's text data setter
+  public void setValue(${klass.langBaseType} value)
+  {
+    this.value = value;
+  }
 {% end %}\
 \
 {% for prop in klass.properties.values() %}\
 {% choose %}\
 {% when (prop.isReference or prop.isBackReference) and prop.maxOccurs > 1 %}
-        // Reference which occurs more than once
-        public int sizeOfLinked${prop.methodName}List()
-        {
-                return ${prop.instanceVariableName}.size();
-        }
+  // Reference which occurs more than once
+  public int sizeOfLinked${prop.methodName}List()
+  {
+    return ${prop.instanceVariableName}.size();
+  }
 
-        public List<${prop.langType}> copyLinked${prop.methodName}List()
-        {
-                return new ArrayList<${prop.langType}>(${prop.instanceVariableName});
-        }
+  public List<${prop.langType}> copyLinked${prop.methodName}List()
+  {
+    return new ArrayList<${prop.langType}>(${prop.instanceVariableName});
+  }
 
-        public ${prop.langType} getLinked${prop.methodName}(int index)
-        {
-                return ${prop.instanceVariableName}.get(index);
-        }
+  public ${prop.langType} getLinked${prop.methodName}(int index)
+  {
+    return ${prop.instanceVariableName}.get(index);
+  }
 
-        public ${prop.langType} setLinked${prop.methodName}(int index, ${prop.langType} o)
-        {
-                return ${prop.instanceVariableName}.set(index, o);
-        }
+  public ${prop.langType} setLinked${prop.methodName}(int index, ${prop.langType} o)
+  {
+    return ${prop.instanceVariableName}.set(index, o);
+  }
 
-        public boolean link${prop.methodName}(${prop.langType} o)
-        {
+  public boolean link${prop.methodName}(${prop.langType} o)
+  {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-                        o.link${klass.type}(this);
+    o.link${klass.type}(this);
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-      o.link${klass.name}${prop.methodName}(this);
+    o.link${klass.name}${prop.methodName}(this);
 {% end %}\
 {% end %}\
-                return ${prop.instanceVariableName}.add(o);
-        }
+    return ${prop.instanceVariableName}.add(o);
+  }
 
-        public boolean unlink${prop.methodName}(${prop.langType} o)
-        {
+  public boolean unlink${prop.methodName}(${prop.langType} o)
+  {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-                        o.unlink${klass.type}(this);
+    o.unlink${klass.type}(this);
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-      o.unlink${klass.name}${prop.methodName}(this);
+    o.unlink${klass.name}${prop.methodName}(this);
 {% end %}\
 {% end %}\
-                return ${prop.instanceVariableName}.remove(o);
-        }
+    return ${prop.instanceVariableName}.remove(o);
+  }
 {% end %}\
 {% when prop.isReference %}
-        // Reference
-        public ${prop.langType} getLinked${prop.methodName}()
-        {
-                return ${prop.instanceVariableName};
-        }
+  // Reference
+  public ${prop.langType} getLinked${prop.methodName}()
+  {
+    return ${prop.instanceVariableName};
+  }
 
-        public void link${prop.methodName}(${prop.langType} o)
-        {
-                ${prop.instanceVariableName} = o;
-        }
+  public void link${prop.methodName}(${prop.langType} o)
+  {
+    ${prop.instanceVariableName} = o;
+  }
 
-        public void unlink${prop.methodName}(${prop.langType} o)
-        {
-                if (${prop.instanceVariableName} == o)
-                {
-                        ${prop.instanceVariableName} = null;
-                }
-        }
+  public void unlink${prop.methodName}(${prop.langType} o)
+  {
+    if (${prop.instanceVariableName} == o)
+    {
+      ${prop.instanceVariableName} = null;
+    }
+  }
 {% end %}\
 {% when prop.hasUnitsCompanion and prop.maxOccurs == 1 and (not klass.isAbstract or prop.isAttribute or not prop.isComplex() or not prop.isChoice) %}
-        // Property ${prop.name} with unit companion ${prop.unitsCompanion.name}
-        public ${prop.instanceVariableType} get${prop.methodName}()
-        {
-                return ${prop.instanceVariableName};
-        }
+  // Property ${prop.name} with unit companion ${prop.unitsCompanion.name}
+  public ${prop.instanceVariableType} get${prop.methodName}()
+  {
+    return ${prop.instanceVariableName};
+  }
 
-        public void set${prop.methodName}(${prop.instanceVariableType} ${prop.argumentName})
-        {
-                this.${prop.instanceVariableName} = ${prop.argumentName};
-        }
+  public void set${prop.methodName}(${prop.instanceVariableType} ${prop.argumentName})
+  {
+    this.${prop.instanceVariableName} = ${prop.argumentName};
+  }
 {% end %}\
 {% when prop.isUnitsEnumeration %}
 {% if debug %}\
-                        // MARKER [RRR]
-                        // Attribute property which is Units enumeration ${prop.name}
+  // MARKER [RRR]
+  // Attribute property which is Units enumeration ${prop.name}
 {% end debug %}\
-        // Property ${prop.name} is a unit companion
-        public static String get${prop.methodName}XsdDefault()
-        {
-                return "${prop.defaultXsdValue}";
-        }
+  // Property ${prop.name} is a unit companion
+  public static String get${prop.methodName}XsdDefault()
+  {
+    return "${prop.defaultXsdValue}";
+  }
 {% end %}\
 {% when prop.maxOccurs == 1 and (not klass.isAbstract or prop.isAttribute or not prop.isComplex() or not prop.isChoice) %}
-        // Property ${prop.name}
-        public ${prop.instanceVariableType} get${prop.methodName}()
-        {
-                return ${prop.instanceVariableName};
-        }
+  // Property ${prop.name}
+  public ${prop.instanceVariableType} get${prop.methodName}()
+  {
+    return ${prop.instanceVariableName};
+  }
 
-        public void set${prop.methodName}(${prop.instanceVariableType} ${prop.argumentName})
-        {
-                this.${prop.instanceVariableName} = ${prop.argumentName};
-        }
+  public void set${prop.methodName}(${prop.instanceVariableType} ${prop.argumentName})
+  {
+    this.${prop.instanceVariableName} = ${prop.argumentName};
+  }
 {% end %}\
 {% when prop.maxOccurs > 1 and not klass.isAbstract %}
-        // Property which occurs more than once
-        public int sizeOf${prop.methodName}List()
-        {
-                return ${prop.instanceVariableName}.size();
-        }
+  // Property which occurs more than once
+  public int sizeOf${prop.methodName}List()
+  {
+    return ${prop.instanceVariableName}.size();
+  }
 
-        public List<${prop.langType}> copy${prop.methodName}List()
-        {
-                return new ArrayList<${prop.langType}>(${prop.instanceVariableName});
-        }
+  public List<${prop.langType}> copy${prop.methodName}List()
+  {
+    return new ArrayList<${prop.langType}>(${prop.instanceVariableName});
+  }
 
-        public ${prop.langType} get${prop.methodName}(int index)
-        {
-                return ${prop.instanceVariableName}.get(index);
-        }
+  public ${prop.langType} get${prop.methodName}(int index)
+  {
+    return ${prop.instanceVariableName}.get(index);
+  }
 
-        public ${prop.langType} set${prop.methodName}(int index, ${prop.langType} ${prop.argumentName})
-        {
+  public ${prop.langType} set${prop.methodName}(int index, ${prop.langType} ${prop.argumentName})
+  {
 {% if klass.type != 'OME' %}\
-        ${prop.argumentName}.set${klass.type}(this);
+    ${prop.argumentName}.set${klass.type}(this);
 {% end %}\
-                return ${prop.instanceVariableName}.set(index, ${prop.argumentName});
-        }
+    return ${prop.instanceVariableName}.set(index, ${prop.argumentName});
+  }
 
-        public void add${prop.methodName}(${prop.langType} ${prop.argumentName})
-        {
+  public void add${prop.methodName}(${prop.langType} ${prop.argumentName})
+  {
 {% if klass.type != 'OME' %}\
-        ${prop.argumentName}.set${klass.type}(this);
+    ${prop.argumentName}.set${klass.type}(this);
 {% end %}\
-                ${prop.instanceVariableName}.add(${prop.argumentName});
-        }
+    ${prop.instanceVariableName}.add(${prop.argumentName});
+  }
 
-        public void remove${prop.methodName}(${prop.langType} ${prop.argumentName})
-        {
-                ${prop.instanceVariableName}.remove(${prop.argumentName});
-        }
+  public void remove${prop.methodName}(${prop.langType} ${prop.argumentName})
+  {
+    ${prop.instanceVariableName}.remove(${prop.argumentName});
+  }
 {% end %}\
 {% otherwise %}
 {% if debug %}\
-        // *** WARNING *** Unhandled or skipped property ${prop.name}
+  // *** WARNING *** Unhandled or skipped property ${prop.name}
 {% end debug %}\
 {% end %}\
 {% end %}\
 {% end %}\
 
-        public Element asXMLElement(Document document)
-        {
-                return asXMLElement(document, null);
-        }
+  public Element asXMLElement(Document document)
+  {
+    return asXMLElement(document, null);
+  }
 
-        protected Element asXMLElement(Document document, Element ${klass.name}_element)
-        {
-                // Creating XML block for ${klass.name}
-                if (${klass.name}_element == null)
-                {
-                        ${klass.name}_element =
-                                        document.createElementNS(NAMESPACE, "${klass.name}");
-                }
+  protected Element asXMLElement(Document document, Element ${klass.name}_element)
+  {
+    // Creating XML block for ${klass.name}
+    if (${klass.name}_element == null)
+    {
+      ${klass.name}_element =
+        document.createElementNS(NAMESPACE, "${klass.name}");
+    }
 
 {% if klass.langBaseType != 'Object' %}\
-                // Element's text data
-                if (this.value != null) {
-                        ${klass.name}_element.setTextContent(this.value.toString());
-                }
+    // Element's text data
+    if (this.value != null) {
+      ${klass.name}_element.setTextContent(this.value.toString());
+    }
 
 {% end if NOT Object %}\
 {% if klass.isAnnotation %}\
-                // Ensure any base annotations add their Elements first
-                ${klass.name}_element = super.asXMLElement(document, ${klass.name}_element);
+    // Ensure any base annotations add their Elements first
+    ${klass.name}_element = super.asXMLElement(document, ${klass.name}_element);
 {% end if isAnnotation %}\
 
 {% for prop in klass.properties.values() %}\
 {% if not prop.isUnitsEnumeration %}\
-                if (${prop.instanceVariableName} != null)
-                {
+    if (${prop.instanceVariableName} != null)
+    {
 {% choose %}\
 {% when prop.name in customAsXMLElementPropertyContent %}\
 {% if debug %}\
-                        // -- BEGIN custom content from ${prop.name} property template --
+      // -- BEGIN custom content from ${prop.name} property template --
 {% end debug %}\
 ${customAsXMLElementPropertyContent[prop.name]}
 {% if debug %}\
-                        // -- END custom content from ${prop.name} property template --
+      // -- END custom content from ${prop.name} property template --
 {% end debug %}\
 {% end when %}\
 {% when prop.hasBaseAttribute %}\
-                        // Element's text data
+      // Element's text data
 {% if not prop.type == 'base64Binary' %}\
-                        ${klass.name}_element.setTextContent(${prop.instanceVariableName}.toString());
+      ${klass.name}_element.setTextContent(${prop.instanceVariableName}.toString());
 {% end if not prop.type %}\
 {% if prop.type == 'base64Binary' %}\
-                        String encodedString = DatatypeConverter.printBase64Binary(${prop.instanceVariableName});
-                        ${klass.name}_element.setTextContent(encodedString);
+      String encodedString = DatatypeConverter.printBase64Binary(${prop.instanceVariableName});
+      ${klass.name}_element.setTextContent(encodedString);
 {% end if prop.type %}\
 {% end when %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
-                        // Reference property ${prop.name} which occurs more than once
-                        for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
-                        {
-                                ${prop.name} o = new ${prop.name}();
-                                o.setID(${prop.instanceVariableName}_value.getID());
-                                ${klass.name}_element.appendChild(o.asXMLElement(document));
-                        }
+      // Reference property ${prop.name} which occurs more than once
+      for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
+      {
+        ${prop.name} o = new ${prop.name}();
+        o.setID(${prop.instanceVariableName}_value.getID());
+        ${klass.name}_element.appendChild(o.asXMLElement(document));
+      }
 {% end when %}\
 {% when prop.isReference %}\
-                        // Reference property ${prop.name}
-                        ${prop.name} o = new ${prop.name}();
-                        o.setID(${prop.instanceVariableName}.getID());
-                        ${klass.name}_element.appendChild(o.asXMLElement(document));
+      // Reference property ${prop.name}
+      ${prop.name} o = new ${prop.name}();
+      o.setID(${prop.instanceVariableName}.getID());
+      ${klass.name}_element.appendChild(o.asXMLElement(document));
 {% end when %}\
 {% when prop.isBackReference %}\
-                        // *** IGNORING *** Skipped back reference ${prop.name}
+      // *** IGNORING *** Skipped back reference ${prop.name}
 {% end when %}\
 {% when prop.hasUnitsCompanion and prop.maxOccurs == 1 and prop.isAttribute %}\
 {% if debug %}\
-                        // MARKER [QQQ]
+      // MARKER [QQQ]
 {% end debug %}\
-                        // Attribute property ${prop.name} with units companion prop.unitsCompanion.name
-                        if (${prop.instanceVariableName}.value() != null)
-                        {
+      // Attribute property ${prop.name} with units companion prop.unitsCompanion.name
+      if (${prop.instanceVariableName}.value() != null)
+      {
 {% if prop.type.endswith('Int') %}
-                                ${klass.name}_element.setAttribute("${prop.name}", Long.toString(${prop.instanceVariableName}.value().longValue()));
+        ${klass.name}_element.setAttribute("${prop.name}", Long.toString(${prop.instanceVariableName}.value().longValue()));
 {% end if prop.type %}
 {% if not prop.type.endswith('Int') %}
-                                ${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName}.value().toString());
+        ${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName}.value().toString());
 {% end if not prop.type %}
-                        }
-                        if (${prop.instanceVariableName}.unit() != null)
-                        {
-                                try
-                                {
-                                        ${prop.unitsCompanion.langType} enumUnits = ${prop.unitsCompanion.langType}.fromString(${prop.instanceVariableName}.unit().getSymbol());
-                                        ${klass.name}_element.setAttribute("${prop.unitsCompanion.name}", enumUnits.toString());
-                                } catch (EnumerationException e)
-                                {
-                                        LOGGER.debug("Unable to create xml for ${klass.name}:${prop.unitsCompanion.name}: {}", e.toString());
-                                }
-                        }
+      }
+      if (${prop.instanceVariableName}.unit() != null)
+      {
+        try
+        {
+          ${prop.unitsCompanion.langType} enumUnits = ${prop.unitsCompanion.langType}.fromString(${prop.instanceVariableName}.unit().getSymbol());
+          ${klass.name}_element.setAttribute("${prop.unitsCompanion.name}", enumUnits.toString());
+        } catch (EnumerationException e)
+        {
+          LOGGER.debug("Unable to create xml for ${klass.name}:${prop.unitsCompanion.name}: {}", e.toString());
+        }
+      }
 {% end when %}\
 {% when prop.maxOccurs == 1 and prop.isAttribute %}\
 {% if debug %}\
-                        // MARKER [III]
+      // MARKER [III]
 {% end debug %}\
-                        // Attribute property ${prop.name}
-                        ${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName}.toString());
+      // Attribute property ${prop.name}
+      ${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName}.toString());
 {% end when %}\
 {% when prop.maxOccurs == 1 and prop.isComplex() %}\
-                        // Element property ${prop.name} which is complex (has
-                        // sub-elements)
+      // Element property ${prop.name} which is complex (has
+      // sub-elements)
 {% if prop.langTypeNS != 'List<MapPair>' %}\
-                        ${klass.name}_element.appendChild(${prop.instanceVariableName}.asXMLElement(document));
+      ${klass.name}_element.appendChild(${prop.instanceVariableName}.asXMLElement(document));
 {% end %}\
 {% if prop.langTypeNS == 'List<MapPair>' %}\
-                        Element ${prop.instanceVariableName}_child =
-                        document.createElementNS(NAMESPACE, "${prop.name}");
-                        for (MapPair entry: ${prop.instanceVariableName}) {
-                                Element pair = document.createElementNS(NAMESPACE, "M");
-                                pair.setAttribute("K", entry.getName());
-                                pair.setTextContent(entry.getValue());
-                                ${prop.instanceVariableName}_child.appendChild(pair);
-                        }
+      Element ${prop.instanceVariableName}_child =
+      document.createElementNS(NAMESPACE, "${prop.name}");
+      for (MapPair entry: ${prop.instanceVariableName}) {
+        Element pair = document.createElementNS(NAMESPACE, "M");
+        pair.setAttribute("K", entry.getName());
+        pair.setTextContent(entry.getValue());
+        ${prop.instanceVariableName}_child.appendChild(pair);
+      }
 
-                        ${klass.name}_element.appendChild(${prop.instanceVariableName}_child);
+    ${klass.name}_element.appendChild(${prop.instanceVariableName}_child);
 {% end %}\
 {% end when %}\
 {% when prop.maxOccurs == 1 %}\
-                        // Element property ${prop.name} which is not complex (has no
-                        // sub-elements)
-                        Element ${prop.instanceVariableName}_element =
-                                        document.createElementNS(NAMESPACE, "${prop.name}");
-                        ${prop.instanceVariableName}_element.setTextContent(${prop.instanceVariableName}.toString());
-                        ${klass.name}_element.appendChild(${prop.instanceVariableName}_element);
+    // Element property ${prop.name} which is not complex (has no
+    // sub-elements)
+    Element ${prop.instanceVariableName}_element =
+      document.createElementNS(NAMESPACE, "${prop.name}");
+      ${prop.instanceVariableName}_element.setTextContent(${prop.instanceVariableName}.toString());
+      ${klass.name}_element.appendChild(${prop.instanceVariableName}_element);
 {% end when %}\
 {% when prop.maxOccurs > 1 and prop.isComplex() %}\
-                        // Element property ${prop.name} which is complex (has
-                        // sub-elements) and occurs more than once
-                        for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
-                        {
-                                ${klass.name}_element.appendChild(${prop.instanceVariableName}_value.asXMLElement(document));
-                        }
+      // Element property ${prop.name} which is complex (has
+      // sub-elements) and occurs more than once
+      for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
+      {
+        ${klass.name}_element.appendChild(${prop.instanceVariableName}_value.asXMLElement(document));
+      }
 {% end when %}\
 {% when prop.maxOccurs > 1 %}\
-                        // Element property ${prop.name} which is not complex (has no
-                        // sub-elements) which occurs more than once
-                        for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
-                        {
-                                Element ${prop.instanceVariableName}_element =
-                                                document.createElementNS(NAMESPACE, "${prop.name}");
-                                ${prop.instanceVariableName}_element.setTextContent(${prop.instanceVariableName}_value.toString());
-                                ${klass.name}_element.appendChild(${prop.instanceVariableName}_element);
-                        }
+      // Element property ${prop.name} which is not complex (has no
+      // sub-elements) which occurs more than once
+      for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
+      {
+        Element ${prop.instanceVariableName}_element =
+        document.createElementNS(NAMESPACE, "${prop.name}");
+        ${prop.instanceVariableName}_element.setTextContent(${prop.instanceVariableName}_value.toString());
+        ${klass.name}_element.appendChild(${prop.instanceVariableName}_element);
+      }
 {% end when %}\
 {% otherwise %}\
 {% if debug %}\
-                        // *** WARNING *** Unhandled or skipped property ${prop.name}
+      // *** WARNING *** Unhandled or skipped property ${prop.name}
 {% end debug %}\
 {% end otherwise %}\
 {% end choose %}\
-                }
+    }
 {% end if %}\
 {% end for %}\
 
 {% choose %}\
 {% when klass.isAnnotation %}\
-                return ${klass.name}_element;
+    return ${klass.name}_element;
 {% end when isAnnotation %}\
 {% otherwise %}\
-                return super.asXMLElement(document, ${klass.name}_element);
+    return super.asXMLElement(document, ${klass.name}_element);
 {% end otherwise %}\
 {% end choose %}\
-        }
+  }
 }

--- a/components/xsd-fu/templates-java/OMEXMLModelObject_Reference.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject_Reference.template
@@ -1,11 +1,11 @@
-                /**
-                 * Retrieves the reference's target object ID.
-                 * @return See above.
-                 */
-                public abstract String getID();
+  /**
+   * Retrieves the reference's target object ID.
+   * @return See above.
+   */
+  public abstract String getID();
 
-                /**
-                 * Sets the reference's target object ID.
-                 * @param id The object ID to set.
-                 */
-                public abstract void setID(String id);
+  /**
+   * Sets the reference's target object ID.
+   * @param id The object ID to set.
+   */
+  public abstract void setID(String id);

--- a/components/xsd-fu/templates-java/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
@@ -1,22 +1,22 @@
-                        Document Value_document = null;
-                        try
-                        {
-                                javax.xml.parsers.DocumentBuilderFactory factory =
-                                        javax.xml.parsers.DocumentBuilderFactory.newInstance();
-                                factory.setNamespaceAware(false);
-                                javax.xml.parsers.DocumentBuilder parser =
-                                        factory.newDocumentBuilder();
-                                org.xml.sax.InputSource is = new org.xml.sax.InputSource();
-                                is.setCharacterStream(new java.io.StringReader("<Value>"+value+"</Value>"));
-                                Value_document = parser.parse(is);
-                        }
-                        catch (Exception e)
-                        {
-                                throw new RuntimeException(e);
-                        }
+      Document Value_document = null;
+      try
+      {
+        javax.xml.parsers.DocumentBuilderFactory factory =
+        javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(false);
+        javax.xml.parsers.DocumentBuilder parser =
+          factory.newDocumentBuilder();
+        org.xml.sax.InputSource is = new org.xml.sax.InputSource();
+        is.setCharacterStream(new java.io.StringReader("<Value>"+value+"</Value>"));
+        Value_document = parser.parse(is);
+      }
+      catch (Exception e)
+      {
+        throw new RuntimeException(e);
+      }
 
-                        NodeList value_subNodes = Value_document.getChildNodes();
-                        Node value_subNode = value_subNodes.item(0);
-                        value_subNode = document.importNode(value_subNode, true);
+      NodeList value_subNodes = Value_document.getChildNodes();
+      Node value_subNode = value_subNodes.item(0);
+      value_subNode = document.importNode(value_subNode, true);
 
-                        XMLAnnotation_element.appendChild(value_subNode);
+      XMLAnnotation_element.appendChild(value_subNode);

--- a/components/xsd-fu/templates-java/OMEXMLModelObject_XMLAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject_XMLAnnotation_update_Value.template
@@ -1,47 +1,47 @@
-                List<Element> Value_nodeList =
-                                getChildrenByTagName(element, "Value");
-                if (Value_nodeList.size() > 1)
-                {
-                        // TODO: Should be its own Exception
-                        throw new RuntimeException(String.format(
-                                        "Value node list size %d != 1",
-                                        Value_nodeList.size()));
-                }
-                else if (Value_nodeList.size() != 0)
-                {
-                        // Element property Value which is complex (has only
-                        // sub-elements, no attributes, no text content)
-                        java.io.StringWriter sw = new java.io.StringWriter();
-                        javax.xml.transform.stream.StreamResult sr =
-                                new javax.xml.transform.stream.StreamResult(sw);
-                        javax.xml.transform.TransformerFactory tf =
-                                javax.xml.transform.TransformerFactory.newInstance();
+    List<Element> Value_nodeList =
+      getChildrenByTagName(element, "Value");
+    if (Value_nodeList.size() > 1)
+    {
+      // TODO: Should be its own Exception
+      throw new RuntimeException(String.format(
+        "Value node list size %d != 1",
+        Value_nodeList.size()));
+    }
+    else if (Value_nodeList.size() != 0)
+    {
+      // Element property Value which is complex (has only
+      // sub-elements, no attributes, no text content)
+      java.io.StringWriter sw = new java.io.StringWriter();
+      javax.xml.transform.stream.StreamResult sr =
+      new javax.xml.transform.stream.StreamResult(sw);
+      javax.xml.transform.TransformerFactory tf =
+      javax.xml.transform.TransformerFactory.newInstance();
 
-                        try
-                        {
-                                javax.xml.transform.Transformer t = tf.newTransformer();
-                                t.setOutputProperty(
-                                        javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION, "yes");
-                                t.setOutputProperty(
-                                        javax.xml.transform.OutputKeys.INDENT, "no");
-                                NodeList childNodeList = Value_nodeList.get(0).getChildNodes();
-                                for (int i = 0; i < childNodeList.getLength(); i++)
-                                {
-                                        // some parsers will pick up text nodes here, which we can ignore
-                                        if (childNodeList.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                                          try {
-                                                  t.transform(new javax.xml.transform.dom.DOMSource(
-                                                                childNodeList.item(i)), sr);
-                                          }
-                                          catch (javax.xml.transform.TransformerException te) {
-                                                        LOGGER.warn("Failed to transform node #" + i, te);
-                                          }
-                                        }
-                                }
-                                setValue(sw.toString().trim());
-                        }
-                        catch (Exception e)
-                        {
-                                throw new RuntimeException(e);
-                        }
-                }
+      try
+      {
+        javax.xml.transform.Transformer t = tf.newTransformer();
+        t.setOutputProperty(
+          javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION, "yes");
+        t.setOutputProperty(
+        javax.xml.transform.OutputKeys.INDENT, "no");
+        NodeList childNodeList = Value_nodeList.get(0).getChildNodes();
+        for (int i = 0; i < childNodeList.getLength(); i++)
+        {
+          // some parsers will pick up text nodes here, which we can ignore
+          if (childNodeList.item(i).getNodeType() == Node.ELEMENT_NODE) {
+          try {
+            t.transform(new javax.xml.transform.dom.DOMSource(
+              childNodeList.item(i)), sr);
+          }
+          catch (javax.xml.transform.TransformerException te) {
+            LOGGER.warn("Failed to transform node #" + i, te);
+          }
+        }
+      }
+      setValue(sw.toString().trim());
+    }
+    catch (Exception e)
+    {
+      throw new RuntimeException(e);
+    }
+  }


### PR DESCRIPTION
Follow-up work of https://github.com/openmicroscopy/bioformats/pull/2450. This commit should update the style of the generated Java classes to match the rest of the code base.

See https://github.com/openmicroscopy/bioformats/pull/2453/files?w=1 for the diff without whitespace changes.

Check all Bio-Formats jobs are green and that the non-whitespace difference between the `develop/latest/generated_sources` and `develop/merge/generated_sources` branches of @snoopycrimecop's fork is empty.