### PR TITLE
xsd-fu: Specialise C++ Quantity types by both unit and value

### DIFF
--- a/components/xsd-fu/python/ome/modeltools/language.py
+++ b/components/xsd-fu/python/ome/modeltools/language.py
@@ -292,11 +292,11 @@ class Java(Language):
     def getDefaultModelBaseClass(self):
         return "AbstractOMEModelObject"
 
-    def typeToUnitsType(self, valueType):
-        return self.model_unit_map[valueType]
+    def typeToUnitsType(self, unitType):
+        return self.model_unit_map[unitType]
 
-    def typeToDefault(self, valueType):
-        return self.model_unit_default[valueType]
+    def typeToDefault(self, unitType):
+        return self.model_unit_default[unitType]
 
     def index_signature(self, name, max_occurs, level, dummy=False):
         """Makes a Java method signature dictionary from an index name."""
@@ -376,8 +376,11 @@ class CXX(Language):
     def getDefaultModelBaseClass(self):
         return "detail::OMEModelObject"
 
-    def typeToUnitsType(self, valueType):
-        return "%s::Quantity<%s > " % (self.omexml_model_quantity_package, valueType)
+    def typeToUnitsType(self, unitType, valueType=None):
+        if valueType is None:
+            return "%s::Quantity<%s > " % (self.omexml_model_quantity_package, unitType)
+        else:
+            return "%s::Quantity<%s, %s > " % (self.omexml_model_quantity_package, unitType, valueType)
 
     def index_signature(self, name, max_occurs, level, dummy=False):
         """Makes a C++ method signature dictionary from an index name."""

--- a/components/xsd-fu/python/ome/modeltools/property.py
+++ b/components/xsd-fu/python/ome/modeltools/property.py
@@ -208,8 +208,14 @@ class OMEModelProperty(OMEModelEntity):
         name = self.langType
         if isinstance(self.model.opts.lang, language.CXX):
             if self.hasUnitsCompanion:
-                name = self.model.opts.lang.typeToUnitsType(
-                    self.unitsCompanion.langTypeNS)
+                if name == "double":
+                    name = self.model.opts.lang.typeToUnitsType(
+                        self.unitsCompanion.langTypeNS)
+                else:
+                    name = self.model.opts.lang.typeToUnitsType(
+                        self.unitsCompanion.langTypeNS,
+                        "%s::primitives::%s"
+                        % (self.model.opts.lang.omexml_model_package, name))
             elif self.isEnumeration:
                 name = ("%s::enums::%s"
                         % (self.model.opts.lang.omexml_model_package, name))
@@ -231,8 +237,11 @@ class OMEModelProperty(OMEModelEntity):
         mstype = None
 
         if self.hasUnitsCompanion:
-            mstype = self.model.opts.lang.typeToUnitsType(
-                self.unitsCompanion.metadataStoreArgType)
+            if isinstance(self.model.opts.lang, language.Java):
+                mstype = self.model.opts.lang.typeToUnitsType(
+                    self.unitsCompanion.metadataStoreArgType)
+            elif isinstance(self.model.opts.lang, language.CXX):
+                mstype = self.langTypeNS
 
         if self.name == "Transform":
             if isinstance(self.model.opts.lang, language.Java):
@@ -268,8 +277,11 @@ class OMEModelProperty(OMEModelEntity):
         mstype = None
 
         if self.hasUnitsCompanion:
-            mstype = self.model.opts.lang.typeToUnitsType(
-                self.unitsCompanion.metadataStoreRetType)
+            if isinstance(self.model.opts.lang, language.Java):
+                mstype = self.model.opts.lang.typeToUnitsType(
+                    self.unitsCompanion.metadataStoreRetType)
+            elif isinstance(self.model.opts.lang, language.CXX):
+                mstype = self.langTypeNS
 
         if self.name == "Transform":
             if isinstance(self.model.opts.lang, language.Java):
@@ -525,8 +537,7 @@ class OMEModelProperty(OMEModelEntity):
                     self.minOccurs > 0):
                 itype = self.langTypeNS
             elif self.hasUnitsCompanion:
-                qtype = self.model.opts.lang.typeToUnitsType(
-                    self.unitsCompanion.langTypeNS)
+                qtype = self.langTypeNS
                 if self.minOccurs == 0:
                     if self.maxOccurs == 1:
                         itype = "const ome::compat::shared_ptr<%s>&" % qtype
@@ -579,8 +590,7 @@ class OMEModelProperty(OMEModelEntity):
                     self.minOccurs > 0):
                 itype = {' const': self.langTypeNS}
             elif self.hasUnitsCompanion:
-                qtype = self.model.opts.lang.typeToUnitsType(
-                    self.unitsCompanion.langTypeNS)
+                qtype = self.langTypeNS
                 if self.minOccurs == 0:
                     if self.maxOccurs == 1:
                         itype = {' const': "const ome::compat::shared_ptr<%s>&" % qtype,
@@ -825,8 +835,7 @@ class OMEModelProperty(OMEModelEntity):
             if ns_sep.startswith('::'):
                 ns_sep = ' ' + ns_sep
             if self.hasUnitsCompanion:
-                qtype = self.model.opts.lang.typeToUnitsType(
-                    self.unitsCompanion.langTypeNS)
+                qtype = self.langTypeNS
                 if self.minOccurs == 0:
                     if self.maxOccurs == 1:
                         itype = "ome::compat::shared_ptr<%s>" % qtype


### PR DESCRIPTION
Tweak the unit types inside the python generator.  This essentially changes `Quantity<Unit, double>` to `Quantity<Unit, Value>`.  Note `double` is the default type in the Quantity template and so not actually generated.  Example: `Quantity<Length>` becomes `Quantity<Length, NonNegativeFloat>`.  This involves no code changes--it's completely transparent from an end use point of view.  Unless you were using values out of range of course, in which case it will now correctly throw an exception!

Future work: A corresponding change to the Java code generator would be useful, if there's a way to do that with the existing Quantity and Unit generics.

--------


Testing: Check jobs are green.  Also check generated source changes.