### PR TITLE
cpp: ome-xml: Throw less exceptions in OMEModelObject::getChildrenByTagName

### DIFF
--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -108,10 +108,17 @@ namespace ome
             {
               try
                 {
-                  common::xml::dom::Element child(pos->get(), false);
-                  if (child && name == stripNamespacePrefix(common::xml::String(child->getNodeName())))
+                  // This pointer check is unnecessary--the Element
+                  // class would throw; but this avoids the need to
+                  // throw and catch many exceptions during document
+                  // processing.
+                  if (dynamic_cast<const xercesc::DOMElement *>(pos->get()))
                     {
-                      ret.push_back(child);
+                      common::xml::dom::Element child(pos->get(), false);
+                      if (child && name == stripNamespacePrefix(common::xml::String(child->getNodeName())))
+                        {
+                          ret.push_back(child);
+                        }
                     }
                 }
               catch (std::logic_error&)

--- a/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
+++ b/cpp/lib/ome/xml/model/detail/OMEModelObject.cpp
@@ -110,8 +110,8 @@ namespace ome
                 {
                   // This pointer check is unnecessary--the Element
                   // class would throw; but this avoids the need to
-                  // throw and catch many exceptions during document
-                  // processing.
+                  // throw and catch many std::logic_error exceptions
+                  // during document processing.
                   if (dynamic_cast<const xercesc::DOMElement *>(pos->get()))
                     {
                       common::xml::dom::Element child(pos->get(), false);


### PR DESCRIPTION
Rather than waiting for an exception to be thrown by the
Element RAII wrapper, check whether it will throw
beforehand.  This isn't strictly necessary, but it makes
the processing slightly more efficient and, more
importantly, makes it easier to debug the model code
since only important exceptions will be thrown.

--------

Testing: Check builds are green.  There's no change in functionality since this is purely an optimisation, so nothing specific to test with respect to behaviour changes.