### PR TITLE
ClassList: discovery improvements 

### DIFF
--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -102,6 +102,14 @@
 
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <additionalClasspathElements>
+              <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -101,24 +101,10 @@ public class ClassList<T> {
   {
     this(base);
     if (file == null) return;
-    classes = parseFile(file, location, true);
+    classes = parseFile(file, location);
   }
 
   // -- ClassList API methods --
-
-  /**
-   * Parses a list of classes from a configuration file.
-   * @param file Configuration file containing the list of classes.
-   * @param location Class indicating which package to search for the file.
-   *        If {@code null}, 'file' is interpreted as an absolute path name.
-   * @return A list of classes parsed from the file
-   * @throws IOException if the file cannot be read.
-   */
-  public List<Class<? extends T>> parseFile(String file, Class<?> location)
-    throws IOException
-  {
-    return parseFile(file, location, false);
-  }
 
    /**
     * Parses a list of classes from a configuration file.
@@ -128,7 +114,7 @@ public class ClassList<T> {
     * @return A list of classes parsed from the file
     * @throws IOException if the file cannot be read.
     */
-  public List<Class<? extends T>> parseFile(String file, Class<?> location, boolean strict)
+  public List<Class<? extends T>> parseFile(String file, Class<?> location)
     throws IOException
   {
     List<Class<? extends T>> parsedClasses = new ArrayList<Class<? extends T>>();
@@ -183,7 +169,7 @@ public class ClassList<T> {
         LOGGER.debug("", exc);
       }
       if (c == null) {
-        if (strict) LOGGER.error("\"{}\" is not valid.", line);
+        LOGGER.error("\"{}\" is not valid.", line);
         continue;
       }
       parsedClasses.add(c);

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -90,7 +90,7 @@ public class ClassList<T> {
    * @param file Configuration file containing the list of classes.
    * @param base Base class to which all classes are assignable.
    * @param location Class indicating which package to search for the file.
-   *  If null, 'file' is interpreted as an absolute path name.
+   *        If {@code null}, 'file' is interpreted as an absolute path name.
    * @throws IOException if the file cannot be read.
    */
   public ClassList(String file, Class<T> base, Class<?> location)
@@ -103,6 +103,20 @@ public class ClassList<T> {
 
   // -- ClassList API methods --
 
+  /**
+   * Parses a list of classes from a configuration file.
+   * @param file Configuration file containing the list of classes.
+   * @param location Class indicating which package to search for the file.
+   *        If {@code null}, 'file' is interpreted as an absolute path name.
+   * @return A list of classes parsed from the file
+   * @throws IOException if the file cannot be read.
+   */
+  public List<Class<? extends T>> parseFile(String file, Class<?> location)
+    throws IOException
+  {
+    return parseFile(file, location, true);
+  }
+
    /**
     * Parses a list of classes from a configuration file.
     * @param file Configuration file containing the list of classes.
@@ -111,7 +125,7 @@ public class ClassList<T> {
     * @return A list of classes parsed from the file
     * @throws IOException if the file cannot be read.
     */
-  public List<Class<? extends T>> parseFile(String file, Class<?> location)
+  public List<Class<? extends T>> parseFile(String file, Class<?> location, boolean strict)
     throws IOException
   {
     List<Class<? extends T>> parsedClasses = new ArrayList<Class<? extends T>>();
@@ -158,7 +172,7 @@ public class ClassList<T> {
         LOGGER.debug("", exc);
       }
       if (c == null) {
-        LOGGER.error("\"{}\" is not valid.", line);
+        if (strict) LOGGER.error("\"{}\" is not valid.", line);
         continue;
       }
       parsedClasses.add(c);

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -100,7 +100,7 @@ public class ClassList<T> {
   {
     this(base);
     if (file == null) return;
-    classes = parseFile(file, location);
+    classes = parseFile(file, location, true);
   }
 
   // -- ClassList API methods --
@@ -116,7 +116,7 @@ public class ClassList<T> {
   public List<Class<? extends T>> parseFile(String file, Class<?> location)
     throws IOException
   {
-    return parseFile(file, location, true);
+    return parseFile(file, location, false);
   }
 
    /**
@@ -195,6 +195,14 @@ public class ClassList<T> {
    * Adds the given class, which must be assignable
    * to the base class, to the list.
    */
+  public void addClass(int index, Class<? extends T> c) {
+    classes.add(index, c);
+  }
+
+  /**
+   * Adds the given class, which must be assignable
+   * to the base class, to the list.
+   */
   public void addClass(Class<? extends T> c) {
     classes.add(c);
   }
@@ -202,6 +210,24 @@ public class ClassList<T> {
   /** Removes the given class from the list. */
   public void removeClass(Class<? extends T> c) {
     classes.remove(c);
+  }
+
+  /**
+   * Appends a list of classes which must be assignable to the base class
+   */
+  public void append(List<Class<? extends T>> l) {
+    for (int i = 0; i < l.size(); i++) {
+      addClass(l.get(i));
+    }
+  }
+
+  /**
+   * Prepends a list of classes which must be assignable to the base class
+   */
+  public void prepend(List<Class<? extends T>> l) {
+    for (int i = l.size() -1; i >= 0; i--) {
+      addClass(0, l.get(i));
+    }
   }
 
   /** Gets the list of classes as an array. */

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -38,6 +38,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -215,10 +216,24 @@ public class ClassList<T> {
   /**
    * Appends a list of classes which must be assignable to the base class
    */
+  public void append(ClassList<T> c) {
+    append(Arrays.asList(c.getClasses()));
+  }
+
+  /**
+   * Appends a list of classes which must be assignable to the base class
+   */
   public void append(List<Class<? extends T>> l) {
     for (int i = 0; i < l.size(); i++) {
       addClass(l.get(i));
     }
+  }
+
+  /**
+   * Appends a list of classes which must be assignable to the base class
+   */
+  public void prepend(ClassList<T> c) {
+    prepend(Arrays.asList(c.getClasses()));
   }
 
   /**

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -184,7 +184,7 @@ public class ClassList<T> {
         classes.add(c);
         for (Map.Entry<String, String> entry : o.entrySet())
         {
-          options.put(line + "." + entry.getKey(), entry.getValue());
+          addOption(line + "." + entry.getKey(), entry.getValue());
         }
       }
   }
@@ -287,6 +287,11 @@ public class ClassList<T> {
   /** Gets the list of options as a map. */
   public Map<String, String> getOptions() {
     return options;
+  }
+
+  /** Add a key/value pair to the list of options.*/
+  public void addOption(String key, String value) {
+    options.put(key, value);
   }
 
   // -- Helper methods --

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -34,7 +34,9 @@ package loci.formats;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -129,16 +131,24 @@ public class ClassList<T> {
     throws IOException
   {
     List<Class<? extends T>> parsedClasses = new ArrayList<Class<? extends T>>();
-    // read classes from file
-    BufferedReader in = null;
+
+    // locate an input stream
+    InputStream stream = null;
     if (location == null) {
-    in = new BufferedReader(new InputStreamReader(
-      new FileInputStream(file), Constants.ENCODING));
+      try {
+        stream = new FileInputStream(file);
+      } catch (FileNotFoundException e) {
+        LOGGER.debug(e.getMessage());
+      }
+    } else stream = location.getResourceAsStream(file);
+    if (stream == null) {
+      LOGGER.warn("Could not find " + file);
+      return parsedClasses;
     }
-    else {
-    in = new BufferedReader(new InputStreamReader(
-      location.getResourceAsStream(file), Constants.ENCODING));
-    }
+
+    // Read classes from file
+    BufferedReader in = null;
+    in = new BufferedReader(new InputStreamReader(stream, Constants.ENCODING));
     while (true) {
       String line = null;
       line = in.readLine();

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -51,8 +51,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ClassList is a list of classes for use with ImageReader or ImageWriter,
- * parsed from a configuration file such as readers.txt or writers.txt.
+ * ClassList is a list of classes for use with {@link ImageReader} or
+ * {@link ImageWriter}, parsed from a configuration file such as readers.txt
+ * or writers.txt.
  *
  * @author Curtis Rueden ctrueden at wisc.edu
  */
@@ -116,7 +117,7 @@ public class ClassList<T> {
   /**
    * Parses one or more options from a string.
    * @param s  A string containing a series of options formatted as
-   *           key1=value1,key2=value2
+   *           <i>key1=value1,key2=value2</i>.
    * @return a map populated with the parsed key/value pairs
    */
   public Map<String, String> parseOptions(String s)
@@ -133,7 +134,7 @@ public class ClassList<T> {
    * Parses a class from a string including options and comments.
    *
    * This function assumes the string is formatted as
-   * "package.class[key1=value1,key2=value2] # comments". Options will be
+   * <i>package.class[key1=value1,key2=value2] # comments</i>. Options will be
    * parsed and stored in a local map. If the class can be loaded, then each
    * key/value pair will be stored in the options as package.class.key/value.
    *
@@ -193,7 +194,6 @@ public class ClassList<T> {
     * @param file Configuration file containing the list of classes.
     * @param location Class indicating which package to search for the file.
     *        If {@code null}, 'file' is interpreted as an absolute path name.
-    * @return A list of classes parsed from the file
     * @throws IOException if the file cannot be read.
     */
   public void parseFile(String file, Class<?> location)
@@ -247,7 +247,7 @@ public class ClassList<T> {
   }
 
   /**
-   * Appends a list of classes which must be assignable to the base class
+   * Appends a class list which must be assignable to the base class
    */
   public void append(ClassList<T> c) {
     append(Arrays.asList(c.getClasses()));
@@ -263,7 +263,7 @@ public class ClassList<T> {
   }
 
   /**
-   * Prepends a list of classes which must be assignable to the base class
+   * Prepends a class list which must be assignable to the base class
    */
   public void prepend(ClassList<T> c) {
     prepend(Arrays.asList(c.getClasses()));
@@ -284,7 +284,7 @@ public class ClassList<T> {
     return classes.toArray(new Class[0]);
   }
 
-  /** Gets the list of classes as an array. */
+  /** Gets the list of options as a map. */
   public Map<String, String> getOptions() {
     return options;
   }

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -63,6 +63,9 @@ public class ClassList<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClassList.class);
 
+  /* A string array containing a list*/
+  private static final String[] KEYS = {};
+
   // -- Fields --
 
   /** Base class to which all classes are assignable. */
@@ -296,8 +299,16 @@ public class ClassList<T> {
     return options;
   }
 
+  /** Returns whether a given key is a whitelisted option.*/
+  public boolean isWhitelistedKey(String key) {
+    return false;
+  }
+
   /** Add a key/value pair to the list of options.*/
   public void addOption(String key, String value) {
+    if (!isWhitelistedKey(key)) {
+      LOGGER.debug("{} is not a whitelisted key", key);
+    }
     options.put(key, value);
   }
 

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -123,9 +123,16 @@ public class ClassList<T> {
   public Map<String, String> parseOptions(String s)
    {
       Map<String, String> map = new HashMap<String, String>();
-      StringTokenizer st = new StringTokenizer(s, ",=");
-      while (st.hasMoreTokens()) {
-        map.put(st.nextToken(), st.nextToken());
+      StringTokenizer st1 = new StringTokenizer(s, ",");
+      StringTokenizer st2;
+      while (st1.hasMoreTokens()) {
+        st2 = new StringTokenizer(st1.nextToken(), "=");
+        if (st2.hasMoreTokens()) {
+          String key = st2.nextToken();
+          if (st2.hasMoreTokens()) {
+            map.put(key, st2.nextToken());
+          }
+        }
       }
       return map;
    }

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -41,7 +41,6 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
-
 import loci.common.Constants;
 
 import org.slf4j.Logger;
@@ -101,7 +100,7 @@ public class ClassList<T> {
   {
     this(base);
     if (file == null) return;
-    classes = parseFile(file, location);
+    parseFile(file, location);
   }
 
   // -- ClassList API methods --
@@ -112,13 +111,13 @@ public class ClassList<T> {
    *             must be formatted as "package.class  # comments".
    * @return A class parsed from the input string or {@code null}.
    */
- public Class<? extends T> parseLine(String line)
+  public void parseLine(String line)
    {
       // ignore characters following # sign (comments)
       int ndx = line.indexOf("#");
       if (ndx >= 0) line = line.substring(0, ndx);
       line = line.trim();
-      if (line.equals("")) return null;
+      if (line.equals("")) return;
 
       // load class
       Class<? extends T> c = null;
@@ -143,8 +142,9 @@ public class ClassList<T> {
       }
       if (c == null) {
         LOGGER.error("\"{}\" is not valid.", line);
+      } else {
+        classes.add(c);
       }
-      return c;
   }
 
    /**
@@ -155,11 +155,9 @@ public class ClassList<T> {
     * @return A list of classes parsed from the file
     * @throws IOException if the file cannot be read.
     */
-  public List<Class<? extends T>> parseFile(String file, Class<?> location)
+  public void parseFile(String file, Class<?> location)
     throws IOException
   {
-    List<Class<? extends T>> parsedClasses = new ArrayList<Class<? extends T>>();
-
     // locate an input stream
     InputStream stream = null;
     if (location == null) {
@@ -171,24 +169,19 @@ public class ClassList<T> {
     } else stream = location.getResourceAsStream(file);
     if (stream == null) {
       LOGGER.warn("Could not find " + file);
-      return parsedClasses;
+      return;
     }
 
     // Read classes from file
     BufferedReader in = null;
     in = new BufferedReader(new InputStreamReader(stream, Constants.ENCODING));
-    Class<? extends T> c;
     while (true) {
       String line = null;
       line = in.readLine();
       if (line == null) break;
-
-      c = parseLine(line);
-      if (c == null) continue;
-      parsedClasses.add(c);
+      parseLine(line);
     }
     in.close();
-    return parsedClasses;
   }
 
   /**

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -111,7 +111,7 @@ public class ClassList<T> {
     * @return A list of classes parsed from the file
     * @throws IOException if the file cannot be read.
     */
-  private List<Class<? extends T>> parseFile(String file, Class<?> location)
+  public List<Class<? extends T>> parseFile(String file, Class<?> location)
     throws IOException
   {
     List<Class<? extends T>> parsedClasses = new ArrayList<Class<? extends T>>();

--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -96,19 +96,34 @@ public class ClassList<T> {
   public ClassList(String file, Class<T> base, Class<?> location)
     throws IOException
   {
-    this.base = base;
-    classes = new ArrayList<Class<? extends T>>();
+    this(base);
     if (file == null) return;
+    classes = parseFile(file, location);
+  }
 
+  // -- ClassList API methods --
+
+   /**
+    * Parses a list of classes from a configuration file.
+    * @param file Configuration file containing the list of classes.
+    * @param location Class indicating which package to search for the file.
+    *        If {@code null}, 'file' is interpreted as an absolute path name.
+    * @return A list of classes parsed from the file
+    * @throws IOException if the file cannot be read.
+    */
+  private List<Class<? extends T>> parseFile(String file, Class<?> location)
+    throws IOException
+  {
+    List<Class<? extends T>> parsedClasses = new ArrayList<Class<? extends T>>();
     // read classes from file
     BufferedReader in = null;
     if (location == null) {
-      in = new BufferedReader(new InputStreamReader(
-        new FileInputStream(file), Constants.ENCODING));
+    in = new BufferedReader(new InputStreamReader(
+      new FileInputStream(file), Constants.ENCODING));
     }
     else {
-      in = new BufferedReader(new InputStreamReader(
-        location.getResourceAsStream(file), Constants.ENCODING));
+    in = new BufferedReader(new InputStreamReader(
+      location.getResourceAsStream(file), Constants.ENCODING));
     }
     while (true) {
       String line = null;
@@ -146,12 +161,11 @@ public class ClassList<T> {
         LOGGER.error("\"{}\" is not valid.", line);
         continue;
       }
-      classes.add(c);
+      parsedClasses.add(c);
     }
     in.close();
+    return parsedClasses;
   }
-
-  // -- ClassList API methods --
 
   /**
    * Adds the given class, which must be assignable

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.lang.Iterable;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.List;
 
 import loci.formats.ClassList;
 
@@ -52,48 +53,56 @@ public class ClassListTest {
   
   @Test
   public void testDefaultConstructor() {
-      c = new ClassList<Iterable>(Iterable.class);
-      assertEquals(c.getClasses().length, 0);
+    c = new ClassList<Iterable>(Iterable.class);
+    assertEquals(c.getClasses().length, 0);
   }
 
   @Test
   public void testNullFileConstructor() throws IOException {
-      c = new ClassList<Iterable>(null, Iterable.class);
-      assertEquals(c.getClasses().length, 0);
+    c = new ClassList<Iterable>(null, Iterable.class);
+    assertEquals(c.getClasses().length, 0);
   }
 
   @Test
   public void testFileConstructor() throws IOException {
-      c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
-      assertEquals(c.getClasses().length, 2);
-      assertEquals(c.getClasses()[0], AbstractList.class);
-      assertEquals(c.getClasses()[1], ArrayList.class);
+    c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
+    assertEquals(c.getClasses().length, 2);
+    assertEquals(c.getClasses()[0], AbstractList.class);
+    assertEquals(c.getClasses()[1], ArrayList.class);
+  }
+
+  @Test
+  public void testParseFile() throws IOException {
+    c = new ClassList<Iterable>(null, Iterable.class);
+    List<Class<? extends Iterable>> classes = c.parseFile(
+      "iterables.txt",ClassListTest.class);
+    assertEquals(classes.toArray(new Class[0]).length, 2);
   }
 
   @Test
   public void testAddClass() {
-      c = new ClassList<Iterable>(Iterable.class);
-      c.addClass(AbstractList.class);
-      assertEquals(c.getClasses().length, 1);
-      assertEquals(c.getClasses()[0], AbstractList.class);
-      c.addClass(ArrayList.class);
-      assertEquals(c.getClasses().length, 2);
-      assertEquals(c.getClasses()[1], ArrayList.class);
-      c.addClass(ArrayList.class);
-      assertEquals(c.getClasses().length, 3);
-      assertEquals(c.getClasses()[2], ArrayList.class);
+    c = new ClassList<Iterable>(Iterable.class);
+    c.addClass(AbstractList.class);
+    assertEquals(c.getClasses().length, 1);
+    assertEquals(c.getClasses()[0], AbstractList.class);
+    c.addClass(ArrayList.class);
+    assertEquals(c.getClasses().length, 2);
+    assertEquals(c.getClasses()[1], ArrayList.class);
+    c.addClass(ArrayList.class);
+    assertEquals(c.getClasses().length, 3);
+    assertEquals(c.getClasses()[2], ArrayList.class);
   }
 
   @Test
   public void testRemoveClass() throws IOException {
-      c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
-      c.removeClass(AbstractList.class);
-      assertEquals(c.getClasses().length, 1);
-      assertEquals(c.getClasses()[0], ArrayList.class);
-      c.removeClass(ArrayList.class);
-      assertEquals(c.getClasses().length, 0);
-      c.removeClass(ArrayList.class);
-      assertEquals(c.getClasses().length, 0);
+    c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
+    c.removeClass(AbstractList.class);
+    assertEquals(c.getClasses().length, 1);
+    assertEquals(c.getClasses()[0], ArrayList.class);
+    c.removeClass(ArrayList.class);
+    assertEquals(c.getClasses().length, 0);
+    c.removeClass(ArrayList.class);
+    assertEquals(c.getClasses().length, 0);
   }
 }
 

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -111,9 +111,8 @@ public class ClassListTest {
   @Test
   public void testParseFile() throws IOException {
     c = new ClassList<Iterable>(null, Iterable.class);
-    List<Class<? extends Iterable>> classes = c.parseFile(
-      "iterables.txt",ClassListTest.class);
-    assertEquals(classes.toArray(new Class[0]).length, 2);
+    c.parseFile("iterables.txt",ClassListTest.class);
+    assertEquals(c.getClasses().length, 2);
   }
 
   @Test
@@ -150,20 +149,6 @@ public class ClassListTest {
     assertEquals(c.getClasses()[0], ArrayList.class);
 
     String configFile2 = writeConfigFile("java.util.AbstractList");
-    c.append(c.parseFile(configFile2, null));
-    assertEquals(c.getClasses().length, 2);
-    assertEquals(c.getClasses()[0], ArrayList.class);
-    assertEquals(c.getClasses()[1], AbstractList.class);
-  }
-
-  @Test
-  public void testAppend2() throws IOException {
-    configFile = writeConfigFile("java.util.ArrayList");
-    c = new ClassList<Iterable>(configFile, Iterable.class, null);
-    assertEquals(c.getClasses().length, 1);
-    assertEquals(c.getClasses()[0], ArrayList.class);
-
-    String configFile2 = writeConfigFile("java.util.AbstractList");
     ClassList<Iterable> c2 = new ClassList<Iterable>(configFile2, Iterable.class, null);
     c.append(c2);
     assertEquals(c.getClasses().length, 2);
@@ -186,20 +171,33 @@ public class ClassListTest {
     assertEquals(c.getClasses()[1], ArrayList.class);
   }
 
+  @DataProvider(name = "skipped lines")
+  public Object[][] createLines() throws ClassNotFoundException {
+    return new Object[][] {
+      {""}, {"  # comment"}, {"# comment"},
+    };
+  }
+
+  @Test(dataProvider = "skipped lines")
+  public void testParseSkippedLine(String line) throws IOException  {
+    c = new ClassList<Iterable>(null, Iterable.class);
+    c.parseLine(line);
+    assertEquals(c.getClasses().length, 0);
+  }
+
   @DataProvider(name = "configuration lines")
   public Object[][] createConfigurationLines() throws ClassNotFoundException {
     return new Object[][] {
-      {"", null},
-      {"java.util.ArrayList", Class.forName("java.util.ArrayList")},
-      {"java.util.ArrayList  ", Class.forName("java.util.ArrayList")},
-      {"java.util.ArrayList  # comment", Class.forName("java.util.ArrayList")},
+      {"java.util.ArrayList", ArrayList.class},
+      {"java.util.ArrayList  ", ArrayList.class},
+      {"java.util.ArrayList  # comment", ArrayList.class},
     };
   }
 
   @Test(dataProvider = "configuration lines")
   public void testParseLine(String line, Object output) throws IOException  {
     c = new ClassList<Iterable>(null, Iterable.class);
-    Class<? extends Iterable> c2 = c.parseLine(line);
-    assertEquals(c2, output);
+    c.parseLine(line);
+    assertEquals(c.getClasses()[0], output);
   }
 }

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -32,6 +32,10 @@
 
 package loci.formats.utests;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.io.IOException;
 import java.lang.Iterable;
 import java.util.AbstractList;
@@ -50,6 +54,16 @@ import org.testng.annotations.Test;
 public class ClassListTest {
 
   private ClassList<Iterable> c;
+
+  public void writeConfigFile(File file, String content) {
+    try {
+      BufferedWriter bw = new BufferedWriter(new FileWriter(file));
+      bw.write(content);
+      bw.close();
+    } catch(IOException e){
+      e.printStackTrace();
+    }
+  }
   
   @Test
   public void testDefaultConstructor() {
@@ -58,13 +72,24 @@ public class ClassListTest {
   }
 
   @Test
-  public void testNullFileConstructor() throws IOException {
+  public void testNullConstructor() throws IOException {
     c = new ClassList<Iterable>(null, Iterable.class);
     assertEquals(c.getClasses().length, 0);
   }
 
   @Test
-  public void testFileConstructor() throws IOException {
+  public void testConfigFileConstructor1() throws IOException {
+    File configFile = File.createTempFile("iterables", ".tmp");
+    configFile.deleteOnExit();
+    writeConfigFile(configFile, "java.util.ArrayList\njava.util.AbstractList");
+    c = new ClassList<Iterable>(configFile.getAbsolutePath(), Iterable.class, null);
+    assertEquals(c.getClasses().length, 2);
+    assertEquals(c.getClasses()[0], ArrayList.class);
+    assertEquals(c.getClasses()[1], AbstractList.class);
+  }
+
+  @Test
+  public void testConfigFileConstructor2() throws IOException {
     c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
     assertEquals(c.getClasses().length, 2);
     assertEquals(c.getClasses()[0], AbstractList.class);

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import loci.formats.ClassList;
 
 import static org.testng.AssertJUnit.assertEquals;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -183,5 +184,22 @@ public class ClassListTest {
     assertEquals(c.getClasses().length, 2);
     assertEquals(c.getClasses()[0], AbstractList.class);
     assertEquals(c.getClasses()[1], ArrayList.class);
+  }
+
+  @DataProvider(name = "configuration lines")
+  public Object[][] createConfigurationLines() throws ClassNotFoundException {
+    return new Object[][] {
+      {"", null},
+      {"java.util.ArrayList", Class.forName("java.util.ArrayList")},
+      {"java.util.ArrayList  ", Class.forName("java.util.ArrayList")},
+      {"java.util.ArrayList  # comment", Class.forName("java.util.ArrayList")},
+    };
+  }
+
+  @Test(dataProvider = "configuration lines")
+  public void testParseLine(String line, Object output) throws IOException  {
+    c = new ClassList<Iterable>(null, Iterable.class);
+    Class<? extends Iterable> c2 = c.parseLine(line);
+    assertEquals(c2, output);
   }
 }

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -40,7 +40,10 @@ import java.io.IOException;
 import java.lang.Iterable;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.HashMap;
 
 import loci.formats.ClassList;
 
@@ -220,5 +223,34 @@ public class ClassListTest {
     assertEquals(c.getClasses()[0], output);
     assertEquals(c.getOptions().size(), 1);
     assertEquals(c.getOptions().get("java.util.ArrayList.a"), "b");
+  }
+
+  @Test
+  public void testSetOption() throws IOException  {
+    c = new ClassList<Iterable>(null, Iterable.class);
+    assertEquals(Collections.emptySet(), c.getOptions().keySet());
+    c.addOption("a", "b");
+    assertEquals(c.getOptions().keySet(), Collections.singleton("a"));
+    assertEquals(c.getOptions().get("a"), "b");
+  }
+
+  @DataProvider(name = "option string")
+  public Object[][] createOptionStrings() {
+    return new Object[][] {
+      {"a=b", new HashMap<String, String>() {{
+        put("a","b");}}
+      },
+      {"a=b,c=d", new HashMap<String, String>() {{
+        put("a","b");
+        put("c","d");}}
+      },
+    };
+  }
+
+
+  @Test(dataProvider = "option string")
+  public void testParseOptions(String options, HashMap map) throws IOException  {
+    c = new ClassList<Iterable>(null, Iterable.class);
+    assertEquals(map, c.parseOptions(options));
   }
 }

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -57,6 +57,12 @@ public class ClassListTest {
   }
 
   @Test
+  public void testNullFileConstructor() throws IOException {
+      c = new ClassList<Iterable>(null, Iterable.class);
+      assertEquals(c.getClasses().length, 0);
+  }
+
+  @Test
   public void testFileConstructor() throws IOException {
       c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
       assertEquals(c.getClasses().length, 2);
@@ -84,6 +90,8 @@ public class ClassListTest {
       c.removeClass(AbstractList.class);
       assertEquals(c.getClasses().length, 1);
       assertEquals(c.getClasses()[0], ArrayList.class);
+      c.removeClass(ArrayList.class);
+      assertEquals(c.getClasses().length, 0);
       c.removeClass(ArrayList.class);
       assertEquals(c.getClasses().length, 0);
   }

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -54,17 +54,17 @@ import org.testng.annotations.Test;
 public class ClassListTest {
 
   private ClassList<Iterable> c;
+  String configFile;
 
-  public void writeConfigFile(File file, String content) {
-    try {
-      BufferedWriter bw = new BufferedWriter(new FileWriter(file));
-      bw.write(content);
-      bw.close();
-    } catch(IOException e){
-      e.printStackTrace();
-    }
+  public String writeConfigFile(String content) throws IOException {
+    File file = File.createTempFile("iterables", ".tmp");
+    file.deleteOnExit();
+    BufferedWriter bw = new BufferedWriter(new FileWriter(file));
+    bw.write(content);
+    bw.close();
+    return file.getAbsolutePath();
   }
-  
+
   @Test
   public void testDefaultConstructor() {
     c = new ClassList<Iterable>(Iterable.class);
@@ -79,10 +79,9 @@ public class ClassListTest {
 
   @Test
   public void testConfigFileConstructor1() throws IOException {
-    File configFile = File.createTempFile("iterables", ".tmp");
-    configFile.deleteOnExit();
-    writeConfigFile(configFile, "java.util.ArrayList\njava.util.AbstractList");
-    c = new ClassList<Iterable>(configFile.getAbsolutePath(), Iterable.class, null);
+    configFile = writeConfigFile(
+      "java.util.ArrayList\njava.util.AbstractList");
+    c = new ClassList<Iterable>(configFile, Iterable.class, null);
     assertEquals(c.getClasses().length, 2);
     assertEquals(c.getClasses()[0], ArrayList.class);
     assertEquals(c.getClasses()[1], AbstractList.class);
@@ -143,39 +142,46 @@ public class ClassListTest {
   }
 
   @Test
-  public void testAppend()  throws IOException{
-      File configFile = File.createTempFile("iterables1", ".tmp");
-      configFile.deleteOnExit();
-      writeConfigFile(configFile, "java.util.ArrayList");
-      c = new ClassList<Iterable>(configFile.getAbsolutePath(), Iterable.class, null);
-      assertEquals(c.getClasses().length, 1);
-      assertEquals(c.getClasses()[0], ArrayList.class);
+  public void testAppend() throws IOException {
+    configFile = writeConfigFile("java.util.ArrayList");
+    c = new ClassList<Iterable>(configFile, Iterable.class, null);
+    assertEquals(c.getClasses().length, 1);
+    assertEquals(c.getClasses()[0], ArrayList.class);
 
-      File configFile2 = File.createTempFile("iterables2", ".tmp");
-      configFile2.deleteOnExit();
-      writeConfigFile(configFile2, "java.util.AbstractList");
-      c.append(c.parseFile(configFile2.getAbsolutePath(), null));
-      assertEquals(c.getClasses().length, 2);
-      assertEquals(c.getClasses()[0], ArrayList.class);
-      assertEquals(c.getClasses()[1], AbstractList.class);
+    String configFile2 = writeConfigFile("java.util.AbstractList");
+    c.append(c.parseFile(configFile2, null));
+    assertEquals(c.getClasses().length, 2);
+    assertEquals(c.getClasses()[0], ArrayList.class);
+    assertEquals(c.getClasses()[1], AbstractList.class);
   }
 
   @Test
-  public void testPrepend()  throws IOException{
-      File configFile = File.createTempFile("iterables1", ".tmp");
-      configFile.deleteOnExit();
-      writeConfigFile(configFile, "java.util.ArrayList");
-      c = new ClassList<Iterable>(configFile.getAbsolutePath(), Iterable.class, null);
-      assertEquals(c.getClasses().length, 1);
-      assertEquals(c.getClasses()[0], ArrayList.class);
+  public void testAppend2() throws IOException {
+    configFile = writeConfigFile("java.util.ArrayList");
+    c = new ClassList<Iterable>(configFile, Iterable.class, null);
+    assertEquals(c.getClasses().length, 1);
+    assertEquals(c.getClasses()[0], ArrayList.class);
 
-      File configFile2 = File.createTempFile("iterables2", ".tmp");
-      configFile2.deleteOnExit();
-      writeConfigFile(configFile2, "java.util.AbstractList");
-      c.prepend(c.parseFile(configFile2.getAbsolutePath(), null));
-      assertEquals(c.getClasses().length, 2);
-      assertEquals(c.getClasses()[0], AbstractList.class);
-      assertEquals(c.getClasses()[1], ArrayList.class);
+    String configFile2 = writeConfigFile("java.util.AbstractList");
+    ClassList<Iterable> c2 = new ClassList<Iterable>(configFile2, Iterable.class, null);
+    c.append(c2);
+    assertEquals(c.getClasses().length, 2);
+    assertEquals(c.getClasses()[0], ArrayList.class);
+    assertEquals(c.getClasses()[1], AbstractList.class);
+  }
+
+  @Test
+  public void testPrepend() throws IOException {
+    configFile = writeConfigFile("java.util.ArrayList");
+    c = new ClassList<Iterable>(configFile, Iterable.class, null);
+    assertEquals(c.getClasses().length, 1);
+    assertEquals(c.getClasses()[0], ArrayList.class);
+
+    String configFile2 = writeConfigFile("java.util.AbstractList");
+    ClassList<Iterable> c2 = new ClassList<Iterable>(configFile2, Iterable.class, null);
+    c.prepend(c2);
+    assertEquals(c.getClasses().length, 2);
+    assertEquals(c.getClasses()[0], AbstractList.class);
+    assertEquals(c.getClasses()[1], ArrayList.class);
   }
 }
-

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -97,6 +97,18 @@ public class ClassListTest {
   }
 
   @Test
+  public void testInvalidFileConstructor1() throws IOException {
+    c = new ClassList<Iterable>("invalid", Iterable.class, null);
+    assertEquals(c.getClasses().length, 0);
+  }
+
+  @Test
+  public void testInvalidFileConstructor2() throws IOException {
+    c = new ClassList<Iterable>("invalid", Iterable.class, ClassListTest.class);
+    assertEquals(c.getClasses().length, 0);
+  }
+
+  @Test
   public void testParseFile() throws IOException {
     c = new ClassList<Iterable>(null, Iterable.class);
     List<Class<? extends Iterable>> classes = c.parseFile(

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -141,5 +141,41 @@ public class ClassListTest {
     c.removeClass(ArrayList.class);
     assertEquals(c.getClasses().length, 0);
   }
+
+  @Test
+  public void testAppend()  throws IOException{
+      File configFile = File.createTempFile("iterables1", ".tmp");
+      configFile.deleteOnExit();
+      writeConfigFile(configFile, "java.util.ArrayList");
+      c = new ClassList<Iterable>(configFile.getAbsolutePath(), Iterable.class, null);
+      assertEquals(c.getClasses().length, 1);
+      assertEquals(c.getClasses()[0], ArrayList.class);
+
+      File configFile2 = File.createTempFile("iterables2", ".tmp");
+      configFile2.deleteOnExit();
+      writeConfigFile(configFile2, "java.util.AbstractList");
+      c.append(c.parseFile(configFile2.getAbsolutePath(), null));
+      assertEquals(c.getClasses().length, 2);
+      assertEquals(c.getClasses()[0], ArrayList.class);
+      assertEquals(c.getClasses()[1], AbstractList.class);
+  }
+
+  @Test
+  public void testPrepend()  throws IOException{
+      File configFile = File.createTempFile("iterables1", ".tmp");
+      configFile.deleteOnExit();
+      writeConfigFile(configFile, "java.util.ArrayList");
+      c = new ClassList<Iterable>(configFile.getAbsolutePath(), Iterable.class, null);
+      assertEquals(c.getClasses().length, 1);
+      assertEquals(c.getClasses()[0], ArrayList.class);
+
+      File configFile2 = File.createTempFile("iterables2", ".tmp");
+      configFile2.deleteOnExit();
+      writeConfigFile(configFile2, "java.util.AbstractList");
+      c.prepend(c.parseFile(configFile2.getAbsolutePath(), null));
+      assertEquals(c.getClasses().length, 2);
+      assertEquals(c.getClasses()[0], AbstractList.class);
+      assertEquals(c.getClasses()[1], ArrayList.class);
+  }
 }
 

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -32,7 +32,10 @@
 
 package loci.formats.utests;
 
+import java.io.IOException;
 import java.lang.Iterable;
+import java.util.AbstractList;
+import java.util.ArrayList;
 
 import loci.formats.ClassList;
 
@@ -50,6 +53,38 @@ public class ClassListTest {
   @Test
   public void testDefaultConstructor() {
       c = new ClassList<Iterable>(Iterable.class);
+      assertEquals(c.getClasses().length, 0);
+  }
+
+  @Test
+  public void testFileConstructor() throws IOException {
+      c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
+      assertEquals(c.getClasses().length, 2);
+      assertEquals(c.getClasses()[0], AbstractList.class);
+      assertEquals(c.getClasses()[1], ArrayList.class);
+  }
+
+  @Test
+  public void testAddClass() {
+      c = new ClassList<Iterable>(Iterable.class);
+      c.addClass(AbstractList.class);
+      assertEquals(c.getClasses().length, 1);
+      assertEquals(c.getClasses()[0], AbstractList.class);
+      c.addClass(ArrayList.class);
+      assertEquals(c.getClasses().length, 2);
+      assertEquals(c.getClasses()[1], ArrayList.class);
+      c.addClass(ArrayList.class);
+      assertEquals(c.getClasses().length, 3);
+      assertEquals(c.getClasses()[2], ArrayList.class);
+  }
+
+  @Test
+  public void testRemoveClass() throws IOException {
+      c = new ClassList<Iterable>("iterables.txt", Iterable.class, ClassListTest.class);
+      c.removeClass(AbstractList.class);
+      assertEquals(c.getClasses().length, 1);
+      assertEquals(c.getClasses()[0], ArrayList.class);
+      c.removeClass(ArrayList.class);
       assertEquals(c.getClasses().length, 0);
   }
 }

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * Top-level reader and writer APIs
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import java.lang.Iterable;
+
+import loci.formats.ClassList;
+
+import static org.testng.AssertJUnit.assertEquals;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link loci.formats.ClassList}.
+ */
+public class ClassListTest {
+
+  private ClassList<Iterable> c;
+  
+  @Test
+  public void testDefaultConstructor() {
+      c = new ClassList<Iterable>(Iterable.class);
+      assertEquals(c.getClasses().length, 0);
+  }
+}
+

--- a/components/formats-api/test/loci/formats/utests/ClassListTest.java
+++ b/components/formats-api/test/loci/formats/utests/ClassListTest.java
@@ -237,6 +237,14 @@ public class ClassListTest {
   @DataProvider(name = "option string")
   public Object[][] createOptionStrings() {
     return new Object[][] {
+      // Invalid key-value pairs
+      {"a", new HashMap<String, String>()},
+      {"a,b", new HashMap<String, String>()},
+      {"=", new HashMap<String, String>()},
+      {"", new HashMap<String, String>()},
+      {"a=", new HashMap<String, String>()},
+      {"=b", new HashMap<String, String>()},
+      // Valid key-value pairs
       {"a=b", new HashMap<String, String>() {{
         put("a","b");}}
       },
@@ -244,12 +252,22 @@ public class ClassListTest {
         put("a","b");
         put("c","d");}}
       },
+      {"a=b,a=b", new HashMap<String, String>() {{
+        put("a","b");}}
+      },
+      {"a=b,c", new HashMap<String, String>() {{
+        put("a","b");}}
+      },
+      {"a=b,=,c=d", new HashMap<String, String>() {{
+        put("a","b");
+        put("c","d");}}
+      },
     };
   }
 
-
   @Test(dataProvider = "option string")
-  public void testParseOptions(String options, HashMap map) throws IOException  {
+  public void testParseOptions(String options, HashMap map) throws IOException
+  {
     c = new ClassList<Iterable>(null, Iterable.class);
     assertEquals(map, c.parseOptions(options));
   }

--- a/components/formats-api/test/loci/formats/utests/iterables.txt
+++ b/components/formats-api/test/loci/formats/utests/iterables.txt
@@ -1,0 +1,2 @@
+java.util.AbstractList
+java.util.ArrayList


### PR DESCRIPTION
This PR is an incremental step towards the reader discoverability described in https://github.com/openmicroscopy/design/issues/42. The changes in this Pull Request are restricted themselves to `ClassList` which is used in conjunction with the `readers.txt/writers.txt` configuration files in `ImageReader/ImageWriter` to instantiate a series classes implementing the `IFormatReader/IFormatWriter` interface.

### Main features

The major changes proposed in this PR are the following:
- refactors the `ClassList` notably decomposes the constructor with a configuration file into  a set of public methods can be tested independently and expose more granularity for the generation of class lists
- improves error handling when dealing with invalid input streams
- add `append()`, `prepend()` methods allowing to combine `ClassList` objects
- add a mechanism for storing a map of options in addition to a list of classes into a `ClassList` object
- add logic for parsing options stored as comma-separated key/value pairs in a configuration file

### Testing

All changes described above as well as generic constructor/method tests for the `loci.formats.ClassList` class should be covered via a set of unit tests in a new `ClassListTest` class using the `java.util.Iterable` interface is used as the base class. 

### Applications

The current state of this PR tries to address the following use cases:
- optional/external/discoverable readers could be annotated into the `readers.txt` class using a controlled key/value pair:

  ```
loci.formats.in.SlideBook6Reader[optional=true]  # sld
```

- additional per-reader options can be specified at the readers.txt level or even parsed externally e.g. using the case of https://github.com/openmicroscopy/bioformats/pull/2458, the following line

```
loci.formats.in.FlexReader[granularity=infinite,depth=10]  # flex
```

would store options `{loci.formats.in.FlexReader.granularity=infinite, loci.formats.in.FlexReader.depth=10}` into the `ClassList` options. A proposed subsequent step at the `ImageReader` level would be to pass these options to the `MetadataOptions` /cc @joshmoore @dgault 
