### PR TITLE
MetadataOptions - Control Group Files Granularity

### DIFF
--- a/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/DefaultMetadataOptions.java
@@ -39,6 +39,8 @@ package loci.formats.in;
 public class DefaultMetadataOptions implements MetadataOptions {
 
   private MetadataLevel level;
+  
+  private MetadataGroupFilesOptions groupFilesOptions;
 
   /**
    * Construct a new DefaultMetadataOptions.
@@ -70,6 +72,22 @@ public class DefaultMetadataOptions implements MetadataOptions {
   @Override
   public void setMetadataLevel(MetadataLevel level) {
     this.level = level;
+  }
+  
+  /* (non-Javadoc)
+   * @see loci.formats.in.MetadataOptions#getMetadataGroupFilesOptions()
+   */
+  @Override
+  public MetadataGroupFilesOptions getMetadataGroupFilesOptions() {
+    return groupFilesOptions;
+  }
+
+  /* (non-Javadoc)
+   * @see loci.formats.in.MetadataOptions#setMetadataGroupFilesOptions(loci.formats.in.MetadataGroupFilesOptions)
+   */
+  @Override
+  public void setMetadataGroupFilesOptions(MetadataGroupFilesOptions options) {
+    this.groupFilesOptions = options;
   }
 
 }

--- a/components/formats-api/src/loci/formats/in/MetadataGroupFilesOptions.java
+++ b/components/formats-api/src/loci/formats/in/MetadataGroupFilesOptions.java
@@ -1,0 +1,52 @@
+package loci.formats.in;
+
+public class MetadataGroupFilesOptions {
+  public enum GroupFilesGranularity {
+    TOP_LEVEL,
+    LIMITED_DEPTH,
+    RECURSIVE;
+  }
+  
+  private int maxDepth;
+  private GroupFilesGranularity granularityLevel;
+  
+  public MetadataGroupFilesOptions() {
+    granularityLevel = GroupFilesGranularity.TOP_LEVEL;
+    maxDepth = 0;
+  }
+  
+  public MetadataGroupFilesOptions(GroupFilesGranularity granularity) {
+    granularityLevel = granularity;
+    maxDepth = 0;
+    if (granularityLevel == GroupFilesGranularity.RECURSIVE) {
+      maxDepth = Integer.MAX_VALUE;
+    }
+  }
+  
+  public MetadataGroupFilesOptions(GroupFilesGranularity granularity, int depth) {
+    granularityLevel = granularity;
+    maxDepth = depth;     
+  }
+
+  public GroupFilesGranularity getGranularityLevel() {
+    return granularityLevel;
+  }
+  
+  public void setGranularityLevel(GroupFilesGranularity level) {
+    granularityLevel = level;
+  }
+
+  public int getMaxDepth() {
+    if (granularityLevel == GroupFilesGranularity.TOP_LEVEL) {
+      return 0;
+    }
+    else if (granularityLevel == GroupFilesGranularity.RECURSIVE) {
+      return Integer.MAX_VALUE;
+    }
+    return maxDepth;
+  }
+  
+  public void setMaxDepth(int depth) {
+    maxDepth = depth;
+  }
+}

--- a/components/formats-api/src/loci/formats/in/MetadataOptions.java
+++ b/components/formats-api/src/loci/formats/in/MetadataOptions.java
@@ -45,5 +45,13 @@ public interface MetadataOptions {
    * @return the MetadataLevel associated with this MetadataOptions
    */
   MetadataLevel getMetadataLevel();
+  
+  /** Set the MetadataGroupFilesOptions associated with this MetadataOptions. */
+  void setMetadataGroupFilesOptions(MetadataGroupFilesOptions options);
+  
+  /**
+   * @return the MetadataGroupFilesOptions associated with this MetadataOptions
+   */
+  MetadataGroupFilesOptions getMetadataGroupFilesOptions();
 
 }


### PR DESCRIPTION
Adding new MetadataOptions which can be used to control the granularity of group files.
The following options are available:
- Top level file grouping for locating files in the immediate directory (default option)
- Recursive for exploring all sub directories for files to group
- A max depth setting for exploring sub directories to a given depth

The new MetadataGroupFilesOptions contains an enum GroupFilesGranularity and a maxDepth value to represent these options. The getMaxDepth will return 0 if the granularity is set to TOP_LEVEL and Intger. MAX_VALUE if the granularity is set to RECURSIVE.

As these options are not yet implemented in any individual readers there is no specific testing required, only to confirm that the proposed options provide the desired functionality for future usage.
