### PR TITLE
2016-06 model

### DIFF
--- a/ant/xsd-fu.xml
+++ b/ant/xsd-fu.xml
@@ -7,7 +7,7 @@ Include this in components generating sources using xsd-fu.
 
 <project>
 
-  <property name="xsdfu.schemaver" value="2016-DEV0"/>
+  <property name="xsdfu.schemaver" value="2016-06"/>
   <property name="xsdfu.schemapath" value="${root.dir}/components/specification/released-schema/${xsdfu.schemaver}"/>
   <property name="xsdfu.templatepath" value="${root.dir}/components/xsd-fu"/>
   <property name="xsdfu.schema.ome" value="${xsdfu.schemapath}/ome.xsd"/>

--- a/components/autogen/build.properties
+++ b/components/autogen/build.properties
@@ -28,5 +28,5 @@ component.runtime-cp     = ${component.classpath}:\
 
 component.meta-support-dir = ${root.dir}/components/formats-gpl
 
-omexml.version=2016-DEV0
+omexml.version=2016-06
 filelist=src/format-pages.txt

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -97,7 +97,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
 {
 
   /** Latest OME-XML version namespace. */
-  public static final String LATEST_VERSION = "2016-DEV0";
+  public static final String LATEST_VERSION = "2016-06";
 
   public static final String NO_OME_XML_MSG =
     "ome-xml.jar is required to read OME-TIFF files.  " +
@@ -131,7 +131,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   private static final String XSLT_201306 =
     XSLT_PATH + "2013-06-to-2015-01.xsl";
   private static final String XSLT_201501 =
-    XSLT_PATH + "2015-01-to-2016-DEV0.xsl";
+    XSLT_PATH + "2015-01-to-2016-06.xsl";
 
   // -- Cached stylesheets --
 
@@ -318,7 +318,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
       else transformed = xml;
       LOGGER.debug("XML updated to at least 2015-01");
 
-      if (version.compareTo("2016-DEV0") < 0) {
+      if (version.compareTo("2016-06") < 0) {
         transformed = verifyOMENamespace(transformed);
         LOGGER.debug("Running UPDATE_201501 stylesheet.");
         if (update201501 == null) {
@@ -328,7 +328,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
         transformed = XMLTools.transformXML(transformed, update201501);
       }
       else transformed = xml;
-      LOGGER.debug("XML updated to at least 2016-DEV0");
+      LOGGER.debug("XML updated to at least 2016-06");
 
       // fix namespaces
       transformed = transformed.replaceAll("<ns.*?:", "<");

--- a/components/formats-bsd/test/loci/formats/utests/SPWModelMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/SPWModelMock.java
@@ -234,7 +234,7 @@ public class SPWModelMock implements ModelMock {
 
   /** XML namespace. */
   public static final String XML_NS =
-    "http://www.openmicroscopy.org/Schemas/OME/2016-DEV0";
+    "http://www.openmicroscopy.org/Schemas/OME/2016-06";
 
   /** XSI namespace. */
   public static final String XSI_NS =
@@ -242,7 +242,7 @@ public class SPWModelMock implements ModelMock {
 
   /** XML schema location. */
   public static final String SCHEMA_LOCATION =
-    "http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd";
+    "http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd";
 
   public SPWModelMock(boolean makeLightSources) {
     ome = new OME();

--- a/components/formats-bsd/test/spec/schema/SchemaResolverTest.java
+++ b/components/formats-bsd/test/spec/schema/SchemaResolverTest.java
@@ -54,7 +54,7 @@ public class SchemaResolverTest {
       {"/Schemas/2008-02"}, {"/Schemas/2008-04"}, {"/Schemas/2008-09"},
       {"/Schemas/2009-09"}, {"/Schemas/2010-04"}, {"/Schemas/2010-06"},
       {"/Schemas/2011-06"}, {"/Schemas/2012-06"}, {"/Schemas/2012-06"},
-      {"/Schemas/2013-06"}, {"/Schemas/2015-01"}, {"/Schemas/2016-DEV0"}};
+      {"/Schemas/2013-06"}, {"/Schemas/2015-01"}, {"/Schemas/2016-06"}};
 
     /** Holds the error, info, warning. */
     protected Logger log = LoggerFactory.getLogger(getClass());

--- a/components/formats-gpl/test/loci/formats/utests/InOutCurrentTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/InOutCurrentTest.java
@@ -285,7 +285,7 @@ public class InOutCurrentTest {
 
   /** XML namespace. */
   public static final String XML_NS =
-    "http://www.openmicroscopy.org/Schemas/OME/2016-DEV0";
+    "http://www.openmicroscopy.org/Schemas/OME/2016-06";
 
   /** XSI namespace. */
   public static final String XSI_NS =
@@ -293,7 +293,7 @@ public class InOutCurrentTest {
 
   /** XML schema location. */
   public static final String SCHEMA_LOCATION =
-    "http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd";
+    "http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd";
 
   private Document document;
 

--- a/components/formats-gpl/test/loci/formats/utests/xml/OMEXMLServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/OMEXMLServiceTest.java
@@ -65,7 +65,7 @@ public class OMEXMLServiceTest {
 
   @Test
   public void testGetLatestVersion() {
-    assertEquals("2016-DEV0", service.getLatestVersion());
+    assertEquals("2016-06", service.getLatestVersion());
   }
 
   @Test
@@ -91,7 +91,7 @@ public class OMEXMLServiceTest {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
-    assertEquals("2016-DEV0",
+    assertEquals("2016-06",
       service.getOMEXMLVersion(service.createOMEXMLMetadata(xml)));
   }
 

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200809Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200809Test.java
@@ -72,7 +72,7 @@ public class Upgrade200809Test {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
-    assertEquals("2016-DEV0", service.getOMEXMLVersion(metadata));
+    assertEquals("2016-06", service.getOMEXMLVersion(metadata));
   }
 
   @Test

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200909Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade200909Test.java
@@ -74,7 +74,7 @@ public class Upgrade200909Test {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
-    assertEquals("2016-DEV0", service.getOMEXMLVersion(metadata));
+    assertEquals("2016-06", service.getOMEXMLVersion(metadata));
   }
 
   @Test

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201004Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201004Test.java
@@ -72,7 +72,7 @@ public class Upgrade201004Test {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
-    assertEquals("2016-DEV0", service.getOMEXMLVersion(metadata));
+    assertEquals("2016-06", service.getOMEXMLVersion(metadata));
   }
 
   @Test

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201006Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201006Test.java
@@ -77,7 +77,7 @@ public class Upgrade201006Test {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
-    assertEquals("2016-DEV0", service.getOMEXMLVersion(metadata));
+    assertEquals("2016-06", service.getOMEXMLVersion(metadata));
   }
 
   @Test

--- a/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201106Test.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/Upgrade201106Test.java
@@ -77,7 +77,7 @@ public class Upgrade201106Test {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
-    assertEquals("2016-DEV0", service.getOMEXMLVersion(metadata));
+    assertEquals("2016-06", service.getOMEXMLVersion(metadata));
   }
 
   @Test

--- a/components/ome-xml/src/ome/xml/meta/AbstractOMEXMLMetadata.java
+++ b/components/ome-xml/src/ome/xml/meta/AbstractOMEXMLMetadata.java
@@ -73,7 +73,7 @@ public abstract class AbstractOMEXMLMetadata implements OMEXMLMetadata {
 
   /** OME-XML schema location. */
   public static final String SCHEMA =
-    "http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd";
+    "http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd";
 
   protected static final Logger LOGGER =
     LoggerFactory.getLogger(AbstractOMEXMLMetadata.class);

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -57,7 +57,7 @@ ismostrecent() {
 # Check if a schema is current (not necessarily the latest version).
 # $1=schema name
 iscurrent() {
-    if [ "${1%.xsd}" = "ome" ]
+    if [ "${1%.xsd}" = "ome" ] || [ "${1%.xsd}" = "OME" ]
     then
         return 0
     fi

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -57,20 +57,12 @@ ismostrecent() {
 # Check if a schema is current (not necessarily the latest version).
 # $1=schema name
 iscurrent() {
-    if [ "${1%.xsd}" = "AnalysisChain" ] || \
-        [ "${1%.xsd}" = "AnalysisModule" ] || \
-        [ "${1%.xsd}" = "CA" ] || \
-        [ "${1%.xsd}" = "CLI" ] || \
-        [ "${1%.xsd}" = "DataHistory" ] || \
-        [ "${1%.xsd}" = "Editor" ] || \
-        [ "${1%.xsd}" = "MLI" ] || \
-        [ "${1%.xsd}" = "OMERO" ] || \
-        [ "${1%.xsd}" = "STD" ]
+    if [ "${1%.xsd}" = "ome" ]
     then
-        return 1
+        return 0
     fi
 
-    return 0
+    return 1
 }
 
 # Check if the a schema is the most recent version (return true) or legacy (return false)

--- a/components/specification/publish
+++ b/components/specification/publish
@@ -99,18 +99,18 @@ schemaversion() {
 schemadesc() {
     case "${1%.xsd}" in
         BinaryFile)
-            echo "Binary File schema used to describe a file location, or the location of a fragment within a file." ;;
+            echo "Binary File schema used to describe a file location, or the location of a fragment within a file. It is combined with the main OME schema as of 2016-06." ;;
         OME|ome)
-            echo "main schema which defines the OME ontology for microscopy. This schema makes use of the others." ;;
+            echo "main schema which defines the OME ontology for microscopy." ;;
 
         OMERO)
             echo "schema extensions used by OMERO. It is not used by the OME schema but provides a structure for data in StructuredAnnotation blocks used by OMERO." ;;
         ROI)
-            echo "Region Of Interest schema." ;;
+            echo "Region Of Interest schema. It is combined with the main OME schema as of 2016-06." ;;
         SA)
-            echo "Structured Annotation schema." ;;
+            echo "Structured Annotation schema. It is combined with the main OME schema as of 2016-06." ;;
         SPW)
-            echo "Screen/Plate/Well schema." ;;
+            echo "Screen/Plate/Well schema. It is combined with the main OME schema as of 2016-06." ;;
         AnalysisChain)
             echo "Analysis Chain schema. Analysis chains are how module outputs are connected to inputs of other modules." ;;
         AnalysisModule)

--- a/components/specification/released-schema/2016-06/catalog.xml
+++ b/components/specification/released-schema/2016-06/catalog.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-  <uri name="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd" uri="ome.xsd"/>
+  <uri name="http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd" uri="ome.xsd"/>
 </catalog>

--- a/components/specification/released-schema/2016-06/ome.xsd
+++ b/components/specification/released-schema/2016-06/ome.xsd
@@ -29,7 +29,7 @@
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
             xmlns:xml="http://www.w3.org/XML/1998/namespace"
-            version="2"
+            version="1"
             elementFormDefault="qualified">
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>

--- a/components/specification/released-schema/2016-06/ome.xsd
+++ b/components/specification/released-schema/2016-06/ome.xsd
@@ -24,10 +24,10 @@
 # Written by: Ilya G. Goldberg, Andrew J Patterson
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->
-<xsd:schema xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0"
-            targetNamespace="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0"
+<xsd:schema xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+            targetNamespace="http://www.openmicroscopy.org/Schemas/OME/2016-06"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0"
+            xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
             xmlns:xml="http://www.w3.org/XML/1998/namespace"
             version="2"
             elementFormDefault="qualified">

--- a/components/specification/released-schema/catalog.xml
+++ b/components/specification/released-schema/catalog.xml
@@ -21,6 +21,6 @@
   <nextCatalog catalog="2012-06/catalog.xml"/>
   <nextCatalog catalog="2013-06/catalog.xml"/>
   <nextCatalog catalog="2015-01/catalog.xml"/>
-  <nextCatalog catalog="2016-DEV0/catalog.xml"/>
+  <nextCatalog catalog="2016-06/catalog.xml"/>
   <nextCatalog catalog="external/catalog.xml"/>
 </catalog>

--- a/components/specification/src/ome/specification/XMLWriter.java
+++ b/components/specification/src/ome/specification/XMLWriter.java
@@ -122,11 +122,11 @@ public class XMLWriter
 
 	/** The schemas. */
 	private static final String[] SCHEMAS = {
-	    "http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd"};
+	    "http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"};
 
 	/** The XML namespace. */
 	private static final String XML_NS =
-		"http://www.openmicroscopy.org/Schemas/OME/2016-DEV0";
+		"http://www.openmicroscopy.org/Schemas/OME/2016-06";
 
 	/** The XSI namespace. */
 	private static final String XSI_NS =
@@ -134,7 +134,7 @@ public class XMLWriter
 
 	/** The schema location. */
 	private static final String SCHEMA_LOCATION =
-		"http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd";
+		"http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd";
 
 	/** A default plane. */
 	private static final String PLANE =

--- a/components/specification/transforms/2015-01-to-2016-06.xsl
+++ b/components/specification/transforms/2015-01-to-2016-06.xsl
@@ -38,11 +38,11 @@
                 xmlns:exsl="http://exslt.org/common"
                 extension-element-prefixes="exsl" version="1.0">
 
-  <xsl:variable name="newOMENS">http://www.openmicroscopy.org/Schemas/OME/2016-DEV0</xsl:variable>
-  <xsl:variable name="newSPWNS">http://www.openmicroscopy.org/Schemas/OME/2016-DEV0</xsl:variable>
-  <xsl:variable name="newBINNS">http://www.openmicroscopy.org/Schemas/OME/2016-DEV0</xsl:variable>
-  <xsl:variable name="newROINS">http://www.openmicroscopy.org/Schemas/OME/2016-DEV0</xsl:variable>
-  <xsl:variable name="newSANS">http://www.openmicroscopy.org/Schemas/OME/2016-DEV0</xsl:variable>
+  <xsl:variable name="newOMENS">http://www.openmicroscopy.org/Schemas/OME/2016-06</xsl:variable>
+  <xsl:variable name="newSPWNS">http://www.openmicroscopy.org/Schemas/OME/2016-06</xsl:variable>
+  <xsl:variable name="newBINNS">http://www.openmicroscopy.org/Schemas/OME/2016-06</xsl:variable>
+  <xsl:variable name="newROINS">http://www.openmicroscopy.org/Schemas/OME/2016-06</xsl:variable>
+  <xsl:variable name="newSANS">http://www.openmicroscopy.org/Schemas/OME/2016-06</xsl:variable>
 
   <xsl:output method="xml" indent="yes"/>
   <xsl:preserve-space elements="*"/>
@@ -79,7 +79,7 @@
       <xsl:with-param name="string" select="'Line,Rectangle,Mask,Ellipse,Point,Polyline,Polygon,Label'"/>
     </xsl:call-template>
   </xsl:variable>
-    
+
   <xsl:template match="OME:LightSource">
     <xsl:variable name="lightSourceRoot" select="." />
     <xsl:variable name="lightSourceType"  >
@@ -97,13 +97,13 @@
       <xsl:apply-templates select="*[name()=concat('OME:',$lightSourceType)]/node()"/>
     </xsl:element>
   </xsl:template>
-  
+
   <xsl:template match="OME:Laser"/>
   <xsl:template match="OME:Arc"/>
   <xsl:template match="OME:Filament"/>
   <xsl:template match="OME:LightEmittingDiode"/>
   <xsl:template match="OME:GenericExcitationSource"/>
-  
+
   <xsl:template match="ROI:Shape">
     <xsl:variable name="shapeRoot" select="." />
     <xsl:variable name="shapeType"  >
@@ -120,8 +120,8 @@
       <xsl:apply-templates select="*[name()=$shapeType]/node()"/>
       <xsl:apply-templates select="*[name()=concat('ROI:',$shapeType)]/node()"/>
     </xsl:element>
-  </xsl:template>  
-  
+  </xsl:template>
+
   <xsl:template match="ROI:Line"/>
   <xsl:template match="ROI:Rectangle"/>
   <xsl:template match="ROI:Mask"/>
@@ -130,7 +130,7 @@
   <xsl:template match="ROI:Polyline"/>
   <xsl:template match="ROI:Polygon"/>
   <xsl:template match="ROI:Label"/>
-  
+
   <!-- strip Namespace from ROI -->
   <xsl:template match="ROI:ROI/@Namespace"/>
 
@@ -171,11 +171,11 @@
   <!-- Rewrite all namespaces -->
 
   <xsl:template match="OME:OME">
-    <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0"
-         xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0"
+    <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+         xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0
-                             http://www.openmicroscopy.org/Schemas/OME/2016-DEV0/ome.xsd">
+         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                             http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
       <xsl:apply-templates select="@UUID|@Creator|node()"/> <!-- copy UUID and Creator attributes and nodes -->
     </OME>
   </xsl:template>

--- a/components/specification/transforms/2016-06-to-2015-01.xsl
+++ b/components/specification/transforms/2016-06-to-2015-01.xsl
@@ -26,7 +26,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-DEV0"
+                xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:xml="http://www.w3.org/XML/1998/namespace"
                 exclude-result-prefixes="OME"
@@ -46,10 +46,10 @@
   <xsl:template match="OME:Line | OME:Rectangle | OME:Mask | OME:Ellipse | OME:Point | OME:Polyline | OME:Polygon | OME:Label">
     <xsl:element name="ROI:Shape"  namespace="{$newROINS}">
       <xsl:apply-templates select="@FillRule | @FillColor | @StrokeColor | @StrokeWidth | @StrokeWidthUnit | @StrokeDashArray | @LineCap |@Text |  @FontFamily | @FontSize | @FontSizeUnit | @FontStyle | @Locked | @ID | @TheZ | @TheT | @TheC"/>
-      <xsl:apply-templates select="node()[local-name() = 'Transform' or local-name() = 'AnnotationRef']"/>             
+      <xsl:apply-templates select="node()[local-name() = 'Transform' or local-name() = 'AnnotationRef']"/>
       <xsl:element name="ROI:{name()}"  namespace="{$newROINS}">
         <xsl:apply-templates select="@*[not(name() = 'FillRule' or name() = 'FillColor' or name() = 'StrokeColor' or name() = 'StrokeWidth' or name() = 'StrokeWidthUnit' or name() = 'StrokeDashArray' or name() = 'LineCap' or name() = 'Text' or  name() = 'FontFamily' or name() = 'FontSize' or name() = 'FontSizeUnit' or name() = 'FontStyle' or name() = 'Locked' or name() = 'ID' or name() = 'TheZ' or name() = 'TheT' or name() = 'TheC')]"/>
-        <xsl:apply-templates select="node()[not(local-name() = 'Transform' or local-name() = 'AnnotationRef')]"/>     
+        <xsl:apply-templates select="node()[not(local-name() = 'Transform' or local-name() = 'AnnotationRef')]"/>
       </xsl:element>
     </xsl:element>
   </xsl:template>
@@ -57,14 +57,14 @@
   <xsl:template match="OME:Laser | OME:Arc | OME:Filament | OME:LightEmittingDiode | OME:GenericExcitationSource">
     <xsl:element name="OME:LightSource"  namespace="{$newOMENS}">
       <xsl:apply-templates select="@ID | @Power | @PowerUnit |@Type"/>
-      <xsl:apply-templates select="node()[local-name() = 'AnnotationRef']"/>             
+      <xsl:apply-templates select="node()[local-name() = 'AnnotationRef']"/>
       <xsl:element name="OME:{name()}"  namespace="{$newOMENS}">
         <xsl:apply-templates select="@*[not(name() = 'ID' or name() = 'Power' or name() = 'PowerUnit' or name() = 'Type')]"/>
-        <xsl:apply-templates select="node()[not(local-name() = 'AnnotationRef')]"/>     
+        <xsl:apply-templates select="node()[not(local-name() = 'AnnotationRef')]"/>
       </xsl:element>
     </xsl:element>
   </xsl:template>
-  
+
   <!-- Rewrite all namespaces -->
 
   <xsl:template match="OME:OME">

--- a/components/specification/transforms/ome-transforms.xml
+++ b/components/specification/transforms/ome-transforms.xml
@@ -31,38 +31,38 @@
 	#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -->
 
-<ome-transforms current="2016-DEV0">
-	<source schema="2016-DEV0">
+<ome-transforms current="2016-06">
+	<source schema="2016-06">
 		<upgrades>
 		</upgrades>
 		<downgrades>
 			<target schema="2015-01" quality="good">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 			</target>
 			<target schema="2013-06" quality="good">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 			</target>
 			<target schema="2012-06" quality="good">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 			</target>
 			<target schema="2011-06" quality="good">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 			</target>
 			<target schema="2010-06" quality="good">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2010-06.xsl"/>
 			</target>
 			<target schema="2010-04" quality="fair">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
@@ -73,7 +73,7 @@
 				<transform file="2009-09-to-2010-04.xsl"/>
 			</target>
 			<target schema="2009-09" quality="fair">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
@@ -83,7 +83,7 @@
 				<transform file="2008-09-to-2009-09.xsl"/>
 			</target>
 			<target schema="2008-09" quality="fair">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
@@ -92,7 +92,7 @@
 				<transform file="2008-02-to-2008-09.xsl"/>
 			</target>
 			<target schema="2008-02" quality="fair">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
@@ -100,7 +100,7 @@
 				<transform file="2010-06-to-2008-02.xsl"/>
 			</target>
 			<target schema="2007-06" quality="poor">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
@@ -109,7 +109,7 @@
 				<transform file="2003-FC-to-2007-06.xsl"/>
 			</target>
 			<target schema="2003-FC" quality="poor">
-				<transform file="2016-DEV0-to-2015-01.xsl"/>
+				<transform file="2016-06-to-2015-01.xsl"/>
 				<transform file="2015-01-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2011-06.xsl"/>
@@ -120,8 +120,8 @@
 	</source>
 	<source schema="2015-01">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+			<target schema="2016-06" quality="excellent">
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 		</upgrades>
 		<downgrades>
@@ -196,9 +196,9 @@
 	</source>
 	<source schema="2013-06">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2013-06-to-2015-01.xsl"/>
@@ -264,10 +264,10 @@
 	</source>
 	<source schema="2012-06">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2012-06-to-2013-06.xsl"/>
@@ -326,11 +326,11 @@
 	</source>
 	<source schema="2011-06">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2011-06-to-2012-06.xsl"/>
@@ -384,12 +384,12 @@
 	</source>
 	<source schema="2010-06">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2010-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2010-06-to-2011-06.xsl"/>
@@ -440,13 +440,13 @@
 	</source>
 	<source schema="2010-04">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2010-04-to-2010-06.xsl"/>
 				<transform file="2010-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2010-04-to-2010-06.xsl"/>
@@ -503,14 +503,14 @@
 	</source>
 	<source schema="2009-09">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2009-09-to-2010-04.xsl"/>
 				<transform file="2010-04-to-2010-06.xsl"/>
 				<transform file="2010-06-to-2011-06.xsl"/>
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2009-09-to-2010-04.xsl"/>
@@ -573,7 +573,7 @@
 	</source>
 	<source schema="2008-09">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2008-09-to-2009-09.xsl"/>
 				<transform file="2009-09-to-2010-04.xsl"/>
 				<transform file="2010-04-to-2010-06.xsl"/>
@@ -581,7 +581,7 @@
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2008-09-to-2009-09.xsl"/>
@@ -650,7 +650,7 @@
 	</source>
 	<source schema="2008-02">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2008-02-to-2008-09.xsl"/>
 				<transform file="2008-09-to-2009-09.xsl"/>
 				<transform file="2009-09-to-2010-04.xsl"/>
@@ -659,7 +659,7 @@
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2008-02-to-2008-09.xsl"/>
@@ -734,7 +734,7 @@
 	</source>
 	<source schema="2007-06">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2007-06-to-2008-09.xsl"/>
 				<transform file="2008-09-to-2009-09.xsl"/>
 				<transform file="2009-09-to-2010-04.xsl"/>
@@ -743,7 +743,7 @@
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2007-06-to-2008-09.xsl"/>
@@ -813,7 +813,7 @@
 	</source>
 	<source schema="2003-FC">
 		<upgrades>
-			<target schema="2016-DEV0" quality="excellent">
+			<target schema="2016-06" quality="excellent">
 				<transform file="2003-FC-to-2008-09.xsl"/>
 				<transform file="2008-09-to-2009-09.xsl"/>
 				<transform file="2009-09-to-2010-04.xsl"/>
@@ -822,7 +822,7 @@
 				<transform file="2011-06-to-2012-06.xsl"/>
 				<transform file="2012-06-to-2013-06.xsl"/>
 				<transform file="2013-06-to-2015-01.xsl"/>
-				<transform file="2015-01-to-2016-DEV0.xsl"/>
+				<transform file="2015-01-to-2016-06.xsl"/>
 			</target>
 			<target schema="2015-01" quality="excellent">
 				<transform file="2003-FC-to-2008-09.xsl"/>

--- a/cpp/cmake/XsdFu.cmake
+++ b/cpp/cmake/XsdFu.cmake
@@ -49,7 +49,7 @@ set(XSD_FU_SCRIPT ${PROJECT_SOURCE_DIR}/components/xsd-fu/xsd-fu)
 set(XSD_FU python ${XSD_FU_SCRIPT})
 
 # Version of the OME-XML model to use
-set(MODEL_VERSION 2016-DEV0)
+set(MODEL_VERSION 2016-06)
 
 # Path to the model within the source tree
 set(MODEL_PATH ${PROJECT_SOURCE_DIR}/components/specification/released-schema/${MODEL_VERSION})

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
 
-    <xsdfu.schemaver>2016-DEV0</xsdfu.schemaver>
+    <xsdfu.schemaver>2016-06</xsdfu.schemaver>
     <xsdfu.schemapath>components/specification/released-schema/${xsdfu.schemaver}</xsdfu.schemapath>
     <xsdfu.ome>${xsdfu.schemapath}/ome.xsd</xsdfu.ome>
 


### PR DESCRIPTION
See https://trello.com/c/dFKmII6U/155-2016-06-schema-release

This PR completes the work on the 2016-06 model by:
- renaming the `2016-DEV0` schema as `2016-06` and updating all locations consuming it
- resetting the version of the 2016-06 schema to 1
- updating the `publish` script to move the deprecated schema namespaces to the legacy section and document the namespace unification

Note this PR does not include the link to the 2016-06 oXygen documentation which requires the new schema publication to be generated. The link will be upgraded (and released) in a follow-up PR.