### PR TITLE
docs: Fix licensing URL in global TOC

### DIFF
--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -2,4 +2,4 @@
 {{ toctree()}}
 <a href="http://downloads.openmicroscopy.org/latest/bio-formats5.2/">{{ _('Bio-Formats Downloads') }}</a></br>
 <a href="http://downloads.openmicroscopy.org/latest/ome-files-cpp/">{{ _('OME Files C++ Downloads') }}</a></br>
-<a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>
+<a href="http://www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
Missing `http:` which breaks the docs when not staged on openmicroscopy.org