### PR TITLE
5.2.0-m4 version history

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -30,12 +30,18 @@ include:
   dropped
 * extended enum metadata has been introduced to better support units
 * `Shape` and `LightSource` are now complexTypes rather than elements
-* BinData has been added to codegen to handle raw binary data
-* various code generation improvements to allow the model to be implemented in
-  C++
+* BinData has been added to code generation to handle raw binary data
+* various code generation improvements to:
+   - simplify and standardize the generation process
+   - remove a number of hard-coded exceptional cases allowing for easier
+     maintenance and growth
+   - allow for genuine abstract model types and enable C++ model
+     implementation
 
-The Bio-Formats C++ native implementation has been completely decoupled from
-the Java codebase and will be released as OME-Files C++ from now on.
+The Bio-Formats C++ native implementation has been decoupled from
+the Java codebase and will be released as OME-Files C++ from now on, with the
+exception of OME-XML which is still within Bio-Formats at present (there is a
+plan to decouple both the Java and the C++ versions of OME-XML in future).
 
 Java format support improvements include:
 
@@ -100,7 +106,7 @@ Other general improvements include:
 * MATLAB fixes
    - improved integration with Octave (thanks to Carnë Draug)
    - added logging initialization
-* CL tools fixes
+* Command-line tools fixes
    - upgrade check no longer run when passing -version
    - common methods refactoring
    - showinf improvements to preload format

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -7,31 +7,51 @@ Version history
 Top-level Bio-Formats API changes:
 
 * Java 1.7 is now the minimum supported version
-* The native-lib-loader dependency has been bumped to version 2.1.4
-* All the ome.jxr classes have been deprecated to make clear that there is no
+* the native-lib-loader dependency has been bumped to version 2.1.4
+* all the ome.jxr classes have been deprecated to make clear that there is no
   jeg-xr support implemented in Bio-Formats as yet
-* The DataTools API has been extended to add a number of utility functions to:
+* the DataTools API has been extended to add a number of utility functions to:
    - account for decimal separators in different locales
    - parse a String into Double, Flat, Integer etc
    - handle NumberFormatException thrown when parsing Unit tests
-* The Logging API has been updated to respect logging frameworks
+* the Logging API has been updated to respect logging frameworks
   (log4j/logback) initialized via a binding-specific configurations file and
   to prevent `DebugTools.enableLogging(String)` from overriding initialized
   logger levels
 
+The Data Model version 2016-06 has been released to introduce
+`Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,
+and to simplify both the graphical aspects of the model and code generation.
+Full details will be available in the
+:model_doc:`OME Model and Formats Documentation <>` shortly. OME-XML changes
+include:
+
+* `Map` is now a complexType rather than an element and `MapPairs` has been
+  dropped
+* extended enum metadata has been introduced to better support units
+* `Shape` and `LightSource` are now complexTypes rather than elements
+* BinData has been added to codegen to handle raw binary data
+* various code generation improvements to allow the model to be implemented in
+  C++
+
 The Bio-Formats C++ native implementation has been completely decoupled from
 the Java codebase and will be released as OME-Files C++ from now on.
 
-Data Model and OME-XML changes:
+Other general improvements include:
 
-* The Data Model version 2016-06 has been released to introduce
-  `Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,
-  and to simplify both the graphical aspects of the model and code generation.
-  Full details will be available in the
-  :model_doc:`OME Model and Formats Documentation <>` shortly.
-* 
+* improved performance of `getUsedFiles`
+* fixes for `FilePatternBlock`, `AxisGuesser`, `FilePattern`
+* fixes for the detection of csv pattern blocks by `FilePatternBlock`
 
 Java format support improvements include:
+
+* added support for Becker & Hickl .spc FIFO files
+* added support for Princeton Instruments .spe files
+* bug fixes for many formats including:
+   - TIff
+       - fixed integer overflow to read resolutions correctly
+       - fixed handling of tiled images with tile width less than 64
+   - 
 
 5.1.10 (2016 May 9)
 -------------------

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,6 +1,38 @@
 Version history
 ===============
 
+5.2.0-m4 (2016 June 24)
+-----------------------
+
+Top-level Bio-Formats API changes:
+
+* Java 1.7 is now the minimum supported version
+* The native-lib-loader dependency has been bumped to version 2.1.4
+* All the ome.jxr classes have been deprecated to make clear that there is no
+  jeg-xr support implemented in Bio-Formats as yet
+* The DataTools API has been extended to add a number of utility functions to:
+   - account for decimal separators in different locales
+   - parse a String into Double, Flat, Integer etc
+   - handle NumberFormatException thrown when parsing Unit tests
+* The Logging API has been updated to respect logging frameworks
+  (log4j/logback) initialized via a binding-specific configurations file and
+  to prevent `DebugTools.enableLogging(String)` from overriding initialized
+  logger levels
+
+The Bio-Formats C++ native implementation has been completely decoupled from
+the Java codebase and will be released as OME-Files C++ from now on.
+
+Data Model and OME-XML changes:
+
+* The Data Model version 2016-06 has been released to introduce
+  `Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,
+  and to simplify both the graphical aspects of the model and code generation.
+  Full details will be available in the
+  :model_doc:`OME Model and Formats Documentation <>` shortly.
+* 
+
+Java format support improvements include:
+
 5.1.10 (2016 May 9)
 -------------------
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -9,15 +9,15 @@ Top-level Bio-Formats API changes:
 * Java 1.7 is now the minimum supported version
 * the native-lib-loader dependency has been bumped to version 2.1.4
 * all the ome.jxr classes have been deprecated to make clear that there is no
-  jeg-xr support implemented in Bio-Formats as yet
+  JPEG-XR support implemented in Bio-Formats as yet
 * the DataTools API has been extended to add a number of utility functions to:
    - account for decimal separators in different locales
-   - parse a String into Double, Flat, Integer etc
+   - parse a String into Double, Float, Integer etc
    - handle NumberFormatException thrown when parsing Unit tests
 * the Logging API has been updated to respect logging frameworks
   (log4j/logback) initialized via a binding-specific configurations file and
   to prevent `DebugTools.enableLogging(String)` from overriding initialized
-  logger levels
+  logger levels (see :doc:`/developers/logging` for more information)
 
 The Data Model version 2016-06 has been released to introduce
 `Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -37,21 +37,75 @@ include:
 The Bio-Formats C++ native implementation has been completely decoupled from
 the Java codebase and will be released as OME-Files C++ from now on.
 
-Other general improvements include:
-
-* improved performance of `getUsedFiles`
-* fixes for `FilePatternBlock`, `AxisGuesser`, `FilePattern`
-* fixes for the detection of csv pattern blocks by `FilePatternBlock`
-
 Java format support improvements include:
 
 * added support for Becker & Hickl .spc FIFO files
 * added support for Princeton Instruments .spe files
 * bug fixes for many formats including:
-   - TIff
+   - Tiff
        - fixed integer overflow to read resolutions correctly
        - fixed handling of tiled images with tile width less than 64
-   - 
+   - PNG writing
+   - Zeiss ZVI
+       - reworked image ordering calculation to allow for tiles
+   - Leica LIF
+       - fixed incorrect plane offsets for large multi-tile files
+   - MRC and Spider
+       - fixes for format type checking
+   - OME-XML
+       - fixed metadata store
+   - CellSens VSI
+       - fixes for correctly reading dimensions
+   - ICS writing
+       - fixed dimension population for split files
+   - FlowSight
+       - fixes to infer channel count from channel names (thanks to Lee
+         Kamentsky)
+   - Hamamatsu VMS
+       - fixed dimensions of full-resolution images
+   - PicoQuant
+       - updated reader to always buffer data
+   - Zeiss LSM
+       - fixed Plane population errors
+   - Nifti
+       - fixed planeSize to prevent crashes when loading large files (thanks 
+         to Christian Niedworok)
+   - LiFlim
+       - fixed ExposureTime check and units usage
+   - SDT
+       - performance improvements for loading of large files
+   - OME-TIFF
+       - fixed Plane population errors
+       - fixed NullPointerException when closing reader for partial multi-file
+         filesets
+   - Zeiss CZI
+       - fixed timestamp indexing when multiple separate channels are present
+   - SVS
+       - fixed FormatNumberException
+
+Other general improvements include:
+
+* improved performance of `getUsedFiles`
+* fixes for `FilePatternBlock`, `AxisGuesser`, `FilePattern`
+* fixes for the detection of csv pattern blocks by `FilePatternBlock`
+* bioformats_package.jar now includes bio-formats-tools as a dependency so
+  ImageConverter, ImageFaker and ImageInfo classes are included in the bundle
+* the JACE C++ implementation has been decoupled as it does not function with
+  Java 1.7 (see `legacy repo <https://github.com/ome/bio-formats-jace>`_)
+* ImageJ fixes
+   - to allow reader delegation when a legacy reader is enabled
+     but not working
+   - to allow ROIs to be imported to the ImageJ ROI manager or added to a new
+     overlay
+* MATLAB fixes
+   - improved integration with Octave (thanks to Carnë Draug)
+   - added logging initialization
+* CL tools fixes
+   - upgrade check no longer run when passing -version
+   - common methods refactoring
+   - showinf improvements to preload format
+* Added more Java examples to the developer documentation
+* Added many automated tests and improved FakeReader testing framework
 
 5.1.10 (2016 May 9)
 -------------------


### PR DESCRIPTION
Based on https://trello.com/c/CCldRgeg/145-final-review-of-the-model-breaking-changes

Staged on http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/about/whats-new.html

Could maybe do with re-ordering/subsections changing but at least we have the content there, although I've maybe given unnecessary detail on some and not enough on others.

Plan is to edit this for the 5.2.0 release rather than leave the milestone as a separate stand-alone history so this is an intermediate 'getting stuff down on the page' PR to a certain extent anyway.