### PR TITLE
Remove dead alicona 3D spec doc link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -65,7 +65,7 @@ extensions = .al3d
 owner = `Alicona Imaging <http://www.alicona.com/>`_
 bsd = no
 versions = 1.0
-weHave = * an `AL3D specification document <http://www.alicona.co.uk/home/fileadmin/alicona/downloads/AL3DFormat.pdf>`_ (v1.0, from 2003, in PDF) \n
+weHave = * an AL3D specification document (v1.0, from 2003, in PDF) \n
 * a few AL3D datasets
 weWant = * more AL3D datasets (Z series, T series, 16-bit)
 pixelsRating = Very good

--- a/docs/sphinx/formats/alicona-3d.txt
+++ b/docs/sphinx/formats/alicona-3d.txt
@@ -25,7 +25,7 @@ Reader: AliconaReader (:bfreader:`Source Code <AliconaReader.java>`, :doc:`Suppo
 
 We currently have:
 
-* an `AL3D specification document <http://www.alicona.co.uk/home/fileadmin/alicona/downloads/AL3DFormat.pdf>`_ (v1.0, from 2003, in PDF) 
+* an AL3D specification document (v1.0, from 2003, in PDF)
 * a few AL3D datasets
 
 We would like to have:


### PR DESCRIPTION
This is the second time I've had to fix this link and as it's no longer hosted by the company and is 13 years old, I propose just dropping the link.

Should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/ green again.