### PR TITLE
Catch LinkageError to fix loci_tools with ImageJ

### DIFF
--- a/components/formats-common/src/loci/common/DebugTools.java
+++ b/components/formats-common/src/loci/common/DebugTools.java
@@ -35,6 +35,7 @@ package loci.common;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.LinkageError;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -80,7 +81,7 @@ public final class DebugTools {
         Method m = k.getMethod("isEnabled");
         return (Boolean) m.invoke(null);
       }
-      catch (ReflectiveOperationException t) {
+      catch (ReflectiveOperationException|LinkageError t) {
         // no-op. Ignore error and try the next class.
       }
     }
@@ -103,7 +104,7 @@ public final class DebugTools {
         m.invoke(null, level);
         return;
       }
-      catch (ReflectiveOperationException t) {
+      catch (ReflectiveOperationException|LinkageError t) {
         // no-op. Ignore error and try the next class.
       }
     }
@@ -127,7 +128,7 @@ public final class DebugTools {
         m.invoke(null);
         return true;
       }
-      catch (ReflectiveOperationException t) {
+      catch (ReflectiveOperationException|LinkageError t) {
         // no-op. Ignore error and try the next class.
       }
     }


### PR DESCRIPTION
The switch from throwable to ReflectiveOperationException does not catch `java.lang.NoClassDefFoundError` thrown by `Log4jTools`.

To test this PR, check `loci_tools.jar` on ImageJ stalls when running the Bio-Formats Importer without this PR but works as expected with this PR included.