### PR TITLE
Micromanager: fix multi-file image stacks and dimensionorder

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -565,7 +565,6 @@ public class MicromanagerReader extends FormatReader {
     // using key alone will result in conflicts with metadata.txt values
     for (int i=plane; i<plane+nPlanes; i++) {
       addSeriesMeta(String.format("Plane #%0" + digits + "d %s", i, key), value);
-      if (i >= p.positions.length) continue;
       if (key.equals("XPositionUm")) {
         try {
           p.positions[i][0] = new Double(value);
@@ -718,6 +717,13 @@ public class MicromanagerReader extends FormatReader {
         }
         else if (key.equals("Slices")) {
           ms.sizeZ = Integer.parseInt(value);
+        }
+        else if (key.equals("SlicesFirst")) {
+          if (value.equals("false")) {
+            ms.dimensionOrder = "XYCZT";
+          } else {
+            ms.dimensionOrder = "XYZCT";
+          }
         }
         else if (key.equals("PixelSize_um")) {
           p.pixelSize = new Double(value);
@@ -910,7 +916,7 @@ public class MicromanagerReader extends FormatReader {
     if (getSizeZ() == 0) ms.sizeZ = 1;
     if (getSizeT() == 0) ms.sizeT = 1;
 
-    ms.dimensionOrder = "XYZCT";
+    if (ms.dimensionOrder == null) ms.dimensionOrder = "XYZCT";
     ms.interleaved = false;
     ms.rgb = false;
     ms.littleEndian = false;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -541,7 +541,7 @@ public class MicromanagerReader extends FormatReader {
                 }
               }
               if (!value.equals("PropVal")) {
-                parseKeyAndValue(key, value, digits, (plane * nIFDs) + i, 1);
+                parseKeyAndValue(key, value, digits, plane + i, 1);
               }
               propType = null;
               key = null;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -565,6 +565,7 @@ public class MicromanagerReader extends FormatReader {
     // using key alone will result in conflicts with metadata.txt values
     for (int i=plane; i<plane+nPlanes; i++) {
       addSeriesMeta(String.format("Plane #%0" + digits + "d %s", i, key), value);
+      if (i >= p.positions.length) continue;
       if (key.equals("XPositionUm")) {
         try {
           p.positions[i][0] = new Double(value);


### PR DESCRIPTION
Fixes https://github.com/openmicroscopy/bioformats/issues/2308

This Pull Request fixes the `MicroManagerReader` reader to handle large datasets saved as image stack and split over multiple files (i.e. datasets larger than 4GB). While testing a sample dataset, a second issue was fixed by improving the way each image dimensionality is parsed from the metadata file.

### Summary of changes

- in `parsePosition()`, the number of IFDs were added to the current plane at the end of each loop as well as in the call to `parseKeyValue()` causing an `ArrayIndexOutOfBoundsException` when dealing with multiple files
- the `dimensionOrder` was previously unconditionally set to `XYZCT` causing wrong files to be returned by `Position.getFile()` under some conditions. For the sample multi-file dataset, this caused `parsePosition()` to scan twice the IFDs of the same file and `parseKeyValue()` to fail with an  `ArrayIndexOutOfBoundsException`. Instead we make use of the `SlicesFirst` metadata value as documented in https://micro-manager.org/wiki/Micro-Manager_File_Formats#Writing_Images to store the correct `DimensionOrder`

### Testing

In addition to the existing datasets available under `curated/micromanager`, a new large fileset was generated using Micro-Manager 1.4.22 with the demo config with 3 channels, 21 z-sections and 140 timepoints composed of 2 OME-TIFF files and a metadata text file. This fileset will be migrated to the `public` folder and be available under http://downloads.openmicroscopy.org/images/Micro-Manager/1.4.22/.

This fileset should fail to open without this PR and open properly with this PR included with the dimensions indicated above (might require to bump the default memory if using the command-line tools). Additionally, the OMERO workflow should be tested as the fileset should be importable and viewable.

The configuration files for a couple of filesets will be updated separately to match the `DimensionOrder` changes described above. Some attention should be put on `curated/micromanager/nico/Untitled_4_multi_file/` where the `Plane` metadata was previously incorrectly populated and should now be fixed by this change. The expected deltaT and position value can be checked using Micro-Manager.
