### PR TITLE
xsd-fu - MetadataConverter validation

### DIFF
--- a/components/xsd-fu/python/ome/modeltools/language.py
+++ b/components/xsd-fu/python/ome/modeltools/language.py
@@ -95,6 +95,8 @@ class Language(object):
         self.template_dir = None
         self.source_suffix = None
         self.header_suffix = None
+        self.converter_dir = None
+        self.converter_name = None
 
         self.omexml_model_package = None
         self.omexml_model_enums_package = None
@@ -121,6 +123,12 @@ class Language(object):
         return os.path.join(self._templatepath, self.getTemplateDirectory(),
                             self.getTemplate(template))
 
+    def getConverterDir(self):
+        return self.converter_dir
+        
+    def getConverterName(self):
+        return self.converter_name
+        
     def generatedFilename(self, name, type):
         gen_name = None
         if type == TYPE_SOURCE and self.source_suffix is not None:
@@ -275,6 +283,8 @@ class Java(Language):
         self.template_dir = "templates-java"
         self.source_suffix = ".java"
         self.header_suffix = None
+        self.converter_name = "MetadataConverter"
+        self.converter_dir = "formats-api/src/loci/formats/meta"
 
         self.omexml_model_package = "ome.xml.model"
         self.omexml_model_enums_package = "ome.xml.model.enums"
@@ -364,6 +374,8 @@ class CXX(Language):
         self.template_dir = "templates-cpp"
         self.source_suffix = ".cpp"
         self.header_suffix = ".h"
+        self.converter_name = "Convert"
+        self.converter_dir = "cpp/lib/ome/xml/meta"
 
         self.omexml_model_package = "ome::xml::model"
         self.omexml_model_enums_package = "ome::xml::model::enums"

--- a/components/xsd-fu/python/ome/modeltools/language.py
+++ b/components/xsd-fu/python/ome/modeltools/language.py
@@ -284,7 +284,7 @@ class Java(Language):
         self.source_suffix = ".java"
         self.header_suffix = None
         self.converter_name = "MetadataConverter"
-        self.converter_dir = "formats-api/src/loci/formats/meta"
+        self.converter_dir = "components/formats-api/src/loci/formats/meta"
 
         self.omexml_model_package = "ome.xml.model"
         self.omexml_model_enums_package = "ome.xml.model.enums"

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -637,6 +637,8 @@ def metadataMain(model, opts):
                 os.path.join(relpath, "DummyMetadata"),
                 model, opts)
 
+    validateMetadataConverter()
+
 def docGenMain(model, opts):
     """
     Documentation main() that does not parse the command line and spits
@@ -694,6 +696,43 @@ def parentlist(model, name, pre):
                         print("%s\t%s" % (prop.minOccurs, prop.maxOccurs ) + "\t" + prop.name + "\t" + prop.type + "\t\t" + pre + prop.name)
                         parentlist(model, prop.type, pre + prop.name + ":")
 
+def validateMetadataConverter():
+    relpath = os.path.join(*opts.lang.omexml_metadata_package.split(opts.lang.package_separator))
+    root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    storeFilename = os.path.join(relpath, "MetadataStore")
+    retrieveFilename = os.path.join(relpath, "MetadataRetrieve")
+    convertFilename = os.path.join(os.path.join(root, opts.lang.getConverterDir()), opts.lang.getConverterName())
+    storeFile = file(os.path.join(opts.outdir, opts.lang.generatedFilename(storeFilename, opts.filetype)))
+    retrieveFile = file(os.path.join(opts.outdir, opts.lang.generatedFilename(retrieveFilename, opts.filetype)))
+    convertFile = file(os.path.join(opts.outdir, opts.lang.generatedFilename(convertFilename, opts.filetype)))
+    regexp = re.compile(r'(?<=[gs]et)[a-zA-Z0-9]*(?=\()')
+    grepper = grep(regexp, lambda line: regexp.search(line) is not None and "Root" not in line and "Datasets" not in line and "Count" not in line)
+    storeSet = set(grepper(storeFile))
+    retrieveSet = set(grepper(retrieveFile))
+    convertSet = set(grepper(convertFile))
+    retrieveDiff = storeSet.symmetric_difference(set(retrieveSet))
+    converterDiff = storeSet.symmetric_difference(set(convertSet))
+    for match in retrieveDiff:
+        if match in retrieveSet:
+            print(MetadataValidation: "%s is present in MetadataRetrieve but missing from MetadataStore" % match)
+        else:
+            print("MetadataValidation: %s is present in MetadataStore but missing from MetadataRetrieve" % match)
+    for match in converterDiff:
+        if match in convertSet:
+            print("MetadataValidation: %s is present in MetadataConverter but missing from MetadataStore" % match)
+        else:
+            print("MetadataValidation: %s is present in MetadataStore but missing from MetadataConverter" % match)
+
+def grep(regexp, *matches):
+    def _do_grep_wrapper(*matches):
+        def _do_grep(lines):
+            for line in lines:
+                for match in matches:
+                    if match(line):
+                        yield re.findall(regexp, line)[0]
+                        break
+        return _do_grep
+    return _do_grep_wrapper(*matches)
 
 class options:
     def __init__(self, args):

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -699,7 +699,7 @@ def parentlist(model, name, pre):
 
 def validateMetadataConverter():
     relpath = os.path.join(*opts.lang.omexml_metadata_package.split(opts.lang.package_separator))
-    root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
     storeFilename = os.path.join(relpath, "MetadataStore")
     retrieveFilename = os.path.join(relpath, "MetadataRetrieve")
     convertFilename = os.path.join(os.path.join(root, opts.lang.getConverterDir()), opts.lang.getConverterName())

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -706,8 +706,9 @@ def validateMetadataConverter():
     storeFile = file(os.path.join(opts.outdir, opts.lang.generatedFilename(storeFilename, opts.filetype)))
     retrieveFile = file(os.path.join(opts.outdir, opts.lang.generatedFilename(retrieveFilename, opts.filetype)))
     convertFile = file(os.path.join(opts.outdir, opts.lang.generatedFilename(convertFilename, opts.filetype)))
-    regexp = re.compile(r'(?<=[gs]et)[a-zA-Z0-9]*(?=\()')
-    grepper = grep(regexp, lambda line: regexp.search(line) is not None and "Root" not in line and "Datasets" not in line and "Count" not in line)
+    white_list = ['Root', 'Datasets', 'Count', 'ShapeType', 'LightSourceType']
+    regexp = re.compile(r'(?<=[\s\.:][gs]et)((?:(?!'+'|'.join(white_list)+r')\w)*)[\(,]')
+    grepper = grep(regexp, lambda line: regexp.search(line))
     storeSet = set(grepper(storeFile))
     retrieveSet = set(grepper(retrieveFile))
     convertSet = set(grepper(convertFile))

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -714,7 +714,7 @@ def validateMetadataConverter():
     converterDiff = storeSet.symmetric_difference(set(convertSet))
     for match in retrieveDiff:
         if match in retrieveSet:
-            print(MetadataValidation: "%s is present in MetadataRetrieve but missing from MetadataStore" % match)
+            print("MetadataValidation: %s is present in MetadataRetrieve but missing from MetadataStore" % match)
         else:
             print("MetadataValidation: %s is present in MetadataStore but missing from MetadataRetrieve" % match)
     for match in converterDiff:

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -637,7 +637,8 @@ def metadataMain(model, opts):
                 os.path.join(relpath, "DummyMetadata"),
                 model, opts)
 
-    validateMetadataConverter()
+    if not opts.dryrun:
+        validateMetadataConverter()
 
 def docGenMain(model, opts):
     """

--- a/components/xsd-fu/xsd-fu
+++ b/components/xsd-fu/xsd-fu
@@ -720,9 +720,9 @@ def validateMetadataConverter():
             print("MetadataValidation: %s is present in MetadataStore but missing from MetadataRetrieve" % match)
     for match in converterDiff:
         if match in convertSet:
-            print("MetadataValidation: %s is present in MetadataConverter but missing from MetadataStore" % match)
+            print("MetadataValidation: %s is present in %s but missing from MetadataStore" % (match, opts.lang.getConverterName()))
         else:
-            print("MetadataValidation: %s is present in MetadataStore but missing from MetadataConverter" % match)
+            print("MetadataValidation: %s is present in MetadataStore but missing from %s" % (match, opts.lang.getConverterName()))
 
 def grep(regexp, *matches):
     def _do_grep_wrapper(*matches):


### PR DESCRIPTION
This PR adds, during code generation, a comparison of the properties used in MetadataStore, MetadataRetrieve and MetadataConverter.

Any discrepancies between these files will list the properties missing during the output of xsd-fu

To test:
- Run the code generation either directly from xsd-fu or through other means eg msv generate-sources
- Verify that the output lists validation differences (can search for the string MetadataValidation)
- Currently the ShapeType and LightSourceType are the only properties returned