### PR TITLE
Tiffcomment: add note about ImageDescription tag

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
@@ -61,7 +61,7 @@ public class TiffComment {
       System.out.println();
 
       System.out.println("This tool requires an ImageDescription tag to be " +
-        "in place in the TIFF file. ");
+        "present in the TIFF file. ");
       System.out.println();
       System.out.println("If using the '-set' option, the new TIFF comment " +
         "must be specified and may take any of the following forms:");

--- a/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
@@ -59,9 +59,12 @@ public class TiffComment {
       System.out.println(
         "tiffcomment [-set comment] [-edit] file1 [file2 ...]");
       System.out.println();
+
+      System.out.println("This tool requires an ImageDescription tag to be " +
+        "in place in the TIFF file. ");
+      System.out.println();
       System.out.println("If using the '-set' option, the new TIFF comment " +
-        "must be specified.");
-      System.out.println("The commment may take any of the following forms:");
+        "must be specified and may take any of the following forms:");
       System.out.println();
       System.out.println("  * the text of the comment, e.g. 'new comment!'");
       System.out.println("  * the name of the file containing the text of " +

--- a/docs/sphinx/users/comlinetools/edit.txt
+++ b/docs/sphinx/users/comlinetools/edit.txt
@@ -1,8 +1,12 @@
 Editing XML in an OME-TIFF
 ==========================
 
-To edit the XML in an OME-TIFF file you can use :command:`tiffcomment`, one of the
-Bio-Formats tools.
+To edit the XML in an OME-TIFF file you can use :command:`tiffcomment`, one of
+the Bio-Formats tools.
+
+.. note::
+  The :command:`tiffcomment` tool requires that the `ImageDescription` tag is
+  in place in the TIFF file and will error otherwise.
 
 To use the built in editor run:
 

--- a/docs/sphinx/users/comlinetools/edit.txt
+++ b/docs/sphinx/users/comlinetools/edit.txt
@@ -6,7 +6,7 @@ the Bio-Formats tools.
 
 .. note::
   The :command:`tiffcomment` tool requires that the `ImageDescription` tag is
-  in place in the TIFF file and will error otherwise.
+  present in the TIFF file and will error otherwise.
 
 To use the built in editor run:
 


### PR DESCRIPTION
See https://trello.com/c/pqx8FSLk/160-can-comment-ome-tiff-but-not-plain-tiff for reference

This PR adds a note to the Sphinx documentation page and the `tiffcomment` usage to mention the `ImageDescription` tag requirement in the TIFF file.