### PR TITLE
Handle NaN values in FormatTools.getStagePosition()

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1452,7 +1452,7 @@ public final class FormatTools {
    *               or {@code unit} is {@code null}.
    */
   public static Length getStagePosition(Double value, Unit<Length> unit) {
-    if (value == null || value.isInfinite()) {
+    if (value == null || value.isNaN() || value.isInfinite()) {
       LOGGER.debug("Expected float value for stage position; got {}", value);
       return null;
     }

--- a/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
+++ b/components/formats-api/test/loci/formats/utests/FormatToolsTest.java
@@ -152,6 +152,7 @@ public class FormatToolsTest {
       {Constants.EPSILON, "mm", new Length(Constants.EPSILON, UNITS.MILLIMETER)},
       {-Constants.EPSILON, "mm", new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, "mm", null},
+      {Double.NaN, "mm", null},
       // Invalid length string units
       {1.0, null, new Length(1.0, UNITS.REFERENCEFRAME)},
       {1.0, "", new Length(1.0, UNITS.REFERENCEFRAME)},
@@ -171,6 +172,7 @@ public class FormatToolsTest {
       {-Constants.EPSILON, UNITS.MILLIMETER, new Length(-Constants.EPSILON, UNITS.MILLIMETER)},
       {Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
       {-Double.POSITIVE_INFINITY, UNITS.MILLIMETER, null},
+      {Double.NaN, UNITS.MILLIMETER, null},
       {1.0, null, null},
     };
   }


### PR DESCRIPTION
Add corresponding unit tests checking the returned length is null

Following up of the discussion in https://github.com/openmicroscopy/bioformats/pull/2448#discussion_r69686940