### PR TITLE
Zeiss CZI: add support for slides

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -951,6 +951,8 @@ public class ZeissCZIReader extends FormatReader {
       name = imageName;
     }
 
+    store.setInstrumentID(MetadataTools.createLSID("Instrument", 0), 0);
+
     int indexLength = String.valueOf(getSeriesCount()).length();
     for (int i=0; i<getSeriesCount(); i++) {
       store.setImageInstrumentRef(MetadataTools.createLSID("Instrument", 0), i);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -675,6 +675,7 @@ public class ZeissCZIReader extends FormatReader {
 
     int seriesCount = positions * acquisitions * angles;
     boolean isPyramid = maxResolution > 0;
+    int originalMosaicCount = mosaics;
     if (!isPyramid) {
       seriesCount *= mosaics;
     }
@@ -762,30 +763,32 @@ public class ZeissCZIReader extends FormatReader {
 
     if (isPyramid) {
       for (int s=0; s<core.size();) {
-        // calculate total stitched size
-        int minRow = Integer.MAX_VALUE;
-        int maxRow = Integer.MIN_VALUE;
-        int minCol = Integer.MAX_VALUE;
-        int maxCol = Integer.MIN_VALUE;
-        for (SubBlock plane : planes) {
-          if (plane.coreIndex != s) {
-            continue;
+        if (originalMosaicCount > 1) {
+          // calculate total stitched size if the image was not fused
+          int minRow = Integer.MAX_VALUE;
+          int maxRow = Integer.MIN_VALUE;
+          int minCol = Integer.MAX_VALUE;
+          int maxCol = Integer.MIN_VALUE;
+          for (SubBlock plane : planes) {
+            if (plane.coreIndex != s) {
+              continue;
+            }
+            if (plane.row < minRow) {
+              minRow = plane.row;
+            }
+            if (plane.row > maxRow) {
+              maxRow = plane.row;
+            }
+            if (plane.col < minCol) {
+              minCol = plane.col;
+            }
+            if (plane.col > maxCol) {
+              maxCol = plane.col;
+            }
           }
-          if (plane.row < minRow) {
-            minRow = plane.row;
-          }
-          if (plane.row > maxRow) {
-            maxRow = plane.row;
-          }
-          if (plane.col < minCol) {
-            minCol = plane.col;
-          }
-          if (plane.col > maxCol) {
-            maxCol = plane.col;
-          }
+          core.get(s).sizeX = (core.get(s).sizeX + maxCol) - minCol;
+          core.get(s).sizeY = (core.get(s).sizeY + maxRow) - minRow;
         }
-        core.get(s).sizeX = (core.get(s).sizeX + maxCol) - minCol;
-        core.get(s).sizeY = (core.get(s).sizeY + maxRow) - minRow;
         for (int r=0; r<core.get(s).resolutionCount; r++) {
           core.get(s + r).sizeX = core.get(s).sizeX / (int) Math.pow(2, r);
           core.get(s + r).sizeY = core.get(s).sizeY / (int) Math.pow(2, r);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -127,6 +127,7 @@ public class ZeissCZIReader extends FormatReader {
   private int mosaics = 1;
   private int phases = 1;
   private int angles = 1;
+  private int maxResolution = 0;
 
   private String imageName;
   private String acquiredDate;
@@ -298,13 +299,13 @@ public class ZeissCZIReader extends FormatReader {
     if (isThumbnailSeries()) {
       // thumbnail, label, or preview image stored as an attachment
 
-      int index = getSeries() - (getSeriesCount() - extraImages.size());
+      int index = getCoreIndex() - (core.size() - extraImages.size());
       return extraImages.get(index).attachmentData;
     }
 
     previousChannel = getZCTCoords(no)[1];
 
-    int currentSeries = getSeries();
+    int currentIndex = getCoreIndex();
 
     Region image = new Region(x, y, w, h);
 
@@ -325,26 +326,28 @@ public class ZeissCZIReader extends FormatReader {
     try {
       int minTileX = Integer.MAX_VALUE, minTileY = Integer.MAX_VALUE;
       for (SubBlock plane : planes) {
-        if ((plane.seriesIndex == currentSeries && plane.planeIndex == no) ||
+        if ((plane.coreIndex == currentIndex && plane.planeIndex == no) ||
           (plane.planeIndex == previousChannel && validScanDim))
         {
-          if (plane.row < minTileY) {
-            minTileY = plane.row;
+          int res = (int) Math.pow(2, plane.resolutionIndex);
+          if ((plane.row / res) < minTileY) {
+            minTileY = plane.row / res;
           }
-          if (plane.col < minTileX) {
-            minTileX = plane.col;
+          if ((plane.col / res) < minTileX) {
+            minTileX = plane.col / res;
           }
         }
       }
       for (SubBlock plane : planes) {
-        if ((plane.seriesIndex == currentSeries && plane.planeIndex == no) ||
+        if ((plane.coreIndex == currentIndex && plane.planeIndex == no) ||
           (plane.planeIndex == previousChannel && validScanDim))
         {
+          int res = (int) Math.pow(2, plane.resolutionIndex);
           if ((prestitched != null && prestitched) || validScanDim) {
-            int realX = plane.x;
-            int realY = plane.y;
+            int realX = plane.x / res;
+            int realY = plane.y / res;
 
-            Region tile = new Region(plane.col, plane.row, realX, realY);
+            Region tile = new Region(plane.col / res, plane.row / res, realX, realY);
             if (validScanDim) {
               tile.y += (no / getSizeC());
               image.height = scanDim;
@@ -477,6 +480,7 @@ public class ZeissCZIReader extends FormatReader {
       indexIntoPlanes.clear();
       parser = null;
       extraImages.clear();
+      maxResolution = 0;
     }
   }
 
@@ -569,21 +573,44 @@ public class ZeissCZIReader extends FormatReader {
       ms0.imageCount = ms0.sizeZ * ms0.sizeT;
     }
 
+    int originalC = getSizeC();
     convertPixelType(planes.get(0).directoryEntry.pixelType);
 
     // remove any invalid SubBlocks
 
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    if (isRGB()) {
+      bpp *= (getSizeC() / originalC);
+    }
     for (int i=0; i<planes.size(); i++) {
       long planeSize = (long) planes.get(i).x * planes.get(i).y * bpp;
       if (planes.get(i).directoryEntry.compression == UNCOMPRESSED) {
         long size = planes.get(i).dataSize;
         if (size < planeSize || planeSize >= Integer.MAX_VALUE || size < 0) {
-          LOGGER.trace(
-            "removing block #{}; calculated size = {}, recorded size = {}",
-            i, planeSize, size);
-          planes.remove(i);
-          i--;
+          // check for reduced resolution in the pyramid
+          DimensionEntry[] entries = planes.get(i).directoryEntry.dimensionEntries;
+          if (planes.get(i).directoryEntry.pyramidType == 2 &&
+            size == entries[0].storedSize * entries[1].storedSize * bpp &&
+            (planes.get(i).x % entries[0].storedSize) == 0 &&
+            (planes.get(i).y % entries[1].storedSize) == 0)
+          {
+            int scale = planes.get(i).x / entries[0].storedSize;
+            planes.get(i).coreIndex = 0;
+            while (scale > 1) {
+              scale /= 2;
+              planes.get(i).coreIndex++;
+            }
+            if (planes.get(i).coreIndex > maxResolution) {
+              maxResolution = planes.get(i).coreIndex;
+            }
+          }
+          else {
+            LOGGER.trace(
+              "removing block #{}; calculated size = {}, recorded size = {}",
+              i, planeSize, size);
+            planes.remove(i);
+            i--;
+          }
         }
         else {
           scanDim = (int) (size / planeSize);
@@ -715,43 +742,87 @@ public class ZeissCZIReader extends FormatReader {
       }
     }
 
+    ms0.dimensionOrder = "XYCZT";
+
     if (seriesCount > 1) {
       core.clear();
       for (int i=0; i<seriesCount; i++) {
-        core.add(ms0);
+        CoreMetadata add = new CoreMetadata(ms0);
+        add.resolutionCount = maxResolution + 1;
+        core.add(add);
+        for (int r=0; r<maxResolution; r++) {
+          CoreMetadata resolution = new CoreMetadata(add);
+          resolution.resolutionCount = 1;
+          core.add(resolution);
+        }
       }
     }
 
-    ms0.dimensionOrder = "XYCZT";
     assignPlaneIndices();
 
     if (isPyramid) {
-      // calculate total stitched size
-      int minRow = Integer.MAX_VALUE;
-      int maxRow = Integer.MIN_VALUE;
-      int minCol = Integer.MAX_VALUE;
-      int maxCol = Integer.MIN_VALUE;
-      for (SubBlock plane : planes) {
-        if (plane.seriesIndex != 0) {
-          continue;
+      for (int s=0; s<core.size();) {
+        // calculate total stitched size
+        int minRow = Integer.MAX_VALUE;
+        int maxRow = Integer.MIN_VALUE;
+        int minCol = Integer.MAX_VALUE;
+        int maxCol = Integer.MIN_VALUE;
+        for (SubBlock plane : planes) {
+          if (plane.coreIndex != s) {
+            continue;
+          }
+          if (plane.row < minRow) {
+            minRow = plane.row;
+          }
+          if (plane.row > maxRow) {
+            maxRow = plane.row;
+          }
+          if (plane.col < minCol) {
+            minCol = plane.col;
+          }
+          if (plane.col > maxCol) {
+            maxCol = plane.col;
+          }
         }
-        if (plane.row < minRow) {
-          minRow = plane.row;
-        }
-        if (plane.row > maxRow) {
-          maxRow = plane.row;
-        }
-        if (plane.col < minCol) {
-          minCol = plane.col;
-        }
-        if (plane.col > maxCol) {
-          maxCol = plane.col;
-        }
-      }
-      for (int s=0; s<getSeriesCount(); s++) {
         core.get(s).sizeX = (core.get(s).sizeX + maxCol) - minCol;
         core.get(s).sizeY = (core.get(s).sizeY + maxRow) - minRow;
+        for (int r=0; r<core.get(s).resolutionCount; r++) {
+          core.get(s + r).sizeX = core.get(s).sizeX / (int) Math.pow(2, r);
+          core.get(s + r).sizeY = core.get(s).sizeY / (int) Math.pow(2, r);
+        }
+        s += core.get(s).resolutionCount;
       }
+    }
+
+    // find and add attached label/overview images
+
+    for (Segment segment : segments) {
+      if (segment instanceof Attachment) {
+        AttachmentEntry entry = ((Attachment) segment).attachment;
+        String name = entry.name.trim();
+
+        if (name.equals("Label") || name.equals("SlidePreview")) {
+          segment.fillInData();
+
+          // label and preview are CZI files embedded as attachments
+
+          ZeissCZIReader thumbReader = new ZeissCZIReader();
+          ByteArrayHandle stream = new ByteArrayHandle(((Attachment) segment).attachmentData);
+          Location.mapFile("image.czi", stream);
+          thumbReader.setId("image.czi");
+
+          CoreMetadata c = thumbReader.getCoreMetadataList().get(0);
+          core.add(new CoreMetadata(c));
+          core.get(core.size() - 1).thumbnail = true;
+          ((Attachment) segment).attachmentData = thumbReader.openBytes(0);
+          thumbReader.close();
+
+          stream.close();
+          Location.mapFile("image.czi", null);
+          extraImages.add((Attachment) segment);
+        }
+      }
+      segment.close();
     }
 
     // populate the OME metadata
@@ -798,28 +869,6 @@ public class ZeissCZIReader extends FormatReader {
             s.close();
           }
         }
-        else if (name.equals("Label") ||
-          name.equals("SlidePreview"))
-        {
-          segment.fillInData();
-
-          // label and preview are CZI files embedded as attachments
-
-          ZeissCZIReader thumbReader = new ZeissCZIReader();
-          ByteArrayHandle stream = new ByteArrayHandle(((Attachment) segment).attachmentData);
-          Location.mapFile("image.czi", stream);
-          thumbReader.setId("image.czi");
-
-          CoreMetadata c = thumbReader.getCoreMetadataList().get(0);
-          core.add(new CoreMetadata(c));
-          core.get(core.size() - 1).thumbnail = true;
-          ((Attachment) segment).attachmentData = thumbReader.openBytes(0);
-          thumbReader.close();
-
-          stream.close();
-          Location.mapFile("image.czi", null);
-          extraImages.add((Attachment) segment);
-        }
       }
       segment.close();
     }
@@ -839,7 +888,7 @@ public class ZeissCZIReader extends FormatReader {
 
     for (int i=0; i<planes.size(); i++) {
       SubBlock p = planes.get(i);
-      Coordinate c = new Coordinate(p.seriesIndex, p.planeIndex, getImageCount());
+      Coordinate c = new Coordinate(p.coreIndex, p.planeIndex, getImageCount());
       ArrayList<Integer> indices = new ArrayList<Integer>();
       if (indexIntoPlanes.containsKey(c)) {
         indices = indexIntoPlanes.get(c);
@@ -888,7 +937,29 @@ public class ZeissCZIReader extends FormatReader {
       while (imageIndex.length() < indexLength) {
         imageIndex = "0" + imageIndex;
       }
-      store.setImageName(name + " #" + imageIndex, i);
+
+      int extraIndex = i - (getSeriesCount() - extraImages.size());
+      if (extraIndex < 0) {
+        if (hasFlattenedResolutions()) {
+          store.setImageName(name + " #" + imageIndex, i);
+        }
+        else if (positions == 1) {
+          store.setImageName("", i);
+        }
+        else {
+          store.setImageName("Scene #" + i, i);
+        }
+      }
+      else if (extraIndex == 0) {
+        store.setImageName("label image", i);
+      }
+      else if (extraIndex == 1) {
+        store.setImageName("macro image", i);
+      }
+      else {
+        store.setImageName("thumbnail image", i);
+      }
+
       if (description != null && description.length() > 0) {
         store.setImageDescription(description, i);
       }
@@ -1367,9 +1438,11 @@ public class ZeissCZIReader extends FormatReader {
       }
 
       plane.planeIndex = getIndex(z, c, t);
-      plane.seriesIndex = FormatTools.positionToRaster(extraLengths, extra);
+      int seriesIndex = FormatTools.positionToRaster(extraLengths, extra);
+      plane.resolutionIndex = plane.coreIndex;
+      plane.coreIndex += seriesIndex * (maxResolution + 1);
       LOGGER.trace("    assigned plane index = {}; series index = {}",
-        plane.planeIndex, plane.seriesIndex);
+        plane.planeIndex, seriesIndex);
     }
   }
 
@@ -2942,7 +3015,8 @@ public class ZeissCZIReader extends FormatReader {
     public DirectoryEntry directoryEntry;
     public String metadata;
 
-    public int seriesIndex;
+    public int coreIndex;
+    public int resolutionIndex;
     public int planeIndex;
 
     private long dataOffset;
@@ -2964,7 +3038,7 @@ public class ZeissCZIReader extends FormatReader {
       this.dataSize = model.dataSize;
       this.directoryEntry = model.directoryEntry;
       this.metadata = model.metadata;
-      this.seriesIndex = model.seriesIndex;
+      this.coreIndex = model.coreIndex;
       this.planeIndex = model.planeIndex;
       this.dataOffset = model.dataOffset;
       this.stageX = model.stageX;
@@ -2978,8 +3052,9 @@ public class ZeissCZIReader extends FormatReader {
 
     @Override
     public String toString() {
-      return "seriesIndex=" + seriesIndex + ", planeIndex=" + planeIndex +
-        ", x=" + x + ", y=" + y + ", row=" + row + ", col=" + col;
+      return "coreIndex=" + coreIndex + ", planeIndex=" + planeIndex +
+        ", x=" + x + ", y=" + y + ", row=" + row + ", col=" + col + ", metadata=" + metadata +
+        ", attachmentSize=" + attachmentSize + ", directoryEntry=" + directoryEntry;
     }
 
     @Override
@@ -3328,9 +3403,20 @@ public class ZeissCZIReader extends FormatReader {
 
     @Override
     public String toString() {
-      return "schemaType = " + schemaType + ", pixelType = " + pixelType + ", filePosition = " +
+      String s = "schemaType = " + schemaType + ", pixelType = " + pixelType + ", filePosition = " +
         filePosition + ", filePart = " + filePart + ", compression = " + compression +
         ", pyramidType = " + pyramidType + ", dimensionCount = " + dimensionCount;
+      if (dimensionCount > 0) {
+        s += ", dimensions = [";
+        for (int i=0; i<dimensionCount; i++) {
+          s += dimensionEntries[i];
+          if (i < dimensionCount - 1) {
+            s += "; ";
+          }
+        }
+        s += "]";
+      }
+      return s;
     }
   }
 
@@ -3347,6 +3433,12 @@ public class ZeissCZIReader extends FormatReader {
       size = s.readInt();
       startCoordinate = s.readFloat();
       storedSize = s.readInt();
+    }
+
+    @Override
+    public String toString() {
+      return "dimension=" + dimension + ", start=" + start + ", size=" + size +
+        ", startCoordinate=" + startCoordinate + ", storedSize=" + storedSize;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -491,7 +491,7 @@ public class ZeissCZIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
-    if (getCoreIndex() < tileWidth.length) {
+    if (tileWidth != null && getCoreIndex() < tileWidth.length) {
       return tileWidth[getCoreIndex()];
     }
     return super.getOptimalTileWidth();
@@ -500,7 +500,7 @@ public class ZeissCZIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
-    if (getCoreIndex() < tileHeight.length) {
+    if (tileHeight != null && getCoreIndex() < tileHeight.length) {
       return tileHeight[getCoreIndex()];
     }
     return super.getOptimalTileHeight();

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1007,6 +1007,12 @@ public class ZeissCZIReader extends FormatReader {
         store.setImageName("thumbnail image", i);
       }
 
+      // remaining acquisition settings (esp. channels) do not apply to
+      // label and macro images
+      if (extraIndex >= 0) {
+        continue;
+      }
+
       if (description != null && description.length() > 0) {
         store.setImageDescription(description, i);
       }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -484,6 +484,30 @@ public class ZeissCZIReader extends FormatReader {
     }
   }
 
+  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  @Override
+  public int getOptimalTileWidth() {
+    for (SubBlock plane : planes) {
+      if (plane.coreIndex == getCoreIndex()) {
+        int res = (int) Math.pow(2, plane.resolutionIndex);
+        return plane.x / res;
+      }
+    }
+    return super.getOptimalTileWidth();
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    for (SubBlock plane : planes) {
+      if (plane.coreIndex == getCoreIndex()) {
+        int res = (int) Math.pow(2, plane.resolutionIndex);
+        return plane.y / res;
+      }
+    }
+    return super.getOptimalTileHeight();
+  }
+
   // -- Internal FormatReader API methods --
 
   /* @see loci.formats.FormatReader#initFile(String) */

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -169,7 +169,7 @@ public class ZeissCZIReader extends FormatReader {
   /** Constructs a new Zeiss .czi reader. */
   public ZeissCZIReader() {
     super("Zeiss CZI", "czi");
-    domains = new String[] {FormatTools.LM_DOMAIN};
+    domains = new String[] {FormatTools.LM_DOMAIN, FormatTools.HISTOLOGY_DOMAIN};
     suffixSufficient = true;
     suffixNecessary = false;
   }
@@ -674,7 +674,7 @@ public class ZeissCZIReader extends FormatReader {
     // finish populating the core metadata
 
     int seriesCount = positions * acquisitions * angles;
-    boolean isPyramid = true;
+    boolean isPyramid = maxResolution > 0;
     if (!isPyramid) {
       seriesCount *= mosaics;
     }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -619,13 +619,24 @@ public class ZeissCZIReader extends FormatReader {
             (planes.get(i).y % entries[1].storedSize) == 0)
           {
             int scale = planes.get(i).x / entries[0].storedSize;
-            planes.get(i).coreIndex = 0;
-            while (scale > 1) {
-              scale /= 2;
-              planes.get(i).coreIndex++;
+            // resolutions must be a power of 2 smaller than the full resolution
+            // some files will contain power-of-3 resolutions, which need to be ignored
+            if ((scale % 2) == 0) {
+              planes.get(i).coreIndex = 0;
+              while (scale > 1) {
+                scale /= 2;
+                planes.get(i).coreIndex++;
+              }
+              if (planes.get(i).coreIndex > maxResolution) {
+                maxResolution = planes.get(i).coreIndex;
+              }
             }
-            if (planes.get(i).coreIndex > maxResolution) {
-              maxResolution = planes.get(i).coreIndex;
+            else {
+              LOGGER.trace(
+               "removing block #{}; calculated size = {}, recorded size = {}, scale = {}",
+                 i, planeSize, size, scale);
+              planes.remove(i);
+              i--;
             }
           }
           else {


### PR DESCRIPTION
See https://trello.com/c/OHKk0BiI/161-jpeg-xr.

This adds more polished support for slide data from Axio Scan.Z1 systems.  Slides should now be detected as a complete full-resolution image (instead of each tile being a separate series), pyramid sub-resolutions are detected, and label/overview images are detected.

This is excluded for now, pending conclusion of m5 and a configuration PR.  Further testing instructions will be added once the configuration PR is set - I'm just in the process of importing the 13 files for which configurations have changed, verifying that the new behavior is correct, and assembling supporting screenshots.