### PR TITLE
Update version history for m5

### DIFF
--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,13 +1,14 @@
 Version history
 ===============
 
-5.2.0-m4 (2016 June 24)
+5.2.0-m5 (2016 July 7)
 -----------------------
 
 Top-level Bio-Formats API changes:
 
 * Java 1.7 is now the minimum supported version
 * the native-lib-loader dependency has been bumped to version 2.1.4
+* the xalan dependency has been bumped to version 2.7.2
 * all the ome.jxr classes have been deprecated to make clear that there is no
   JPEG-XR support implemented in Bio-Formats as yet
 * the DataTools API has been extended to add a number of utility functions to:
@@ -18,13 +19,18 @@ Top-level Bio-Formats API changes:
   (log4j/logback) initialized via a binding-specific configurations file and
   to prevent `DebugTools.enableLogging(String)` from overriding initialized
   logger levels (see :doc:`/developers/logging` for more information)
+* helper methods have been added to FormatTools allowing a stage position to
+  be formatted from an input Double and an input unit
+* the Formats API has also been updated to add a new validate property to
+  MetadataOptions and support for MetadataOptions has been moved to
+  FormatHandler level to allow it to be used by both Readers and Writers
 
 The Data Model version 2016-06 has been released to introduce
 `Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,
 and to simplify both the graphical aspects of the model and code generation.
-Full details will be available in the
-:model_doc:`OME Model and Formats Documentation <>` shortly. OME-XML changes
-include:
+Full details are available in the
+:model_doc:`OME Model and Formats Documentation <schemas/june-2016.html>`.
+OME-XML changes include:
 
 * `Map` is now a complexType rather than an element and `MapPairs` has been
   dropped
@@ -96,6 +102,11 @@ Other general improvements include:
 * fixes for the detection of csv pattern blocks by `FilePatternBlock`
 * bioformats_package.jar now includes bio-formats-tools as a dependency so
   ImageConverter, ImageFaker and ImageInfo classes are included in the bundle
+* initial work on
+  `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_ now allows
+  optional/external Readers to be annotated into the Readers class and
+  additional per-Reader options to be specified at the :file:`readers.txt`
+  level or even parsed externally
 * the JACE C++ implementation has been decoupled as it does not function with
   Java 1.7 (see `legacy repo <https://github.com/ome/bio-formats-jace>`_)
 * ImageJ fixes
@@ -110,6 +121,9 @@ Other general improvements include:
    - upgrade check no longer run when passing -version
    - common methods refactoring
    - showinf improvements to preload format
+* Micromanager fixes:
+   - improved handling of large datasets saved as image stacks and split over
+     multiple files
 * Added more Java examples to the developer documentation
 * Added many automated tests and improved FakeReader testing framework
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -94,6 +94,9 @@ Java format support improvements include:
        - fixed timestamp indexing when multiple separate channels are present
    - SVS
        - fixed FormatNumberException
+   - Micro-Manager
+       - fixed handling of large datasets saved as image stacks and split
+         over multiple files
 
 Other general improvements include:
 
@@ -120,9 +123,6 @@ Other general improvements include:
    - upgrade check no longer run when passing -version
    - common methods refactoring
    - showinf improvements to preload format
-* Micro-Manager fixes:
-   - improved handling of large datasets saved as image stacks and split over
-     multiple files
 * Added more Java examples to the developer documentation
 * Added many automated tests and improved FakeReader testing framework
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -103,10 +103,9 @@ Other general improvements include:
 * bioformats_package.jar now includes bio-formats-tools as a dependency so
   ImageConverter, ImageFaker and ImageInfo classes are included in the bundle
 * initial work on
-  `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_ now allows
-  optional/external Readers to be annotated into the Readers class and
-  additional per-Reader options to be specified at the :file:`readers.txt`
-  level or even parsed externally
+  `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_ now allows the
+  :file:`readers.txt` configuration file to be annotated using key/value pairs
+  to mark optional Readers and specify additional per-Reader options
 * the JACE C++ implementation has been decoupled as it does not function with
   Java 1.7 (see `legacy repo <https://github.com/ome/bio-formats-jace>`_)
 * ImageJ fixes

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -120,7 +120,7 @@ Other general improvements include:
    - upgrade check no longer run when passing -version
    - common methods refactoring
    - showinf improvements to preload format
-* Micromanager fixes:
+* Micro-Manager fixes:
    - improved handling of large datasets saved as image stacks and split over
      multiple files
 * Added more Java examples to the developer documentation

--- a/docs/sphinx/index.txt
+++ b/docs/sphinx/index.txt
@@ -20,7 +20,7 @@ supported by Bio-Formats.
     - :doc:`developers/index`
     - :doc:`formats/index`
 
-    The version *5.1* releases use the *January 2015* release of the
+    The version *5.2* releases use the *June 2016* release of the
     :model_doc:`OME-Model <>`.
     
     **Bio-Formats is a community project and we welcome your input.** You can


### PR DESCRIPTION
See https://trello.com/c/9mgNoo67/21-version-history-prs

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/about/whats-new.html

m4 content is edited as plan is to build up content but end up with only 1 version history entry for 5.2.0.