### PR TITLE
Add format page for SPE

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1914,6 +1914,22 @@ utilityRating = Good
 reader = PrairieReader
 mif = true
 
+[Princeton Instruments SPE]
+extensions = .spe
+developer = `Princeton Instruments <http://www.princetoninstruments.com>`_
+bsd = no
+versions = 3.0
+weHave = * `An official specification document <ftp://ftp.princetoninstruments.com/public/Manuals/Princeton%20Instruments/SPE%203.0%20File%20Format%20Specification.pdf>`_ \n
+* two SPE files
+weWant = * more SPE files
+pixelsRating = Good
+metadataRating = Very good
+opennessRating = Very good
+presenceRating = Fair
+utilityRating = Good
+reader = SPEReader
+mif = true
+
 [Quesant]
 extensions = .afm
 owner = `KLA-Tencor Corporation <http://www.kla-tencor.com/surface-profilometry-and-metrology.html>`_

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -65,7 +65,7 @@ extensions = .al3d
 owner = `Alicona Imaging <http://www.alicona.com/>`_
 bsd = no
 versions = 1.0
-weHave = * an AL3D specification document (v1.0, from 2003, in PDF) \n
+weHave = * an AL3D specification document (v1.0, from 2003, in PDF)\n
 * a few AL3D datasets
 weWant = * more AL3D datasets (Z series, T series, 16-bit)
 pixelsRating = Very good

--- a/docs/sphinx/formats/alicona-3d.txt
+++ b/docs/sphinx/formats/alicona-3d.txt
@@ -25,7 +25,7 @@ Reader: AliconaReader (:bfreader:`Source Code <AliconaReader.java>`, :doc:`Suppo
 
 We currently have:
 
-* an AL3D specification document (v1.0, from 2003, in PDF)
+* an AL3D specification document (v1.0, from 2003, in PDF) 
 * a few AL3D datasets
 
 We would like to have:

--- a/docs/sphinx/formats/alicona-3d.txt
+++ b/docs/sphinx/formats/alicona-3d.txt
@@ -25,7 +25,7 @@ Reader: AliconaReader (:bfreader:`Source Code <AliconaReader.java>`, :doc:`Suppo
 
 We currently have:
 
-* an AL3D specification document (v1.0, from 2003, in PDF) 
+* an AL3D specification document (v1.0, from 2003, in PDF)
 * a few AL3D datasets
 
 We would like to have:

--- a/docs/sphinx/formats/princeton-instruments-spe.txt
+++ b/docs/sphinx/formats/princeton-instruments-spe.txt
@@ -1,0 +1,49 @@
+.. index:: Princeton Instruments SPE
+.. index:: .spe
+
+Princeton Instruments SPE
+===============================================================================
+
+Extensions: .spe
+
+Developer: `Princeton Instruments <http://www.princetoninstruments.com>`_
+
+
+**Support**
+
+
+BSD-licensed: |no|
+
+Export: |no|
+
+Officially Supported Versions: 3.0
+
+Reader: SPEReader (:bfreader:`Source Code <SPEReader.java>`, :doc:`Supported Metadata Fields </metadata/SPEReader>`)
+
+
+
+
+We currently have:
+
+* `An official specification document <ftp://ftp.princetoninstruments.com/public/Manuals/Princeton%20Instruments/SPE%203.0%20File%20Format%20Specification.pdf>`_ 
+* two SPE files
+
+We would like to have:
+
+* more SPE files
+
+**Ratings**
+
+
+Pixels: |Good|
+
+Metadata: |Very good|
+
+Openness: |Very good|
+
+Presence: |Fair|
+
+Utility: |Good|
+
+
+

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1248,6 +1248,17 @@ Supported Formats
      - |no|
      - |yes|
      - |no|
+   * - :doc:`formats/princeton-instruments-spe`
+     - .spe
+     - |Good|
+     - |Very good|
+     - |Very good|
+     - |Fair|
+     - |Good|
+     - |no|
+     - |no|
+     - |yes|
+     - |no|
    * - :doc:`formats/quesant`
      - .afm
      - |Good|
@@ -1590,7 +1601,7 @@ Supported Formats
      - |yes|
      - |no|
 
-Bio-Formats currently supports **142** formats
+Bio-Formats currently supports **143** formats
 
 .. glossary::
     Ratings legend and definitions
@@ -1771,6 +1782,7 @@ Bio-Formats currently supports **142** formats
     formats/pict-macintosh-picture
     formats/png
     formats/prairie-tech-tiff
+    formats/princeton-instruments-spe
     formats/quesant
     formats/quicktime-movie
     formats/rhk


### PR DESCRIPTION
See https://trello.com/c/PxU8TWGe/66-new-formats-documentation

This adds a format page for SPE and adds it to the supported formats table. Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/supported-formats.html


N.B. Alicona 3D whitespace fix because I didn't run autogen build to update the docs page on #2468