### PR TITLE
Add SPC FIFO format page

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -284,7 +284,8 @@ utilityRating = Good
 reader = BDReader
 mif = true
 
-[Becker & Hickl FIFO]
+[Becker & Hickl SPC FIFO]
+pagename = becker-hickl-fifo
 extensions = .spc
 owner = `Becker-Hickl <http://www.becker-hickl.de/>`_
 bsd = no

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -284,6 +284,21 @@ utilityRating = Good
 reader = BDReader
 mif = true
 
+[Becker & Hickl FIFO]
+extensions = .spc
+owner = `Becker-Hickl <http://www.becker-hickl.de/>`_
+bsd = no
+weHave = * an `SPC specification document <http://www.becker-hickl.com/handbookphp.htm>`_ \n
+* an SPC dataset
+weWant = * more SPC sample files
+pixelsRating = Poor
+metadataRating = Fair
+opennessRating = Good
+presenceRating = Poor
+utilityRating = Fair
+reader = SPCReader
+mif = true
+
 [Becker & Hickl SPCImage]
 extensions = .sdt
 owner = `Becker-Hickl <http://www.becker-hickl.de/>`_

--- a/components/formats-gpl/src/loci/formats/in/SPCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SPCReader.java
@@ -171,7 +171,7 @@ public class SPCReader extends FormatReader {
 
   /** Constructs a new SPC reader. */
   public SPCReader() {
-    super("SPCImage Data", new String[] {"spc", "set"});
+    super("SPC FIFO Data", new String[] {"spc", "set"});
     domains = new String[] {FormatTools.FLIM_DOMAIN};
     suffixSufficient = true;
     hasCompanionFiles = true;

--- a/docs/sphinx/formats/becker-hickl-fifo.txt
+++ b/docs/sphinx/formats/becker-hickl-fifo.txt
@@ -1,0 +1,49 @@
+.. index:: Becker & Hickl FIFO
+.. index:: .spc
+
+Becker & Hickl FIFO
+===============================================================================
+
+Extensions: .spc
+
+
+Owner: `Becker-Hickl <http://www.becker-hickl.de/>`_
+
+**Support**
+
+
+BSD-licensed: |no|
+
+Export: |no|
+
+Officially Supported Versions: 
+
+Reader: SPCReader (:bfreader:`Source Code <SPCReader.java>`, :doc:`Supported Metadata Fields </metadata/SPCReader>`)
+
+
+
+
+We currently have:
+
+* an `SPC specification document <http://www.becker-hickl.com/handbookphp.htm>`_ 
+* an SPC dataset
+
+We would like to have:
+
+* more SPC sample files
+
+**Ratings**
+
+
+Pixels: |Poor|
+
+Metadata: |Fair|
+
+Openness: |Good|
+
+Presence: |Poor|
+
+Utility: |Fair|
+
+
+

--- a/docs/sphinx/formats/becker-hickl-fifo.txt
+++ b/docs/sphinx/formats/becker-hickl-fifo.txt
@@ -1,7 +1,7 @@
-.. index:: Becker & Hickl FIFO
+.. index:: Becker & Hickl SPC FIFO
 .. index:: .spc
 
-Becker & Hickl FIFO
+Becker & Hickl SPC FIFO
 ===============================================================================
 
 Extensions: .spc

--- a/docs/sphinx/metadata/SPCReader.txt
+++ b/docs/sphinx/metadata/SPCReader.txt
@@ -2,7 +2,7 @@
 SPCReader
 *******************************************************************************
 
-This page lists supported metadata fields for the Bio-Formats SPCImage Data format reader.
+This page lists supported metadata fields for the Bio-Formats SPC FIFO Data format reader.
 
 These fields are from the :model_doc:`OME data model <>`.
 Bio-Formats standardizes each format's original metadata to and from the OME
@@ -16,7 +16,7 @@ Of the 476 fields documented in the :doc:`metadata summary table </metadata-summ
 Supported fields
 ===============================================================================
 
-These fields are fully supported by the Bio-Formats SPCImage Data format reader:
+These fields are fully supported by the Bio-Formats SPC FIFO Data format reader:
   * :schema:`Channel : ID <OME-2016-06/ome_xsd.html#Channel_ID>`
   * :schema:`Channel : SamplesPerPixel <OME-2016-06/ome_xsd.html#Channel_SamplesPerPixel>`
   * :schema:`Image : AcquisitionDate <OME-2016-06/ome_xsd.html#Image_AcquisitionDate>`

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -192,6 +192,17 @@ Supported Formats
      - |no|
      - |yes|
      - |no|
+   * - :doc:`formats/becker-hickl-fifo`
+     - .spc
+     - |Poor|
+     - |Fair|
+     - |Good|
+     - |Poor|
+     - |Fair|
+     - |no|
+     - |no|
+     - |yes|
+     - |no|
    * - :doc:`formats/becker-hickl-spcimage`
      - .sdt
      - |Very good|
@@ -1601,7 +1612,7 @@ Supported Formats
      - |yes|
      - |no|
 
-Bio-Formats currently supports **143** formats
+Bio-Formats currently supports **144** formats
 
 .. glossary::
     Ratings legend and definitions
@@ -1686,6 +1697,7 @@ Bio-Formats currently supports **143** formats
     formats/avi
     formats/axon-raw-format
     formats/bd-pathway
+    formats/becker-hickl-fifo
     formats/becker-hickl-spcimage
     formats/bio-rad-gel
     formats/bio-rad-pic


### PR DESCRIPTION
This documents the format support added in https://github.com/openmicroscopy/bioformats/pull/1992

I've assumed MIF because when I looked at the reader it talks about companion files, this may not be correct.

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/metadata/SPCReader.html and http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/formats/becker-hickl-fifo.html