### PR TITLE
MemoizerTest: check return value of setWritable(false)

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -279,8 +279,10 @@ public class MemoizerTest {
       // Check existing non-writeable memo directory returns null
       if (File.separator.equals("/")) {
         // File.setWritable() does not work properly on Windows
-        directory.setWritable(false);
-        assertEquals(memoizer.getMemoFile(id), null);
+        boolean success = directory.setWritable(false);
+        if (success) {
+          assertEquals(memoizer.getMemoFile(id), null);
+        }
       }
 
       // Check existing writeable memo diretory returns a memo file
@@ -301,8 +303,10 @@ public class MemoizerTest {
       // Check non-writeable file directory returns null for in-place caching
       if (File.separator.equals("/")) {
         // File.setWritable() does not work properly on Windows
-        idDir.setWritable(false);
-        assertEquals(memoizer.getMemoFile(id), null);
+        boolean success = idDir.setWritable(false);
+        if (success) {
+          assertEquals(memoizer.getMemoFile(id), null);
+        }
       }
 
       // Check writeable file directory returns memo file beside file
@@ -319,8 +323,10 @@ public class MemoizerTest {
       // Check non-writeable file directory returns null for in-place caching
       if (File.separator.equals("/")) {
         // File.setWritable() does not work properly on Windows
-        idDir.setWritable(false);
-        assertEquals(memoizer.getMemoFile(id), null);
+        boolean success = idDir.setWritable(false);
+        if (success) {
+          assertEquals(memoizer.getMemoFile(id), null);
+        }
       }
       // Check writeable file directory returns memo file beside file
       idDir.setWritable(true);


### PR DESCRIPTION
This prevents asserts from being called when the directory permissions
haven't changed, as that will guarantee that the memo permissions tests
will fail.

Following discussion with @aleksandra-tarkowska, some Docker builds fail the 3 ```testGetMemoFilePermissions*``` tests in ```loci.formats.utests.MemoizerTest``` (see https://gist.github.com/aleksandra-tarkowska/c12d83c769b536a5888636180a51ca7f#file-bf-log-L2846).  While it be good to understand why the directory permissions can't be changed in that case, this PR should allow the tests to pass in the meantime and perhaps will help to track down the underlying problem.