### PR TITLE
Kodak: handle CCD temperature stored in hexadecimal

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/KodakReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KodakReader.java
@@ -241,12 +241,13 @@ public class KodakReader extends FormatReader {
         if (hexMatcher.matches()) {
           // CCD temperature stored as a hexadecimal string such as "0xEB".
           temp = new Double(Integer.parseInt(hexMatcher.group(1), 16));
+          LOGGER.debug("CCD temperature detected as {}; assumed to be invalid", temp);
         }
         else {
           temp = new Double(value.substring(0, value.indexOf(" ")));
-        }
-        store.setImagingEnvironmentTemperature(
+          store.setImagingEnvironmentTemperature(
                 new Temperature(temp, UNITS.CELSIUS), 0);
+        }
       }
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/KodakReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KodakReader.java
@@ -26,6 +26,8 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import loci.common.Constants;
 import loci.common.DateTools;
@@ -234,7 +236,15 @@ public class KodakReader extends FormatReader {
         }
       }
       else if (key.equals("CCD Temperature")) {
-        Double temp = new Double(value.substring(0, value.indexOf(" ")));
+        Double temp;
+        Matcher hexMatcher = Pattern.compile("0x([0-9A-F]+)").matcher(value);
+        if (hexMatcher.matches()) {
+          // CCD temperature stored as a hexadecimal string such as "0xEB".
+          temp = new Double(Integer.parseInt(hexMatcher.group(1), 16));
+        }
+        else {
+          temp = new Double(value.substring(0, value.indexOf(" ")));
+        }
         store.setImagingEnvironmentTemperature(
                 new Temperature(temp, UNITS.CELSIUS), 0);
       }


### PR DESCRIPTION
Fixes the bug reported in https://github.com/openmicroscopy/bioformats/issues/2491.

We don't have any shareable files that exhibit this problem out of the box, but there is an artificial one uploaded to ```curated/bip/samples/``` (see the readme in that folder for provenance).  To test, use that file and confirm that ```showinf -normalize``` without this change results in an exception as reported in the above issue.  With this change, ```showinf -normalize``` should show the image window without an exception.

Corresponding config PR: https://github.com/openmicroscopy/data_repo_config/pull/114