### PR TITLE
Added .nii.gz support to NiftiReader...

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
+import loci.common.GZipHandle;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
@@ -228,6 +229,11 @@ public class NiftiReader extends FormatReader {
     else if (id.endsWith(".nii")) {
       pixelsFilename = id;
       pixelFile = in;
+    } else if (id.endsWith(".nii.gz")) {
+      pixelsFilename = id;
+      pixelFile = new RandomAccessInputStream(new GZipHandle(id));
+    } else {
+    	throw new FormatException("File does not have one of the required NIfTI extensions (.hdr, .nii, .nii.gz)");
     }
 
     in.order(little);


### PR DESCRIPTION
… Also ended the switch block with a `FormatException` if the suffix is not identified, to better handle future issues with reading NIfTI.

Using `mvn install` to build, the resulting `formats-gpl-5.2.0-SNAPSHOT.jar`, with the patched `NiftiReader`, was tested by dragging and dropping into `Fiji.app/jars/bio-formats` and deleting the earlier version, `formats-gpl-5.1.10.jar`. Fiji was then able to read .nii.gz files directly so the patch works. It was also tested to make sure it still reads `.nii`, `.hdr` and `.img` files and it does.

Gzipped NIfTI files are arguably the most common NIfTI in fMRI imaging and this PR will enable ImageJ to open them without a problem.