### PR TITLE
Add SPC-FIFO public images & support note

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -290,7 +290,7 @@ extensions = .spc
 owner = `Becker-Hickl <http://www.becker-hickl.de/>`_
 bsd = no
 weHave = * an `SPC specification document <http://www.becker-hickl.com/handbookphp.htm>`_ \n
-* an SPC dataset
+* `public sample images <http://downloads.openmicroscopy.org/images/SPC-FIFO/>`__
 weWant = * more SPC sample files
 pixelsRating = Poor
 metadataRating = Fair
@@ -299,6 +299,8 @@ presenceRating = Poor
 utilityRating = Fair
 reader = SPCReader
 mif = true
+notes = * Only files containing frame, line and pixel clock information \n
+  are currently supported
 
 [Becker & Hickl SPCImage]
 extensions = .sdt

--- a/docs/sphinx/formats/becker-hickl-fifo.txt
+++ b/docs/sphinx/formats/becker-hickl-fifo.txt
@@ -26,7 +26,7 @@ Reader: SPCReader (:bfreader:`Source Code <SPCReader.java>`, :doc:`Supported Met
 We currently have:
 
 * an `SPC specification document <http://www.becker-hickl.com/handbookphp.htm>`_ 
-* an SPC dataset
+* `public sample images <http://downloads.openmicroscopy.org/images/SPC-FIFO/>`__
 
 We would like to have:
 
@@ -45,5 +45,8 @@ Presence: |Poor|
 
 Utility: |Fair|
 
+**Additional Information**
 
 
+* Only files containing frame, line and pixel clock information 
+  are currently supported


### PR DESCRIPTION
See https://trello.com/c/hjZpniE2/166-make-becker-hickl-fifo-spc-files-public
This adds a link to the now public samples and a note regarding what the files are currently supported as suggested by @imunro 

Will be staged at http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/formats/becker-hickl-fifo.html