### PR TITLE
Fix MATLAB root logger level overriding in bftest.m

### DIFF
--- a/docs/sphinx/developers/examples/bftest.m
+++ b/docs/sphinx/developers/examples/bftest.m
@@ -122,7 +122,7 @@ delete('metadata.ome.tiff');
 
 % logging-start
 % Set the logging level to DEBUG
-loci.common.DebugTools.enableLogging('DEBUG');
+loci.common.DebugTools.setRootLevel('DEBUG');
 % logging-end
 
 % memoizer-start


### PR DESCRIPTION
While answering https://github.com/openmicroscopy/bioformats/issues/2497, I noticed `bftest.m` and hence the Sphinx MATLAB documentation page still used to the 5.1.x logic for setting the root logger level.

This PR updates the test and the documentation page to match the 5.2 API. To test it:
- check the `bftest.m` runs as expected in the CI job and that the logging level is set to `DEBUG` (while the call should have been a no-op previously)
- review the logging section in [the staging documentation page](http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/developers/matlab-dev.html)