### PR TITLE
Add nifti public sample link & missed extension

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1492,12 +1492,13 @@ notes = .. seealso:: \n
   `NEF Conversion <http://www.outbackphoto.com/workshop/NEF_conversion/nefconversion.html>`_
 
 [NIfTI]
-extensions = .img, .hdr
+extensions = .img, .hdr, .nii
 developer = `National Institutes of Health <http://www.nih.gov/>`_
 bsd = no
 samples = `Official test data <http://afni.nimh.nih.gov/pub/dist/data/>`_
 weHave = * `NIfTI specification documents <http://afni.nimh.nih.gov/pub/dist/doc/nifti/nifti_revised.html>`_ \n
-* several NIfTI datasets
+* several NIfTI datasets \n
+* `public sample images <http://downloads.openmicroscopy.org/images/NIfTI/>`__
 pixelsRating = Very good
 metadataRating = Good
 opennessRating = Very good

--- a/docs/sphinx/formats/nifti.txt
+++ b/docs/sphinx/formats/nifti.txt
@@ -1,10 +1,10 @@
 .. index:: NIfTI
-.. index:: .img, .hdr
+.. index:: .img, .hdr, .nii
 
 NIfTI
 ===============================================================================
 
-Extensions: .img, .hdr
+Extensions: .img, .hdr, .nii
 
 Developer: `National Institutes of Health <http://www.nih.gov/>`_
 
@@ -29,7 +29,8 @@ Sample Datasets:
 We currently have:
 
 * `NIfTI specification documents <http://afni.nimh.nih.gov/pub/dist/doc/nifti/nifti_revised.html>`_ 
-* several NIfTI datasets
+* several NIfTI datasets 
+* `public sample images <http://downloads.openmicroscopy.org/images/NIfTI/>`__
 
 We would like to have:
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -974,7 +974,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/nifti`
-     - .img, .hdr
+     - .img, .hdr, .nii
      - |Very good|
      - |Good|
      - |Very good|


### PR DESCRIPTION
See https://trello.com/c/HAiHHpHf/126-nifti-public-samples
and https://github.com/openmicroscopy/data_repo_config/pull/116
This adds the public samples link and also the .nii file extension to the supported formats table and format page (it had previously only been added the the dataset structure table as this is updated from the reader code automatically).

Will be staged at http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/formats/nifti.html

N.B. we may also want to add .nii.gz when https://github.com/openmicroscopy/bioformats/pull/2493 is merged.