### PR TITLE
Re-include OME-XML and OME-TIFF samples when testing valid OME-XML

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -64,6 +64,7 @@ public class Configuration {
   private static final String ACCESS_TIME = "access_ms";
   private static final String MEMORY = "mem_mb";
   private static final String TEST = "test";
+  private static final String HAS_VALID_XML = "hasValidXML";
   private static final String READER = "reader";
   private static final String SERIES = " series_";
 
@@ -166,6 +167,11 @@ public class Configuration {
 
   public boolean doTest() {
     return new Boolean(globalTable.get(TEST)).booleanValue();
+  }
+
+  public boolean hasValidXML() {
+    if (globalTable.get(HAS_VALID_XML) == null) return true;
+    return new Boolean(globalTable.get(HAS_VALID_XML)).booleanValue();
   }
 
   public String getReader() {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -594,6 +594,11 @@ public class FormatReaderTest {
   public void testSaneOMEXML() {
     String testName = "testSaneOMEXML";
     if (!initFile()) result(testName, false, "initFile");
+    if (!config.hasValidXML()) {
+      LOGGER.debug("Skipping valid XML test");
+      result(testName, true);
+      return;
+    }
     String msg = null;
     try {
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -596,11 +596,6 @@ public class FormatReaderTest {
     if (!initFile()) result(testName, false, "initFile");
     String msg = null;
     try {
-      String format = config.getReader();
-      if (format.equals("OMETiffReader") || format.equals("OMEXMLReader")) {
-        result(testName, true);
-        return;
-      }
 
       MetadataRetrieve retrieve = (MetadataRetrieve) reader.getMetadataStore();
       boolean success = omexmlService.isOMEXMLMetadata(retrieve);
@@ -1396,12 +1391,6 @@ public class FormatReaderTest {
     boolean success = true;
     String msg = null;
     try {
-      String format = config.getReader();
-      if (format.equals("OMETiffReader") || format.equals("OMEXMLReader")) {
-        result(testName, true);
-        return;
-      }
-
       MetadataStore store = reader.getMetadataStore();
       success = omexmlService.isOMEXMLMetadata(store);
       if (!success) msg = TestTools.shortClassName(store);
@@ -1844,27 +1833,22 @@ public class FormatReaderTest {
     String testName = "testValidXML";
     if (!initFile()) result(testName, false, "initFile");
     String format = config.getReader();
-    if (format.equals("OMETiffReader") || format.equals("OMEXMLReader")) {
-      result(testName, true);
-    }
-    else {
-      boolean success = true;
-      try {
-        MetadataStore store = reader.getMetadataStore();
-        MetadataRetrieve retrieve = omexmlService.asRetrieve(store);
-        String xml = omexmlService.getOMEXML(retrieve);
-        // prevent issues due to thread-unsafeness of
-        // javax.xml.validation.Validator as used during XML validation
-        synchronized (configTree) {
-          success = xml != null && omexmlService.validateOMEXML(xml);
-        }
+    boolean success = true;
+    try {
+      MetadataStore store = reader.getMetadataStore();
+      MetadataRetrieve retrieve = omexmlService.asRetrieve(store);
+      String xml = omexmlService.getOMEXML(retrieve);
+      // prevent issues due to thread-unsafeness of
+      // javax.xml.validation.Validator as used during XML validation
+      synchronized (configTree) {
+        success = xml != null && omexmlService.validateOMEXML(xml);
       }
-      catch (Throwable t) {
-        LOGGER.info("", t);
-        success = false;
-      }
-      result(testName, success);
     }
+    catch (Throwable t) {
+      LOGGER.info("", t);
+      success = false;
+    }
+    result(testName, success);
     try {
       close();
     }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1832,6 +1832,11 @@ public class FormatReaderTest {
     if (config == null) throw new SkipException("No config tree");
     String testName = "testValidXML";
     if (!initFile()) result(testName, false, "initFile");
+    if (!config.hasValidXML()) {
+      LOGGER.debug("Skipping valid XML test");
+      result(testName, true);
+      return;
+    }
     String format = config.getReader();
     boolean success = true;
     try {


### PR DESCRIPTION
This PR reverts skips in https://github.com/openmicroscopy/bioformats/commit/dbd5f824f8c581d5f8476f03d5f580b4090ac077 to investigate issues when converting/validating OME-XML /cc @dgault @rleigh-dundee 