### PR TITLE
Fix for invalid setPixelsBinDataBigEndian

### DIFF
--- a/components/formats-bsd/src/loci/formats/gui/ImageViewer.java
+++ b/components/formats-bsd/src/loci/formats/gui/ImageViewer.java
@@ -379,7 +379,7 @@ public class ImageViewer extends JFrame implements ActionListener,
         omeMeta = omexmlService.createOMEXMLMetadata();
         omeMeta.setImageID(MetadataTools.createLSID("Image", 0), 0);
         omeMeta.setPixelsID(MetadataTools.createLSID("Pixels", 0), 0);
-        omeMeta.setPixelsBinDataBigEndian(false, 0, 0);
+        omeMeta.setPixelsBigEndian(false, 0);
 
         String order = "XYCZT";
         if (in != null) order = in.getDimensionOrder();

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -248,7 +248,14 @@ public class OMETiffReader extends FormatReader {
       }
 
       for (int i=0; i<meta.getImageCount(); i++) {
-        meta.setPixelsBinDataBigEndian(Boolean.TRUE, i, 0);
+        if (meta.getPixelsBinDataCount(i) > 0) {
+          for (int j=0; j<meta.getPixelsBinDataCount(i); j++) {
+            meta.setPixelsBinDataBigEndian(Boolean.TRUE, i, j);
+          }
+        }
+        else {
+          meta.setPixelsBigEndian(Boolean.TRUE, i);
+        }
         MetadataTools.verifyMinimumPopulated(meta, i);
       }
       return meta.getImageCount() > 0;
@@ -1056,7 +1063,14 @@ public class OMETiffReader extends FormatReader {
     int realSeries = getSeries();
     for (int i=0; i<getSeriesCount(); i++) {
       setSeries(i);
-      store.setPixelsBinDataBigEndian(new Boolean(!isLittleEndian()), i, 0);
+      if (meta.getPixelsBinDataCount(i) > 0) {
+        for (int j=0; j<meta.getPixelsBinDataCount(i); j++) {
+          store.setPixelsBinDataBigEndian(new Boolean(!isLittleEndian()), i, j);
+        }
+      }
+      else {
+        store.setPixelsBigEndian(Boolean.TRUE, i);
+      }
     }
     setSeries(realSeries);
     return store;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -248,13 +248,11 @@ public class OMETiffReader extends FormatReader {
       }
 
       for (int i=0; i<meta.getImageCount(); i++) {
+        meta.setPixelsBigEndian(Boolean.TRUE, i);
         if (meta.getPixelsBinDataCount(i) > 0) {
           for (int j=0; j<meta.getPixelsBinDataCount(i); j++) {
             meta.setPixelsBinDataBigEndian(Boolean.TRUE, i, j);
           }
-        }
-        else {
-          meta.setPixelsBigEndian(Boolean.TRUE, i);
         }
         MetadataTools.verifyMinimumPopulated(meta, i);
       }
@@ -1067,9 +1065,6 @@ public class OMETiffReader extends FormatReader {
         for (int j=0; j<meta.getPixelsBinDataCount(i); j++) {
           store.setPixelsBinDataBigEndian(new Boolean(!isLittleEndian()), i, j);
         }
-      }
-      else {
-        store.setPixelsBigEndian(Boolean.TRUE, i);
       }
     }
     setSeries(realSeries);

--- a/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
+++ b/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
@@ -58,7 +58,7 @@ if is_octave()
 else
     java_true = java.lang.Boolean.TRUE;
 end
-metadata.setPixelsBigEndian(java_true, 0, 0);
+metadata.setPixelsBigEndian(java_true, 0);
 
 % Set dimension order
 dimensionOrderEnumHandler = javaObject('ome.xml.model.enums.handlers.DimensionOrderEnumHandler');

--- a/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
+++ b/components/formats-gpl/matlab/createMinimalOMEXMLMetadata.m
@@ -58,7 +58,7 @@ if is_octave()
 else
     java_true = java.lang.Boolean.TRUE;
 end
-metadata.setPixelsBinDataBigEndian(java_true, 0, 0);
+metadata.setPixelsBigEndian(java_true, 0, 0);
 
 % Set dimension order
 dimensionOrderEnumHandler = javaObject('ome.xml.model.enums.handlers.DimensionOrderEnumHandler');


### PR DESCRIPTION
This is a fix for the generation of invalid OME XML when files are read through OMETiffReader.
The setPixelsBinDataBigEndian is only called if the PixelsBinData > 0 otherwise setPixelsBigEndian is used instead.

This can be tested using the FormatReaderTests with the following PR included - https://github.com/openmicroscopy/bioformats/pull/2501