### PR TITLE
Fix timestamp annotation 2016-06 OME-XML sample

### DIFF
--- a/components/specification/samples/2016-06/timestampannotation.ome.xml
+++ b/components/specification/samples/2016-06/timestampannotation.ome.xml
@@ -203,7 +203,7 @@
       </Rectangle>
       <Label ID="Shape:3" FillRule="EvenOdd" FontStyle="Normal" FontFamily="serif"
                  Text="Hello World Text Value!(from shape 3)" X="1" Y="1"/>
-      <Polygon ID="Shape:4" StrokeWidth="2" StrokeColor="15"> Points="1,1 10,20, 20,20 20,10"></Polygon>
+      <Polygon ID="Shape:4" StrokeWidth="2" StrokeColor="15" Points="1,1 10,20, 20,20 20,10"></Polygon>
       <Polyline ID="Shape:5" StrokeWidth="2" StrokeColor="16" Points="15,15 15,25, 25,25 25,15" MarkerStart="Arrow"
                  MarkerEnd="Arrow"/>
       <Polyline ID="Shape:6" StrokeWidth="2" StrokeColor="161" Points="1.1,1.1 10.1,20.1, 20.1,20.1 20.1,10.1" 


### PR DESCRIPTION
For some reason, an extra `>` got inserted in the sample during the generation making it invalid. Since this sample contains non-POSIX timestamps, it is excluded from the C++ tests and could not be detected. The re-enabling of the XML tests for the OME-XML/OME-TIFF readers in https://github.com/openmicroscopy/bioformats/pull/2501 successfully flagged this file as invalid.

To test this PR check that `xmlvalid` fails on the OME-XML file without this PR but passes with the PR included.