### PR TITLE
update schema link to 2016-06 for publication

### DIFF
--- a/components/specification/publish
+++ b/components/specification/publish
@@ -372,7 +372,7 @@ EOF
 <h2>Schemas</h2>
 <p>This has the schema name, the current version, a link to the XSD file, and
 a short description. Generated documentation for the schemas is available at:
-<a href="http://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2015-01/ome.html">http://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2015-01/ome.html</a></a>
+<a href="http://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome.html">http://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome.html</a></a>
 </p>
 <p><em>Note: Some browsers will try to render XSD files when you view them.
 This can result in either a blank screen or unformatted text. Choose to either


### PR DESCRIPTION
Under http://www.openmicroscopy.org/Schemas/ --

> Generated documentation for the schemas is available at: http://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2015-01/ome.html

should now be OME-2016-06.