### PR TITLE
if offline, skip LocationTest cases that require connectivity

### DIFF
--- a/components/formats-common/test/loci/common/utests/LocationTest.java
+++ b/components/formats-common/test/loci/common/utests/LocationTest.java
@@ -139,8 +139,8 @@ public class LocationTest {
     for (int i=0; i<files.length; i++) {
       skipIfOffline(i);
       String msg = files[i].getName();
-      assertEquals(msg, files[i].canRead(), mode[i].indexOf("r") != -1);
-      assertEquals(msg, files[i].canWrite(), mode[i].indexOf("w") != -1);
+      assertEquals(msg, files[i].canRead(), mode[i].contains("r"));
+      assertEquals(msg, files[i].canWrite(), mode[i].contains("w"));
     }
   }
 
@@ -233,7 +233,7 @@ public class LocationTest {
   public void testToURL() throws IOException {
     for (Location file : files) {
       String path = file.getAbsolutePath();
-      if (path.indexOf("://") == -1) {
+      if (!path.contains("://")) {
         if (IS_WINDOWS) {
           path = "file:/" + path;
         }

--- a/components/formats-common/test/loci/common/utests/LocationTest.java
+++ b/components/formats-common/test/loci/common/utests/LocationTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 import loci.common.Location;
 
 import org.testng.SkipException;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -68,7 +68,7 @@ public class LocationTest {
 
   // -- Setup methods --
 
-  @BeforeMethod
+  @BeforeClass
   public void setup() throws IOException {
     File tmpDirectory = new File(System.getProperty("java.io.tmpdir"),
       System.currentTimeMillis() + "-location-test");
@@ -116,7 +116,7 @@ public class LocationTest {
     };
   }
 
-  @BeforeMethod
+  @BeforeClass
   public void checkIfOnline() throws IOException {
     try {
       new Socket("www.openmicroscopy.org", 80).close();


### PR DESCRIPTION
Fix https://trac.openmicroscopy.org/ome/ticket/13272 by allowing Maven tests to pass even when offline. Specifically, check that:

* when online, *all* `LocationTest` methods pass
* when offline, *some* `LocationTest` methods skip, the rest pass
* in both cases, `mvn test` succeeds.