### PR TITLE
OME Tiff - Deprecating getMetadataStoreForConversion and Display

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -941,9 +941,6 @@ public class ImageInfo {
     if (baseReader instanceof ImageReader) {
       baseReader = ((ImageReader) baseReader).getReader();
     }
-    if (baseReader instanceof OMETiffReader) {
-      ms = ((OMETiffReader) baseReader).getMetadataStoreForDisplay();
-    }
 
     OMEXMLService service;
     try {

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -119,7 +119,7 @@ public class ImageInfo {
   private boolean ascii = false;
   private boolean usedFiles = true;
   private boolean omexmlOnly = false;
-  private boolean validate = false;
+  private boolean validate = true;
   private boolean flat = true;
   private String omexmlVersion = null;
   private int start = 0;
@@ -169,7 +169,7 @@ public class ImageInfo {
     preload = false;
     usedFiles = true;
     omexmlOnly = false;
-    validate = false;
+    validate = true;
     flat = true;
     omexmlVersion = null;
     xmlSpaces = 3;
@@ -204,10 +204,7 @@ public class ImageInfo {
         else if (args[i].equals("-separate")) separate = true;
         else if (args[i].equals("-expand")) expand = true;
         else if (args[i].equals("-cache")) cache = true;
-        else if (args[i].equals("-omexml")) {
-          omexml = true; 
-          validate = true;
-        }
+        else if (args[i].equals("-omexml")) omexml = true;
         else if (args[i].equals("-no-sas")) originalMetadata = false;
         else if (args[i].equals("-normalize")) normalize = true;
         else if (args[i].equals("-fast")) fastBlit = true;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -204,7 +204,10 @@ public class ImageInfo {
         else if (args[i].equals("-separate")) separate = true;
         else if (args[i].equals("-expand")) expand = true;
         else if (args[i].equals("-cache")) cache = true;
-        else if (args[i].equals("-omexml")) omexml = true;
+        else if (args[i].equals("-omexml")) {
+          omexml = true; 
+          validate = true;
+        }
         else if (args[i].equals("-no-sas")) originalMetadata = false;
         else if (args[i].equals("-normalize")) normalize = true;
         else if (args[i].equals("-fast")) fastBlit = true;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1021,45 +1021,45 @@ public class OMETiffReader extends FormatReader {
             new Timestamp(acquiredDates[i]), i);
       }
     }
-    metadataStore = getMetadataStoreForConversion();
   }
 
   // -- OMETiffReader API methods --
 
   /**
-   * Returns a MetadataStore that is populated in such a way as to
-   * produce valid OME-XML.  The returned MetadataStore cannot be used
-   * by an IFormatWriter, as it will not contain the required
-   * BinData.BigEndian attributes.
+   * Get a MetadataStore suitable for display.
+   *
+   * @note Historically, this method removed certain elements
+   * for display purposes and was not be suitable for use with
+   * FormatWriter due to not containing required BinData
+   * BigEndian attributes pthis requirement has long been
+   * unnecessary].  This is no longer the case; the general
+   * FormatReader::getMetadataStore() method will always create
+   * valid metadata which is suitable for both display and use
+   * with FormatWriter, and so should be used instead.
+   *
+   * @returns the metadata store.
+   * @deprecated Use the general FormatReader::getMetadataStore() method.
    */
   public MetadataStore getMetadataStoreForDisplay() {
-    MetadataStore store = getMetadataStore();
-    if (service.isOMEXMLMetadata(store)) {
-      service.removeBinData((OMEXMLMetadata) store);
-      for (int i=0; i<getSeriesCount(); i++) {
-        if (((OMEXMLMetadata) store).getTiffDataCount(i) == 0) {
-          service.addMetadataOnly((OMEXMLMetadata) store, i);
-        }
-      }
-    }
-    return store;
+    return getMetadataStore();
   }
 
   /**
-   * Returns a MetadataStore that is populated in such a way as to be
-   * usable by an IFormatWriter.  Any OME-XML generated from this
-   * MetadataStore is <em>very unlikely</em> to be valid, as more than
-   * likely both BinData and TiffData element will be present.
+   * Get a MetadataStore suitable for writing.
+   *
+   * @note Historically, this method created metadata suitable
+   * for use with FormatWriter, but would possibly not generate
+   * valid OME-XML if both BinData and TiffData elements were
+   * present.  This is no longer the case; the general
+   * FormatReader::getMetadataStore() method will always create
+   * valid metadata which is suitable for use with FormatWriter,
+   * and so should be used instead.
+   *
+   * @returns the metadata store.
+   * @deprecated Use the general FormatReader::getMetadataStore() method.
    */
   public MetadataStore getMetadataStoreForConversion() {
-    MetadataStore store = getMetadataStore();
-    int realSeries = getSeries();
-    for (int i=0; i<getSeriesCount(); i++) {
-      setSeries(i);
-      store.setPixelsBinDataBigEndian(new Boolean(!isLittleEndian()), i, 0);
-    }
-    setSeries(realSeries);
-    return store;
+    return getMetadataStore();
   }
 
   // -- Helper methods --

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1064,22 +1064,7 @@ public class OMETiffReader extends FormatReader {
    * @deprecated Use the general FormatReader::getMetadataStore() method.
    */
   public MetadataStore getMetadataStoreForConversion() {
-<<<<<<< HEAD
     return getMetadataStore();
-=======
-    MetadataStore store = getMetadataStore();
-    int realSeries = getSeries();
-    for (int i=0; i<getSeriesCount(); i++) {
-      setSeries(i);
-      if (meta.getPixelsBinDataCount(i) > 0) {
-        for (int j=0; j<meta.getPixelsBinDataCount(i); j++) {
-          store.setPixelsBinDataBigEndian(new Boolean(!isLittleEndian()), i, j);
-        }
-      }
-    }
-    setSeries(realSeries);
-    return store;
->>>>>>> openmicroscopy/develop
   }
 
   // -- Helper methods --

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1036,14 +1036,13 @@ public class OMETiffReader extends FormatReader {
    * Note: Historically, this method removed certain elements
    * for display purposes and was not be suitable for use with
    * FormatWriter due to not containing required BinData
-   * BigEndian attributes pthis requirement has long been
-   * unnecessary].  This is no longer the case; the general
-   * FormatReader::getMetadataStore() method will always create
+   * BigEndian attributes. This is no longer the case; the general
+   * {@link FormatReader#getMetadataStore()} method will always create
    * valid metadata which is suitable for both display and use
    * with FormatWriter, and so should be used instead.
    *
    * @return the metadata store.
-   * @deprecated Use the general FormatReader::getMetadataStore() method.
+   * @deprecated Use the general {@link FormatReader#getMetadataStore()} method.
    */
   public MetadataStore getMetadataStoreForDisplay() {
     return getMetadataStore();
@@ -1056,12 +1055,12 @@ public class OMETiffReader extends FormatReader {
    * for use with FormatWriter, but would possibly not generate
    * valid OME-XML if both BinData and TiffData elements were
    * present.  This is no longer the case; the general
-   * FormatReader::getMetadataStore() method will always create
+   * {@link FormatReader#getMetadataStore()} method will always create
    * valid metadata which is suitable for use with FormatWriter,
    * and so should be used instead.
    *
    * @return the metadata store.
-   * @deprecated Use the general FormatReader::getMetadataStore() method.
+   * @deprecated Use the general {@link FormatReader#getMetadataStore()} method.
    */
   public MetadataStore getMetadataStoreForConversion() {
     return getMetadataStore();

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1033,7 +1033,7 @@ public class OMETiffReader extends FormatReader {
   /**
    * Get a MetadataStore suitable for display.
    *
-   * @note Historically, this method removed certain elements
+   * Note: Historically, this method removed certain elements
    * for display purposes and was not be suitable for use with
    * FormatWriter due to not containing required BinData
    * BigEndian attributes pthis requirement has long been
@@ -1042,7 +1042,7 @@ public class OMETiffReader extends FormatReader {
    * valid metadata which is suitable for both display and use
    * with FormatWriter, and so should be used instead.
    *
-   * @returns the metadata store.
+   * @return the metadata store.
    * @deprecated Use the general FormatReader::getMetadataStore() method.
    */
   public MetadataStore getMetadataStoreForDisplay() {
@@ -1052,7 +1052,7 @@ public class OMETiffReader extends FormatReader {
   /**
    * Get a MetadataStore suitable for writing.
    *
-   * @note Historically, this method created metadata suitable
+   * Note: Historically, this method created metadata suitable
    * for use with FormatWriter, but would possibly not generate
    * valid OME-XML if both BinData and TiffData elements were
    * present.  This is no longer the case; the general
@@ -1060,7 +1060,7 @@ public class OMETiffReader extends FormatReader {
    * valid metadata which is suitable for use with FormatWriter,
    * and so should be used instead.
    *
-   * @returns the metadata store.
+   * @return the metadata store.
    * @deprecated Use the general FormatReader::getMetadataStore() method.
    */
   public MetadataStore getMetadataStoreForConversion() {


### PR DESCRIPTION
This is a follow up PR to https://github.com/openmicroscopy/bioformats/pull/2502

In this PR I have made the following changes based on discussions and feedback:
 - Deprecated the getMetadataStoreForConversion and getMetadataStoreForDisplay  methods in the OMETiffReader as done in ome/ome-files-cpp@5bc636b
- Dropped the call to getMetadataForConversion in OMETiffReader
- Dropped the call oto getMetadataForDisplay in ImageInfo 
- When using using showinf with the --omexml flag is set then the validation flag will also be set to true (unless the novalid flag is also set in which case it will override)