### PR TITLE
Add nii.gz support to NiFTi reader

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1494,7 +1494,7 @@ notes = .. seealso:: \n
   `NEF Conversion <http://www.outbackphoto.com/workshop/NEF_conversion/nefconversion.html>`_
 
 [NIfTI]
-extensions = .img, .hdr, .nii
+extensions = .img, .hdr, .nii, .nii.gz
 developer = `National Institutes of Health <http://www.nih.gov/>`_
 bsd = no
 samples = `Official test data <http://afni.nimh.nih.gov/pub/dist/data/>`_

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -100,7 +100,7 @@ loci.formats.in.SPEReader             # spe
 
 # multi-extension messes
 loci.formats.in.JEOLReader            # dat, img, par
-loci.formats.in.NiftiReader           # hdr, img, nii
+loci.formats.in.NiftiReader           # hdr, img, nii, nii.gz
 loci.formats.in.AnalyzeReader         # hdr, img
 loci.formats.in.APLReader             # apl, mtb, tnb
 loci.formats.in.NRRDReader            # nrrd, nhdr, pic

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
+import loci.common.GZipHandle;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
@@ -228,6 +229,11 @@ public class NiftiReader extends FormatReader {
     else if (id.endsWith(".nii")) {
       pixelsFilename = id;
       pixelFile = in;
+    } else if (id.endsWith(".nii.gz")) {
+      pixelsFilename = id;
+      pixelFile = new RandomAccessInputStream(new GZipHandle(id));
+    } else {
+    	throw new FormatException("File does not have one of the required NIfTI extensions (.hdr, .nii, .nii.gz)");
     }
 
     in.order(little);

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -147,6 +147,7 @@ public class NiftiReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
+    pixelFile.seek(0);
     long planeSize = FormatTools.getPlaneSize(this);
     pixelFile.seek(pixelOffset + no * planeSize);
     readPlane(pixelFile, x, y, w, h, buf);

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -230,7 +230,7 @@ public class NiftiReader extends FormatReader {
       pixelsFilename = id;
       pixelFile = in;
     } else {
-      throw new FormatException("File does not have one of the required NIfTI extensions (.hdr, .nii, .nii.gz)");
+      throw new FormatException("File does not have one of the required NIfTI extensions (.img, .hdr, .nii, .nii.gz)");
     }
 
     in.order(little);

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -226,14 +226,11 @@ public class NiftiReader extends FormatReader {
       pixelsFilename = id.substring(0, id.lastIndexOf(".")) + ".img";
       pixelFile = new RandomAccessInputStream(pixelsFilename);
     }
-    else if (id.endsWith(".nii")) {
+    else if (checkSuffix(id, "nii")) {
       pixelsFilename = id;
       pixelFile = in;
-    } else if (id.endsWith(".nii.gz")) {
-      pixelsFilename = id;
-      pixelFile = new RandomAccessInputStream(new GZipHandle(id));
     } else {
-    	throw new FormatException("File does not have one of the required NIfTI extensions (.hdr, .nii, .nii.gz)");
+      throw new FormatException("File does not have one of the required NIfTI extensions (.hdr, .nii, .nii.gz)");
     }
 
     in.order(little);

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -82,13 +82,13 @@ public class NiftiReader extends FormatReader {
 
   /** Constructs a new NIfTI reader. */
   public NiftiReader() {
-    super("NIfTI", new String[] {"nii", "img", "hdr"});
+    super("NIfTI", new String[] {"nii", "img", "hdr", "nii.gz"});
     suffixSufficient = false;
     domains = new String[] {FormatTools.MEDICAL_DOMAIN,
       FormatTools.UNKNOWN_DOMAIN};
     hasCompanionFiles = true;
-    datasetDescription = "A single .nii file or one .img file and a " +
-      "similarly-named .hdr file";
+    datasetDescription = "A single .nii file or a single .nii.gz file or one" +
+      " .img file and a similarly-named .hdr file";
   }
 
   // -- IFormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
-import loci.common.GZipHandle;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -288,8 +288,8 @@ to open/import a dataset in a particular format.
      - .mng
      - Single file
    * - NIfTI
-     - .nii, .img, .hdr
-     - A single .nii file or one .img file and a similarly-named .hdr file
+     - .nii, .img, .hdr, .nii.gz
+     - A single .nii file or a single .nii.gz file or one .img file and a similarly-named .hdr file
    * - NOAA-HRD Gridded Data Format
      - (no extension)
      - Single file

--- a/docs/sphinx/formats/nifti.txt
+++ b/docs/sphinx/formats/nifti.txt
@@ -1,10 +1,10 @@
 .. index:: NIfTI
-.. index:: .img, .hdr, .nii
+.. index:: .img, .hdr, .nii, .nii.gz
 
 NIfTI
 ===============================================================================
 
-Extensions: .img, .hdr, .nii
+Extensions: .img, .hdr, .nii, .nii.gz
 
 Developer: `National Institutes of Health <http://www.nih.gov/>`_
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -974,7 +974,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/nifti`
-     - .img, .hdr, .nii
+     - .img, .hdr, .nii, .nii.gz
      - |Very good|
      - |Good|
      - |Very good|


### PR DESCRIPTION
Supersedes https://github.com/openmicroscopy/bioformats/pull/2493

This PR adds support for gzipped compressed `.nii.gz` filesets by using  `checkSuffix()` which supports compression extensions rather than `String.endsWith()`. The `RandomAccessInputStream` constructor internally uses `Location.getHandle()` which in turns handles compressed files. 

The new extension is also registered in the reader, `readers.txt` and `format-pages.txt` and the documentation pages are regenerated accordingly.

A data repository PR will be opened to add the configuration for the public `nii.gz` samples available at http://nifti.nimh.nih.gov/nifti-1/data.