### PR TITLE
Update ImageJ/Fiji links & docs

### DIFF
--- a/docs/sphinx/about/index.txt
+++ b/docs/sphinx/about/index.txt
@@ -43,15 +43,10 @@ include:
 -  `ome-users mailing
    list <http://lists.openmicroscopy.org.uk/pipermail/ome-users>`_
    (searchable using google with 'site:lists.openmicroscopy.org.uk')
--  ImageJ mailing list (for ImageJ/Fiji issues)
-   `forum archive <http://imagej.1557.n6.nabble.com/>`_ and
-   `mailing list <http://imagej.nih.gov/ij/list.html>`_
--  `ImageJ developer mailing
-   list <http://imagej.net/mailman/listinfo/imagej-devel>`_
--  `Fiji Bugzilla (for ImageJ/Fiji
-   issues) <http://fiji.sc/cgi-bin/bugzilla/index.cgi>`_
--  `Fiji developer google
-   group <https://groups.google.com/forum/#!forum/fiji-devel>`_
+-  `ImageJ forum <http://forum.imagej.net>`_ (for ImageJ/Fiji issues)
+-  `ImageJ mailing list <http://imagej.nih.gov/ij/list.html>`_ (and
+   `archive <http://imagej.1557.n6.nabble.com/>`_)
+-  `Fiji GitHub Issues <https://github.com/fiji/fiji/issues>`_
 -  `Confocal microscopy mailing
    list <http://lists.umn.edu/cgi-bin/wa?A0=confocalmicroscopy>`_
 

--- a/docs/sphinx/users/fiji/index.txt
+++ b/docs/sphinx/users/fiji/index.txt
@@ -4,15 +4,14 @@ Fiji overview
 `Fiji <http://fiji.sc/>`_ is an image processing package. It
 can be described as a distribution of :doc:`ImageJ </users/imagej/index>`
 together with Java, Java 3D and a lot of plugins organized into a
-`coherent menu
-structure <http://fiji.sc/Plugins_Menu>`_.
-Fiji compares to ImageJ as Ubuntu compares to Linux.
+coherent menu structure. Fiji compares to ImageJ as Ubuntu compares to Linux.
 
 Fiji works with Bio-Formats out of the box, because it comes bundled
 with the :doc:`Bio-Formats ImageJ plugins </users/imagej/index>`.
 
-For further details on Bio-Formats in Fiji, see the
-`Bio-Formats Fiji wiki page <http://fiji.sc/Bio-Formats>`_.
+The Fiji documentation has been combined with the ImageJ wiki; for further
+details on Bio-Formats in Fiji, see the
+`Bio-Formats ImageJ page <http://imagej.net/Bio-Formats>`_.
 
 Upgrading
 ---------
@@ -30,7 +29,7 @@ Fiji currently shipping with the 5.1.x release versions of Bio-Formats.
 However, if you have encountered a bug which has been fixed by the Bio-Formats
 team but not yet released, you can use the Bio-Formats update site to
 access the daily build as described in the
-`Fiji documentation <http://fiji.sc/Bio-Formats#Daily_builds>`_.
+`documentation <http://imagej.net/Bio-Formats#Daily_builds>`_.
 
 .. warning:: These builds are **not yet released** and should be considered
     **beta** in quality. In particular, you should **avoid exporting data

--- a/docs/sphinx/users/fiji/index.txt
+++ b/docs/sphinx/users/fiji/index.txt
@@ -22,24 +22,6 @@ checks for updates every time it is launched, so you will always be
 notified when new versions of Bio-Formats (or any other bundled plugin)
 are available.
 
-Using Bio-Formats daily builds
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Fiji currently shipping with the 5.1.x release versions of Bio-Formats.
-However, if you have encountered a bug which has been fixed by the Bio-Formats
-team but not yet released, you can use the Bio-Formats update site to
-access the daily build as described in the
-`documentation <http://imagej.net/Bio-Formats#Daily_builds>`_.
-
-.. warning:: These builds are **not yet released** and should be considered
-    **beta** in quality. In particular, you should **avoid exporting data
-    using the Bio-Formats Exporter** in case you write incompatible files
-    which cannot be read by released versions of Bio-Formats or other
-    OME-compliant tools.
-    
-    We recommend waiting for a fully tested release version of Bio-Formats if
-    possible.
-
 Manual upgrade
 ^^^^^^^^^^^^^^
 

--- a/docs/sphinx/users/imagej/index.txt
+++ b/docs/sphinx/users/imagej/index.txt
@@ -1,7 +1,7 @@
 ImageJ overview
 ===============
 
-`ImageJ <http://rsb.info.nih.gov/ij/>`_ is an image processing and
+`ImageJ <https://imagej.nih.gov/ij/index.html>`_ is an image processing and
 analysis application written in Java, widely used in the life sciences
 fields, with an extensible plugin infrastructure. You can use
 Bio-Formats as a plugin for ImageJ to read and write images in the
@@ -38,7 +38,7 @@ explicitly choosing
 menu.
 
 For a more detailed description of each plugin, see the `Bio-Formats
-page <http://fiji.sc/Bio-Formats>`_ of the Fiji wiki.
+page <http://imagej.net/Bio-Formats>`_ of the ImageJ wiki.
 
 Upgrading
 ---------
@@ -46,11 +46,7 @@ Upgrading
 To upgrade, just overwrite the old **bioformats_package.jar** with the
 :downloads:`latest one <>`.
 
-You may want to download the latest version of ImageJ first, to take
-advantage of new features and bug-fixes.
-
-As of the 4.0.0 release, you can also upgrade the Bio-Formats plugin
-directly from ImageJ. Select
+You can also upgrade the Bio-Formats plugin directly from ImageJ. Select
 :menuselection:`Plugins --> Bio-Formats --> Update Bio-Formats Plugins`
 from the ImageJ menu, then select which release you would like to use. You
 will then need to restart ImageJ to complete the upgrade process.

--- a/docs/sphinx/users/imagej/installing.txt
+++ b/docs/sphinx/users/imagej/installing.txt
@@ -12,55 +12,8 @@ Installing Bio-Formats in ImageJ
 
 Once you `download <http://rsbweb.nih.gov/ij/download.html>`__ and
 install ImageJ, you can install the Bio-Formats plugin by going to the
-Bio-Formats :downloads:`download page <>`.
-
-For most end-users, we recommend downloading the **bioformats\_package.jar**
-complete bundle.
-
-However, you must decide which version of it you want to install. There
-are three primary versions of Bio-Formats: the latest builds, the daily
-builds, and the release versions. Which version you should download
-depends on your needs:
-
-- The **latest build** is automatically updated every time any change is
-  made to the source code on the main "dev_5_0" branch in Git, Bio-Formats'
-  software version control system. This build has the latest bug fixes,
-  but it is not well tested and may have also introduced new bugs.
-
-- The **daily build** is a compilation of that day's changes that occurs
-  daily around midnight. It is not any better tested than the latest build;
-  but if you download it multiple times in a day, you can be sure you will
-  get the same version each time.
-
-- The **release** is thoroughly tested and has documentation to
-  match. The list of supported formats on the Bio-Formats site corresponds
-  to the most recent release. We do not add new formats to the list
-  until a release containing support for that format has been completed.
-  The release is less likely to contain bugs.
-
-The release version is also more useful to programmers because they can
-link their software to a known, fixed version of Bio-Formats.
-Bio-Formats' behavior will not be changing "out from under them" as they
-continue developing their own programs.
-
-.. note:: There are currently **two** release version of Bio-Formats as we
-    are maintaining support for the 4.4.x series while only actively
-    developing the new 5.x series. Unless you are using Bio-Formats with the
-    OMERO ImageJ plugin and an OMERO 4.4.x server, we recommend you
-    use Bio-Formats 5. A new 4.4.x version will only be released if a major
-    bug fix is required.
-
-We often **recommend that most people simply use the latest build** for
-two reasons. First, it may contain bug-fixes or new features you want
-anyway; secondly, you will have to reproduce any bug you encounter in
-Bio-Formats against the latest build before submitting a bug
-report. Rather than using the release until you find a bug that
-requires you to upgrade and reproduce it, why not just use the latest
-build to begin with?
-
-Once you decide which version you need, go to the Bio-Formats
-:downloads:`download page <>` and save the appropriate **bioformats\_package.jar** 
-to the Plugins directory within ImageJ.
+Bio-Formats :downloads:`download page <>` and saving the
+**bioformats\_package.jar** to the Plugins directory within ImageJ.
 
 .. figure:: /images/PluginDirectory.png
     :align: center
@@ -69,7 +22,7 @@ to the Plugins directory within ImageJ.
     Plugin Directory for ImageJ: Where in ImageJ's file structure you
     should place the file once you downloaded it.
 
-You may have to quit and restart ImageJ.  Once you restart it, you will
+You may have to quit and restart ImageJ. Once you restart it, you will
 find Bio-Formats in the Bio-Formats option under the Plugins menu:
 
 .. image:: /images/PluginsMenu.png

--- a/docs/sphinx/users/imagej/load-images.txt
+++ b/docs/sphinx/users/imagej/load-images.txt
@@ -183,7 +183,7 @@ particular image:
     :align: center
     :alt: Histogram
 
-Notice that the histogram heavily skews right. Even though there are
+Notice that the histogram heavily skews left. Even though there are
 256 possible values, only 0 thorough 125 are being used.
 
 Autoscale adjusts the image so the smallest and largest number in that


### PR DESCRIPTION
Fiji wiki is now redirecting to ImageJ wiki and a bunch of the contact methods have been updated/replaced/discontinued. This fixes up the links, removes things no longer in use and generally updates the docs.

Should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/ green

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/about/index.html, https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/users/imagej/index.html and following pages.

If whoever reviews this has time to check the rest of the ImageJ/Fiji pages for any more updates needed, that would be much appreciated - would be good to have them up-to-date for 5.2.0