### PR TITLE
Quicktime download links & reader clarifications

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1969,7 +1969,7 @@ reader = QuesantReader
 extensions = .mov
 owner = `Apple Computer <http://www.apple.com/>`_
 bsd = yes
-software = `QuickTime Player <http://www.apple.com/quicktime/download/>`_
+software = `QuickTime Player <https://support.apple.com/downloads/quicktime>`_
 weHave = * a `QuickTime specification document <http://developer.apple.com/documentation/Quicktime/QTFF/>`_ (from 2001 March 1, in HTML) \n
 * several QuickTime datasets \n
 * the ability to produce more datasets
@@ -1986,7 +1986,7 @@ reader = NativeQTReader
 writer = QTWriter
 notes = Bio-Formats has two modes of operation for QuickTime: \n
 \n
-* QTJava mode requires `QuickTime <http://www.apple.com/quicktime/download/>`_ to be \n
+* QTJava mode requires `QuickTime <https://support.apple.com/downloads/quicktime>`_ to be \n
   installed (32-bit JVM only, not supported with 64-bit). \n
 * Native mode works on systems with no QuickTime (e.g. Linux). \n
 \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1890,9 +1890,8 @@ opennessRating = Fair
 presenceRating = Very good
 utilityRating = Poor
 reader = PictReader
-notes = `QuickTime for Java \n
-<http://www.apple.com/quicktime/download/standalone.html>`_ is required \n
-for reading vector files and some compressed files. \n
+notes = QuickTime for Java is required for reading vector files and some \n
+compressed files but note that this is no longer available from Apple. \n
 \n
 .. seealso:: \n
   `PICT technical overview <http://www.faqs.org/faqs/graphics/fileformats-faq/part3/section-107.html>`_ \n
@@ -1986,8 +1985,8 @@ reader = NativeQTReader
 writer = QTWriter
 notes = Bio-Formats has two modes of operation for QuickTime: \n
 \n
-* QTJava mode requires `QuickTime <https://support.apple.com/downloads/quicktime>`_ to be \n
-  installed (32-bit JVM only, not supported with 64-bit). \n
+* QTJava mode requires QuickTime for Java to be installed (no longer available \n
+  from Apple) and is 32-bit JVM only, not supported with 64-bit. \n
 * Native mode works on systems with no QuickTime (e.g. Linux). \n
 \n
 Bio-Formats can save image stacks as QuickTime movies. \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1985,8 +1985,8 @@ reader = NativeQTReader, LegacyQTReader
 writer = QTWriter
 notes = Bio-Formats has two modes of operation for QuickTime: \n
 \n
-* The Legacy QTJava mode requires QuickTime for Java to be installed \n
-  (no longer available from Apple) and is 32-bit JVM only, not supported with 64-bit. \n
+* The legacy QTJava mode requires QuickTime for Java which will only run \n
+  with a 32-bit JVM and is no longer available from Apple. \n
 * Native mode works on systems with no QuickTime (e.g. Linux). \n
 \n
 Bio-Formats can save image stacks as QuickTime movies. \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1981,19 +1981,19 @@ metadataRating = Very good
 opennessRating = Fair
 presenceRating = Outstanding
 utilityRating = Poor
-reader = NativeQTReader
+reader = NativeQTReader, LegacyQTReader
 writer = QTWriter
 notes = Bio-Formats has two modes of operation for QuickTime: \n
 \n
-* QTJava mode requires QuickTime for Java to be installed (no longer available \n
-  from Apple) and is 32-bit JVM only, not supported with 64-bit. \n
+* The Legacy QTJava mode requires QuickTime for Java to be installed \n
+  (no longer available from Apple) and is 32-bit JVM only, not supported with 64-bit. \n
 * Native mode works on systems with no QuickTime (e.g. Linux). \n
 \n
 Bio-Formats can save image stacks as QuickTime movies. \n
 The following table shows supported codecs: \n
 \n
 ====== ================================== =================== ============ \n
-Codec  Description                        Native              QTJava \n
+Codec  Description                        Native              LegacyQTJava \n
 ====== ================================== =================== ============ \n
 raw    Full Frames (Uncompressed)         read & write        read & write \n
 iraw   Intel YUV Uncompressed             read only           read & write \n

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -47,12 +47,6 @@ same folder.
     - LGPL
     - Java library; for HDF5-based formats (Imaris 5.5, MINC MRI)
 
-  *
-    - `QuickTime for Java <http://www.apple.com/quicktime/download/standalone.html>`_
-    - **QTJava.zip**
-    - Commercial
-    - For additional QuickTime codecs
-
 See the list in the :source:`Bio-Formats toplevel build file <build.xml>`
 for a complete and up-to-date list of all optional libraries, which can
 all be found in our :sourcedir:`Git repository <jar>`.

--- a/docs/sphinx/formats/pict-macintosh-picture.txt
+++ b/docs/sphinx/formats/pict-macintosh-picture.txt
@@ -46,9 +46,8 @@ Utility: |Poor|
 **Additional Information**
 
 
-`QuickTime for Java 
-<http://www.apple.com/quicktime/download/standalone.html>`_ is required 
-for reading vector files and some compressed files. 
+QuickTime for Java is required for reading vector files and some 
+compressed files but note that this is no longer available from Apple. 
 
 .. seealso:: 
   `PICT technical overview <http://www.faqs.org/faqs/graphics/fileformats-faq/part3/section-107.html>`_ 

--- a/docs/sphinx/formats/quicktime-movie.txt
+++ b/docs/sphinx/formats/quicktime-movie.txt
@@ -58,8 +58,8 @@ Utility: |Poor|
 
 Bio-Formats has two modes of operation for QuickTime: 
 
-* QTJava mode requires `QuickTime <https://support.apple.com/downloads/quicktime>`_ to be 
-  installed (32-bit JVM only, not supported with 64-bit). 
+* QTJava mode requires QuickTime for Java to be installed (no longer available 
+  from Apple) and is 32-bit JVM only, not supported with 64-bit. 
 * Native mode works on systems with no QuickTime (e.g. Linux). 
 
 Bio-Formats can save image stacks as QuickTime movies. 

--- a/docs/sphinx/formats/quicktime-movie.txt
+++ b/docs/sphinx/formats/quicktime-movie.txt
@@ -61,8 +61,8 @@ Utility: |Poor|
 
 Bio-Formats has two modes of operation for QuickTime: 
 
-* The Legacy QTJava mode requires QuickTime for Java to be installed 
-  (no longer available from Apple) and is 32-bit JVM only, not supported with 64-bit. 
+* The legacy QTJava mode requires QuickTime for Java which will only run 
+  with a 32-bit JVM and is no longer available from Apple. 
 * Native mode works on systems with no QuickTime (e.g. Linux). 
 
 Bio-Formats can save image stacks as QuickTime movies. 

--- a/docs/sphinx/formats/quicktime-movie.txt
+++ b/docs/sphinx/formats/quicktime-movie.txt
@@ -24,7 +24,7 @@ Writer: QTWriter (:bsd-writer:`Source Code <QTWriter.java>`)
 
 Freely Available Software:
 
-- `QuickTime Player <http://www.apple.com/quicktime/download/>`_
+- `QuickTime Player <https://support.apple.com/downloads/quicktime>`_
 
 
 We currently have:
@@ -58,7 +58,7 @@ Utility: |Poor|
 
 Bio-Formats has two modes of operation for QuickTime: 
 
-* QTJava mode requires `QuickTime <http://www.apple.com/quicktime/download/>`_ to be 
+* QTJava mode requires `QuickTime <https://support.apple.com/downloads/quicktime>`_ to be 
   installed (32-bit JVM only, not supported with 64-bit). 
 * Native mode works on systems with no QuickTime (e.g. Linux). 
 

--- a/docs/sphinx/formats/quicktime-movie.txt
+++ b/docs/sphinx/formats/quicktime-movie.txt
@@ -18,7 +18,10 @@ Export: |yes|
 
 Officially Supported Versions: 
 
-Reader: NativeQTReader (:bsd-reader:`Source Code <NativeQTReader.java>`, :doc:`Supported Metadata Fields </metadata/NativeQTReader>`)
+Readers:
+
+- NativeQTReader (:bsd-reader:`Source Code <NativeQTReader.java>`, :doc:`Supported Metadata Fields </metadata/NativeQTReader>`)
+- LegacyQTReader (:bsd-reader:`Source Code <LegacyQTReader.java>`, :doc:`Supported Metadata Fields </metadata/LegacyQTReader>`)
 
 Writer: QTWriter (:bsd-writer:`Source Code <QTWriter.java>`)
 
@@ -58,15 +61,15 @@ Utility: |Poor|
 
 Bio-Formats has two modes of operation for QuickTime: 
 
-* QTJava mode requires QuickTime for Java to be installed (no longer available 
-  from Apple) and is 32-bit JVM only, not supported with 64-bit. 
+* The Legacy QTJava mode requires QuickTime for Java to be installed 
+  (no longer available from Apple) and is 32-bit JVM only, not supported with 64-bit. 
 * Native mode works on systems with no QuickTime (e.g. Linux). 
 
 Bio-Formats can save image stacks as QuickTime movies. 
 The following table shows supported codecs: 
 
 ====== ================================== =================== ============ 
-Codec  Description                        Native              QTJava 
+Codec  Description                        Native              LegacyQTJava 
 ====== ================================== =================== ============ 
 raw    Full Frames (Uncompressed)         read & write        read & write 
 iraw   Intel YUV Uncompressed             read only           read & write 


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/353/warnings3Result/ - Apple have moved their download links under support.apple.com/downloads breaking our links.

In investigating this I discovered the other links we have (in the java-library.txt & pict-mactintosh-picture.txt format page) are referencing Quicktime for Java which seems to have been depreciated in 2009 so I'm not sure how to handle these. @sbesson suggests the reader using it may be essentially legacy anyway, so we could remove the reference from https://www.openmicroscopy.org/site/support/bio-formats5.2/developers/java-library.html altogether, but that still leaves https://www.openmicroscopy.org/site/support/bio-formats5.2/formats/pict-macintosh-picture.html - should this reader become legacy @melissalinkert ?