### PR TITLE
DelegateReader - Remove call to super.setId(id);

### DIFF
--- a/components/formats-api/src/loci/formats/DelegateReader.java
+++ b/components/formats-api/src/loci/formats/DelegateReader.java
@@ -272,16 +272,17 @@ public abstract class DelegateReader extends FormatReader {
   /* @see IFormatHandler#setId(String) */
   @Override
   public void setId(String id) throws FormatException, IOException {
-    super.setId(id);
     if (useLegacy && !nativeReaderInitialized && !legacyReaderInitialized) {
       try {
         legacyReader.setId(id);
         legacyReaderInitialized = true;
+        currentId = legacyReader.getCurrentFile();
       }
       catch (FormatException e) {
         LOGGER.debug("", e);
         nativeReader.setId(id);
         nativeReaderInitialized = true;
+        currentId = nativeReader.getCurrentFile();
       }
     }
     else {
@@ -289,6 +290,7 @@ public abstract class DelegateReader extends FormatReader {
       try {
         nativeReader.setId(id);
         nativeReaderInitialized = true;
+        currentId = nativeReader.getCurrentFile();
       }
       catch (FormatException e) { exc = e; }
       catch (IOException e) { exc = e; }
@@ -297,6 +299,7 @@ public abstract class DelegateReader extends FormatReader {
         LOGGER.info("", exc);
         legacyReader.setId(id);
         legacyReaderInitialized = true;
+        currentId = legacyReader.getCurrentFile();
       }
       if (legacyReaderInitialized) {
         nativeReaderInitialized = false;


### PR DESCRIPTION
This is a followup to issues spotted in https://github.com/openmicroscopy/bioformats/pull/2473#issuecomment-237785374 which is as a result of https://github.com/openmicroscopy/bioformats/pull/2473

After investigation this was caused by the delegateReader making 2 calls to setID, once using the super.setId and then another to setId on the legacy or native reader. The first call was initialising a blank OMEXML object in AbstractOMEXMLMetadata as part of the dumpXML command. This meant that any future calls to dumpXML were using the blank root object.

As the first call to super is redundant this can be removed. This will allow the delegateReader to initialise with only a single call to setID. It may also be worth investigating if the dumpXML function is required to set the root object.

This issue only impacts calls through the command line tools were the validation is on by default.