### PR TITLE
ImageConverter: Allow disabling of LUT conversion

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -97,6 +97,7 @@ public final class ImageConverter {
   private boolean stitch = false, separate = false, merge = false, fill = false;
   private boolean bigtiff = false, group = true;
   private boolean printVersion = false;
+  private boolean lookup = true;
   private boolean autoscale = false;
   private Boolean overwrite = null;
   private int series = -1;
@@ -141,6 +142,7 @@ public final class ImageConverter {
         else if (args[i].equals("-map")) map = args[++i];
         else if (args[i].equals("-compression")) compression = args[++i];
         else if (args[i].equals("-nogroup")) group = false;
+        else if (args[i].equals("-nolookup")) lookup = false;
         else if (args[i].equals("-autoscale")) autoscale = true;
         else if (args[i].equals("-novalid")) validate = false;
         else if (args[i].equals("-validate")) validate = true;
@@ -220,8 +222,8 @@ public final class ImageConverter {
       "  bfconvert [-debug] [-stitch] [-separate] [-merge] [-expand]",
       "    [-bigtiff] [-compression codec] [-series series] [-map id]",
       "    [-range start end] [-crop x,y,w,h] [-channel channel] [-z Z]",
-      "    [-timepoint timepoint] [-nogroup] [-autoscale] [-version]",
-      "    [-no-upgrade] in_file out_file",
+      "    [-timepoint timepoint] [-nogroup] [-nolookup] [-autoscale]",
+      "    [-version] [-no-upgrade] in_file out_file",
       "",
       "    -version: print the library version and exit",
       " -no-upgrade: do not perform the upgrade check",
@@ -237,6 +239,7 @@ public final class ImageConverter {
       "      -range: specify range of planes to convert (inclusive)",
       "    -nogroup: force multi-file datasets to be read as individual" +
       "              files",
+      "   -nolookup: disable the conversion of lookup tables",
       "  -autoscale: automatically adjust brightness and contrast before",
       "              converting; this may mean that the original pixel",
       "              values are not preserved",
@@ -848,18 +851,20 @@ public final class ImageConverter {
   private void applyLUT(IFormatWriter writer)
     throws FormatException, IOException
   {
-    byte[][] lut = reader.get8BitLookupTable();
-    if (lut != null) {
-      IndexColorModel model = new IndexColorModel(8, lut[0].length,
-        lut[0], lut[1], lut[2]);
-      writer.setColorModel(model);
-    }
-    else {
-      short[][] lut16 = reader.get16BitLookupTable();
-      if (lut16 != null) {
-        Index16ColorModel model = new Index16ColorModel(16, lut16[0].length,
-          lut16, reader.isLittleEndian());
+    if (lookup) {
+      byte[][] lut = reader.get8BitLookupTable();
+      if (lut != null) {
+        IndexColorModel model = new IndexColorModel(8, lut[0].length,
+          lut[0], lut[1], lut[2]);
         writer.setColorModel(model);
+      }
+      else {
+        short[][] lut16 = reader.get16BitLookupTable();
+        if (lut16 != null) {
+          Index16ColorModel model = new Index16ColorModel(16, lut16[0].length,
+            lut16, reader.isLittleEndian());
+          writer.setColorModel(model);
+        }
       }
     }
   }

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -112,6 +112,15 @@ name pattern, then the other must be included too.  The only exception is if
 
       bfconvert -nooverwrite /path/to/input /path/to/output
 
+.. option:: -nolookup
+
+    To disable the conversion of lookup tables, leaving the output
+    file without any lookup tables::
+
+      bfconvert -nolookup /path/to/input /path/to/output
+
+    .. versionadded:: 5.2.0
+
 .. option:: -bigtiff
 
     This option forces the writing of a BigTiff file::

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -129,7 +129,7 @@ name pattern, then the other must be included too.  The only exception is if
 
     .. versionadded:: 5.1.2
 
-      The :option:`-bigtiff` option is not necessary if a BigTiff extension is
-      used for the output file, e.g.::
+    The :option:`-bigtiff` option is not necessary if a BigTiff extension is
+    used for the output file, e.g.::
 
-        bfconvert /path/to/input output.ome.btf
+      bfconvert /path/to/input output.ome.btf

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -119,7 +119,7 @@ name pattern, then the other must be included too.  The only exception is if
 
       bfconvert -nolookup /path/to/input /path/to/output
 
-    .. versionadded:: 5.2.0
+    .. versionadded:: 5.2.1
 
 .. option:: -bigtiff
 


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/13273

Testing:

Run `bfconvert test.image [-nolookup] test.ome.tiff`.  Run `showinf` and `tiffinfo` on the result to check that the image remains viewable and has the correct photometric interpretation.  Given a source image with a lookup table, the OME-TIFF output should contain photometric=palette; with `-nolookup` it will contain photometric=minisblack.