### PR TITLE
Add reference URLs for the Simplified BSD license in the POMs

### DIFF
--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/forks/turbojpeg/pom.xml
+++ b/components/forks/turbojpeg/pom.xml
@@ -27,6 +27,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/formats-common/pom.xml
+++ b/components/formats-common/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/specification/pom.xml
+++ b/components/specification/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
     <license>

--- a/components/stubs/lwf-stubs/pom.xml
+++ b/components/stubs/lwf-stubs/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/stubs/mipav/pom.xml
+++ b/components/stubs/mipav/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/components/xsd-fu/pom.xml
+++ b/components/xsd-fu/pom.xml
@@ -22,6 +22,7 @@
   <licenses>
     <license>
       <name>Simplified BSD License</name>
+      <url>https://opensource.org/licenses/BSD-2-Clause</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
While working on generating the [list of dependencies](https://trello.com/c/QYoTKrkG/62-review-dependencies) for 5.2.0, I realized the `url` section is not defined for the components licensed with the Simplified (2-clause) BSD license. This commit should add a reference to a proper URL.

To test it, check the `share/server/dependencies.html` page from the OMERO-DEV-merge-build server and verify the licenses of the `ome` components include correct hyperlinks in the license column.