### PR TITLE
Docs: Update developer code examples

### DIFF
--- a/docs/sphinx/developers/export.txt
+++ b/docs/sphinx/developers/export.txt
@@ -39,7 +39,8 @@ Now, we set up our writer:
       IFormatWriter writer = new ImageWriter();
       // give the writer a MetadataRetrieve object, which encapsulates all of the
       // dimension information for the dataset (among many other things)
-      writer.setMetadataRetrieve(MetadataTools.asRetrieve(reader.getMetadataStore()));
+      OMEXMLService service = factory.getInstance(OMEXMLService.class);
+      writer.setMetadataRetrieve(service.asRetrieve(reader.getMetadataStore()));
       // initialize the writer
       writer.setId("/path/to/output/file");
 
@@ -73,65 +74,6 @@ Fortunately, closing the files is very easy:
       reader.close();
       writer.close();
 
-Converting large images
------------------------
-
-The flaw in the previous example is that it requires an image plane to
-be fully read into memory before it can be saved. In many cases this is
-fine, but if you are working with very large images (especially > 4 GB)
-this is problematic. The solution is to break each image plane into a
-set of reasonably-sized tiles and save each tile separately - thus
-substantially reducing the amount of memory required for conversion.
-
-For now, we'll assume that your tile size is 1024 x 1024, though in
-practice you will likely want to adjust this. Assuming you have an
-IFormatReader and IFormatWriter set up as in the previous example, let's
-start writing planes:
-
-::
-
-      int tileWidth = 1024;
-      int tileHeight = 1024;
-
-      for (int series=0; series<reader.getSeriesCount(); series++) {
-        reader.setSeries(series);
-        writer.setSeries(series);
-
-        // determine how many tiles are in each image plane
-        // for simplicity, we'll assume that the image width and height are
-        // multiples of 1024
-
-        int tileRows = reader.getSizeY() / tileHeight;
-        int tileColumns = reader.getSizeX() / tileWidth;
-
-        for (int image=0; image<reader.getImageCount(); image++) {
-          for (int row=0; row<tileRows; row++) {
-            for (int col=0; col<tileColumns; col++) {
-              // open a tile - in addition to the image index, we need to specify
-              // the (x, y) coordinate of the upper left corner of the tile,
-              // along with the width and height of the tile
-
-              int xCoordinate = col * tileWidth;
-              int yCoordinate = row * tileHeight;
-              byte[] tile =
-                reader.openBytes(image, xCoordinate, yCoordinate, tileWidth, tileHeight);
-              writer.saveBytes(
-                image, tile, xCoordinate, yCoordinate, tileWidth, tileHeight);
-            }
-          }
-        }
-      }
-
-As noted, the example assumes that the width and height of the image are
-multiples of the tile dimensions. Be careful, as this is not always the
-case; the last column and/or row may be smaller than preceding
-columns/rows. An exception will be thrown if you attempt to read or
-write a tile that is not completely contained by the original image
-plane. Most writers perform best if the tile width is equal to the image
-width, although specifying any valid width should work.
-
-As before, you need to close the reader and writer.
-
 Converting to multiple files
 ----------------------------
 
@@ -142,7 +84,8 @@ single IFormatWriter, like so:
 
       // you should have set up a reader as in the first example
       ImageWriter writer = new ImageWriter();
-      writer.setMetadataRetrieve(MetadataTools.asRetrieve(reader.getMetadataStore()));
+      OMEXMLService service = factory.getInstance(OMEXMLService.class);
+      writer.setMetadataRetrieve(service.asRetrieve(reader.getMetadataStore()));
       // replace this with your own filename definitions
       // in this example, we're going to write half of the planes to one file
       // and half of the planes to another file
@@ -169,13 +112,13 @@ formats (e.g. JPEG, AVI, MOV), then you could also use a separate
 IFormatWriter for each file, like this:
 
 ::
-
+      OMEXMLService service = factory.getInstance(OMEXMLService.class);
       // again, you should have set up a reader already
       String[] outputFiles = new String[] {"/path/to/file/1.avi", "/path/to/file/2.avi"};
       int planesPerFile = reader.getImageCount() / outputFiles.length;
       for (int file=0; file<outputFiles.length; file++) {
         ImageWriter writer = new ImageWriter();
-        writer.setMetadataRetrieve(MetadataTools.asRetrieve(reader.getMetadataStore()));
+        writer.setMetadataRetrieve(service.asRetrieve(reader.getMetadataStore()));
         writer.setId(outputFiles[file]);
         for (int image=0; image<planesPerFile; image++) {
           int index = file * planesPerFile + image;


### PR DESCRIPTION
Due to limitations of the tiling example provided this has been removed until further investigation and work can be carried out. The example that was provided did not function correctly across the board and relied on specific parameters and files being used.

The examples have also been updated to fix the asRetrieve function which was no longer correct. Instead it has been moved to OMEXMLService instead of MetadataTools