### PR TITLE
Docs: New Physical Size Example

### DIFF
--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -62,30 +62,27 @@ public class ReadPhysicalSize {
         
         Unit<Length> targetUnit = UNITS.MICROMETER;
         
-        for (int series=0; series<reader.getSeriesCount(); series++) {
-            reader.setSeries(series);
-            for (int image=0; image<reader.getImageCount(); image++) {
-                Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
-                Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
-                Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
+        for (int image=0; image<omeMeta.getImageCount(); image++) {
+            Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
+            Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
+            Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
                 
-                System.out.println("Physical calibration - Series: " + series + " Image: " + image);
+            System.out.println("Physical calibration - Image: " + image);
                 
-                if (physSizeX != null) {
-                    Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
-                    System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
-                                       + " = " + convertedSizeX.value() + " " + convertedSizeX.unit().getSymbol());
-                }
-                if (physSizeY != null) {
-                    Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
-                    System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
-                                       + " = " + convertedSizeY.value() + " " + convertedSizeY.unit().getSymbol());
-                }
-                if (physSizeZ != null) {
-                    Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
-                    System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
-                                       + " = " + convertedSizeZ.value() + " " + convertedSizeZ.unit().getSymbol());
-                }
+            if (physSizeX != null) {
+                Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
+                System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
+                            + " = " + convertedSizeX.value() + " " + convertedSizeX.unit().getSymbol());
+            }
+            if (physSizeY != null) {
+                Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
+                System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
+                            + " = " + convertedSizeY.value() + " " + convertedSizeY.unit().getSymbol());
+            }
+            if (physSizeZ != null) {
+                Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
+                System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
+                            + " = " + convertedSizeZ.value() + " " + convertedSizeZ.unit().getSymbol());
             }
         }
         reader.close();

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ * Copyright (C) 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -25,23 +25,13 @@
 
 import java.io.IOException;
 
-import loci.common.services.DependencyException;
-import loci.common.services.ServiceException;
-import loci.common.services.ServiceFactory;
 import loci.formats.FormatException;
-import loci.formats.FormatTools;
 import loci.formats.ImageReader;
-import loci.formats.ImageWriter;
 import loci.formats.MetadataTools;
 import loci.formats.meta.IMetadata;
-import loci.formats.services.OMEXMLService;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.units.unit.Unit;
-import ome.xml.model.enums.DimensionOrder;
-import ome.xml.model.enums.EnumerationException;
-import ome.xml.model.enums.PixelType;
-import ome.xml.model.primitives.PositiveInteger;
 
 /**
  * Example class that shows how to read and convert the physical X, Y and Z dimensions of a file
@@ -50,37 +40,39 @@ import ome.xml.model.primitives.PositiveInteger;
 public class ReadPhysicalSize {
 
   /**
-   * Construct a new ReadPhysicalSize that will read and convert the physical dimensions of a file
+   * Reads the physical dimensions of the input file provided then converts and displays them in micrometers
    *
    * @param inputFile the file to be read
+   * @throws FormatException if a parsing error occurs processing the file.
+   * @throws IOException if an I/O error occurs processing the file
    */
-  public ReadPhysicalSize(String inputFile) throws FormatException, IOException {
-    ImageReader reader = new ImageReader();
-    IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
+  public static void readPhysicalSize(final String inputFile) throws FormatException, IOException {
+    final ImageReader reader = new ImageReader();
+    final IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
     reader.setMetadataStore(omeMeta);
     reader.setId(inputFile);
 
-    Unit<Length> targetUnit = UNITS.MICROMETER;
+    final Unit<Length> targetUnit = UNITS.MICROMETER;
 
     for (int image=0; image<omeMeta.getImageCount(); image++) {
-      Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
-      Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
-      Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
+      final Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
+      final Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
+      final Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
 
       System.out.println("Physical calibration - Image: " + image);
 
       if (physSizeX != null) {
-        Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
+        final Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
         System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
             + " = " + convertedSizeX.value() + " " + convertedSizeX.unit().getSymbol());
       }
       if (physSizeY != null) {
-        Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
+        final Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
         System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
             + " = " + convertedSizeY.value() + " " + convertedSizeY.unit().getSymbol());
       }
       if (physSizeZ != null) {
-        Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
+        final Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
         System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
             + " = " + convertedSizeZ.value() + " " + convertedSizeZ.unit().getSymbol());
       }
@@ -94,7 +86,7 @@ public class ReadPhysicalSize {
    * $ java ReadPhysicalSize input-file.ome.tiff
    */
   public static void main(String[] args) throws Exception {
-    ReadPhysicalSize exporter = new ReadPhysicalSize(args[0]);
+    readPhysicalSize(args[0]);
   }
 
 }

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -37,6 +37,7 @@ import loci.formats.meta.IMetadata;
 import loci.formats.services.OMEXMLService;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
+import ome.units.unit.Unit;
 import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.PixelType;
@@ -59,22 +60,33 @@ public class ReadPhysicalSize {
         reader.setMetadataStore(omeMeta);
         reader.setId(inputFile);
         
-        Length physSizeX = omeMeta.getPixelsPhysicalSizeX(0);
-        Length physSizeY = omeMeta.getPixelsPhysicalSizeY(0);
-        Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(0);
+        Unit<Length> targetUnit = UNITS.MICROMETER;
         
-        System.out.println("Physical calibration:");
-        if (physSizeX != null) {
-            System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
-                               + " = " + physSizeX.value(UNITS.MICROMETER) + " microns");
-        }
-        if (physSizeY != null) {
-            System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
-                               + " = " + physSizeY.value(UNITS.MICROMETER) + " microns");
-        }
-        if (physSizeZ != null) {
-            System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
-                               + " = " + physSizeZ.value(UNITS.MICROMETER) + " microns");
+        for (int series=0; series<reader.getSeriesCount(); series++) {
+            reader.setSeries(series);
+            for (int image=0; image<reader.getImageCount(); image++) {
+                Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
+                Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
+                Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
+                
+                System.out.println("Physical calibration - Series: " + series + " Image: " + image);
+                
+                if (physSizeX != null) {
+                    Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
+                    System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
+                                       + " = " + convertedSizeX.value() + " " + convertedSizeX.unit().getSymbol());
+                }
+                if (physSizeY != null) {
+                    Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
+                    System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
+                                       + " = " + convertedSizeY.value() + " " + convertedSizeY.unit().getSymbol());
+                }
+                if (physSizeZ != null) {
+                    Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
+                    System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
+                                       + " = " + convertedSizeZ.value() + " " + convertedSizeZ.unit().getSymbol());
+                }
+            }
         }
         reader.close();
     }

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -48,54 +48,53 @@ import ome.xml.model.primitives.PositiveInteger;
  * Bio-Formats version 5.1 or later.
  */
 public class ReadPhysicalSize {
-    
-    /**
-     * Construct a new ReadPhysicalSize that will read and convert the physical dimensions of a file
-     *
-     * @param inputFile the file to be read
-     */
-    public ReadPhysicalSize(String inputFile) {
-        ImageReader reader = new ImageReader();
-        IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
-        reader.setMetadataStore(omeMeta);
-        reader.setId(inputFile);
-        
-        Unit<Length> targetUnit = UNITS.MICROMETER;
-        
-        for (int image=0; image<omeMeta.getImageCount(); image++) {
-            Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
-            Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
-            Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
-                
-            System.out.println("Physical calibration - Image: " + image);
-                
-            if (physSizeX != null) {
-                Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
-                System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
-                            + " = " + convertedSizeX.value() + " " + convertedSizeX.unit().getSymbol());
-            }
-            if (physSizeY != null) {
-                Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
-                System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
-                            + " = " + convertedSizeY.value() + " " + convertedSizeY.unit().getSymbol());
-            }
-            if (physSizeZ != null) {
-                Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
-                System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
-                            + " = " + convertedSizeZ.value() + " " + convertedSizeZ.unit().getSymbol());
-            }
-        }
-        reader.close();
+
+  /**
+   * Construct a new ReadPhysicalSize that will read and convert the physical dimensions of a file
+   *
+   * @param inputFile the file to be read
+   */
+  public ReadPhysicalSize(String inputFile) {
+    ImageReader reader = new ImageReader();
+    IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
+    reader.setMetadataStore(omeMeta);
+    reader.setId(inputFile);
+
+    Unit<Length> targetUnit = UNITS.MICROMETER;
+
+    for (int image=0; image<omeMeta.getImageCount(); image++) {
+      Length physSizeX = omeMeta.getPixelsPhysicalSizeX(image);
+      Length physSizeY = omeMeta.getPixelsPhysicalSizeY(image);
+      Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(image);
+
+      System.out.println("Physical calibration - Image: " + image);
+
+      if (physSizeX != null) {
+        Length convertedSizeX = new Length(physSizeX.value(targetUnit), targetUnit);
+        System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
+            + " = " + convertedSizeX.value() + " " + convertedSizeX.unit().getSymbol());
+      }
+      if (physSizeY != null) {
+        Length convertedSizeY = new Length(physSizeY.value(targetUnit), targetUnit);
+        System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
+            + " = " + convertedSizeY.value() + " " + convertedSizeY.unit().getSymbol());
+      }
+      if (physSizeZ != null) {
+        Length convertedSizeZ = new Length(physSizeZ.value(targetUnit), targetUnit);
+        System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
+            + " = " + convertedSizeZ.value() + " " + convertedSizeZ.unit().getSymbol());
+      }
     }
+    reader.close();
+  }
     
-    /**
-     * To read the physical size dimensions and units of a file and display them in micrometers:
-     *
-     * $ java ReadPhysicalSize input-file.ome.tiff
-     */
-    public static void main(String[] args) throws Exception {
-        ReadPhysicalSize exporter = new ReadPhysicalSize(args[0]);
-        
-    }
-    
+  /**
+   * To read the physical size dimensions and units of a file and display them in micrometers:
+   *
+   * $ java ReadPhysicalSize input-file.ome.tiff
+   */
+  public static void main(String[] args) throws Exception {
+    ReadPhysicalSize exporter = new ReadPhysicalSize(args[0]);
+  }
+
 }

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -45,7 +45,7 @@ import ome.xml.model.primitives.PositiveInteger;
 
 /**
  * Example class that shows how to read and convert the physical X, Y and Z dimensions of a file
- * Bio-Formats version 5.2 or later.
+ * Bio-Formats version 5.1 or later.
  */
 public class ReadPhysicalSize {
     

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -54,7 +54,7 @@ public class ReadPhysicalSize {
    *
    * @param inputFile the file to be read
    */
-  public ReadPhysicalSize(String inputFile) {
+  public ReadPhysicalSize(String inputFile) throws FormatException, IOException {
     ImageReader reader = new ImageReader();
     IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
     reader.setMetadataStore(omeMeta);

--- a/docs/sphinx/developers/ReadPhysicalSize.java
+++ b/docs/sphinx/developers/ReadPhysicalSize.java
@@ -1,0 +1,92 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.ImageReader;
+import loci.formats.ImageWriter;
+import loci.formats.MetadataTools;
+import loci.formats.meta.IMetadata;
+import loci.formats.services.OMEXMLService;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.EnumerationException;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.PositiveInteger;
+
+/**
+ * Example class that shows how to read and convert the physical X, Y and Z dimensions of a file
+ * Bio-Formats version 5.2 or later.
+ */
+public class ReadPhysicalSize {
+    
+    /**
+     * Construct a new ReadPhysicalSize that will read and convert the physical dimensions of a file
+     *
+     * @param inputFile the file to be read
+     */
+    public ReadPhysicalSize(String inputFile) {
+        ImageReader reader = new ImageReader();
+        IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
+        reader.setMetadataStore(omeMeta);
+        reader.setId(inputFile);
+        
+        Length physSizeX = omeMeta.getPixelsPhysicalSizeX(0);
+        Length physSizeY = omeMeta.getPixelsPhysicalSizeY(0);
+        Length physSizeZ = omeMeta.getPixelsPhysicalSizeZ(0);
+        
+        System.out.println("Physical calibration:");
+        if (physSizeX != null) {
+            System.out.println("\tX = " + physSizeX.value() + " " + physSizeX.unit().getSymbol()
+                               + " = " + physSizeX.value(UNITS.MICROMETER) + " microns");
+        }
+        if (physSizeY != null) {
+            System.out.println("\tY = " + physSizeY.value() + " " + physSizeY.unit().getSymbol()
+                               + " = " + physSizeY.value(UNITS.MICROMETER) + " microns");
+        }
+        if (physSizeZ != null) {
+            System.out.println("\tZ = " + physSizeZ.value() + " " + physSizeZ.unit().getSymbol()
+                               + " = " + physSizeZ.value(UNITS.MICROMETER) + " microns");
+        }
+        reader.close();
+    }
+    
+    /**
+     * To read the physical size dimensions and units of a file and display them in micrometers:
+     *
+     * $ java ReadPhysicalSize input-file.ome.tiff
+     */
+    public static void main(String[] args) throws Exception {
+        ReadPhysicalSize exporter = new ReadPhysicalSize(args[0]);
+        
+    }
+    
+}

--- a/docs/sphinx/developers/export2.txt
+++ b/docs/sphinx/developers/export2.txt
@@ -57,10 +57,18 @@ We populate that metadata as follows:
       omexml.setPixelsSizeT(new PositiveInteger(timepointCount), 0);
 
       for (int channel=0; channel<channelCount; channel++) {
-       omexml.setChannelID("Channel:0:" + channel, 0, channel);
-       omexml.setChannelSamplesPerPixel(new PositiveInteger(samplesPerChannel),
-       0, channel);
-       }
+        omexml.setChannelID("Channel:0:" + channel, 0, channel);
+        omexml.setChannelSamplesPerPixel(new PositiveInteger(samplesPerChannel),
+          0, channel);
+      }
+      
+      Unit<Length> unit = UNITS.MICROMETER;
+      Length physicalSizeX = new Length(1.0, unit);
+      Length physicalSizeY = new Length(1.5, unit);
+      Length physicalSizeZ = new Length(2, unit);
+      omexml.setPixelsPhysicalSizeX(physicalSizeX, 0);
+      omexml.setPixelsPhysicalSizeY(physicalSizeY, 0);
+      omexml.setPixelsPhysicalSizeZ(physicalSizeZ, 0);
 
 There is much more metadata that can be stored; please see the Javadoc for
 loci.formats.meta.MetadataStore for a complete list.

--- a/docs/sphinx/developers/file-reader.txt
+++ b/docs/sphinx/developers/file-reader.txt
@@ -80,7 +80,7 @@ table below together with the appropriate accessor method:
 All file formats are guaranteed to accurately report core metadata.
 
 Bio-Formats also converts and stores additional information which can be stored and retrieved 
-from the OME Metadata. These fields can be accessed in a similar way to the core metadata above.
+from the OME-XML Metadata. These fields can be accessed in a similar way to the core metadata above.
 An example of such values would be the physical size of dimensions X, Y and Z. The accessor methods 
 for these properties return a :javadoc:`Length <ome/units/quantity/Length.html>` object which 
 contains both the value and unit of the dimension. These lengths can also be converted to other units using 

--- a/docs/sphinx/developers/file-reader.txt
+++ b/docs/sphinx/developers/file-reader.txt
@@ -79,6 +79,15 @@ table below together with the appropriate accessor method:
 
 All file formats are guaranteed to accurately report core metadata.
 
+Bio-Formats also converts and stores additional information which can be stored and retrieved 
+from the OME Metadata. These fields can be accessed in a similar way to the core metadata above.
+An example of such values would be the physical size of dimensions X, Y and Z. The accessor methods 
+for these properties return a :javadoc:`Length <ome/units/quantity/Length.html>` object which 
+contains both the value and unit of the dimension. These lengths can also be converted to other units using 
+:javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value(ome.units.unit.Unit)>`
+An example of reading and converting these physical sizes values can be found in 
+:download:`ReadPhysicalSize.java <ReadPhysicalSize.java>`
+
 Format-specific metadata refers to any other data specified in the file - this
 includes acquisition and hardware parameters, among other things. This data
 is stored internally in a **java.util.Hashtable**, and can be accessed in one


### PR DESCRIPTION
This PR adds a new sample file and brief documentation regarding the reading of physical size dimensions and converting them to display in another quantity unit.

The need for this was raised in a discussion of the ImageJ forums - http://imagej.1557.x6.nabble.com/bioformats-retrieve-calibration-in-JAVA-td5014616.html#a5014627

The new sample file provided is based on the ImageJ example provided here https://gist.github.com/ctrueden/6282856