### PR TITLE
Docs: Eclipse instructions for using Maven

### DIFF
--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -114,7 +114,7 @@ and JAR dependencies (stored in the Maven repository in
 :file:`~/.m2/repository`) on the build path, depending on which projects are
 currently open.
 
-We recommend using Eclipse 4.3 (Kepler), specifically -
+We recommend using Eclipse 4.3 (Kepler) or later, specifically -
 "Eclipse IDE for Java developers". It comes with m2e installed
 (http://eclipse.org/downloads/compare.php?release=kepler).
 
@@ -123,6 +123,8 @@ dependency can be added to the project pom file and should include the
 desired Bio-Formats version. Using bioformats_package as the artifactId
 will include the complete Bio-Formats package, or individual components 
 can be chosen as desired.
+
+::
 
   <dependency>
     <groupId>OME</groupId>
@@ -134,6 +136,8 @@ In order to include this Bio-Formats dependency a custom repository
 must also be added to the project pom or ${user.home}/.m2/settings.xml 
 The repositories element is inherited so for a group of projects the 
 repositories element can be defined at the top of your inheritance chain. 
+
+::
 
   <repositories>
     <repository>

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -120,7 +120,7 @@ We recommend using Eclipse 4.3 (Kepler) or later, specifically -
 
 Bio-Formats can be included as a dependency in any Maven project. The 
 dependency can be added to the project pom file and should include the
-desired Bio-Formats version. Using bioformats_package as the artifactId
+desired Bio-Formats version. Using `bioformats_package` as the artifactId
 will include the complete Bio-Formats package, or individual components 
 can be chosen as desired.
 
@@ -133,7 +133,7 @@ can be chosen as desired.
   </dependency>
 
 In order to include this Bio-Formats dependency a custom repository 
-must also be added to the project pom or ${user.home}/.m2/settings.xml 
+must also be added to the project pom or :file:`${user.home}/.m2/settings.xml`.
 The repositories element is inherited so for a group of projects the 
 repositories element can be defined at the top of your inheritance chain. 
 

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -147,7 +147,7 @@ repositories element can be defined at the top of your inheritance chain.
     </repository>
   </repositories>
 
-Alternatively you can import the Bio-Formats source by choosing
+If you wish you can instead import the Bio-Formats source by choosing
 :menuselection:`File --> Import --> Existing Maven Projects` from the menu
 and browsing to the top-level folder of your Bio-Formats working copy.
 Alternatively, run the Eclipse Maven target with :command:`mvn

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -127,7 +127,7 @@ can be chosen as desired.
 ::
 
   <dependency>
-    <groupId>OME</groupId>
+    <groupId>ome</groupId>
     <artifactId>bioformats_package</artifactId>
     <version>5.2.0</version>
   </dependency>
@@ -141,7 +141,7 @@ repositories element can be defined at the top of your inheritance chain.
 
   <repositories>
     <repository>
-      <id>OME</id>
+      <id>ome</id>
       <name>Bio-Formats Repo</name>
       <url>http://artifacts.openmicroscopy.org/artifactory/repo</url>
     </repository>

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -118,36 +118,7 @@ We recommend using Eclipse 4.3 (Kepler) or later, specifically -
 "Eclipse IDE for Java developers". It comes with m2e installed
 (http://eclipse.org/downloads/compare.php?release=kepler).
 
-Bio-Formats can be included as a dependency in any Maven project. The 
-dependency can be added to the project pom file and should include the
-desired Bio-Formats version. Using `bioformats_package` as the artifactId
-will include the complete Bio-Formats package, or individual components 
-can be chosen as desired.
-
-::
-
-  <dependency>
-    <groupId>ome</groupId>
-    <artifactId>bioformats_package</artifactId>
-    <version>5.2.0</version>
-  </dependency>
-
-In order to include this Bio-Formats dependency a custom repository 
-must also be added to the project pom or :file:`${user.home}/.m2/settings.xml`.
-The repositories element is inherited so for a group of projects the 
-repositories element can be defined at the top of your inheritance chain. 
-
-::
-
-  <repositories>
-    <repository>
-      <id>ome</id>
-      <name>Bio-Formats Repo</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/maven</url>
-    </repository>
-  </repositories>
-
-If you wish you can instead import the Bio-Formats source by choosing
+You can import the Bio-Formats source by choosing
 :menuselection:`File --> Import --> Existing Maven Projects` from the menu
 and browsing to the top-level folder of your Bio-Formats working copy.
 Alternatively, run the Eclipse Maven target with :command:`mvn

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -143,7 +143,7 @@ repositories element can be defined at the top of your inheritance chain.
     <repository>
       <id>ome</id>
       <name>Bio-Formats Repo</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/repo</url>
+      <url>http://artifacts.openmicroscopy.org/artifactory/maven</url>
     </repository>
   </repositories>
 

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -118,7 +118,32 @@ We recommend using Eclipse 4.3 (Kepler), specifically -
 "Eclipse IDE for Java developers". It comes with m2e installed
 (http://eclipse.org/downloads/compare.php?release=kepler).
 
-You can then import the Bio-Formats source by choosing
+Bio-Formats can be included as a dependency in any Maven project. The 
+dependency can be added to the project pom file and should include the
+desired Bio-Formats version. Using bioformats_package as the artifactId
+will include the complete Bio-Formats package, or individual components 
+can be chosen as desired.
+
+  <dependency>
+    <groupId>OME</groupId>
+    <artifactId>bioformats_package</artifactId>
+    <version>5.2.0</version>
+  </dependency>
+
+In order to include this Bio-Formats dependency a custom repository 
+must also be added to the project pom or ${user.home}/.m2/settings.xml 
+The repositories element is inherited so for a group of projects the 
+repositories element can be defined at the top of your inheritance chain. 
+
+  <repositories>
+    <repository>
+      <id>OME</id>
+      <name>Bio-Formats Repo</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/repo</url>
+    </repository>
+  </repositories>
+
+Alternatively you can import the Bio-Formats source by choosing
 :menuselection:`File --> Import --> Existing Maven Projects` from the menu
 and browsing to the top-level folder of your Bio-Formats working copy.
 Alternatively, run the Eclipse Maven target with :command:`mvn

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -1,7 +1,43 @@
 Using Bio-Formats as a Java library
 ===================================
 
-If you wish to make use of Bio-Formats within your own software, you can
+Bio-Formats as a Maven dependency
+-----------------
+
+If you wish to make use of Bio-Formats within your own software it can be 
+included as a dependency in any Maven project. The dependency can be added 
+to the project pom file and should include the desired Bio-Formats version. 
+Using `bioformats_package` as the artifactId will include the complete 
+Bio-Formats package, or individual components can be chosen as desired.
+
+::
+
+  <dependency>
+    <groupId>ome</groupId>
+    <artifactId>bioformats_package</artifactId>
+    <version>5.2.0</version>
+  </dependency>
+
+In order to include this Bio-Formats dependency a custom repository 
+must also be added to the project pom or :file:`${user.home}/.m2/settings.xml`.
+The repositories element is inherited so for a group of projects the 
+repositories element can be defined at the top of your inheritance chain. 
+
+::
+
+  <repositories>
+    <repository>
+      <id>ome</id>
+      <name>Bio-Formats Repo</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/maven</url>
+    </repository>
+  </repositories>
+  
+
+Bio-Formats as a Java library
+-----------------
+
+Alternatively Bio-Formats can be used by including its component jar files. You can
 :downloads:`download formats-gpl.jar <artifacts/formats-gpl.jar>` to use it as
 a library. Just add **formats-gpl.jar** to your CLASSPATH or build path. You
 will also need **common.jar** for common I/O functions, **ome-xml.jar** for

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -2,7 +2,7 @@ Using Bio-Formats as a Java library
 ===================================
 
 Bio-Formats as a Maven dependency
------------------
+---------------------------------
 
 If you wish to make use of Bio-Formats within your own software it can be 
 included as a dependency in any Maven project. The dependency can be added 
@@ -35,7 +35,7 @@ repositories element can be defined at the top of your inheritance chain.
   
 
 Bio-Formats as a Java library
------------------
+-----------------------------
 
 Alternatively Bio-Formats can be used by including its component jar files. You can
 :downloads:`download formats-gpl.jar <artifacts/formats-gpl.jar>` to use it as


### PR DESCRIPTION
This PR adds documentation on using Bio-Formats as a Maven dependancy through Eclipse. Sample code for the pom dependancy as well as the custom repository are provided. The repository can be added in either the pom or the users settings file, so its worth ensuring that the instructions are clear for either purpose.

Some additional things of note:
- Is the repo location correct (http://artifacts.openmicroscopy.org/artifactory/repo) ?
- Should we recommend using the bioformats-package or individual componets?