### PR TITLE
docs: Add code formatting page

### DIFF
--- a/docs/sphinx/developers/code-formatting.txt
+++ b/docs/sphinx/developers/code-formatting.txt
@@ -19,7 +19,8 @@ Java
 All Java code is formatted with:
 
 - an indentation size of two spaces
-- braces use the Java variant of K&R style
+- braces use the `Java variant of K&R style
+  <https://en.wikipedia.org/wiki/Indent_style#Variant:_Java>`__
 
 XML
 ---

--- a/docs/sphinx/developers/code-formatting.txt
+++ b/docs/sphinx/developers/code-formatting.txt
@@ -3,7 +3,7 @@ Code formatting
 
 Note, these guidelines do not cover:
 
-- third party code imported into the source tree, which is covered by
+- third-party code imported into the source tree, which is covered by
   the guidelines for the upstream projects
 - released schema files which would require re-releasing if changed by
   reindenting

--- a/docs/sphinx/developers/code-formatting.txt
+++ b/docs/sphinx/developers/code-formatting.txt
@@ -1,0 +1,30 @@
+Code formatting
+===============
+
+Note, these guidelines do not cover:
+
+- third party code imported into the source tree, which is covered by
+  the guidelines for the upstream projects
+- released schema files which would require re-releasing if changed by
+  reindenting
+
+All languages
+-------------
+
+- Use spaces to indent; do not ever use tabs
+
+Java
+----
+
+All Java code is formatted with:
+
+- an indentation size of two spaces
+- braces use the Java variant of K&R style
+
+XML
+---
+
+All XML code is formatted with:
+
+- an indentation size of two spaces
+- attributes on multiple lines aligned vertically after the element name.

--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -54,6 +54,7 @@ Contributing to Bio-Formats
 .. toctree::
     :maxdepth: 1
 
+    code-formatting
     commit-testing
     generating-test-images
     reader-guide


### PR DESCRIPTION
Add initial page for documenting code formatting style.  It's initially minimal, covering basic Java and XML formatting.

https://trello.com/c/8cJWPYOQ/429-document-new-xml-style