### PR TITLE
Set SPHINXOPTS option to fail on warnings in Travis build

### DIFF
--- a/tools/test-build
+++ b/tools/test-build
@@ -62,8 +62,7 @@ sphinx_html()
 {
     (
         cd docs/sphinx
-        export SPHINXOPTS="-W"
-        ant -Dsphinx.warnopts=$SPHINXOPTS html
+        ant -Dsphinx.warnopts=-W html
      )
  }
 

--- a/tools/test-build
+++ b/tools/test-build
@@ -62,6 +62,7 @@ sphinx_html()
 {
     (
         cd docs/sphinx
+        export SPHINXOPTS="-W"
         ant -Dsphinx.warnopts=$SPHINXOPTS html
      )
  }


### PR DESCRIPTION
While reviewing https://github.com/openmicroscopy/bioformats/pull/2520, I realized that Travis was no longer treating warnings as error as we do in our CI jobs. This commit should restore this behavior.

See https://travis-ci.org/sbesson/bioformats/builds/152396660 for an expected of failure on top of this commit.