### PR TITLE
Finalise 5.2.0 history

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2447,6 +2447,7 @@ opennessRating = Very good
 presenceRating = Fair
 utilityRating = Good
 privateSpecification = true
+pyramid = yes
 reader = ZeissCZIReader
 mif = true
 notes = Bio-Formats does not support CZI files generated using JPEG-XR compression.

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -126,11 +126,12 @@ Other general improvements include:
    - showinf improvements to preload format
    - tiffcomment now warns that it requires an ImageDescription tag to be
      present in the TIFF file
-* added more Java examples to the developer documentation
 * added many automated tests and improved FakeReader testing framework
 * documentation improvements include:
    - clarifying status of legacy Quicktime and ND2 readers
    - noting that the Gatan reader does not currently support stacks
+   - more Java examples added to the developer documentation
+   - new units page for developers
 
 The Data Model version 2016-06 has been released to introduce
 `Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -37,7 +37,8 @@ OMERO.
    - Nifti
        - fixed planeSize to prevent crashes when loading large files (thanks
          to Christian Niedworok)
-       - added support for gzipped compressed .nii.gz files
+       - added support for gzipped compressed .nii.gz files (thanks to Eric
+         Barnhill)
        - added public samples and updated documented supported file extensions
    - OME-TIFF
        - fixed Plane population errors
@@ -55,9 +56,9 @@ OMERO.
    - SDT
        - performance improvements for loading of large files
    - Slidebook
-       - Slide6Reader is now completely external (see
-         http://www.openmicroscopy.org/info/slidebook) and is specified as
-         such in the :file:`readers.txt` configuration file
+       - Slidebook6Reader is now completely external and fully maintained by
+         3i (see http://www.openmicroscopy.org/info/slidebook) and is
+         specified as such in the :file:`readers.txt` configuration file
    - SVS
        - fixed FormatNumberException
    - Tiff

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -10,7 +10,8 @@ Java format support improvements are listed below.
 metadata). Code changes or re-import may be necessary in ImageJ/FIJI and
 OMERO.
 
-* added support for :doc:`Becker & Hickl .spc FIFO </formats/becker-hickl-fifo>` data
+* added support (and public sample files) for
+  :doc:`Becker & Hickl .spc FIFO </formats/becker-hickl-fifo>` data
 * added support for :doc:`Princeton Instruments .spe </formats/princeton-instruments-spe>` data
 * bug fixes for many formats including:
    - Tiff
@@ -41,6 +42,8 @@ OMERO.
    - Nifti
        - fixed planeSize to prevent crashes when loading large files (thanks
          to Christian Niedworok)
+       - added support for gzipped compressed .nii.gz files
+       - added public samples and updated documented supported file extensions
    - LiFlim
        - fixed ExposureTime check and units usage
    - SDT
@@ -49,13 +52,27 @@ OMERO.
        - fixed Plane population errors
        - fixed NullPointerException when closing reader for partial multi-file
          filesets
+       - reduced buffer size for RandomAccessInputStreams to improve
+         performance
+       - deprecated getMetadataStoreForConversion and
+         getMetadataStoreForDisplay methods
    - Zeiss CZI
        - fixed timestamp indexing when multiple separate channels are present
+       - improved slide support - slides are now detected as a complete
+         full-resolution image (instead of each tile being a separate series)
+         and pyramid sub-resolutions and label/overview images are also
+         detected
    - SVS
        - fixed FormatNumberException
    - Micro-Manager
        - fixed handling of large datasets saved as image stacks and split
          over multiple files
+   - Slidebook
+       - Slide6Reader is now completely external (see
+         http://www.openmicroscopy.org/info/slidebook) and is specified as
+         such in the :file:`readers.txt` configuration file
+   - Kodak BIP
+       - fixed handling of CCD temperature stored in hexadecimal
 
 Top-level Bio-Formats API changes:
 
@@ -77,6 +94,10 @@ Top-level Bio-Formats API changes:
 * the Formats API has also been updated to add a new validate property to
   MetadataOptions and support for MetadataOptions has been moved to
   FormatHandler level to allow it to be used by both Readers and Writers
+* initial work on `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_
+  extended the ClassList API to allow the :file:`readers.txt` configuration
+  file to be annotated using key/value pairs to mark optional Readers and
+  specify additional per-Reader options
 
 Other general improvements include:
 
@@ -85,10 +106,6 @@ Other general improvements include:
 * fixes for the detection of csv pattern blocks by `FilePatternBlock`
 * bioformats_package.jar now includes bio-formats-tools as a dependency so
   ImageConverter, ImageFaker and ImageInfo classes are included in the bundle
-* initial work on
-  `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_ now allows the
-  :file:`readers.txt` configuration file to be annotated using key/value pairs
-  to mark optional Readers and specify additional per-Reader options
 * the JACE C++ implementation has been decoupled as it does not function with
   Java 1.7 (see `legacy repo <https://github.com/ome/bio-formats-jace>`_)
 * ImageJ fixes
@@ -103,8 +120,13 @@ Other general improvements include:
    - upgrade check no longer run when passing -version
    - common methods refactoring
    - showinf improvements to preload format
-* Added more Java examples to the developer documentation
-* Added many automated tests and improved FakeReader testing framework
+   - tiffcomment now warns that it requires an ImageDescription tag to be
+     present in the TIFF file
+* added more Java examples to the developer documentation
+* added many automated tests and improved FakeReader testing framework
+* documentation improvements include:
+   - clarifying status of legacy Quicktime and ND2 readers
+   - noting that the Gatan reader does not currently support stacks
 
 The Data Model version 2016-06 has been released to introduce
 `Folders <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_,
@@ -124,13 +146,21 @@ OME-XML changes include:
      maintenance and growth
    - allow for genuine abstract model types and enable C++ model
      implementation
+* updated OME-XML and OME-TIFF public sample files
 
 The Bio-Formats C++ native implementation has been decoupled from
 the Java codebase and will be released as
 `OME-Files C++ <http://downloads.openmicroscopy.org/ome-files-cpp/>`_ from now
 on, with the exception of OME-XML which is still within Bio-Formats at present
 (there is a plan to decouple both the Java and the C++ versions of OME-XML in
-future).
+future). All the C++ dependencies remaining in the main Bio-Formats repository
+have had their licensing updated to simplified (2-clause) BSD. This now
+covers:
+
+* XSL transforms
+* specification code
+* xsd-fu python code
+
 
 5.1.10 (2016 May 9)
 -------------------

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -28,7 +28,7 @@ OMERO.
    - Leica LIF
        - fixed incorrect plane offsets for large multi-tile files
    - LiFlim
-       - fixed ExposureTime check and units usage
+       - fixed ``ExposureTime`` check and units usage
    - Micro-Manager
        - fixed handling of large datasets saved as image stacks and split
          over multiple files
@@ -36,13 +36,13 @@ OMERO.
    - MRC and Spider
        - fixed format type checking
    - Nifti
-       - fixed planeSize to prevent crashes when loading large files (thanks
-         to Christian Niedworok)
+       - fixed ``planeSize`` to prevent crashes when loading large files
+         (thanks to Christian Niedworok)
        - added support for gzipped compressed .nii.gz files (thanks to Eric
          Barnhill)
        - added public samples and updated documented supported file extensions
    - OME-TIFF
-       - fixed Plane population errors
+       - fixed ``Plane`` population errors
        - fixed ``NullPointerException`` when closing reader for partial
          multi-file filesets
        - reduced buffer size for ``RandomAccessInputStreams`` to improve
@@ -72,7 +72,7 @@ OMERO.
          and pyramid sub-resolutions and label/overview images are also
          detected
    - Zeiss LSM
-       - fixed Plane population errors
+       - fixed ``Plane`` population errors
    - Zeiss ZVI†
        - reworked image ordering calculation to allow for tiles
 
@@ -104,7 +104,7 @@ Top-level Bio-Formats API changes:
 
 Other general improvements include:
 
-* improved performance of `getUsedFiles`
+* improved performance of ``getUsedFiles``
 * fixes for ``FilePatternBlock``, ``AxisGuesser``, ``FilePattern``
 * fixes for the detection of CSV pattern blocks by ``FilePatternBlock``
 * :file:`bioformats_package.jar` now includes bio-formats-tools as a

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -29,7 +29,7 @@ OMERO.
        - fixed incorrect plane offsets for large multi-tile files
    - LiFlim
        - fixed ExposureTime check and units usage
-    - Micro-Manager
+   - Micro-Manager
        - fixed handling of large datasets saved as image stacks and split
          over multiple files
        - added user documentation for file saving options
@@ -90,7 +90,7 @@ Top-level Bio-Formats API changes:
    - handle ``NumberFormatException`` thrown when parsing Unit tests
 * the Logging API has been updated to respect logging frameworks
   (log4j/logback) initialized via a binding-specific configuration file and
-  to prevent `DebugTools.enableLogging(String)` from overriding initialized
+  to prevent ``DebugTools.enableLogging(String)`` from overriding initialized
   logger levels (see :doc:`/developers/logging` for more information)
 * helper methods have been added to FormatTools allowing a stage position to
   be formatted from an input ``Double`` and an input unit

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -509,7 +509,7 @@ Java bug fixes:
 * Improvements to developer documentation
 * Initial version of `native C++ implementation <http://www.openmicroscopy.org/site/support/bio-formats5.1/developers/cpp/overview.html>`__
 * Improved support for opening and saving ROI data with ImageJ
-* Added support for :doc:`CellH5 </formats/cellh5>` data (thanks to Christophe Sommer)
+* Added support for :doc:`CellH5 </formats/cellh5>` data (thanks to Christoph Sommer)
 * Added support for :doc:`Perkin Elmer Nuance </formats/perkinelmer-nuance>` data (thanks to Lee Kamentsky)
 * Added support for :doc:`Amnis FlowSight </formats/amnis-flowsight>` data (thanks to Lee Kamentsky and Sebastien Simard)
 * Added support for :doc:`Veeco AFM </formats/veeco-afm>` data

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -1,8 +1,8 @@
 Version history
 ===============
 
-5.2.0-m5 (2016 July 7)
------------------------
+5.2.0 (2016 August 18)
+----------------------
 
 Java format support improvements are listed below.
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -14,40 +14,31 @@ OMERO.
   :doc:`Becker & Hickl .spc FIFO </formats/becker-hickl-fifo>` data
 * added support for :doc:`Princeton Instruments .spe </formats/princeton-instruments-spe>` data
 * bug fixes for many formats including:
-   - Tiff
-       - fixed integer overflow to read resolutions correctly
-       - fixed handling of tiled images with tile width less than 64
-   - PNG writing
-   - Zeiss ZVI†
-       - reworked image ordering calculation to allow for tiles
-   - Leica LIF
-       - fixed incorrect plane offsets for large multi-tile files
-   - MRC and Spider
-       - fixes for format type checking
-   - OME-XML
-       - fixed metadata store
    - CellSens VSI†
        - fixes for correctly reading dimensions
-   - ICS writing
-       - fixed dimension population for split files
    - FlowSight
        - fixes to infer channel count from channel names (thanks to Lee
          Kamentsky)
    - Hamamatsu VMS†
        - fixed dimensions of full-resolution images
-   - PicoQuant
-       - updated reader to always buffer data
-   - Zeiss LSM
-       - fixed Plane population errors
+   - ICS writing
+       - fixed dimension population for split files
+   - Kodak BIP
+       - fixed handling of CCD temperature stored in hexadecimal
+   - Leica LIF
+       - fixed incorrect plane offsets for large multi-tile files
+   - LiFlim
+       - fixed ExposureTime check and units usage
+   - MRC and Spider
+       - fixed format type checking
+   - Micro-Manager
+       - fixed handling of large datasets saved as image stacks and split
+         over multiple files
    - Nifti
        - fixed planeSize to prevent crashes when loading large files (thanks
          to Christian Niedworok)
        - added support for gzipped compressed .nii.gz files
        - added public samples and updated documented supported file extensions
-   - LiFlim
-       - fixed ExposureTime check and units usage
-   - SDT
-       - performance improvements for loading of large files
    - OME-TIFF
        - fixed Plane population errors
        - fixed NullPointerException when closing reader for partial multi-file
@@ -56,23 +47,33 @@ OMERO.
          performance
        - deprecated getMetadataStoreForConversion and
          getMetadataStoreForDisplay methods
+   - OME-XML
+       - fixed metadata store
+   - PicoQuant
+       - updated reader to always buffer data
+   - PNG writing
+   - SDT
+       - performance improvements for loading of large files
+   - Slidebook
+       - Slide6Reader is now completely external (see
+         http://www.openmicroscopy.org/info/slidebook) and is specified as
+         such in the :file:`readers.txt` configuration file
+   - SVS
+       - fixed FormatNumberException
+   - Tiff
+       - fixed integer overflow to read resolutions correctly
+       - fixed handling of tiled images with tile width less than 64
    - Zeiss CZI
        - fixed timestamp indexing when multiple separate channels are present
        - improved slide support - slides are now detected as a complete
          full-resolution image (instead of each tile being a separate series)
          and pyramid sub-resolutions and label/overview images are also
          detected
-   - SVS
-       - fixed FormatNumberException
-   - Micro-Manager
-       - fixed handling of large datasets saved as image stacks and split
-         over multiple files
-   - Slidebook
-       - Slide6Reader is now completely external (see
-         http://www.openmicroscopy.org/info/slidebook) and is specified as
-         such in the :file:`readers.txt` configuration file
-   - Kodak BIP
-       - fixed handling of CCD temperature stored in hexadecimal
+   - Zeiss LSM
+       - fixed Plane population errors
+   - Zeiss ZVI†
+       - reworked image ordering calculation to allow for tiles
+
 
 Top-level Bio-Formats API changes:
 

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -157,13 +157,14 @@ the Java codebase and will be released as
 `OME-Files C++ <http://downloads.openmicroscopy.org/ome-files-cpp/>`_ from now
 on, with the exception of OME-XML which is still within Bio-Formats at present
 (there is a plan to decouple both the Java and the C++ versions of OME-XML in
-future). All the C++ dependencies remaining in the main Bio-Formats repository
-have had their licensing updated to simplified (2-clause) BSD. This now
-covers:
+future).
+
+The following components have had their licensing updated to Simplified
+(2-clause) BSD:
 
 * XSL transforms
 * specification code
-* xsd-fu python code
+* xsd-fu Python code
 
 
 5.1.10 (2016 May 9)

--- a/docs/sphinx/about/whats-new.txt
+++ b/docs/sphinx/about/whats-new.txt
@@ -29,11 +29,12 @@ OMERO.
        - fixed incorrect plane offsets for large multi-tile files
    - LiFlim
        - fixed ExposureTime check and units usage
-   - MRC and Spider
-       - fixed format type checking
-   - Micro-Manager
+    - Micro-Manager
        - fixed handling of large datasets saved as image stacks and split
          over multiple files
+       - added user documentation for file saving options
+   - MRC and Spider
+       - fixed format type checking
    - Nifti
        - fixed planeSize to prevent crashes when loading large files (thanks
          to Christian Niedworok)
@@ -42,12 +43,12 @@ OMERO.
        - added public samples and updated documented supported file extensions
    - OME-TIFF
        - fixed Plane population errors
-       - fixed NullPointerException when closing reader for partial multi-file
-         filesets
-       - reduced buffer size for RandomAccessInputStreams to improve
+       - fixed ``NullPointerException`` when closing reader for partial
+         multi-file filesets
+       - reduced buffer size for ``RandomAccessInputStreams`` to improve
          performance
-       - deprecated getMetadataStoreForConversion and
-         getMetadataStoreForDisplay methods
+       - deprecated ``getMetadataStoreForConversion`` and
+         ``getMetadataStoreForDisplay`` methods
    - OME-XML
        - fixed metadata store
    - PicoQuant
@@ -60,7 +61,7 @@ OMERO.
          3i (see http://www.openmicroscopy.org/info/slidebook) and is
          specified as such in the :file:`readers.txt` configuration file
    - SVS
-       - fixed FormatNumberException
+       - fixed ``NumberFormatException``
    - Tiff
        - fixed integer overflow to read resolutions correctly
        - fixed handling of tiled images with tile width less than 64
@@ -85,16 +86,16 @@ Top-level Bio-Formats API changes:
   JPEG-XR support implemented in Bio-Formats as yet
 * the DataTools API has been extended to add a number of utility functions to:
    - account for decimal separators in different locales
-   - parse a String into Double, Float, Integer etc
-   - handle NumberFormatException thrown when parsing Unit tests
+   - parse a ``String`` into ``Double``, ``Float``, ``Integer`` etc
+   - handle ``NumberFormatException`` thrown when parsing Unit tests
 * the Logging API has been updated to respect logging frameworks
   (log4j/logback) initialized via a binding-specific configuration file and
   to prevent `DebugTools.enableLogging(String)` from overriding initialized
   logger levels (see :doc:`/developers/logging` for more information)
 * helper methods have been added to FormatTools allowing a stage position to
-  be formatted from an input Double and an input unit
+  be formatted from an input ``Double`` and an input unit
 * the Formats API has also been updated to add a new validate property to
-  MetadataOptions and support for MetadataOptions has been moved to
+  ``MetadataOptions`` and support for ``MetadataOptions`` has been moved to
   FormatHandler level to allow it to be used by both Readers and Writers
 * initial work on `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_
   extended the ClassList API to allow the :file:`readers.txt` configuration
@@ -104,12 +105,13 @@ Top-level Bio-Formats API changes:
 Other general improvements include:
 
 * improved performance of `getUsedFiles`
-* fixes for `FilePatternBlock`, `AxisGuesser`, `FilePattern`
-* fixes for the detection of csv pattern blocks by `FilePatternBlock`
-* bioformats_package.jar now includes bio-formats-tools as a dependency so
-  ImageConverter, ImageFaker and ImageInfo classes are included in the bundle
+* fixes for ``FilePatternBlock``, ``AxisGuesser``, ``FilePattern``
+* fixes for the detection of CSV pattern blocks by ``FilePatternBlock``
+* :file:`bioformats_package.jar` now includes bio-formats-tools as a
+  dependency so ``ImageConverter``, ``ImageFaker`` and ``ImageInfo`` classes
+  are included in the bundle
 * the JACE C++ implementation has been decoupled as it does not function with
-  Java 1.7 (see `legacy repo <https://github.com/ome/bio-formats-jace>`_)
+  Java 1.8 (see `legacy repo <https://github.com/ome/bio-formats-jace>`_)
 * ImageJ fixes
    - to allow reader delegation when a legacy reader is enabled
      but not working

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1599,7 +1599,7 @@ Supported Formats
      - |no|
      - |no|
      - |yes|
-     - |no|
+     - |yes|
    * - :doc:`formats/zeiss-lsm`
      - .lsm, .mdb
      - |Outstanding|


### PR DESCRIPTION
See https://trello.com/c/hboEAfgG/21-version-history-prs - this should add all the remaining items, bar any currently open docs additions which we may want to add.

Also adds pyramid support to CZI as I noted no docs follow-up had happened from https://github.com/openmicroscopy/bioformats/pull/2481

Staged at http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/about/whats-new.html