### PR TITLE
Add BF dependencies table to java-library

### DIFF
--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -140,7 +140,7 @@ The complete list of current dependencies is as follows:
       - `Apache License v2.0`_
     * - `Native Library Loader v2.1.4 <http://github.com/scijava/native-lib-loader>`_
       - org.scijava:native-lib-loader:2.1.4
-      - `Simplified BSD License`_
+      - `BSD License`_
     * - `SLF4J API v1.7.4 <http://www.slf4j.org>`_
       - org.slf4j:slf4j-api:1.7.6
       - `MIT License`_
@@ -175,7 +175,6 @@ The complete list of current dependencies is as follows:
 
 .. _Apache License v2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
 .. _MIT License: http://opensource.org/licenses/MIT
-.. _Simplified BSD License: https://github.com/scijava/native-lib-loader/blob/master/LICENSE.txt
 .. _BSD 3-Clause: http://opensource.org/licenses/BSD-3-Clause
 .. _Sun Public License / LGPL: http://www.beanshell.org/license.html
 .. _Common Public License v1.0: http://www.opensource.org/licenses/cpl1.0.txt

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -4,10 +4,10 @@ Using Bio-Formats as a Java library
 Bio-Formats as a Maven dependency
 ---------------------------------
 
-If you wish to make use of Bio-Formats within your own software it can be 
-included as a dependency in any Maven project. The dependency can be added 
-to the project pom file and should include the desired Bio-Formats version. 
-Using `bioformats_package` as the artifactId will include the complete 
+If you wish to make use of Bio-Formats within your own software it can be
+included as a dependency in any Maven project. The dependency can be added
+to the project pom file and should include the desired Bio-Formats version.
+Using `bioformats_package` as the artifactId will include the complete
 Bio-Formats package, or individual components can be chosen as desired.
 
 ::
@@ -18,10 +18,11 @@ Bio-Formats package, or individual components can be chosen as desired.
     <version>5.2.0</version>
   </dependency>
 
-In order to include this Bio-Formats dependency a custom repository 
-must also be added to the project pom or :file:`${user.home}/.m2/settings.xml`.
-The repositories element is inherited so for a group of projects the 
-repositories element can be defined at the top of your inheritance chain. 
+In order to include this Bio-Formats dependency a custom repository
+must also be added to the project pom or
+:file:`${user.home}/.m2/settings.xml`.
+The repositories element is inherited so for a group of projects the
+repositories element can be defined at the top of your inheritance chain.
 
 ::
 
@@ -37,55 +38,152 @@ repositories element can be defined at the top of your inheritance chain.
 Bio-Formats as a Java library
 -----------------------------
 
-Alternatively Bio-Formats can be used by including its component jar files. You can
-:downloads:`download formats-gpl.jar <artifacts/formats-gpl.jar>` to use it as
-a library. Just add **formats-gpl.jar** to your CLASSPATH or build path. You
-will also need **common.jar** for common I/O functions, **ome-xml.jar** for
-metadata standardization, and `SLF4J <http://slf4j.org/>`_ for :doc:`logging`.
+Alternatively Bio-Formats can be used by including its component jar files.
+You can :downloads:`download formats-gpl.jar <artifacts/formats-gpl.jar>` to
+use it as a library. Just add :file:`formats-gpl.jar` to your CLASSPATH or
+build path. You will also need :file:`common.jar` for common I/O functions,
+:file:`ome-xml.jar` for metadata standardization, and
+`SLF4J <http://slf4j.org/>`_ for :doc:`logging`.
 
-There are also certain packages that if present will be utilized to
-provide additional functionality. To include one, just place it in the
-same folder.
-
-.. tabularcolumns:: |l|c|c|p{8.5cm}|
-
-.. list-table::
-  :header-rows: 1
-  :widths:  10, 10, 10, 40
-
-  *
-    - Package
-    - Filename
-    - License
-    - Notes
-
-  *
-    - `Apache Jakarta POI <http://jakarta.apache.org/poi/>`_
-    - :downloads:`ome-poi.jar <artifacts/ome-poi.jar>`
-    - Apache
-    - OME fork; for OLE-based formats (zvi, oib, ipw, cxd)
-
-  *
-    - `MDB Tools <http://sourceforge.net/projects/mdbtools>`_
-    - :downloads:`mdbtools-java.jar <artifacts/mdbtools-java.jar>`
-    - LGPL
-    - Java port, OME fork; for Olympus CellR and Zeiss LSM metadata (mdb)
-
-  *
-    - `JAI Image I/O Tools <http://java.net/projects/jai-imageio>`_
-    - :downloads:`jai_imageio.jar <artifacts/jai_imageio.jar>`
-    - BSD
-    - Pure Java implementation, OME fork; for JPEG2000-based formats (nd2, jp2)
-
-  *
-    - `NetCDF <http://www.unidata.ucar.edu/software/netcdf-java/>`_
-    - :downloads:`netcdf-4.3.19.jar <artifacts/netcdf-4.3.19.jar>`
-    - LGPL
-    - Java library; for HDF5-based formats (Imaris 5.5, MINC MRI)
-
-See the list in the :source:`Bio-Formats toplevel build file <build.xml>`
+See the list in the
+:source:`Bio-Formats toplevel build file <build.xml>`
 for a complete and up-to-date list of all optional libraries, which can
 all be found in our :sourcedir:`Git repository <jar>`.
+
+Dependencies
+^^^^^^^^^^^^
+
+The complete list of current dependencies is as follows:
+
+.. tabularcolumns:: |l|l|l|
+
+.. list-table::
+    :header-rows: 1
+
+    * - Package
+      - Maven name
+      - License
+    * - `Logback Classic v1.1.1 <http://logback.qos.ch>`_
+      - ch.qos.logback:logback-classic:1.1.1
+      - `Eclipse Public License v1.0`_
+    * - `Logback Core v1.1.1 <http://logback.qos.ch>`_
+      - ch.qos.logback:logback-core:1.1.1
+      - `Eclipse Public License v1.0`_
+    * - `JHDF5 v14.12.0 <https://wiki-bsse.ethz.ch/display/JHDF5>`_
+      - ch.systems.cisd:jhdf5:14.12.0
+      - `Apache License v2.0`_
+    * - `XMP Library for Java v5.1.2 <http://www.adobe.com/devnet/xmp.html>`_
+      - com.adobe.xmp:xmpcore:5.1.2
+      - `BSD License`_
+    * - `JCommander v1.27 <http://beust.com/jcommander>`_
+      - com.beust:jcommander:1.27
+      - `Apache License v2.0`_
+    * - `metadata-extractor v2.6.2 <https://github.com/drewnoakes/metadata-extractor>`_
+      - com.drewnoakes:metadata-extractor:2.6.2
+      - `Apache License v2.0`_
+    * - `Kryo v2.24.0 <http://github.com/EsotericSoftware/kryo>`_
+      - com.esotericsoftware.kryo:kryo:2.24.0
+      - `BSD License`_
+    * - `MinLog v1.2 <https://github.com/EsotericSoftware/minlog>`_
+      - com.esotericsoftware.minlog:minlog:1.2
+      - `BSD License`_
+    * - `Guava v17.0 <http://github.com/google/guava>`_
+      - com.google.guava:guava:17.0
+      - `Apache License v2.0`_
+    * - `JGoodies Common v1.7.0 <http://www.jgoodies.com/downloads/libraries/>`_
+      - com.jgoodies:jgoodies-common:1.7.0
+      - `BSD License`_
+    * - `JGoodies Forms v1.7.2 <http://www.jgoodies.com/downloads/libraries/>`_
+      - com.jgoodies:jgoodies-forms:1.7.2
+      - `BSD License`_
+    * - `Commons Collections v3.2.1 <http://commons.apache.org/collections/>`_
+      - commons-collections:commons-collections:3.2.1
+      - `Apache License v2.0`_
+    * - `Commons Lang v2.4 <http://commons.apache.org/lang/>`_
+      - commons-lang:commons-lang:2.4
+      - `Apache License v2.0`_
+    * - `Commons Logging v1.1.1 <http://commons.apache.org/logging/>`_
+      - commons-logging:commons-logging:1.1.1
+      - `Apache License v2.0`_
+    * - `NetCDF-Java Library v4.3.19 <http://www.unidata.ucar.edu/software/netcdf-java/documentation.htm>`_
+      - edu.ucar:netcdf:4.3.19
+      - `MIT-Style License`_
+    * - `Joda time v2.2 <http://github.com/JodaOrg/joda-time>`_
+      - joda-time:joda-time:2.2
+      - `Apache License v2.0`_
+    * - `JUnit v4.10 <http://www.junit.org>`_
+      - junit:junit:4.10
+      - `Common Public License v1.0`_
+    * - `Apache Log4j v1.2.17 <http://logging.apache.org/log4j/1.2>`_
+      - log4j:log4j:1.2.17
+      - `Apache License v2.0`_
+    * - `ImageJ v1.48s <http://imagej.net>`_
+      - net.imagej:ij:1.48s
+      - Public domain
+    * - `Assume NG v1.2.4 <http://github.com/hierynomus/assumeng>`_
+      - nl.javadude.assumeng:assumeng:1.2.4
+      - `Apache License v2.0`_
+    * - `Apache Velocity v1.6.4 <http://velocity.apache.org/engine/releases/velocity-1.6.2>`_
+      - org.apache.velocity:velocity:1.6.4
+      - `Apache License v2.0`_
+    * - `BeanShell v2.0b4 <http://www.beanshell.org>`_
+      - org.beanshell:bsh:2.0b4
+      - `Sun Public License / LGPL`_
+    * - `Hamcrest Core v1.1 <http://hamcrest.org/JavaHamcrest>`_
+      - org.hamcrest:hamcrest-core:1.1
+      - `BSD 3-Clause`_
+    * - `Objenesis v2.1 <http://objenesis.org>`_
+      - org.objenesis:objenesis:2.1
+      - `Apache License v2.0`_
+    * - `Perf4J v0.9.13 <http://www.perf4j.org>`_
+      - org.perf4j:perf4j:0.9.13
+      - `Apache License v2.0`_
+    * - `Native Library Loader v2.1.4 <http://github.com/scijava/native-lib-loader>`_
+      - org.scijava:native-lib-loader:2.1.4
+      - `Simplified BSD License`_
+    * - `SLF4J API v1.7.4 <http://www.slf4j.org>`_
+      - org.slf4j:slf4j-api:1.7.6
+      - `MIT License`_
+    * - `SLF4J LOG4J-12 Binding v1.7.6 <http://www.slf4j.org>`_
+      - org.slf4j:slf4j-log4j12:1.7.6
+      - `MIT License`_
+    * - `TestNG v6.8 <http://testng.org>`_
+      - org.testng:testng:6.8
+      - `Apache License v2.0`_
+    * - `SnakeYAML v1.6 <https://bitbucket.org/asomov/snakeyaml>`_
+      - org.yaml:snakeyaml:1.6
+      - `Apache License v2.0`_
+    * - `Jakarta ORO v2.0.8 <http://jakarta.apache.org/oro>`_
+      - oro:oro:2.0.8
+      - `Apache License v2.0`_
+    * - `Woolz v1.4.0 <http://www.emouseatlas.org/emap/analysis_tools_resources/software/woolz.html>`_
+      - woolz:JWlz:1.4.0
+      - `GPL v2`_
+    * - `Xalan Java Serializer v2.7.2 <http://xml.apache.org/xalan-j>`_
+      - xalan:serializer:2.7.2
+      - `Apache License v2.0`_
+    * - `Xalan Java v2.7.2 <http://xml.apache.org/xalan-j>`_
+      - xalan:xalan:2.7.2
+      - `Apache License v2.0`_
+    * - `Xerces2 Java Parser v2.8.1 <http://xerces.apache.org/xerces2-j>`_
+      - xerces:xercesImpl:2.8.1
+      - `Apache License v2.0`_
+    * - `XML Commons External Components XML APIs v1.3.04 <http://xml.apache.org/commons/components/external>`_
+      - xml-apis:xml-apis:1.3.04
+      - `Apache License v2.0`_
+
+
+.. _Apache License v2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
+.. _MIT License: http://opensource.org/licenses/MIT
+.. _Simplified BSD License: https://github.com/scijava/native-lib-loader/blob/master/LICENSE.txt
+.. _BSD 3-Clause: http://opensource.org/licenses/BSD-3-Clause
+.. _Sun Public License / LGPL: http://www.beanshell.org/license.html
+.. _Common Public License v1.0: http://www.opensource.org/licenses/cpl1.0.txt
+.. _MIT-Style License: https://github.com/Unidata/thredds/blob/v4.3.19/cdm/license.txt
+.. _BSD License: http://opensource.org/licenses/BSD-2-Clause
+.. _Eclipse Public License v1.0: http://opensource.org/licenses/EPL-1.0
+.. _GPL v2: http://opensource.org/licenses/GPL-2.0
+
 
 Examples of usage
 -----------------

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -123,7 +123,7 @@ The complete list of current dependencies is as follows:
     * - `Assume NG v1.2.4 <http://github.com/hierynomus/assumeng>`_
       - nl.javadude.assumeng:assumeng:1.2.4
       - `Apache License v2.0`_
-    * - `Apache Velocity v1.6.4 <http://velocity.apache.org/engine/releases/velocity-1.6.2>`_
+    * - `Apache Velocity v1.6.4 <http://velocity.apache.org>`_
       - org.apache.velocity:velocity:1.6.4
       - `Apache License v2.0`_
     * - `BeanShell v2.0b4 <http://www.beanshell.org>`_


### PR DESCRIPTION
See https://trello.com/c/BR4c2921/41-keep-up-to-date-concise-list-of-dependencies

Note that code.google.com URLs don't work any more so I've updated the links from the file attached to the card to the redirected URLs (some were auto-redirecting, others just had a holding page with a new link one - I've replaced both)

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/developers/java-library.html