### PR TITLE
Add C++ download link in notebox

### DIFF
--- a/docs/sphinx/developers/index.txt
+++ b/docs/sphinx/developers/index.txt
@@ -46,7 +46,8 @@ Using Bio-Formats as a Java library
 Using Bio-Formats as a native C++ library
 =========================================
 
-.. note:: See new location for C++ documentation.
+.. note:: See the `OME-Files C++ downloads page <http://downloads.openmicroscopy.org/latest/ome-files-cpp/>`_
+    for more information.
 
 Contributing to Bio-Formats
 ===========================


### PR DESCRIPTION
Temporary fix until we have the navigation sorted and can link to the properly web-hosted docs.

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.2-staging/developers/index.html