### PR TITLE
Remove unnecessary BinData/MetadataOnly handling in ImageInfo

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -956,16 +956,6 @@ public class ImageInfo {
       LOGGER.info("Generating OME-XML (schema version {})", version);
     }
     if (ms instanceof MetadataRetrieve) {
-      // adding MetadataOnly elements to an OME-TIFF's XML will cause
-      // validation errors
-      if (!(baseReader instanceof OMETiffReader)) {
-        service.removeBinData(service.getOMEMetadata((MetadataRetrieve) ms));
-        for (int i=0; i<reader.getSeriesCount(); i++) {
-          service.addMetadataOnly(
-            service.getOMEMetadata((MetadataRetrieve) ms), i);
-        }
-      }
-
       if (omexmlOnly) {
         DebugTools.setRootLevel("INFO");
       }


### PR DESCRIPTION
The addition of MetadataOnly elements for OME-XML containing no BinData or TiffData elements should now be handled via the MetadataTools API. There is no reason to have some special handling in the ImageInfo class which should return the OME-XML using the MetadataRetrieve interface directly.

To review this PR, run 

```
showinf -nopix -omexml /path/to/ome.xml
```

on a valid OME-XML file e.g. one of the OME samples and check the `MetadataOnly` block is no longer populated but `BinData` blocks are available.