### PR TITLE
CZI Reader - Correct dimensions per series

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1268,7 +1268,7 @@ public class ZeissCZIReader extends FormatReader {
     for (int i=0; i <getSeriesCount(); i++){
       setSeries(i);
       CoreMetadata seriesCore = core.get(i);
-      seriesCore.imageCount = getSizeZ() * getSizeC();
+      seriesCore.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC()) * getSizeT();
     }
     setSeries(oldSeries);
   }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -804,6 +804,7 @@ public class ZeissCZIReader extends FormatReader {
     }
 
     assignPlaneIndices();
+    calculateSeriesDimensions();
 
     if (maxResolution > 0) {
       tileWidth = new int[core.size()];
@@ -1254,101 +1255,121 @@ public class ZeissCZIReader extends FormatReader {
     }
   }
 
+  private void calculateSeriesDimensions() {
+    int oldSeries = getSeries();
+    for (int i=0; i <getSeriesCount(); i++){
+      CoreMetadata seriesCore = core.get(i);
+      seriesCore.sizeZ = 1;
+    }
+    for (SubBlock plane : planes) {
+      setSeries(plane.coreIndex);
+      calculateDimensions(plane, plane.coreIndex);
+    }
+    for (int i=0; i <getSeriesCount(); i++){
+      setSeries(i);
+      CoreMetadata seriesCore = core.get(i);
+      seriesCore.imageCount = getSizeZ() * getSizeC();
+    }
+    setSeries(oldSeries);
+  }
+  
+  private void calculateDimensions(SubBlock plane, int index) {
+    ArrayList<Integer> uniqueT = new ArrayList<Integer>();
+    CoreMetadata ms0 = core.get(index);
+    for (DimensionEntry dimension : plane.directoryEntry.dimensionEntries) {
+      if (dimension == null) {
+        continue;
+      }
+      switch (dimension.dimension.charAt(0)) {
+        case 'X':
+          plane.x = dimension.size;
+          plane.col = dimension.start;
+          if ((prestitched == null || prestitched) &&
+            getSizeX() > 0 && dimension.size != getSizeX())
+          {
+            prestitched = true;
+            continue;
+          }
+          ms0.sizeX = dimension.size;
+          break;
+        case 'Y':
+          plane.y = dimension.size;
+          plane.row = dimension.start;
+          if ((prestitched == null || prestitched) &&
+            getSizeY() > 0 && dimension.size != getSizeY())
+          {
+            prestitched = true;
+            continue;
+          }
+          ms0.sizeY = dimension.size;
+          break;
+        case 'C':
+          if (dimension.start >= getSizeC()) {
+            ms0.sizeC = dimension.start + 1;
+          }
+          break;
+        case 'Z':
+          if (dimension.start >= getSizeZ()) {
+            ms0.sizeZ = dimension.start + 1;
+          }
+          else if (dimension.size > getSizeZ()) {
+            ms0.sizeZ = dimension.size;
+          }
+          break;
+        case 'T':
+          if (!uniqueT.contains(dimension.start)) {
+            uniqueT.add(dimension.start);
+            ms0.sizeT = uniqueT.size();
+          }
+          if (dimension.size > getSizeT()) {
+            ms0.sizeT = dimension.size;
+          }
+          break;
+        case 'R':
+          if (dimension.start >= rotations) {
+            rotations = dimension.start + 1;
+          }
+          break;
+        case 'S':
+          if (dimension.start >= positions) {
+            positions = dimension.start + 1;
+          }
+          break;
+        case 'I':
+          if (dimension.start >= illuminations) {
+            illuminations = dimension.start + 1;
+          }
+          break;
+        case 'B':
+          if (dimension.start >= acquisitions) {
+            acquisitions = dimension.start + 1;
+          }
+          break;
+        case 'M':
+          if (dimension.start >= mosaics) {
+            mosaics = dimension.start + 1;
+          }
+          break;
+        case 'H':
+          if (dimension.start >= phases) {
+            phases = dimension.start + 1;
+          }
+          break;
+        case 'V':
+          if (dimension.start >= angles) {
+            angles = dimension.start + 1;
+          }
+          break;
+        default:
+          LOGGER.warn("Unknown dimension '{}'", dimension.dimension);
+      }
+    }
+  }
+  
   private void calculateDimensions() {
     // calculate the dimensions
-    CoreMetadata ms0 = core.get(0);
-
-    ArrayList<Integer> uniqueT = new ArrayList<Integer>();
-
     for (SubBlock plane : planes) {
-      for (DimensionEntry dimension : plane.directoryEntry.dimensionEntries) {
-        if (dimension == null) {
-          continue;
-        }
-        switch (dimension.dimension.charAt(0)) {
-          case 'X':
-            plane.x = dimension.size;
-            plane.col = dimension.start;
-            if ((prestitched == null || prestitched) &&
-              getSizeX() > 0 && dimension.size != getSizeX())
-            {
-              prestitched = true;
-              continue;
-            }
-            ms0.sizeX = dimension.size;
-            break;
-          case 'Y':
-            plane.y = dimension.size;
-            plane.row = dimension.start;
-            if ((prestitched == null || prestitched) &&
-              getSizeY() > 0 && dimension.size != getSizeY())
-            {
-              prestitched = true;
-              continue;
-            }
-            ms0.sizeY = dimension.size;
-            break;
-          case 'C':
-            if (dimension.start >= getSizeC()) {
-              ms0.sizeC = dimension.start + 1;
-            }
-            break;
-          case 'Z':
-            if (dimension.start >= getSizeZ()) {
-              ms0.sizeZ = dimension.start + 1;
-            }
-            else if (dimension.size > getSizeZ()) {
-              ms0.sizeZ = dimension.size;
-            }
-            break;
-          case 'T':
-            if (!uniqueT.contains(dimension.start)) {
-              uniqueT.add(dimension.start);
-              ms0.sizeT = uniqueT.size();
-            }
-            if (dimension.size > getSizeT()) {
-              ms0.sizeT = dimension.size;
-            }
-            break;
-          case 'R':
-            if (dimension.start >= rotations) {
-              rotations = dimension.start + 1;
-            }
-            break;
-          case 'S':
-            if (dimension.start >= positions) {
-              positions = dimension.start + 1;
-            }
-            break;
-          case 'I':
-            if (dimension.start >= illuminations) {
-              illuminations = dimension.start + 1;
-            }
-            break;
-          case 'B':
-            if (dimension.start >= acquisitions) {
-              acquisitions = dimension.start + 1;
-            }
-            break;
-          case 'M':
-            if (dimension.start >= mosaics) {
-              mosaics = dimension.start + 1;
-            }
-            break;
-          case 'H':
-            if (dimension.start >= phases) {
-              phases = dimension.start + 1;
-            }
-            break;
-          case 'V':
-            if (dimension.start >= angles) {
-              angles = dimension.start + 1;
-            }
-            break;
-          default:
-            LOGGER.warn("Unknown dimension '{}'", dimension.dimension);
-        }
-      }
+      calculateDimensions(plane, 0);
     }
   }
 


### PR DESCRIPTION
This is a PR to fix an issue raised in https://github.com/openmicroscopy/bioformats/issues/2467

Previously the dimension values (Z and C) across each series would be identical, with the largest value be replicated across each series.

With the PR in place the dimensions will be calculated and stored for each individual series giving them the correct values.

Testing:
- Unit tests and data repo jobs should remain green
  Using the sample file provided in https://github.com/openmicroscopy/bioformats/issues/2467
- Verify that without the PR the same dimensions are displayed for each series
- Verify that with the PR applied that the correct dimensions for each individual series are stored
- Verify that each series still opens and displays correctly but with the correct metadata 
