### PR TITLE
Make the INI parser less stringent

### DIFF
--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -177,7 +177,10 @@ public class IniParser {
 
       // parse key/value pair
       int equals = line.indexOf("=");
-      if (equals < 0) throw new IOException(no + ": bad line");
+      if (equals < 0) {
+        LOGGER.debug("Ignoring line {}", no);
+        continue;
+      }
       String key = line.substring(0, equals).trim();
       String value = line.substring(equals + 1).trim();
       attrs.put(key, value);


### PR DESCRIPTION
This fixes a bug which was [reported on the ImageJ forum](http://forum.imagej.net/t/2443).

The sample non-working file has been uploaded as [QA 17305](http://qa.openmicroscopy.org.uk/qa/feedback/17305/).

-------

Here is a sample TIFF description header produced by a Hamamatsu instrument which previously failed to parse using the `IniParser`:

```
Created by Hamamatsu Inc.
Fri, 19 Aug 2016 15:42:31 Central Daylight Time

[ CALIBRATION ]
title = Default
units = Pixels
symbol = Px
factor = 1.000000
scale_len = 100.000000
[ CAPTURE DEVICE ]
 Camera Type = D_CAM
 Camera Name = C12345-67CU S/N: 987654
 Camera Size = 2048x2048
 Bit Depth = 16-Bit
 Binning = 1
 Capture Region = (X0=300, Y0=900, Width=1600, Height=324)

[ CAPTURE SETTINGS ]
 eOffset1 = 100.00
 eCoeff1 = 0.49000
 Exposure1 = 0.450000 s

[ CAPTURE TIME ]
 Time_From_Start = 00:00:32.2370
 Time_From_Last = 00:00:15.2410

[ EVENT MARKER ]
Event1+Event2
```

The issue is that some of the lines do not have an equals sign, nor enclosing square brackets. So we have a couple of choices here:

1. Detect this not-quite-an-INI flavor of TIFF metadata, and parse it using something other than the `IniParser`.
2. Loosen up the `IniParser` to do a "best effort" rather than failing.

This commit chooses the latter option, since it was a simple change.

In short: let's follow Postel's Law here: permissive when reading, conservative when writing.