### PR TITLE
Remove dead java4cpp link

### DIFF
--- a/docs/sphinx/users/i3dcore/index.txt
+++ b/docs/sphinx/users/i3dcore/index.txt
@@ -11,8 +11,8 @@ and `i4dcore <http://cbia.fi.muni.cz/user_dirs/of_doc/libi4d.html>`_,
 i3dcore forms a continuously developed templated cross-platform C++
 suite of libraries for multidimensional image processing and analysis.
 
-i3dcore is capable of reading images with Bio-Formats using `Java for
-C++ <http://java4cpp.kapott.org/>`_ (java4cpp).
+i3dcore is capable of reading images with Bio-Formats using Java for
+C++ (java4cpp).
 
 .. seealso::
     `Download i3dcore <http://cbia.fi.muni.cz/user_dirs/i3dlib_doc/i3dcore/index.html#download>`_


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/380/warnings5Result/ - googling didn't reveal anything that looked like a definitive homepage for this, just a bunch of different GitHub repos, tutorials etc so I've removed the link altogether but if someone wants to suggest a good replacement, I'll be happy to add one back in.
