### PR TITLE
ImageJ plugin: fix file pattern prefix

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -211,8 +211,7 @@ public class FilePatternDialog extends ImporterDialog {
       }
     }
     else if (useRanges) {
-      String pattern =
-        originalID.substring(0, originalID.lastIndexOf(File.separator) + 1);
+      String pattern = "";
       for (int i=0; i<counts.length; i++) {
         BigInteger first = new BigInteger(firsts[i]);
         BigInteger fileCount = new BigInteger(counts[i]);


### PR DESCRIPTION
What it does
-----------
Fixes the stitching of file patterns in the ImageJ plugin, where the dirname part was being duplicated.

Background
----------
#2352 changed the semantics of `FilePattern.getPrefix` to allow pattern blocks in the whole filename, rather than in the basename alone. Now the first prefix of a file pattern string is whatever comes before the first pattern block, *including* parent directories, if any. This means that the logic in `FilePatternDialog.harvestResults`, which rebuilds the pattern string from prefixes and blocks, has to start from an empty string.

Testing
-------

Place two single-plane images corresponding to different time points (or z sections, or channels: all that matters is that they have the same XY size) in a newly created directory, e.g.:

```
/tmp/ij_test/foo_t0.tif
/tmp/ij_test/foo_t1.tif
```

Download the latest Fiji, update the BF plugin to make sure it's the one released with 5.2.0 and use the bio-formats importer to open the first file, checking "Group files with similar names" in the import options. Press OK, then OK again in the "Bio-Formats File Stitching" dialog box. You should get an import error, and the Log window should show a `FileNotFoundException` for `/tmp/ij_test/tmp/ij_test/foo_t0.tif` (duplicate dir).

Now close Fiji, build the version of Bio-Formats corresponding to this PR and update Fiji's plugin with it. You can use https://github.com/fiji/fiji/blob/master/bin/update-bf.sh: comment out the `mvn dependency:get ...` line and supply the snapshot version as the second arg (e.g., `5.2.1-SNAPSHOT`). Restart Fiji and retry the above import. This time it should work fine.