### PR TITLE
Dimension Swap Dialog - Incorrect dimension sizes

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/SwapDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/SwapDialog.java
@@ -68,14 +68,14 @@ public class SwapDialog extends ImporterDialog implements ItemListener {
     GenericDialog gd = new GenericDialog("Dimension swapping options");
 
     String[] labels = {"Z", "C", "T"};
-    String[] sizes = new String[] {
-      String.valueOf(reader.getSizeZ()), String.valueOf(reader.getSizeC()),
-      String.valueOf(reader.getSizeT())
-    };
     for (int s=0; s<seriesCount; s++) {
       if (!options.isSeriesOn(s)) continue;
       reader.setSeries(s);
 
+      String[] sizes = new String[] {
+          String.valueOf(reader.getSizeZ()), String.valueOf(reader.getSizeC()),
+          String.valueOf(reader.getSizeT())
+        };
       gd.addMessage("Series " + (s + 1) + ":\n");
 
       for (int i=0; i<labels.length; i++) {


### PR DESCRIPTION
Issue was discovered by user email - http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-August/006129.html
Associated QA-17311

To reproduce:
- Using Fiji import an image with different dimension sizes for each series
- Select the Swap Dimensions
- Select a series with dimensions differing that of the last series
- Verify that the dimensions shown in the Swap Dialog are incorrect
- Verify that an IllegalArgumentException is thrown when attempting to open the image

To test:
- With the PR applied reproduce the steps above
- Verify that the correct dimensions are displayed in the dialog
- Verify that the image opens as expected
- Retest with other series and combinations of series