### PR TITLE
Maven examples: add top-level example suite class

### DIFF
--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -36,6 +36,14 @@ import java.io.File;
 
 public class ExampleSuite {
 
+  public static void execute(String name, String[] args) throws Exception {
+    System.out.println("Executing " + name);
+    Class c = Class.forName(name);
+    Object passedArgs[] = {args};
+    c.getMethod("main", args.getClass()).invoke(null, passedArgs);
+    System.out.println("Success");
+  }
+
   /**
    * Execute a series of examples using the test files
    *
@@ -52,10 +60,10 @@ public class ExampleSuite {
     File exportSPWFile = new File(parentDir, "exportSPW.ome.tiff");
 
     // Execute examples
-    ReadPhysicalSize.main(new String[] {inputFile.getAbsolutePath()});
-    FileConvert.main(new String[] {
+    execute("ReadPhysicalSize", new String[] {inputFile.getAbsolutePath()});
+    execute("FileConvert", new String[] {
       inputFile.getAbsolutePath(), convertedFile.getAbsolutePath()});
-    FileExport.main(new String[] {exportFile.getAbsolutePath()});
-    FileExport.main(new String[] {exportSPWFile.getAbsolutePath()});
+    execute("FileExport", new String[] {exportFile.getAbsolutePath()});
+    execute("FileExportSPW", new String[] {exportSPWFile.getAbsolutePath()});
   }
 }

--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import java.net.URL;
+import java.io.File;
+
+
+public class ExampleSuite {
+
+  /**
+   * Execute a series of examples using the test files
+   *
+   * $ java ExampleSuite
+   */
+  public static void main(String[] args) throws Exception {
+
+    // Retrieve local test files
+    URL resource =  ExampleSuite.class.getResource("test.fake");
+    File inputFile = new File(resource.toURI());
+    File parentDir = inputFile.getParentFile();
+    File convertedFile = new File(parentDir, "converted.ome.tiff");
+    File exportFile = new File(parentDir, "export.ome.tiff");
+    File exportSPWFile = new File(parentDir, "exportSPW.ome.tiff");
+
+    // Execute examples
+    ReadPhysicalSize.main(new String[] {inputFile.getAbsolutePath()});
+    FileConvert.main(new String[] {
+      inputFile.getAbsolutePath(), convertedFile.getAbsolutePath()});
+    FileExport.main(new String[] {exportFile.getAbsolutePath()});
+    FileExport.main(new String[] {exportSPWFile.getAbsolutePath()});
+  }
+}

--- a/docs/sphinx/pom.xml
+++ b/docs/sphinx/pom.xml
@@ -51,6 +51,7 @@
         <directory>${project.basedir}/developers/examples</directory>
         <includes>
             <include>**/*.xml</include>
+            <include>**/*.fake*</include>
         </includes>
       </resource> 
     </resources>      
@@ -61,55 +62,14 @@
         <version>1.2.1</version>
         <executions>
           <execution>
-            <id>ReadPhysicalSize</id>
             <phase>test</phase>
             <goals>
               <goal>java</goal>
             </goals>
             <configuration>
-              <mainClass>ReadPhysicalSize</mainClass>
+              <mainClass>ExampleSuite</mainClass>
               <arguments>
                 <argument>${project.basedir}/developers/examples/test.fake</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>FileConvert</id>
-            <phase>test</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-            <configuration>
-              <mainClass>FileConvert</mainClass>
-              <arguments>
-                <argument>${project.basedir}/developers/examples/test.fake</argument>
-                <argument>${project.build.directory}/converted.ome.tiff</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>FileExport</id>
-            <phase>test</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-            <configuration>
-              <mainClass>FileExport</mainClass>
-              <arguments>
-                <argument>${project.build.directory}/export.ome.tiff</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>FileExportSPW</id>
-            <phase>test</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-            <configuration>
-              <mainClass>FileExportSPW</mainClass>
-              <arguments>
-                <argument>${project.build.directory}/exportSPW.ome.tiff</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
See https://trello.com/c/lFM1xUyH/40-sphinx-example-suite-class

Following the migration of all Java examples under `docs/sphinx/developers/examples`, this PR adds a top-level class to run all examples with a single command and uses this class in the top-level `pom.xml`.

To review this PR:
- check Travis is green as the Maven matrix builds will execute this class as part of the test phase of the `docs/sphinx` component
- run `mvn` locally and check `docs/sphinx/target/classes` contains the fake files used for running the example and the OME-TIFF files generated from the conversion/export examples.

A few comments:
- except for `ReadPhysicalSize` which outputs some content, there is no console trace of the example executed. Is it worth adding some logging/`System.out.println` to the main class
- I used BSD to license `ExampleSuite` and realized the existing examples are GPL licensed. There is no GPL specificity so we could consider moving everything to BSD.
