### PR TITLE
FV1000 reader: fix preview names ordering

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -437,7 +437,6 @@ public class FV1000Reader extends FormatReader {
 
     previewNames = new ArrayList<String>();
     SortedMap<Integer, String> previewFileNames = new TreeMap<Integer, String>();
-    Integer previewIndex;
     boolean laserEnabled = true;
 
     IniList f = getIniFile(oifName);
@@ -475,7 +474,7 @@ public class FV1000Reader extends FormatReader {
           RandomAccessInputStream s = getFile(path + value.trim());
           if (s != null) {
             s.close();
-            previewIndex = getPreviewNameIndex(key);
+            Integer previewIndex = getPreviewNameIndex(key);
             if (previewIndex != null) {
               previewFileNames.put(previewIndex, path + value.trim());
             } else {
@@ -493,9 +492,7 @@ public class FV1000Reader extends FormatReader {
     }
 
     // Store sorted list of preview names
-    for (Integer key : previewFileNames.keySet()) {
-      previewNames.add(previewFileNames.get(key));
-    }
+    previewNames.addAll(previewFileNames.values());
 
     if (filenames.isEmpty()) addPtyFiles();
 

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -431,6 +431,7 @@ public class FV1000Reader extends FormatReader {
     pixelSize = new Double[NUM_DIMENSIONS];
 
     previewNames = new ArrayList<String>();
+    Map<Integer, String> previewFileNames = new HashMap<Integer, String>();
     boolean laserEnabled = true;
 
     IniList f = getIniFile(oifName);
@@ -468,7 +469,8 @@ public class FV1000Reader extends FormatReader {
           RandomAccessInputStream s = getFile(path + value.trim());
           if (s != null) {
             s.close();
-            previewNames.add(path + value.trim());
+            previewFileNames.put(Integer.valueOf(key.substring(11)),
+              path + value.trim());
           }
         }
         catch (FormatException e) {
@@ -478,6 +480,11 @@ public class FV1000Reader extends FormatReader {
           LOGGER.debug("Preview file not found", e);
         }
       }
+    }
+
+    // Store sorted list of preview names
+    for (Integer key : previewFileNames.keySet()) {
+      previewNames.add(previewFileNames.get(key));
     }
 
     if (filenames.isEmpty()) addPtyFiles();

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -81,6 +81,9 @@ public class FV1000Reader extends FormatReader {
   public static final String[] OIF_SUFFIX = {"oif"};
   public static final String[] FV1000_SUFFIXES = {"oib", "oif"};
 
+  public static final String[] PREVIEWNAME_PREFIXES = {
+    "IniFileName", "PtyFileNameReference"};
+
   public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
   private static final int NUM_DIMENSIONS = 9;
@@ -432,6 +435,7 @@ public class FV1000Reader extends FormatReader {
 
     previewNames = new ArrayList<String>();
     Map<Integer, String> previewFileNames = new HashMap<Integer, String>();
+    Integer previewIndex;
     boolean laserEnabled = true;
 
     IniList f = getIniFile(oifName);
@@ -469,8 +473,12 @@ public class FV1000Reader extends FormatReader {
           RandomAccessInputStream s = getFile(path + value.trim());
           if (s != null) {
             s.close();
-            previewFileNames.put(Integer.valueOf(key.substring(11)),
-              path + value.trim());
+            previewIndex = getPreviewNameIndex(key);
+            if (previewIndex != null) {
+              previewFileNames.put(previewIndex, path + value.trim());
+            } else {
+              previewNames.add(path + value.trim());
+            }
           }
         }
         catch (FormatException e) {
@@ -1657,6 +1665,16 @@ public class FV1000Reader extends FormatReader {
     catch (FormatException e) { }
     catch (IOException e) { }
     return plane;
+  }
+
+  /* Parse the index of the preview name file using a set of prefixes */
+  private Integer getPreviewNameIndex(String key) {
+    Integer previewIndex = null;
+    for (String prefix: PREVIEWNAME_PREFIXES) {
+      if (!key.startsWith(prefix)) continue;
+      return DataTools.parseInteger(key.substring(prefix.length()));
+    }
+    return previewIndex;
   }
 
   private boolean isPreviewName(String name) {

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -34,6 +34,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import loci.common.ByteArrayHandle;
 import loci.common.DataTools;
@@ -434,7 +436,7 @@ public class FV1000Reader extends FormatReader {
     pixelSize = new Double[NUM_DIMENSIONS];
 
     previewNames = new ArrayList<String>();
-    Map<Integer, String> previewFileNames = new HashMap<Integer, String>();
+    SortedMap<Integer, String> previewFileNames = new TreeMap<Integer, String>();
     Integer previewIndex;
     boolean laserEnabled = true;
 


### PR DESCRIPTION
The usage of JDK 8 on various full repository jobs (Windows, breaking) highlighted some issues with the series 1 of some of the FV1000 filesets. Preliminary testing shows that the ordering of the `previewNames` was not fixed and depends on the parsing of the INI file. See https://trello.com/c/l2oMl30u/37-investigate-jdk-specific-automated-test-failures

This PR should address these ordering issues by:
- parsing the indexes of the preview/reference files from the INI keys into a `Map<Integer, String>` using the same strategy as the parsing of `filenames` and `roiFilenames`
- converting this map into a list of `previewNames`.

As multiple key prefixes where found across our sample files, a new static field `PREVIEWNAMES_PREFIX` is added to the review for future additions and the parsing includes a fallback to the default handling (unsorted addition to the `previewNames` list). Note this static field addition falls under the [serialization policy](https://github.com/openmicroscopy/design/issues/55) banner and can be reverted/modified depending on the decision made on this front.

A companion configuration PR will be opened to fix affected filesets in the data repository. For testing this PR:
- the full repository jobs should now pass against the `fv1000` format with various JDK implementations
- the affected FV1000 filesets should be reviewed - in particular the channel ordering in the second series should now match the first series
