### PR TITLE
Use ThreadLocal with NumberFormat

### DIFF
--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -58,8 +58,8 @@ public final class DataTools {
   // -- Static fields --
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTools.class);
 
-  private static final ThreadLocal <NumberFormat> nf =
-      new ThreadLocal <NumberFormat>() {
+  private static final ThreadLocal<NumberFormat> nf =
+      new ThreadLocal<NumberFormat>() {
         @Override protected NumberFormat initialValue() {
             return DecimalFormat.getInstance(Locale.ENGLISH);
         }

--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -58,7 +58,12 @@ public final class DataTools {
   // -- Static fields --
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTools.class);
 
-  private static NumberFormat nf = DecimalFormat.getInstance(Locale.ENGLISH);
+  private static final ThreadLocal <NumberFormat> nf =
+      new ThreadLocal <NumberFormat>() {
+        @Override protected NumberFormat initialValue() {
+            return DecimalFormat.getInstance(Locale.ENGLISH);
+        }
+    };
   // -- Constructor --
 
   private DataTools() { }
@@ -476,7 +481,7 @@ public final class DataTools {
   public static Float parseFloat(String value) {
     if (value == null) return null;
     try {
-      return nf.parse(value.replaceAll(",", ".")).floatValue();
+      return nf.get().parse(value.replaceAll(",", ".")).floatValue();
     } catch (ParseException e) {
       LOGGER.debug("Could not parse float value", e);
     }
@@ -491,7 +496,7 @@ public final class DataTools {
   public static Double parseDouble(String value) {
     if (value == null) return null;
     try {
-      return nf.parse(value.replaceAll(",", ".")).doubleValue();
+      return nf.get().parse(value.replaceAll(",", ".")).doubleValue();
     } catch (ParseException e) {
       LOGGER.debug("Could not parse double value", e);
     }

--- a/components/formats-common/test/loci/common/utests/DataToolsTest.java
+++ b/components/formats-common/test/loci/common/utests/DataToolsTest.java
@@ -229,4 +229,9 @@ public class DataToolsTest {
     assertEquals(DataTools.parseDouble("0,1"), 0.1d);
     assertEquals(DataTools.parseDouble("not a number"), null);
   }
+  
+  @Test(threadPoolSize = 10, invocationCount = 1000)
+    public void testThreadSafety() {
+      assertEquals(DataTools.parseDouble("1.0"), 1.0d);
+    }
 }


### PR DESCRIPTION
Issue raised in - https://github.com/openmicroscopy/bioformats/issues/2551

As NumberFormat in Java is not thread-safe it is recommended to create a separate format instance for each thread. See Synchronization under https://docs.oracle.com/javase/8/docs/api/java/text/NumberFormat.html  

To achieve this I have wrapped the NumberFormat instance in ThreadLocal to provide a separate instance for each individual thread.

To reproduce:
An example of a failing test can be found here: https://github.com/sbesson/bioformats/commit/8697cf56c575e02532b307e61858995f90b8014d