### PR TITLE
add enumeration values for acquisition mode

### DIFF
--- a/components/specification/released-schema/2016-06/ome.xsd
+++ b/components/specification/released-schema/2016-06/ome.xsd
@@ -24,7 +24,7 @@
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
             xmlns:xml="http://www.w3.org/XML/1998/namespace"
-            version="1"
+            version="2"
             elementFormDefault="qualified">
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>

--- a/components/specification/released-schema/2016-06/ome.xsd
+++ b/components/specification/released-schema/2016-06/ome.xsd
@@ -670,11 +670,9 @@
         <xsd:simpleType>
           <xsd:restriction base="xsd:string">
             <xsd:enumeration value="WideField"/>
-            <xsd:enumeration value="BrightField"/>
             <xsd:enumeration value="LaserScanningConfocalMicroscopy"/> <!-- CLSM or LSCM -->
             <xsd:enumeration value="SpinningDiskConfocal"/>
             <xsd:enumeration value="SlitScanConfocal"/>
-            <xsd:enumeration value="SweptFieldConfocal"/>
             <xsd:enumeration value="MultiPhotonMicroscopy"/><!-- laser scanning multiphoton microscopy (LSMM), two photon microscopy -->
             <xsd:enumeration value="StructuredIllumination"/>
             <xsd:enumeration value="SingleMoleculeImaging"/>
@@ -690,8 +688,10 @@
             <xsd:enumeration value="TIRF"/><!-- total internal reflection fluorescence (TIRFM) -->
             <xsd:enumeration value="FSM"/><!-- Fluorescence speckle microscopy -->
             <xsd:enumeration value="LCM"/><!-- Laser capture microdissection -->
-            <xsd:enumeration value="SPIM"/><!-- Selective or Single Plane Illumination Microscopy -->
             <xsd:enumeration value="Other"/>
+            <xsd:enumeration value="BrightField"/>
+            <xsd:enumeration value="SweptFieldConfocal"/>
+            <xsd:enumeration value="SPIM"/><!-- Selective or Single Plane Illumination Microscopy -->
           </xsd:restriction>
         </xsd:simpleType>
       </xsd:attribute>

--- a/components/specification/released-schema/2016-06/ome.xsd
+++ b/components/specification/released-schema/2016-06/ome.xsd
@@ -670,9 +670,11 @@
         <xsd:simpleType>
           <xsd:restriction base="xsd:string">
             <xsd:enumeration value="WideField"/>
+            <xsd:enumeration value="BrightField"/>
             <xsd:enumeration value="LaserScanningConfocalMicroscopy"/> <!-- CLSM or LSCM -->
             <xsd:enumeration value="SpinningDiskConfocal"/>
             <xsd:enumeration value="SlitScanConfocal"/>
+            <xsd:enumeration value="SweptFieldConfocal"/>
             <xsd:enumeration value="MultiPhotonMicroscopy"/><!-- laser scanning multiphoton microscopy (LSMM), two photon microscopy -->
             <xsd:enumeration value="StructuredIllumination"/>
             <xsd:enumeration value="SingleMoleculeImaging"/>
@@ -688,6 +690,7 @@
             <xsd:enumeration value="TIRF"/><!-- total internal reflection fluorescence (TIRFM) -->
             <xsd:enumeration value="FSM"/><!-- Fluorescence speckle microscopy -->
             <xsd:enumeration value="LCM"/><!-- Laser capture microdissection -->
+            <xsd:enumeration value="SPIM"/><!-- Selective or Single Plane Illumination Microscopy -->
             <xsd:enumeration value="Other"/>
           </xsd:restriction>
         </xsd:simpleType>

--- a/components/specification/transforms/2016-06-to-2015-01.xsl
+++ b/components/specification/transforms/2016-06-to-2015-01.xsl
@@ -128,6 +128,15 @@
   <xsl:template match="OME:Folder"/>
   <xsl:template match="OME:FolderRef"/>
 
+  <!-- Remove new enumeration values -->
+  <xsl:template match="OME:Channel/@AcquisitionMode[. = 'BrightField' or
+                                                    . = 'SweptFieldConfocal' or
+                                                    . = 'SPIM']">
+    <xsl:attribute name="AcquisitionMode">
+      <xsl:text>Other</xsl:text>
+    </xsl:attribute>
+  </xsl:template>
+
   <!-- Default processing -->
 
   <xsl:template match="@*|node()">

--- a/components/xsd-fu/cfg/enum_handler.cfg
+++ b/components/xsd-fu/cfg/enum_handler.cfg
@@ -1,5 +1,7 @@
 [AcquisitionMode]
 ".*Widefield.*" = "WideField"
+"^Laser Scan Confocal$" = "LaserScanningConfocalMicroscopy"
+"^Swept Field Confocal$" = "SweptFieldConfocal"
 
 [Correction]
 ".*Pl.*Apo.*" = "PlanApo"


### PR DESCRIPTION
Increments OME-XML schema version attribute value and adds acquisition modes,
* BrightField
* SweptFieldConfocal
* SPIM

and parsing for,
* Laser Scan Confocal
* Swept Field Confocal

The schema namespace is left unchanged.