### PR TITLE
IniParser unit tests

### DIFF
--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -143,18 +143,18 @@ public class IniParser {
       }
 
       // check for chapter header
-      if (isHeader(line, "{")) {
-        chapter = parseHeader(line, "{", "}");
+      if (isHeader(line, '{')) {
+        chapter = parseHeader(line, '{', '}');
         continue;
       }
 
       // check for section header
-      if (isHeader(line, "[")) {
+      if (isHeader(line, '[')) {
         attrs = new IniTable();
         list.add(attrs);
 
         // strip brackets
-        String header = parseHeader(line, "[", "]");
+        String header = parseHeader(line, '[', ']');
         if (chapter != null) header = chapter + ": " + header;
 
         attrs.put(IniTable.HEADER_KEY, header);
@@ -206,15 +206,17 @@ public class IniParser {
   // -- Helper methods --
 
   /** Checks whether the input line is a INI header **/
-  private boolean isHeader(String line, String start) {
-    return (line != null && line.length() > 1 && line.startsWith(start));
+  private boolean isHeader(String line, char start) {
+    return (line != null && line.length() > 1 && line.charAt(0) == start);
   }
 
   /** Parse a header line given input delimiters **/
-  private String parseHeader(String line, String start, String end) {
+  private String parseHeader(String line, char start, char end) {
     if (line == null || line.length() <= 1) return null;
-    if (!line.startsWith(start)) return null;
-    if (line.endsWith(end)) return line.substring(1, line.length() - 1);
+    if (line.charAt(0) != start) return null;
+    if (line.charAt(line.length() - 1) == end) {
+      return line.substring(1, line.length() - 1);
+    }
     return line.substring(1);
   }
 

--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -178,7 +178,7 @@ public class IniParser {
       }
       String key = line.substring(0, equals).trim();
       String value = line.substring(equals + 1).trim();
-      attrs.put(key, value);
+      if (!key.isEmpty() && !value.isEmpty()) attrs.put(key, value);
       no += num;
     }
     return list;

--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -178,7 +178,7 @@ public class IniParser {
       }
       String key = line.substring(0, equals).trim();
       String value = line.substring(equals + 1).trim();
-      if (!key.isEmpty() && !value.isEmpty()) attrs.put(key, value);
+      attrs.put(key, value);
       no += num;
     }
     return list;

--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -143,23 +143,18 @@ public class IniParser {
       }
 
       // check for chapter header
-      if (line.startsWith("{")) {
-        // strip curly braces
-        int end = line.length();
-        if (line.endsWith("}")) end--;
-        chapter = line.substring(1, end);
+      if (isHeader(line, "{")) {
+        chapter = parseHeader(line, "{", "}");
         continue;
       }
 
       // check for section header
-      if (line.startsWith("[")) {
+      if (isHeader(line, "[")) {
         attrs = new IniTable();
         list.add(attrs);
 
         // strip brackets
-        int end = line.length();
-        if (line.endsWith("]")) end--;
-        String header = line.substring(1, end);
+        String header = parseHeader(line, "[", "]");
         if (chapter != null) header = chapter + ": " + header;
 
         attrs.put(IniTable.HEADER_KEY, header);
@@ -209,6 +204,19 @@ public class IniParser {
   }
 
   // -- Helper methods --
+
+  /** Checks whether the input line is a INI header **/
+  private boolean isHeader(String line, String start) {
+    return (line != null && line.length() > 1 && line.startsWith(start));
+  }
+
+  /** Parse a header line given input delimiters **/
+  private String parseHeader(String line, String start, String end) {
+    if (line == null || line.length() <= 1) return null;
+    if (!line.startsWith(start)) return null;
+    if (line.endsWith(end)) return line.substring(1, line.length() - 1);
+    return line.substring(1);
+  }
 
   /**
    * Reads (at least) one line from the given input stream

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -53,8 +53,6 @@ import org.testng.annotations.Test;
  */
 public class IniParserTest {
   private IniParser parser = new IniParser();
-  private IniList list;
-  private IniTable table;
   final Charset utf8charset = Charset.forName("UTF-8");
 
   public BufferedReader stringToBufferedReader(String s) {
@@ -78,29 +76,32 @@ public class IniParserTest {
   public void testSimpleKeyValue(String s) throws IOException {
     BufferedReader reader = stringToBufferedReader(s);
     
-    list = parser.parseINI(reader);
-    assertEquals(list.size(), 1);
-    table = list.getTable(IniTable.DEFAULT_HEADER);
-    assertEquals(table.keySet().size(), 2);
-    assertEquals(table.get("key"), "value");
+    IniTable table = new IniTable();
+    table.put(IniTable.HEADER_KEY, IniTable.DEFAULT_HEADER);
+    table.put("key", "value");
+    IniList list = new IniList();
+    list.add(table);
+
+    assertEquals(parser.parseINI(reader), list);
   }
 
   @Test
   public void testMultiValueINI() throws IOException {
-    String s = "{chapter}\n[header]\n" +
-      "key1=value1 # comment\n\n" +
+    String s = "key1=value1 # comment\n\n" +
       "key2=line1\\\nline2\n" +
       "ignored line\n" +
       "key3 = value3";
     BufferedReader reader = stringToBufferedReader(s);
 
-    list = parser.parseINI(reader);
-    assertEquals(list.size(), 1);
-    table = list.getTable("chapter: header");
-    assertEquals(table.keySet().size(), 4);
-    assertEquals(table.get("key1"), "value1");
-    assertEquals(table.get("key2"), "line1 line2");
-    assertEquals(table.get("key3"), "value3");
+    IniTable table = new IniTable();
+    table.put(IniTable.HEADER_KEY, IniTable.DEFAULT_HEADER);
+    table.put("key1", "value1");
+    table.put("key2", "line1 line2");
+    table.put("key3", "value3");
+    IniList list = new IniList();
+    list.add(table);
+
+    assertEquals(parser.parseINI(reader), list);
   }
 
   @Test
@@ -111,19 +112,24 @@ public class IniParserTest {
       "[header3]\nkey3=value3\n";
     BufferedReader reader = stringToBufferedReader(s);
 
-    list = parser.parseINI(reader);
-    assertEquals(list.size(), 4);
-    table = list.getTable(IniTable.DEFAULT_HEADER);
-    assertEquals(table.keySet().size(), 2);
-    assertEquals(table.get("key0"), "value0");
-    table = list.getTable("header1");
-    assertEquals(table.keySet().size(), 2);
-    assertEquals(table.get("key1"), "value1");
-    table = list.getTable("chapter: header2");
-    assertEquals(table.keySet().size(), 2);
-    assertEquals(table.get("key2"), "value2");
-    table = list.getTable("chapter: header3");
-    assertEquals(table.keySet().size(), 2);
-    assertEquals(table.get("key3"), "value3");
+    IniTable table0 = new IniTable();
+    table0.put(IniTable.HEADER_KEY, IniTable.DEFAULT_HEADER);
+    table0.put("key0", "value0");
+    IniTable table1 = new IniTable();
+    table1.put(IniTable.HEADER_KEY, "header1");
+    table1.put("key1", "value1");
+    IniTable table2 = new IniTable();
+    table2.put(IniTable.HEADER_KEY, "chapter: header2");
+    table2.put("key2", "value2");
+    IniTable table3 = new IniTable();
+    table3.put(IniTable.HEADER_KEY, "chapter: header3");
+    table3.put("key3", "value3");
+    IniList list = new IniList();
+    list.add(table0);
+    list.add(table1);
+    list.add(table2);
+    list.add(table3);
+
+    assertEquals(parser.parseINI(reader), list);
   }
 }

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -62,32 +62,25 @@ public class IniParserTest {
     return new BufferedReader(new InputStreamReader(stream));
   }
 
-  @DataProvider(name = "simpleini")
-  public Object[][] createSimpleIni() {
+  @DataProvider(name = "simplekeyvalue")
+  public Object[][] createSimpleKeyValuePair() {
     return new Object[][] {
-      {"key=value", IniTable.DEFAULT_HEADER},
-      {"key = value", IniTable.DEFAULT_HEADER},
-      {"\nkey=value\n", IniTable.DEFAULT_HEADER},
-      {"key=value#comment", IniTable.DEFAULT_HEADER},
-      {"key=value # comment", IniTable.DEFAULT_HEADER},
-      {"key=value\nignored line", IniTable.DEFAULT_HEADER},
-      {"[header]\nkey=value", "header"},
-      {"\n[header]\n\nkey=value\n", "header"},
-      {"[header]\nkey=value#comment", "header"},
-      {"[header]\nkey=value # comment", "header"},
-      {"[header]\nkey=value\nignored line", "header"},
-      {"{chapter}\n[header]\nkey=value", "chapter: header"},
+      {"key=value"},
+      {"key = value"},         // whitespaces around equal sign
+      {"key=value  "},         // trailing whitespace
+      {"  key=value"},         // leading whitespace
+      {"key=value#comment"},   // comment without whitespaces
+      {"key=value # comment"}, // comment with whitespaces
     };
   }
   
-  @Test(dataProvider="simpleini")
-  public void testSimpleINI(String s, String header) throws IOException {
+  @Test(dataProvider="simplekeyvalue")
+  public void testSimpleKeyValue(String s) throws IOException {
     BufferedReader reader = stringToBufferedReader(s);
     
     list = parser.parseINI(reader);
     assertEquals(list.size(), 1);
-    table = list.getTable(header);
-    assertFalse(table == null);
+    table = list.getTable(IniTable.DEFAULT_HEADER);
     assertEquals(table.keySet().size(), 2);
     assertEquals(table.get("key"), "value");
   }
@@ -104,7 +97,6 @@ public class IniParserTest {
     list = parser.parseINI(reader);
     assertEquals(list.size(), 1);
     table = list.getTable("chapter: header");
-    assertFalse(table == null);
     assertEquals(table.keySet().size(), 4);
     assertEquals(table.get("key1"), "value1");
     assertEquals(table.get("key2"), "line1 line2");

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * Common package for I/O and related utilities
+ * %%
+ * Copyright (C)  2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.common.utests;
+
+import loci.common.IniParser;
+import loci.common.IniList;
+import loci.common.IniTable;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link loci.common.IniParser}.
+ */
+public class IniParserTest {
+  private IniParser parser = new IniParser();
+  private IniList list;
+  private IniTable table;
+  final Charset utf8charset = Charset.forName("UTF-8");
+
+  public BufferedReader stringToBufferedReader(String s) {
+    InputStream stream = new ByteArrayInputStream(s.getBytes(utf8charset));
+    return new BufferedReader(new InputStreamReader(stream));
+  }
+
+  @DataProvider(name = "simpleini")
+  public Object[][] createSimpleIni() {
+    return new Object[][] {
+      {"key=value", IniTable.DEFAULT_HEADER},
+      {"\nkey=value\n", IniTable.DEFAULT_HEADER},
+      {"key=value#comment", IniTable.DEFAULT_HEADER},
+      {"key=value # comment", IniTable.DEFAULT_HEADER},
+      {"key=value\nignored line", IniTable.DEFAULT_HEADER},
+      {"[header]\nkey=value", "header"},
+      {"\n[header]\n\nkey=value\n", "header"},
+      {"[header]\nkey=value#comment", "header"},
+      {"[header]\nkey=value # comment", "header"},
+      {"[header]\nkey=value\nignored line", "header"},
+      {"{chapter}\n[header]\nkey=value", "chapter: header"},
+    };
+  }
+  
+  @Test(dataProvider="simpleini")
+  public void testSimpleINI(String s, String header) throws IOException {
+    BufferedReader reader = stringToBufferedReader(s);
+    
+    list = parser.parseINI(reader);
+    assertEquals(list.size(), 1);
+    table = list.getTable(header);
+    assertFalse(table == null);
+    assertEquals(table.keySet().size(), 2);
+    assertEquals(table.get("key"), "value");
+  }
+}

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -84,6 +84,33 @@ public class IniParserTest {
     assertEquals(parser.parseINI(reader), list);
   }
 
+  @DataProvider(name = "simpleheader")
+  public Object[][] createSimpleHeader() {
+    return new Object[][] {
+      {"key=value", IniTable.DEFAULT_HEADER},
+      {"{chapter}\nkey=value", IniTable.DEFAULT_HEADER},
+      {"[header]\nkey=value", "header"},
+      {"[ header ]\nkey=value", " header "},
+      {"[header\nkey=value", "header"},
+      {"[[header]]\nkey=value", "[header]"},
+      {"{chapter}\n[header]\nkey=value", "chapter: header"},
+      {"{chapter\n[header\nkey=value", "chapter: header"},
+    };
+  }
+
+  @Test(dataProvider="simpleheader")
+  public void testHeader(String s, String header) throws IOException {
+    BufferedReader reader = stringToBufferedReader(s);
+
+    IniTable table = new IniTable();
+    table.put(IniTable.HEADER_KEY, header);
+    table.put("key", "value");
+    IniList list = new IniList();
+    list.add(table);
+
+    assertEquals(parser.parseINI(reader), list);
+  }
+
   @Test
   public void testMultiValueINI() throws IOException {
     String s = "key1=value1 # comment\n\n" +

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -43,8 +43,7 @@ import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.Assert.assertEquals;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -52,8 +51,8 @@ import org.testng.annotations.Test;
  * Unit tests for {@link loci.common.IniParser}.
  */
 public class IniParserTest {
-  private IniParser parser = new IniParser();
-  final Charset utf8charset = Charset.forName("UTF-8");
+  private final IniParser parser = new IniParser();
+  private final Charset utf8charset = Charset.forName("UTF-8");
 
   public BufferedReader stringToBufferedReader(String s) {
     InputStream stream = new ByteArrayInputStream(s.getBytes(utf8charset));

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -88,7 +88,11 @@ public class IniParserTest {
   public Object[][] createSimpleHeader() {
     return new Object[][] {
       {"key=value", IniTable.DEFAULT_HEADER},
+      {"[\nkey=value", IniTable.DEFAULT_HEADER},
+      {"{\nkey=value", IniTable.DEFAULT_HEADER},
       {"{chapter}\nkey=value", IniTable.DEFAULT_HEADER},
+      {"{}\nkey=value", IniTable.DEFAULT_HEADER},
+      {"[]\nkey=value", ""},
       {"[header]\nkey=value", "header"},
       {"[ header ]\nkey=value", " header "},
       {"[header\nkey=value", "header"},
@@ -109,6 +113,35 @@ public class IniParserTest {
     list.add(table);
 
     assertEquals(parser.parseINI(reader), list);
+  }
+
+  @DataProvider(name = "invalidheader")
+  public Object[][] createSingleString() {
+    return new Object[][] {
+      {"="}, {"["}, {"{"}
+    };
+  }
+
+  @Test(dataProvider="invalidheader")
+  public void testInvalidHeader(String s) throws IOException {
+    BufferedReader reader = stringToBufferedReader(s);
+
+    IniTable table = new IniTable();
+    table.put(IniTable.HEADER_KEY, IniTable.DEFAULT_HEADER);
+    IniList list = new IniList();
+    list.add(table);
+
+    assertEquals(parser.parseINI(reader), list);
+  }
+
+  public void testEmptyString() throws IOException {
+    BufferedReader reader = stringToBufferedReader("");
+    assertEquals(parser.parseINI(reader), new IniTable());
+  }
+
+  public void testNull() throws IOException {
+    BufferedReader reader = stringToBufferedReader(null);
+    assertEquals(parser.parseINI(reader), new IniTable());
   }
 
   @Test

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -66,6 +66,7 @@ public class IniParserTest {
   public Object[][] createSimpleIni() {
     return new Object[][] {
       {"key=value", IniTable.DEFAULT_HEADER},
+      {"key = value", IniTable.DEFAULT_HEADER},
       {"\nkey=value\n", IniTable.DEFAULT_HEADER},
       {"key=value#comment", IniTable.DEFAULT_HEADER},
       {"key=value # comment", IniTable.DEFAULT_HEADER},
@@ -89,5 +90,24 @@ public class IniParserTest {
     assertFalse(table == null);
     assertEquals(table.keySet().size(), 2);
     assertEquals(table.get("key"), "value");
+  }
+
+  @Test
+  public void testMultiValueINI() throws IOException {
+    String s = "{chapter}\n[header]\n" +
+      "key1=value1 # comment\n\n" +
+      "key2=line1\\\nline2\n" +
+      "ignored line\n" +
+      "key3 = value3";
+    BufferedReader reader = stringToBufferedReader(s);
+
+    list = parser.parseINI(reader);
+    assertEquals(list.size(), 1);
+    table = list.getTable("chapter: header");
+    assertFalse(table == null);
+    assertEquals(table.keySet().size(), 4);
+    assertEquals(table.get("key1"), "value1");
+    assertEquals(table.get("key2"), "line1 line2");
+    assertEquals(table.get("key3"), "value3");
   }
 }

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -118,7 +118,7 @@ public class IniParserTest {
   @DataProvider(name = "invalidheader")
   public Object[][] createSingleString() {
     return new Object[][] {
-      {"="}, {"["}, {"{"}
+      {"["}, {"{"}
     };
   }
 
@@ -142,6 +142,18 @@ public class IniParserTest {
   public void testNull() throws IOException {
     BufferedReader reader = stringToBufferedReader(null);
     assertEquals(parser.parseINI(reader), new IniTable());
+  }
+
+  public void testEmptyKeyValue() throws IOException {
+    BufferedReader reader = stringToBufferedReader("=");
+
+    IniTable table = new IniTable();
+    table.put(IniTable.HEADER_KEY, IniTable.DEFAULT_HEADER);
+    table.put("", "");
+    IniList list = new IniList();
+    list.add(table);
+
+    assertEquals(parser.parseINI(reader), list);
   }
 
   @Test

--- a/components/formats-common/test/loci/common/utests/IniParserTest.java
+++ b/components/formats-common/test/loci/common/utests/IniParserTest.java
@@ -110,4 +110,28 @@ public class IniParserTest {
     assertEquals(table.get("key2"), "line1 line2");
     assertEquals(table.get("key3"), "value3");
   }
+
+  @Test
+  public void testMultiHeaderINI() throws IOException {
+    String s = "key0=value0\n" +
+      "[header1]\nkey1=value1\n" +
+      "{chapter}\n[header2]\nkey2=value2\n" +
+      "[header3]\nkey3=value3\n";
+    BufferedReader reader = stringToBufferedReader(s);
+
+    list = parser.parseINI(reader);
+    assertEquals(list.size(), 4);
+    table = list.getTable(IniTable.DEFAULT_HEADER);
+    assertEquals(table.keySet().size(), 2);
+    assertEquals(table.get("key0"), "value0");
+    table = list.getTable("header1");
+    assertEquals(table.keySet().size(), 2);
+    assertEquals(table.get("key1"), "value1");
+    table = list.getTable("chapter: header2");
+    assertEquals(table.keySet().size(), 2);
+    assertEquals(table.get("key2"), "value2");
+    table = list.getTable("chapter: header3");
+    assertEquals(table.keySet().size(), 2);
+    assertEquals(table.get("key3"), "value3");
+  }
 }


### PR DESCRIPTION
See https://trello.com/c/RsYkLAFK/18-tests-add-ini-parser-unit-tests

Following https://github.com/openmicroscopy/bioformats/pull/2537, this PR adds a new unit test class covering the various forms of INI files currently handled by the `loci.common.IniParser` class. It also fixes the warnings in `IniParser` reported by `mvn findbugs:check` by refactoring the header parsing logic.

To test this PR, check Travis is green and/or run the Maven tests on `formats-common` locally and review whether all use cases of the implementation in `IniParser.parseINI(BufferedReader)` are unit tested.