### PR TITLE
Use chunkmap for Nikon ND2 files to speed up processing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -586,17 +586,12 @@ public class NativeND2Reader extends FormatReader {
           if(useChunkMap) {
             long lastImagePosition = 0;
             for(ChunkMapEntry entry : allChunkPositions.values()) {
-              if(entry.position < in.getFilePointer()) {
-                continue;
-              }
               if(entry.name.startsWith("ImageDataSeq")) {
                 lastImagePosition = entry.position;
                 imageOffsets.add(new Long(entry.position + 16));
                 imageLengths.add(new int[] {nameLength, (int)entry.length, getSizeX() * getSizeY()});
                 imageNames.add(entry.name.substring(12));
                 // assumption nameLength is constant throughout the file for image blocks!
-              } else {
-                break;
               }
             }
             in.seek(allChunkPositions.higherKey(lastImagePosition));

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -586,12 +586,17 @@ public class NativeND2Reader extends FormatReader {
           if(useChunkMap) {
             long lastImagePosition = 0;
             for(ChunkMapEntry entry : allChunkPositions.values()) {
+              if(entry.position < in.getFilePointer()) {
+                continue;
+              }
               if(entry.name.startsWith("ImageDataSeq")) {
                 lastImagePosition = entry.position;
                 imageOffsets.add(new Long(entry.position + 16));
                 imageLengths.add(new int[] {nameLength, (int)entry.length, getSizeX() * getSizeY()});
                 imageNames.add(entry.name.substring(12));
                 // assumption nameLength is constant throughout the file for image blocks!
+              } else {
+                break;
               }
             }
             in.seek(allChunkPositions.higherKey(lastImagePosition));

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -27,7 +27,6 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -347,12 +346,6 @@ public class NativeND2Reader extends FormatReader {
     public long length;
 
     public String toString() {
-      String name;
-	  try {
-		name = URLEncoder.encode(this.name, "UTF-8");
-	  } catch (UnsupportedEncodingException e) {
-		name = "<unprintable>";
-	  }
       return String.format("ChunkMapEntry<%s@%d(%d)>", name, position, length);
     }
   }
@@ -596,9 +589,9 @@ public class NativeND2Reader extends FormatReader {
               if(entry.name.startsWith("ImageDataSeq")) {
                 lastImagePosition = entry.position;
                 imageOffsets.add(new Long(entry.position + 16));
-                imageLengths.add(new int[] {lenOne, (int)entry.length, getSizeX() * getSizeY()});
+                imageLengths.add(new int[] {nameLength, (int)entry.length, getSizeX() * getSizeY()});
                 imageNames.add(entry.name.substring(12));
-                // assumption lenOne is constant throughout the file for image blocks!
+                // assumption nameLength is constant throughout the file for image blocks!
               }
             }
             in.seek(allChunkPositions.higherKey(lastImagePosition));

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -431,6 +431,8 @@ public class NativeND2Reader extends FormatReader {
           long chunkMapLength = in.readLong();
 
           chunkMapPosition += 16 + tmpLenTwo;
+          in.seek(chunkMapPosition);
+
           long chunkMapEnd = chunkMapPosition + chunkMapLength;
 
           while(in.getFilePointer() + 1 + 16 < chunkMapEnd) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -26,6 +26,8 @@
 package loci.formats.in;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -339,6 +341,22 @@ public class NativeND2Reader extends FormatReader {
 
   // -- Internal FormatReader API methods --
 
+  static class ChunkMapEntry {
+    public String name;
+    public long position;
+    public long length;
+
+    public String toString() {
+      String name;
+	  try {
+		name = URLEncoder.encode(this.name, "UTF-8");
+	  } catch (UnsupportedEncodingException e) {
+		name = "<unprintable>";
+	  }
+      return String.format("ChunkMapEntry<%s@%d(%d)>", name, position, length);
+    }
+  }
+
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
@@ -382,15 +400,6 @@ public class NativeND2Reader extends FormatReader {
       boolean useLastText = false;
       int blockCount = 0;
 
-      class ChunkMapEntry {
-        public String name;
-        public long position;
-        public long length;
-
-        public String toString() {
-          return String.format("ChunkMapEntry<%s@%d(%d)>", name, position, length);
-        }
-      }
 
       TreeMap<Long, ChunkMapEntry> allChunkPositions = new TreeMap<Long, ChunkMapEntry>();
 
@@ -444,7 +453,9 @@ public class NativeND2Reader extends FormatReader {
 
             allChunkPositions.put(entry.position, entry);
 
-            LOGGER.info("ND2 {}", entry.toString());
+            if (LOGGER.isDebugEnabled()) {
+              LOGGER.debug("ND2 {}", entry.toString());
+            }
           }
         }
 


### PR DESCRIPTION
Hello,

this is a 're-open' of #1232, which I couldn't reopen after pushing the patch rebased to current develop.

It's been two years since I proposed this; and I still think that it's very useful for people working with ND2 files, especially for large files (hundreds of GB) over network (eg. 100 Mbit), the current state is … suboptimal.

Given the great speed advantage possible with this, I think it's definitely worthwhile to debug any remaining problems (@melissalinkert mentioned wrong C/Z/T demensions for certain non-public files).
Maybe with a heuristical approach the chunk map code could just be used when it's known to deliver the right results. (If no 'complete' bugfix can be found.) (However, given my knowledge of ND2 files I'm unaware of any scenarios where wrong dimensions should even be possible, except for damaged files).

I'd love to offer help with integrating this and/or working on necessary changes.

Best regards,
Christian
