### PR TITLE
switch to String.indexOf(int) in various classes including Metakit

### DIFF
--- a/components/formats-api/src/loci/formats/ClassList.java
+++ b/components/formats-api/src/loci/formats/ClassList.java
@@ -176,14 +176,14 @@ public class ClassList<T> {
   public void parseLine(String line)
    {
       // Ignore characters following # sign (comments)
-      int ndx = line.indexOf("#");
+      int ndx = line.indexOf('#');
       if (ndx >= 0) line = line.substring(0, ndx);
       line = line.trim();
       if (line.equals("")) return;
 
       Map<String, String> o = new HashMap<String, String>();
       if (line.endsWith("]")) {
-        ndx = line.indexOf("[");
+        ndx = line.indexOf('[');
         if (ndx >= 0) {
           o = parseOptions(line.substring(ndx + 1, line.length() - 1));
           line = line.substring(0, ndx).trim();

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -394,9 +394,9 @@ public final class FormatTools {
     if (!order.startsWith("XY") && !order.startsWith("YX")) {
       throw new IllegalArgumentException("Invalid dimension order: " + order);
     }
-    int iz = order.indexOf("Z") - 2;
-    int ic = order.indexOf("C") - 2;
-    int it = order.indexOf("T") - 2;
+    int iz = order.indexOf('Z') - 2;
+    int ic = order.indexOf('C') - 2;
+    int it = order.indexOf('T') - 2;
     if (iz < 0 || iz > 2 || ic < 0 || ic > 2 || it < 0 || it > 2) {
       throw new IllegalArgumentException("Invalid dimension order: " + order);
     }
@@ -544,9 +544,9 @@ public final class FormatTools {
     if (!order.startsWith("XY") && !order.startsWith("YX")) {
       throw new IllegalArgumentException("Invalid dimension order: " + order);
     }
-    int iz = order.indexOf("Z") - 2;
-    int ic = order.indexOf("C") - 2;
-    int it = order.indexOf("T") - 2;
+    int iz = order.indexOf('Z') - 2;
+    int ic = order.indexOf('C') - 2;
+    int it = order.indexOf('T') - 2;
     if (iz < 0 || iz > 2 || ic < 0 || ic > 2 || it < 0 || it > 2) {
       throw new IllegalArgumentException("Invalid dimension order: " + order);
     }

--- a/components/formats-bsd/src/loci/formats/gui/DataConverter.java
+++ b/components/formats-bsd/src/loci/formats/gui/DataConverter.java
@@ -714,17 +714,17 @@ public class DataConverter extends JFrame implements
       swap.setId(pattern);
 
       String z = zLabel.getText();
-      z = z.substring(0, z.indexOf("<"));
+      z = z.substring(0, z.indexOf('<'));
       z += "<1-" + swap.getSizeZ() + ">";
       zLabel.setText(z);
 
       String t = tLabel.getText();
-      t = t.substring(0, t.indexOf("<"));
+      t = t.substring(0, t.indexOf('<'));
       t += "<1-" + swap.getSizeT() + ">";
       tLabel.setText(t);
 
       String c = cLabel.getText();
-      c = c.substring(0, c.indexOf("<"));
+      c = c.substring(0, c.indexOf('<'));
       c += "<1-" + swap.getEffectiveSizeC() + ">";
       cLabel.setText(c);
 

--- a/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
@@ -255,7 +255,7 @@ public class NetCDFServiceImpl extends AbstractService
    * @return Group or <code>root</code> if the group cannot be found.
    */
   private Group getGroup(String path) {
-    if (path.indexOf("/") == -1) {
+    if (path.indexOf('/') == -1) {
       return root;
     }
 

--- a/components/formats-gpl/utils/ExtractSDTData.java
+++ b/components/formats-gpl/utils/ExtractSDTData.java
@@ -37,7 +37,7 @@ public class ExtractSDTData {
       System.exit(1);
     }
     String id = args[0];
-    String tid = id.substring(0, id.indexOf("."));
+    String tid = id.substring(0, id.indexOf('.'));
     SDTReader r = new SDTReader();
     r.setId(id);
     int bins = r.getTimeBinCount();

--- a/components/metakit/src/ome/metakit/Column.java
+++ b/components/metakit/src/ome/metakit/Column.java
@@ -46,7 +46,7 @@ public class Column {
    * "fieldID:I".
    */
   public Column(String definition) {
-    int separator = definition.indexOf(":");
+    int separator = definition.indexOf(':');
     name = definition.substring(0, separator);
     typeString = definition.substring(separator + 1);
   }

--- a/components/metakit/src/ome/metakit/MetakitReader.java
+++ b/components/metakit/src/ome/metakit/MetakitReader.java
@@ -305,11 +305,11 @@ public class MetakitReader {
 
     for (int i=0; i<tables.length; i++) {
       String table = tables[i];
-      int openBracket = table.indexOf("[");
+      int openBracket = table.indexOf('[');
       tableNames[i] = table.substring(0, openBracket);
       String columnList = table.substring(openBracket + 1);
 
-      openBracket = columnList.indexOf("[");
+      openBracket = columnList.indexOf('[');
       hasSubviews[i] = openBracket >= 0;
 
       columnList = columnList.substring(openBracket + 1);


### PR DESCRIPTION
Inspired by https://github.com/openmicroscopy/bioformats/pull/2528#discussion_r76218340 -

> this is really just about switching to calling a method that can assume searching for a single character instead of having to care about search string length

this is a mechanical change so that a simpler library method can be used. It may not make much difference but sets a good example for others writing further code based on our existing code. https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/ suffices for testing.

In the event of conflicts I'll remove the problem changes from this PR.