### PR TITLE
switch to String.indexOf(int) in various BSD formats code

### DIFF
--- a/components/formats-bsd/src/loci/formats/ChannelMerger.java
+++ b/components/formats-bsd/src/loci/formats/ChannelMerger.java
@@ -102,9 +102,9 @@ public class ChannelMerger extends ReaderWrapper {
     String order = reader.getDimensionOrder();
     if (canMerge()) {
       final StringBuilder sb = new StringBuilder(order);
-      while (order.indexOf("C") != 2) {
-        char pre = order.charAt(order.indexOf("C") - 1);
-        sb.setCharAt(order.indexOf("C"), pre);
+      while (order.indexOf('C') != 2) {
+        char pre = order.charAt(order.indexOf('C') - 1);
+        sb.setCharAt(order.indexOf('C'), pre);
         sb.setCharAt(order.indexOf(pre), 'C');
         order = sb.toString();
       }

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -119,7 +119,7 @@ public class ChannelSeparator extends ReaderWrapper {
     String order = super.getDimensionOrder();
     if (reader.isRGB() && !reader.isIndexed()) {
       String newOrder = "XYC";
-      if (order.indexOf("Z") > order.indexOf("T")) newOrder += "TZ";
+      if (order.indexOf('Z') > order.indexOf("T")) newOrder += "TZ";
       else newOrder += "ZT";
       return newOrder;
     }

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -119,7 +119,7 @@ public class ChannelSeparator extends ReaderWrapper {
     String order = super.getDimensionOrder();
     if (reader.isRGB() && !reader.isIndexed()) {
       String newOrder = "XYC";
-      if (order.indexOf('Z') > order.indexOf("T")) newOrder += "TZ";
+      if (order.indexOf('Z') > order.indexOf('T')) newOrder += "TZ";
       else newOrder += "ZT";
       return newOrder;
     }

--- a/components/formats-bsd/src/loci/formats/DimensionSwapper.java
+++ b/components/formats-bsd/src/loci/formats/DimensionSwapper.java
@@ -92,11 +92,11 @@ public class DimensionSwapper extends ReaderWrapper {
         order.length() + ")");
     }
 
-    int newX = order.indexOf("X");
-    int newY = order.indexOf("Y");
-    int newZ = order.indexOf("Z");
-    int newC = order.indexOf("C");
-    int newT = order.indexOf("T");
+    int newX = order.indexOf('X');
+    int newY = order.indexOf('Y');
+    int newZ = order.indexOf('Z');
+    int newC = order.indexOf('C');
+    int newT = order.indexOf('T');
 
     if (newX < 0) throw new IllegalArgumentException("X does not appear");
     if (newY < 0) throw new IllegalArgumentException("Y does not appear");
@@ -115,11 +115,11 @@ public class DimensionSwapper extends ReaderWrapper {
 
     int[] dims = new int[5];
 
-    int oldX = oldOrder.indexOf("X");
-    int oldY = oldOrder.indexOf("Y");
-    int oldZ = oldOrder.indexOf("Z");
-    int oldC = oldOrder.indexOf("C");
-    int oldT = oldOrder.indexOf("T");
+    int oldX = oldOrder.indexOf('X');
+    int oldY = oldOrder.indexOf('Y');
+    int oldZ = oldOrder.indexOf('Z');
+    int oldC = oldOrder.indexOf('C');
+    int oldT = oldOrder.indexOf('T');
 
     if (oldC != newC && reader.getRGBChannelCount() > 1) {
       throw new IllegalArgumentException(

--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -646,7 +646,7 @@ public class FilePattern {
     String[] nameList)
   {
     String baseSuffix = base.substring(base.lastIndexOf(File.separator) + 1);
-    int dot = baseSuffix.indexOf(".");
+    int dot = baseSuffix.indexOf('.');
     if (dot < 0) baseSuffix = "";
     else baseSuffix = baseSuffix.substring(dot + 1);
 
@@ -660,7 +660,7 @@ public class FilePattern {
       int start = pattern.lastIndexOf(File.separator) + 1;
       if (start < 0) start = 0;
       String patternSuffix = pattern.substring(start);
-      dot = patternSuffix.indexOf(".");
+      dot = patternSuffix.indexOf('.');
       if (dot < 0) patternSuffix = "";
       else patternSuffix = patternSuffix.substring(dot + 1);
 

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1221,7 +1221,7 @@ public class FileStitcher extends ReaderWrapper {
       String newOrder = ((DimensionSwapper) reader).getInputOrder();
       if ((externals[external].getFiles().length > 1 || !r.isOrderCertain()) &&
         (r.getRGBChannelCount() == 1 ||
-        newOrder.indexOf("C") == r.getDimensionOrder().indexOf("C")))
+        newOrder.indexOf('C') == r.getDimensionOrder().indexOf("C")))
       {
         r.swapDimensions(newOrder);
       }

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1221,7 +1221,7 @@ public class FileStitcher extends ReaderWrapper {
       String newOrder = ((DimensionSwapper) reader).getInputOrder();
       if ((externals[external].getFiles().length > 1 || !r.isOrderCertain()) &&
         (r.getRGBChannelCount() == 1 ||
-        newOrder.indexOf('C') == r.getDimensionOrder().indexOf("C")))
+        newOrder.indexOf('C') == r.getDimensionOrder().indexOf('C')))
       {
         r.swapDimensions(newOrder);
       }

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -561,7 +561,7 @@ public class Memoizer extends ReaderWrapper {
       }
 
       String minor = releaseVersion;
-      int firstDot = minor.indexOf(".");
+      int firstDot = minor.indexOf('.');
       if (firstDot >= 0) {
         int secondDot = minor.indexOf(".", firstDot + 1);
         if (secondDot >= 0) {
@@ -570,7 +570,7 @@ public class Memoizer extends ReaderWrapper {
       }
 
       String currentMinor = FormatTools.VERSION.substring(0,
-        FormatTools.VERSION.indexOf(".", FormatTools.VERSION.indexOf(".") + 1));
+        FormatTools.VERSION.indexOf(".", FormatTools.VERSION.indexOf('.') + 1));
       if (!currentMinor.equals(minor)) {
         LOGGER.info("Different release version: {} not {}",
           releaseVersion, FormatTools.VERSION);

--- a/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/BaseTiffReader.java
@@ -453,7 +453,7 @@ public abstract class BaseTiffReader extends MinimalTiffReader {
 
       if (artist != null) {
         String firstName = null, lastName = null;
-        int ndx = artist.indexOf(" ");
+        int ndx = artist.indexOf(' ');
         if (ndx < 0) lastName = artist;
         else {
           firstName = artist.substring(0, ndx);

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -850,7 +850,7 @@ public class DicomReader extends FormatReader {
         catch (NumberFormatException e) { }
       }
       else if (key.indexOf("Palette Color LUT Data") != -1) {
-        String color = key.substring(0, key.indexOf(" ")).trim();
+        String color = key.substring(0, key.indexOf(' ')).trim();
         int ndx = color.equals("Red") ? 0 : color.equals("Green") ? 1 : 2;
         long fp = in.getFilePointer();
         in.seek(in.getFilePointer() - elementLength + 1);

--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -310,7 +310,7 @@ public class EPSReader extends FormatReader {
         else {
           // parse key/value pairs
 
-          int ndx = line.indexOf(":");
+          int ndx = line.indexOf(':');
           if (ndx != -1) {
             String key = line.substring(0, ndx);
             String value = line.substring(ndx + 1);

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -630,7 +630,7 @@ public class FakeReader extends FormatReader {
         name = token;
         continue;
       }
-      int equals = token.indexOf("=");
+      int equals = token.indexOf('=');
       if (equals < 0) {
         LOGGER.warn("ignoring token: {}", token);
         continue;
@@ -707,7 +707,7 @@ public class FakeReader extends FormatReader {
         // 'color' and 'color_x' can be used together, but 'color_x' takes
         // precedence.  'color' will in that case be used for any missing
         // or invalid 'color_x' values.
-        int index = Integer.parseInt(key.substring(key.indexOf("_") + 1));
+        int index = Integer.parseInt(key.substring(key.indexOf('_') + 1));
 
         while (index >= color.size()) {
           color.add(null);

--- a/components/formats-bsd/src/loci/formats/in/FitsReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FitsReader.java
@@ -110,7 +110,7 @@ public class FitsReader extends FormatReader {
       line = in.readString(LINE_LENGTH);
 
       // parse key/value pair
-      int ndx = line.indexOf("=");
+      int ndx = line.indexOf('=');
       int comment = line.indexOf("/", ndx);
       if (comment < 0) comment = line.length();
 

--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -976,7 +976,7 @@ public class ICSReader extends FormatReader {
           else if (key.equalsIgnoreCase("history date") ||
                    key.equalsIgnoreCase("history created on"))
           {
-            if (value.indexOf(" ") > 0) {
+            if (value.indexOf(' ') > 0) {
               date = value.substring(0, value.lastIndexOf(" "));
               date = DateTools.formatDate(date, DATE_FORMATS);
             }
@@ -1050,7 +1050,7 @@ public class ICSReader extends FormatReader {
             }
             else if (key.equalsIgnoreCase("history laser rep rate")) {
               String repRate = value;
-              if (repRate.indexOf(" ") != -1) {
+              if (repRate.indexOf(' ') != -1) {
                 repRate = repRate.substring(0, repRate.lastIndexOf(" "));
               }
               laserRepetitionRate = new Double(repRate);
@@ -1162,8 +1162,8 @@ public class ICSReader extends FormatReader {
             }
             else if (key.equalsIgnoreCase("history Exposure")) {
               String expTime = value;
-              if (expTime.indexOf(" ") != -1) {
-                expTime = expTime.substring(0, expTime.indexOf(" "));
+              if (expTime.indexOf(' ') != -1) {
+                expTime = expTime.substring(0, expTime.indexOf(' '));
               }
               Double expDouble = new Double(expTime);
               if (expDouble != null) {
@@ -1329,14 +1329,14 @@ public class ICSReader extends FormatReader {
       }
       else if (axes[i].equals("z")) {
         m.sizeZ = axisLengths[i];
-        if (getDimensionOrder().indexOf("Z") == -1) {
+        if (getDimensionOrder().indexOf('Z') == -1) {
           m.dimensionOrder += "Z";
         }
       }
       else if (axes[i].equals("t")) {
         if (getSizeT() == 0) m.sizeT = axisLengths[i];
         else m.sizeT *= axisLengths[i];
-        if (getDimensionOrder().indexOf("T") == -1) {
+        if (getDimensionOrder().indexOf('T') == -1) {
           m.dimensionOrder += "T";
         }
       }
@@ -1346,7 +1346,7 @@ public class ICSReader extends FormatReader {
         channelLengths.add(new Integer(axisLengths[i]));
         storedRGB = getSizeX() == 0;
         m.rgb = getSizeX() == 0 && getSizeC() <= 4 && getSizeC() > 1;
-        if (getDimensionOrder().indexOf("C") == -1) {
+        if (getDimensionOrder().indexOf('C') == -1) {
           m.dimensionOrder += "C";
         }
 

--- a/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEG2000Reader.java
@@ -243,7 +243,7 @@ public class JPEG2000Reader extends FormatReader {
     LOGGER.debug("Found {} comments", comments.size());
     for (int i=0; i<comments.size(); i++) {
       String comment = comments.get(i);
-      int equal = comment.indexOf("=");
+      int equal = comment.indexOf('=');
       if (equal >= 0) {
         String key = comment.substring(0, equal);
         String value = comment.substring(equal + 1);

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -667,8 +667,8 @@ public class MicromanagerReader extends FormatReader {
     int[] slice = new int[3];
     while (st.hasMoreTokens()) {
       String token = st.nextToken().trim();
-      boolean open = token.indexOf("[") != -1;
-      boolean closed = token.indexOf("]") != -1;
+      boolean open = token.indexOf('[') != -1;
+      boolean closed = token.indexOf(']') != -1;
       if (open || (!open && !closed && !token.equals("{") &&
         !token.startsWith("}")))
       {
@@ -677,13 +677,13 @@ public class MicromanagerReader extends FormatReader {
         String value = null;
 
         if (open == closed) {
-          value = token.substring(token.indexOf(":") + 1);
+          value = token.substring(token.indexOf(':') + 1);
         }
         else if (!closed) {
           final StringBuilder valueBuffer = new StringBuilder();
           while (!closed) {
             token = st.nextToken();
-            closed = token.indexOf("]") != -1;
+            closed = token.indexOf(']') != -1;
             valueBuffer.append(token);
           }
           value = valueBuffer.toString();
@@ -691,8 +691,8 @@ public class MicromanagerReader extends FormatReader {
         }
         if (value == null) continue;
 
-        int startIndex = value.indexOf("[");
-        int endIndex = value.indexOf("]");
+        int startIndex = value.indexOf('[');
+        int endIndex = value.indexOf(']');
         if (endIndex == -1) endIndex = value.length();
 
         value = value.substring(startIndex + 1, endIndex).trim();
@@ -766,7 +766,7 @@ public class MicromanagerReader extends FormatReader {
       }
 
       if (token.startsWith("\"FrameKey")) {
-        int dash = token.indexOf("-") + 1;
+        int dash = token.indexOf('-') + 1;
         int nextDash = token.indexOf("-", dash);
         slice[2] = Integer.parseInt(token.substring(dash, nextDash));
         dash = nextDash + 1;
@@ -805,7 +805,7 @@ public class MicromanagerReader extends FormatReader {
             }
           }
           else {
-            int colon = token.indexOf(":");
+            int colon = token.indexOf(':');
             key = token.substring(1, colon).trim();
             value = token.substring(colon + 1, token.length() - 1).trim();
 
@@ -829,7 +829,7 @@ public class MicromanagerReader extends FormatReader {
           }
           else if (key.equals("Core-Camera")) p.cameraRef = value;
           else if (key.equals(p.cameraRef + "-Binning")) {
-            if (value.indexOf("x") != -1) p.binning = value;
+            if (value.indexOf('x') != -1) p.binning = value;
             else p.binning = value + "x" + value;
           }
           else if (key.equals(p.cameraRef + "-CameraID")) p.detectorID = value;
@@ -869,12 +869,12 @@ public class MicromanagerReader extends FormatReader {
         }
       }
       else if (token.startsWith("\"Coords-")) {
-        String path = token.substring(token.indexOf("-") + 1, token.lastIndexOf("\""));
+        String path = token.substring(token.indexOf('-') + 1, token.lastIndexOf("\""));
 
         int[] zct = new int[3];
         int position = 0;
         while (!token.startsWith("}")) {
-          int sep = token.indexOf(":");
+          int sep = token.indexOf(':');
           if (sep > 0) {
             String key = token.substring(0, sep);
             String value = token.substring(sep + 1);
@@ -972,8 +972,8 @@ public class MicromanagerReader extends FormatReader {
 
           if (blocks[2].length() > 0) {
             String channel = p.channels[c];
-            if (channel.indexOf("-") != -1) {
-              channel = channel.substring(0, channel.indexOf("-"));
+            if (channel.indexOf('-') != -1) {
+              channel = channel.substring(0, channel.indexOf('-'));
             }
             filename.append(channel);
           }
@@ -1067,7 +1067,7 @@ public class MicromanagerReader extends FormatReader {
   }
 
   private String getPrefixMetadataName(String baseName) {
-    int dot = baseName.indexOf(".");
+    int dot = baseName.indexOf('.');
     if (dot > 0) {
       return baseName.substring(0, dot) + "_" + METADATA;
     }

--- a/components/formats-bsd/src/loci/formats/in/NRRDReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NRRDReader.java
@@ -119,7 +119,7 @@ public class NRRDReader extends FormatReader {
       return true;
     }
 
-    if (name.indexOf(".") >= 0) {
+    if (name.indexOf('.') >= 0) {
       name = name.substring(0, name.lastIndexOf("."));
     }
 
@@ -256,12 +256,12 @@ public class NRRDReader extends FormatReader {
     while (line != null && line.length() > 0) {
       if (!line.startsWith("#") && !line.startsWith("NRRD")) {
         // parse key/value pair
-        key = line.substring(0, line.indexOf(":")).trim();
-        v = line.substring(line.indexOf(":") + 1).trim();
+        key = line.substring(0, line.indexOf(':')).trim();
+        v = line.substring(line.indexOf(':') + 1).trim();
         addGlobalMeta(key, v);
 
         if (key.equals("type")) {
-          if (v.indexOf("char") != -1 || v.indexOf("8") != -1) {
+          if (v.indexOf("char") != -1 || v.indexOf('8') != -1) {
             m.pixelType = FormatTools.UINT8;
           }
           else if (v.indexOf("short") != -1 || v.indexOf("16") != -1) {

--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -161,7 +161,7 @@ public class TiffReader extends BaseTiffReader {
             String metadata =
               DataTools.stripString(new String(b, Constants.ENCODING));
             if (metadata.indexOf("xml") != -1) {
-              metadata = metadata.substring(metadata.indexOf("<"));
+              metadata = metadata.substring(metadata.indexOf('<'));
               metadata = "<root>" + XMLTools.sanitizeXML(metadata) + "</root>";
               try {
                 Hashtable<String, String> xmlMetadata =
@@ -206,8 +206,8 @@ public class TiffReader extends BaseTiffReader {
       if (files != null) {
         for (String file : files) {
           String name = file;
-          if (name.indexOf(".") != -1) {
-            name = name.substring(0, name.indexOf("."));
+          if (name.indexOf('.') != -1) {
+            name = name.substring(0, name.indexOf('.'));
           }
 
           if (currentName.startsWith(name) &&
@@ -269,7 +269,7 @@ public class TiffReader extends BaseTiffReader {
     while (st.hasMoreTokens()) {
       String token = st.nextToken();
       String value = null;
-      int eq = token.indexOf("=");
+      int eq = token.indexOf('=');
       if (eq >= 0) value = token.substring(eq + 1);
 
       if (token.startsWith("channels=")) c = parseInt(value);
@@ -407,7 +407,7 @@ public class TiffReader extends BaseTiffReader {
     StringTokenizer st = new StringTokenizer(comment, "\n");
     while (st.hasMoreTokens()) {
       String line = st.nextToken();
-      int colon = line.indexOf(":");
+      int colon = line.indexOf(':');
       if (colon < 0) {
         addGlobalMeta("Comment", line);
         description = line;
@@ -425,7 +425,7 @@ public class TiffReader extends BaseTiffReader {
     if (lines.length > 1) {
       comment = "";
       for (String line : lines) {
-        int eq = line.indexOf("=");
+        int eq = line.indexOf('=');
         if (eq != -1) {
           String key = line.substring(0, eq).trim();
           String value = line.substring(eq + 1).trim();

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -268,8 +268,8 @@ public class OMETiffWriter extends TiffWriter {
     }
 
     // insert warning comment
-    String prefix = xml.substring(0, xml.indexOf(">") + 1);
-    String suffix = xml.substring(xml.indexOf(">") + 1);
+    String prefix = xml.substring(0, xml.indexOf('>') + 1);
+    String suffix = xml.substring(xml.indexOf('>') + 1);
     return prefix + WARNING_COMMENT + suffix;
   }
 


### PR DESCRIPTION
Inspired by https://github.com/openmicroscopy/bioformats/pull/2528#discussion_r76218340 -

> this is really just about switching to calling a method that can assume searching for a single character instead of having to care about search string length

this is a mechanical change so that a simpler library method can be used. It may not make much difference but sets a good example for others writing further code based on our existing code. https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/ suffices for testing.

In the event of conflicts I'll remove the problem changes from this PR.