### PR TITLE
cpp: OMETransform: Handle validation errors during transformation

### DIFF
--- a/cpp/lib/ome/xml/OMETransform.h
+++ b/cpp/lib/ome/xml/OMETransform.h
@@ -102,7 +102,18 @@ namespace ome
               ome::common::xml::EntityResolver& entity_resolver,
               OMETransformResolver&             transform_resolver)
     {
-      ome::common::xml::dom::Document inputdoc(ome::common::xml::dom::createDocument(input, entity_resolver));
+      ome::common::xml::dom::Document inputdoc;
+      try
+        {
+          inputdoc = ome::common::xml::dom::createDocument(input, entity_resolver);
+        }
+      catch (const std::runtime_error&) // retry without strict validation
+        {
+          ome::common::xml::dom::ParseParameters params;
+          params.doSchema = false;
+          params.validationSchemaFullChecking = false;
+          inputdoc = ome::common::xml::dom::createDocument(input, entity_resolver, params);
+        }
 
       const std::string source_schema(getModelVersion(inputdoc));
 


### PR DESCRIPTION
A pre-2016-06 OME-TIFF with spurious `MetadataOnly` element (i.e. most of them) would throw an exception on upgrade during transformation.  We retry without validation as done elsewhere; this logs a warning to the terminal:

```
Image: /home/rleigh/images/vessels.ome.tiff
Using reader: OME-TIFF (Open Microscopy Environment TIFF)
Error at file "OME-XML text", line 1, column 60942
   Message: element 'MetadataOnly' is not allowed for content model '(Channel*,(BinData+|TiffData+|MetadataOnly),Plane*,AnnotationRef*)'
Error at file "membuf", line 1, column 60959
   Message: element 'MetadataOnly' is not allowed for content model '(Channel*,(BinData+|TiffData+|MetadataOnly),Plane*,AnnotationRef*)'
Error at file "OME-XML text (current schema)", line 1199, column 10
   Message: element 'MetadataOnly' is not allowed for content model '(Channel*,(BinData+|TiffData+|MetadataOnly),Plane*)'
Reader setup took 00:00:00.883531

Filename = "/home/rleigh/images/vessels.ome.tiff"
Used files = ["/home/rleigh/images/vessels.ome.tiff"]
```

There is more than one warning since it's hit several times during processing--initial read, transform start and post-transform.

Testing: Run something like:

```
bin/ome-files info ~/images/vessels.ome.tiff
```

with a file containing `MetadataOnly`. I can provide a suitable file if needed.  It will fail with builds before today, and pass with today's build.