### PR TITLE
Enable support for BigTIFF reader file extensions

### DIFF
--- a/components/autogen/src/FormatPageAutogen.java
+++ b/components/autogen/src/FormatPageAutogen.java
@@ -221,7 +221,7 @@ public class FormatPageAutogen {
       realPageName = realPageName.replaceAll(" ", "-");
       realPageName = realPageName.toLowerCase();
     }
-    realPageName = "formats" + File.separator + realPageName;
+    realPageName = "formats/" + realPageName;
 
     return realPageName;
   }

--- a/components/autogen/src/MakeDatasetStructureTable.java
+++ b/components/autogen/src/MakeDatasetStructureTable.java
@@ -49,7 +49,7 @@ public class MakeDatasetStructureTable {
   private void printHeader() {
     out.println(".. Please don't even think about editing this file directly.");
     out.println(".. It is generated using the 'gen-structure-table' Ant");
-    out.println(".. target in components/bio-formats, which uses");
+    out.println(".. target in components/autogen, which uses");
     out.println(".. loci.formats.tools.MakeDatasetStructureTable, so please");
     out.println(".. update that instead.");
     out.println();

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1682,8 +1682,8 @@ utilityRating = Good
 reader = SISReader
 
 [OME-TIFF]
-indexExtensions = .ome.tiff
-extensions = `.ome.tiff <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+indexExtensions = .ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf
+extensions = `.ome.tiff , .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01
@@ -2142,7 +2142,7 @@ notes = Reads tabular pixel data produced by a variety of software.
 
 [TIFF (Tagged Image File Format)]
 pagename = tiff
-extensions = .tif
+extensions = .tiff, .tif, .tf2, .tf8, .btf
 owner = `Adobe <http://www.adobe.com>`_
 developer = Aldus and Microsoft
 bsd = yes

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1683,7 +1683,7 @@ reader = SISReader
 
 [OME-TIFF]
 indexExtensions = .ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf
-extensions = `.ome.tiff , .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+extensions = `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -105,7 +105,7 @@ public class MinimalTiffReader extends FormatReader {
 
   /** Constructs a new MinimalTiffReader. */
   public MinimalTiffReader() {
-    this("Minimal TIFF", new String[] {"tif", "tiff"});
+    this("Minimal TIFF", new String[] {"tif", "tiff", "tf2", "tf8", "btf"});
   }
 
   /** Constructs a new MinimalTiffReader. */

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -102,7 +102,8 @@ public class OMETiffReader extends FormatReader {
 
   /** Constructs a new OME-TIFF reader. */
   public OMETiffReader() {
-    super("OME-TIFF", new String[] {"ome.tif", "ome.tiff", "companion.ome"});
+    super("OME-TIFF", new String[] {"ome.tif", "ome.tiff", "ome.tf2",
+                                    "ome.tf8", "ome.btf", "companion.ome"});
     suffixNecessary = false;
     suffixSufficient = false;
     domains = FormatTools.NON_GRAPHICS_DOMAINS;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -102,7 +102,7 @@ public class OMETiffReader extends FormatReader {
 
   /** Constructs a new OME-TIFF reader. */
   public OMETiffReader() {
-    super("OME-TIFF", new String[] {"ome.tif", "ome.tiff", "ome.tf2",
+    super("OME-TIFF", new String[] {"ome.tiff", "ome.tif", "ome.tf2",
                                     "ome.tf8", "ome.btf", "companion.ome"});
     suffixNecessary = false;
     suffixSufficient = false;
@@ -1087,7 +1087,11 @@ public class OMETiffReader extends FormatReader {
 
   /** Extracts the OME-XML from the current {@link #metadataFile}. */
   private String readMetadataFile() throws IOException {
-    if (checkSuffix(metadataFile, "tif") || checkSuffix(metadataFile, "tiff")) {
+    if (checkSuffix(metadataFile, "ome.tiff") ||
+        checkSuffix(metadataFile, "ome.tif") ||
+        checkSuffix(metadataFile, "ome.tf2") ||
+        checkSuffix(metadataFile, "ome.tf8") ||
+        checkSuffix(metadataFile, "ome.btf")) {
       // metadata file is an OME-TIFF file; extract OME-XML comment
       return new TiffParser(metadataFile).getComment();
     }

--- a/components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java
+++ b/components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java
@@ -65,29 +65,29 @@ public class MakeTestOmeTiff {
   public boolean isModulo = false;
 
   public void makeSamples() throws FormatException, IOException {
-    makeOmeTiff("single-channel", "439", "167", "1", "1", "1", "XYZCT");
-    makeOmeTiff("multi-channel", "439", "167", "1", "3", "1", "XYZCT");
-    makeOmeTiff("z-series", "439", "167", "5", "1", "1", "XYZCT");
-    makeOmeTiff("multi-channel-z-series", "439", "167", "5", "3", "1", "XYZCT");
-    makeOmeTiff("time-series", "439", "167", "1", "1", "7", "XYZCT");
-    makeOmeTiff("multi-channel-time-series", "439", "167", "1", "3", "7",
+    makeOmeTiffExtensions("single-channel", "439", "167", "1", "1", "1", "XYZCT");
+    makeOmeTiffExtensions("multi-channel", "439", "167", "1", "3", "1", "XYZCT");
+    makeOmeTiffExtensions("z-series", "439", "167", "5", "1", "1", "XYZCT");
+    makeOmeTiffExtensions("multi-channel-z-series", "439", "167", "5", "3", "1", "XYZCT");
+    makeOmeTiffExtensions("time-series", "439", "167", "1", "1", "7", "XYZCT");
+    makeOmeTiffExtensions("multi-channel-time-series", "439", "167", "1", "3", "7",
       "XYZCT");
-    makeOmeTiff("4D-series", "439", "167", "5", "1", "7", "XYZCT");
-    makeOmeTiff("multi-channel-4D-series", "439", "167", "5", "3", "7",
+    makeOmeTiffExtensions("4D-series", "439", "167", "5", "1", "7", "XYZCT");
+    makeOmeTiffExtensions("multi-channel-4D-series", "439", "167", "5", "3", "7",
       "XYZCT");
-    makeOmeTiff("modulo-6D-Z", "250", "200", "8", "3", "2",
+    makeOmeTiffExtensions("modulo-6D-Z", "250", "200", "8", "3", "2",
       "XYZCT", "4", "1", "1");
-    makeOmeTiff("modulo-6D-C", "250", "200", "4", "9", "2",
+    makeOmeTiffExtensions("modulo-6D-C", "250", "200", "4", "9", "2",
       "XYZCT", "1", "3", "1");
-    makeOmeTiff("modulo-6D-T", "250", "200", "4", "3", "6",
+    makeOmeTiffExtensions("modulo-6D-T", "250", "200", "4", "3", "6",
       "XYZCT", "1", "1", "2");
-    makeOmeTiff("modulo-7D-ZC", "250", "220", "8", "9", "2",
+    makeOmeTiffExtensions("modulo-7D-ZC", "250", "220", "8", "9", "2",
       "XYZCT", "4", "3", "1");
-    makeOmeTiff("modulo-7D-CT", "250", "220", "4", "9", "6",
+    makeOmeTiffExtensions("modulo-7D-CT", "250", "220", "4", "9", "6",
       "XYZCT", "1", "3", "2");
-    makeOmeTiff("modulo-7D-ZT", "250", "220", "8", "3", "6",
+    makeOmeTiffExtensions("modulo-7D-ZT", "250", "220", "8", "3", "6",
       "XYZCT", "4", "1", "2");
-    makeOmeTiff("modulo-8D", "200", "250", "8", "9", "6",
+    makeOmeTiffExtensions("modulo-8D", "200", "250", "8", "9", "6",
       "XYZCT", "4", "3", "2");
   }
 
@@ -127,6 +127,23 @@ public class MakeTestOmeTiff {
     
     makeOmeTiff(name, info);
     return 0;
+  }
+
+  public void makeOmeTiffExtensions(final String... args) throws FormatException,
+    IOException
+  {
+    final String name = args[0];
+
+    args[0] = name + ".ome.tif";
+    makeOmeTiff(args);
+    args[0] = name + ".ome.tiff";
+    makeOmeTiff(args);
+    args[0] = name + ".ome.tf2";
+    makeOmeTiff(args);
+    args[0] = name + ".ome.tf8";
+    makeOmeTiff(args);
+    args[0] = name + ".ome.btf";
+    makeOmeTiff(args);
   }
 
   public void makeOmeTiff(final String name, final CoreMetadata info)
@@ -179,8 +196,15 @@ public class MakeTestOmeTiff {
 
   private String getId(final String name) {
     final String id;
-    if (name.toLowerCase().endsWith(".ome.tif")) id = name;
-    else id = name + ".ome.tif";
+    if (name.toLowerCase().endsWith(".ome.tiff") ||
+        name.toLowerCase().endsWith(".ome.tif") ||
+        name.toLowerCase().endsWith(".ome.tf2") ||
+        name.toLowerCase().endsWith(".ome.tf8") ||
+        name.toLowerCase().endsWith(".ome.btf")) {
+        id = name;
+    } else {
+        id = name + ".ome.tiff";
+    }
     return id;
   }
 

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -1,6 +1,6 @@
 .. Please don't even think about editing this file directly.
 .. It is generated using the 'gen-structure-table' Ant
-.. target in components/bio-formats, which uses
+.. target in components/autogen, which uses
 .. loci.formats.tools.MakeDatasetStructureTable, so please
 .. update that instead.
 
@@ -312,7 +312,7 @@ to open/import a dataset in a particular format.
      - .obf, .msr
      - OBF file
    * - OME-TIFF
-     - .ome.tif, .ome.tiff, .companion.ome
+     - .ome.tif, .ome.tiff, .ome.tf2, .ome.tf8, .ome.btf, .companion.ome
      - One or more .ome.tiff files
    * - OME-XML
      - .ome, .ome.xml

--- a/docs/sphinx/formats/ome-tiff.txt
+++ b/docs/sphinx/formats/ome-tiff.txt
@@ -1,10 +1,10 @@
 .. index:: OME-TIFF
-.. index:: .ome.tiff
+.. index:: .ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf
 
 OME-TIFF
 ===============================================================================
 
-Extensions: `.ome.tiff <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+Extensions: `.ome.tiff , .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
 
 Developer: `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 

--- a/docs/sphinx/formats/tiff.txt
+++ b/docs/sphinx/formats/tiff.txt
@@ -1,10 +1,10 @@
 .. index:: TIFF (Tagged Image File Format)
-.. index:: .tif
+.. index:: .tiff, .tif, .tf2, .tf8, .btf
 
 TIFF (Tagged Image File Format)
 ===============================================================================
 
-Extensions: .tif
+Extensions: .tiff, .tif, .tf2, .tf8, .btf
 
 Developer: Aldus and Microsoft
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1084,7 +1084,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/ome-tiff`
-     - `.ome.tiff <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+     - `.ome.tiff , .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
      - |Outstanding|
      - |Outstanding|
      - |Outstanding|
@@ -1392,7 +1392,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/tiff`
-     - .tif
+     - .tiff, .tif, .tf2, .tf8, .btf
      - |Very good|
      - |Very good|
      - |Outstanding|


### PR DESCRIPTION
To match the available writer extensions, and to match the C++ behaviour.

Testing: It should be possible to save and then read `ome.tf2`, `ome.tf8` or `ome.btf` files.  Likewise without the `ome.` part for plain big TIFFs.