### PR TITLE
ICS Writer - incorrect planes

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -163,7 +163,7 @@ public class ICSWriter extends FormatWriter {
         pixels.skipBytes(bytesPerPixel * rgbChannels * (sizeX - w - x));
       }
     }
-    lastPlane = no;
+    lastPlane = realIndex;
     if (lastPlane != getPlaneCount() - 1 || uniqueFiles.size() > 1) {
       overwriteDimensions(getMetadataRetrieve());
     }

--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -164,9 +164,7 @@ public class ICSWriter extends FormatWriter {
       }
     }
     lastPlane = realIndex;
-    if (lastPlane != getPlaneCount() - 1 || uniqueFiles.size() > 1) {
-      overwriteDimensions(getMetadataRetrieve());
-    }
+    overwriteDimensions(getMetadataRetrieve());
 
     pixels.close();
     pixels = null;

--- a/components/formats-bsd/src/loci/formats/out/ICSWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/ICSWriter.java
@@ -342,7 +342,7 @@ public class ICSWriter extends FormatWriter {
 
     if (rgbChannels > 1) {
       dimOrder.append("ch\t");
-      sizes[nextSize++] = pos[1] + 1;
+      sizes[nextSize++] = rgbChannels;
     }
 
     for (int i=0; i<outputOrder.length(); i++) {


### PR DESCRIPTION
This issue was raised via the Image J forum - http://forum.imagej.net/t/release-of-bio-formats-5-2-0/2523/9

When exporting to ics format the ordering of the image dimensions was incorrect with images from different channels being displayed in the wrong position.

This issue started occuring after other fixes to the ICSWriter in this PR: https://github.com/openmicroscopy/bioformats/pull/2315

The original issue that the PR was solving was: https://github.com/openmicroscopy/bioformats/issues/2237

Note there is an additional issue which can lock up the exporter, this is still open and is not aimed to be fixed yet - https://github.com/openmicroscopy/bioformats/issues/2238

**To reproduce:**
- Import a suitable multi dimensioned image using Bio-Formats
- Export the image to the ICS format
- Open the original image and the ICS image and compare the image planes to verify that they differ

**To test:**
Ensure that the test cases from the original PR pass:
1) Tried checking the same macro in Fiji https://github.com/openmicroscopy/bioformats/issues/2237 to export the file with a splitC to non ".ome" extensions and the export worked. (This meant the issue was not at the exporter level)

2) Tried bfconvert with splitC to convert it into ".ics" files. Even though this does not throw any exceptions, it still does not do the conversion properly. Ensure each channel file is correctly generated.

Additional the following test cases should be used:
3) Import a suitable multi dimensioned image using Bio-Formats
- Export the image to the ICS format
- Open the original image and the ICS image and compare the image planes to verify they match

4) Import a suitable multi dimensioned image using Bio-Formats
- Export the image to the ICS format using combinations of split dimensions
- Open the original image and each ICS dimension image to verify the files have been generated correctly
