### PR TITLE
OME formats pages: add 2016-06 version

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1686,7 +1686,7 @@ indexExtensions = .ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf
 extensions = `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
-versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01
+versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01, 2016-06
 weHave = * an :model_doc:`OME-TIFF specification document <ome-tiff/specification.html>`\n
 * many OME-TIFF datasets\n
 * `public sample images <http://downloads.openmicroscopy.org/images/OME-TIFF/>`__\n
@@ -1714,7 +1714,7 @@ indexExtensions = .ome, .ome.xml
 extensions = `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
-versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01
+versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01, 2016-06
 weHave = * `OME-XML specification documents <http://www.openmicroscopy.org/Schemas/>`_\n
 * many OME-XML datasets\n
 * `public sample images <http://downloads.openmicroscopy.org/images/OME-XML/>`__\n

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -312,7 +312,7 @@ to open/import a dataset in a particular format.
      - .obf, .msr
      - OBF file
    * - OME-TIFF
-     - .ome.tif, .ome.tiff, .ome.tf2, .ome.tf8, .ome.btf, .companion.ome
+     - .ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf, .companion.ome
      - One or more .ome.tiff files
    * - OME-XML
      - .ome, .ome.xml

--- a/docs/sphinx/formats/ome-tiff.txt
+++ b/docs/sphinx/formats/ome-tiff.txt
@@ -4,7 +4,7 @@
 OME-TIFF
 ===============================================================================
 
-Extensions: `.ome.tiff , .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+Extensions: `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
 
 Developer: `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 
@@ -16,7 +16,7 @@ BSD-licensed: |yes|
 
 Export: |yes|
 
-Officially Supported Versions: 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01
+Officially Supported Versions: 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01, 2016-06
 
 Reader: OMETiffReader (:bsd-reader:`Source Code <OMETiffReader.java>`, :doc:`Supported Metadata Fields </metadata/OMETiffReader>`)
 

--- a/docs/sphinx/formats/ome-xml.txt
+++ b/docs/sphinx/formats/ome-xml.txt
@@ -16,7 +16,7 @@ BSD-licensed: |yes|
 
 Export: |yes|
 
-Officially Supported Versions: 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01
+Officially Supported Versions: 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01, 2016-06
 
 Reader: OMEXMLReader (:bsd-reader:`Source Code <OMEXMLReader.java>`, :doc:`Supported Metadata Fields </metadata/OMEXMLReader>`)
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1084,7 +1084,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/ome-tiff`
-     - `.ome.tiff , .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+     - `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
      - |Outstanding|
      - |Outstanding|
      - |Outstanding|


### PR DESCRIPTION
Noticed while reviewing https://github.com/openmicroscopy/bioformats/pull/2565, the OME-TIFF and OME-XML pages do not include the 2016-06 schema version. This PR adds the version to the `format-pages.txt` and regenerates the format pages using the `autogen` targets.