### PR TITLE
switch to String.indexOf(int) in various GPL-licensed readers (part one)

### DIFF
--- a/components/formats-common/src/loci/common/DataTools.java
+++ b/components/formats-common/src/loci/common/DataTools.java
@@ -809,8 +809,8 @@ public final class DataTools {
   /** Check if two filenames have the same prefix. */
   public static boolean samePrefix(String s1, String s2) {
     if (s1 == null || s2 == null) return false;
-    int n1 = s1.indexOf(".");
-    int n2 = s2.indexOf(".");
+    int n1 = s1.indexOf('.');
+    int n2 = s2.indexOf('.');
     if ((n1 == -1) || (n2 == -1)) return false;
 
     int slash1 = s1.lastIndexOf(File.pathSeparator);

--- a/components/formats-common/src/loci/common/IniParser.java
+++ b/components/formats-common/src/loci/common/IniParser.java
@@ -171,7 +171,7 @@ public class IniParser {
       }
 
       // parse key/value pair
-      int equals = line.indexOf("=");
+      int equals = line.indexOf('=');
       if (equals < 0) {
         LOGGER.debug("Ignoring line {}", no);
         continue;

--- a/components/formats-common/src/loci/common/ReflectedUniverse.java
+++ b/components/formats-common/src/loci/common/ReflectedUniverse.java
@@ -172,7 +172,7 @@ public class ReflectedUniverse {
     }
 
     // get variable where results of command should be stored
-    int eqIndex = command.indexOf("=");
+    int eqIndex = command.indexOf('=');
     String target = null;
     if (eqIndex >= 0) {
       target = command.substring(0, eqIndex).trim();
@@ -182,7 +182,7 @@ public class ReflectedUniverse {
     Object result = null;
 
     // parse parentheses
-    int leftParen = command.indexOf("(");
+    int leftParen = command.indexOf('(');
     if (leftParen < 0) {
       // command is a simple assignment
       result = getVar(command);
@@ -190,7 +190,7 @@ public class ReflectedUniverse {
       return result;
     }
     else if (leftParen != command.lastIndexOf("(") ||
-      command.indexOf(")") != command.length() - 1)
+      command.indexOf(')') != command.length() - 1)
     {
       throw new ReflectException("Invalid parentheses");
     }
@@ -265,7 +265,7 @@ public class ReflectedUniverse {
     }
     else {
       // command is a method call
-      int dot = command.indexOf(".");
+      int dot = command.indexOf('.');
       if (dot < 0) throw new ReflectException("Syntax error");
       String varName = command.substring(0, dot).trim();
       String methodName = command.substring(dot + 1).trim();
@@ -406,7 +406,7 @@ public class ReflectedUniverse {
     catch (NumberFormatException exc) {
       throw new ReflectException("Invalid literal: " + varName, exc);
     }
-    int dot = varName.indexOf(".");
+    int dot = varName.indexOf('.');
     if (dot >= 0) {
       // get field value of variable
       String className = varName.substring(0, dot).trim();

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -236,13 +236,13 @@ public abstract class BaseZeissReader extends FormatReader {
       int deltaZ = zct2[0] - zct1[0];
       int deltaC = zct2[1] - zct1[1];
       int deltaT = zct2[2] - zct1[2];
-      if (deltaZ > 0 && getDimensionOrder().indexOf("Z") == -1) {
+      if (deltaZ > 0 && getDimensionOrder().indexOf('Z') == -1) {
         m.dimensionOrder += "Z";
       }
-      if (deltaC > 0 && getDimensionOrder().indexOf("C") == -1) {
+      if (deltaC > 0 && getDimensionOrder().indexOf('C') == -1) {
         m.dimensionOrder += "C";
       }
-      if (deltaT > 0 && getDimensionOrder().indexOf("T") == -1) {
+      if (deltaT > 0 && getDimensionOrder().indexOf('T') == -1) {
         m.dimensionOrder += "T";
       }
     }
@@ -925,7 +925,7 @@ public abstract class BaseZeissReader extends FormatReader {
         else if (key.startsWith("Objective Name")) {
           String[] tokens = value.split(" ");
           for (int q=0; q<tokens.length; q++) {
-            int slash = tokens[q].indexOf("/");
+            int slash = tokens[q].indexOf('/');
             if (slash != -1 && slash - q > 0) {
               Double mag = 
                   Double.parseDouble(tokens[q].substring(0, slash - q));

--- a/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadGelReader.java
@@ -172,10 +172,10 @@ public class BioRadGelReader extends FormatReader {
         in.skipBytes(8);
         String imageArea = in.readCString();
 
-        imageArea = imageArea.substring(imageArea.indexOf(":") + 1).trim();
-        int xIndex = imageArea.indexOf("x");
+        imageArea = imageArea.substring(imageArea.indexOf(':') + 1).trim();
+        int xIndex = imageArea.indexOf('x');
         if (xIndex > 0) {
-          int space = imageArea.indexOf(" ");
+          int space = imageArea.indexOf(' ');
           if (space >= 0) {
             String width = imageArea.substring(1, space);
             int nextSpace = imageArea.indexOf(" ", xIndex + 2);

--- a/components/formats-gpl/src/loci/formats/in/BioRadReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadReader.java
@@ -646,9 +646,9 @@ public class BioRadReader extends FormatReader {
             addGlobalMetaList("Note", n.toString());
             break;
           case NOTE_TYPE_VARIABLE:
-            if (n.p.indexOf("=") >= 0) {
-              String key = n.p.substring(0, n.p.indexOf("=")).trim();
-              String value = n.p.substring(n.p.indexOf("=") + 1).trim();
+            if (n.p.indexOf('=') >= 0) {
+              String key = n.p.substring(0, n.p.indexOf('=')).trim();
+              String value = n.p.substring(n.p.indexOf('=') + 1).trim();
               addGlobalMeta(key, value);
 
               if (key.equals("INFO_OBJECTIVE_NAME")) {

--- a/components/formats-gpl/src/loci/formats/in/BioRadSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BioRadSCNReader.java
@@ -136,7 +136,7 @@ public class BioRadSCNReader extends FormatReader {
     while (in.getFilePointer() < in.length() && line != null) {
       line = line.trim();
       if (line.startsWith("Content-Type")) {
-        currentType = line.substring(line.indexOf(" ") + 1);
+        currentType = line.substring(line.indexOf(' ') + 1);
 
         int boundary = currentType.indexOf("boundary");
         if (boundary > 0) {
@@ -144,15 +144,15 @@ public class BioRadSCNReader extends FormatReader {
             currentType.substring(boundary + 10, currentType.length() - 1);
         }
 
-        if (currentType.indexOf(";") > 0) {
-          currentType = currentType.substring(0, currentType.indexOf(";"));
+        if (currentType.indexOf(';') > 0) {
+          currentType = currentType.substring(0, currentType.indexOf(';'));
         }
       }
       else if (line.equals("--" + currentBoundary)) {
         currentLength = 0;
       }
       else if (line.startsWith("Content-Length")) {
-        currentLength = Integer.parseInt(line.substring(line.indexOf(" ") + 1));
+        currentLength = Integer.parseInt(line.substring(line.indexOf(' ') + 1));
       }
       else if (line.length() == 0) {
         if (currentType.equals("application/octet-stream")) {

--- a/components/formats-gpl/src/loci/formats/in/GatanDM2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanDM2Reader.java
@@ -284,7 +284,7 @@ public class GatanDM2Reader extends FormatReader {
 
       if (label.equals("Acquisition Date")) {
         date = value.toString();
-        if (date != null && date.indexOf("/") != -1) {
+        if (date != null && date.indexOf('/') != -1) {
           // if the year is stored as a single digit, then it will be parsed
           // literally, e.g. '7' -> '0007', when we want '7' -> '2007'
           String year = date.substring(date.lastIndexOf("/") + 1);

--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -294,8 +294,8 @@ public class GatanReader extends FormatReader {
       for (String token : scopeInfo) {
         token = token.trim();
         if (token.startsWith("Mode")) {
-          token = token.substring(token.indexOf(" ")).trim();
-          String mode = token.substring(0, token.indexOf(" ")).trim();
+          token = token.substring(token.indexOf(' ')).trim();
+          String mode = token.substring(0, token.indexOf(' ')).trim();
           if (mode.equals("TEM")) mode = "Other";
           store.setChannelAcquisitionMode(getAcquisitionMode(mode), 0, 0);
         }
@@ -481,7 +481,7 @@ public class GatanReader extends FormatReader {
         addGlobalMeta(labelString, value);
 
         if (labelString.equals("Scale") && !parent.equals("Calibration")) {
-          if (value.indexOf(",") == -1) {
+          if (value.indexOf(',') == -1) {
             pixelSizes.add(f.parse(value).doubleValue());
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -548,7 +548,7 @@ public class ImarisHDFReader extends FormatReader {
           }
         }
 
-        int underscore = attr.indexOf("_") + 1;
+        int underscore = attr.indexOf('_') + 1;
         int cIndex = Integer.parseInt(attr.substring(underscore,
           attr.indexOf("/", underscore)));
 

--- a/components/formats-gpl/src/loci/formats/in/ImarisTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisTiffReader.java
@@ -135,7 +135,7 @@ public class ImarisTiffReader extends BaseTiffReader {
         StringTokenizer st = new StringTokenizer(comment, "\n");
         while (st.hasMoreTokens()) {
           String line = st.nextToken();
-          int equals = line.indexOf("=");
+          int equals = line.indexOf('=');
           if (equals < 0) continue;
           String key = line.substring(0, equals).trim();
           String value = line.substring(equals + 1).trim();
@@ -156,7 +156,7 @@ public class ImarisTiffReader extends BaseTiffReader {
           }
           else if (key.equals("RecordingDate")) {
             value = value.replaceAll(" ", "T");
-            creationDate = value.substring(0, value.indexOf("."));
+            creationDate = value.substring(0, value.indexOf('.'));
           }
         }
         metadata.remove("Comment");

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -1623,7 +1623,7 @@ public class LIFReader extends FormatReader {
         final StringBuilder model = new StringBuilder();
         while (!foundMag) {
           String token = tokens.nextToken();
-          int x = token.indexOf("x");
+          int x = token.indexOf('x');
           if (x != -1) {
             foundMag = true;
 
@@ -2039,13 +2039,13 @@ public class LIFReader extends FormatReader {
       }
     }
 
-    if (ms.dimensionOrder.indexOf("Z") == -1) {
+    if (ms.dimensionOrder.indexOf('Z') == -1) {
       ms.dimensionOrder += "Z";
     }
-    if (ms.dimensionOrder.indexOf("C") == -1) {
+    if (ms.dimensionOrder.indexOf('C') == -1) {
       ms.dimensionOrder += "C";
     }
-    if (ms.dimensionOrder.indexOf("T") == -1) {
+    if (ms.dimensionOrder.indexOf('T') == -1) {
       ms.dimensionOrder += "T";
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -621,7 +621,7 @@ public class LeicaHandler extends BaseHandler {
         final StringBuilder model = new StringBuilder();
         while (!foundMag) {
           String token = tokens.nextToken();
-          int x = token.indexOf("x");
+          int x = token.indexOf('x');
           if (x != -1) {
             foundMag = true;
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -192,13 +192,13 @@ public class LeicaReader extends FormatReader {
 
     // check for that there is an .lei file in the same directory
     String prefix = name;
-    if (prefix.indexOf(".") != -1) {
+    if (prefix.indexOf('.') != -1) {
       prefix = prefix.substring(0, prefix.lastIndexOf("."));
     }
     Location lei = new Location(prefix + ".lei");
     if (!lei.exists()) {
       lei = new Location(prefix + ".LEI");
-      while (!lei.exists() && prefix.indexOf("_") != -1) {
+      while (!lei.exists() && prefix.indexOf('_') != -1) {
         prefix = prefix.substring(0, prefix.lastIndexOf("_"));
         lei = new Location(prefix + ".lei");
         if (!lei.exists()) lei = new Location(prefix + ".LEI");
@@ -804,9 +804,9 @@ public class LeicaReader extends FormatReader {
       String line = null, key = null, value = null;
       while (lines.hasMoreTokens()) {
         line = lines.nextToken();
-        if (line.indexOf("=") == -1) continue;
-        key = line.substring(0, line.indexOf("=")).trim();
-        value = line.substring(line.indexOf("=") + 1).trim();
+        if (line.indexOf('=') == -1) continue;
+        key = line.substring(0, line.indexOf('=')).trim();
+        value = line.substring(line.indexOf('=') + 1).trim();
         addGlobalMeta(key, value);
 
         if (key.startsWith("Series Name")) lei += value;
@@ -843,13 +843,13 @@ public class LeicaReader extends FormatReader {
     else if (checkSuffix(baseFile, "raw") && isGroupFiles()) {
       // check for that there is an .lei file in the same directory
       String prefix = baseFile;
-      if (prefix.indexOf(".") != -1) {
+      if (prefix.indexOf('.') != -1) {
         prefix = prefix.substring(0, prefix.lastIndexOf("."));
       }
       Location lei = new Location(prefix + ".lei");
       if (!lei.exists()) {
         lei = new Location(prefix + ".LEI");
-        while (!lei.exists() && prefix.indexOf("_") != -1) {
+        while (!lei.exists() && prefix.indexOf('_') != -1) {
           prefix = prefix.substring(0, prefix.lastIndexOf("_"));
           lei = new Location(prefix + ".lei");
           if (!lei.exists()) lei = new Location(prefix + ".LEI");
@@ -1035,7 +1035,7 @@ public class LeicaReader extends FormatReader {
 
     String name = getString(fileLength * 2);
 
-    if (name.indexOf(".") != -1) {
+    if (name.indexOf('.') != -1) {
       name = name.substring(0, name.lastIndexOf("."));
     }
 
@@ -1113,21 +1113,21 @@ public class LeicaReader extends FormatReader {
       else if (dimType.equals("channel")) {
         if (getSizeC() == 0) ms.sizeC = 1;
         ms.sizeC *= size;
-        if (getDimensionOrder().indexOf("C") == -1) {
+        if (getDimensionOrder().indexOf('C') == -1) {
           ms.dimensionOrder += "C";
         }
         physicalSizes[seriesIndex][3] = physical;
       }
       else if (dimType.equals("z")) {
         ms.sizeZ = size;
-        if (getDimensionOrder().indexOf("Z") == -1) {
+        if (getDimensionOrder().indexOf('Z') == -1) {
           ms.dimensionOrder += "Z";
         }
         physicalSizes[seriesIndex][2] = physical;
       }
       else {
         ms.sizeT = size;
-        if (getDimensionOrder().indexOf("T") == -1) {
+        if (getDimensionOrder().indexOf('T') == -1) {
           ms.dimensionOrder += "T";
         }
         physicalSizes[seriesIndex][4] = physical;
@@ -1349,7 +1349,7 @@ public class LeicaReader extends FormatReader {
             else if (tokens[2].equals("State")) {
               detector.active = data.equals("Active");
 
-              String index = tokens[1].substring(tokens[1].indexOf(" ") + 1);
+              String index = tokens[1].substring(tokens[1].indexOf(' ') + 1);
               detector.index = -1;
               try {
                 detector.index = Integer.parseInt(index) - 1;
@@ -1379,10 +1379,10 @@ public class LeicaReader extends FormatReader {
           String mag = null, na = null;
           String immersion = null, correction = null;
           for (int i=0; i<objectiveData.length; i++) {
-            if (objectiveData[i].indexOf("x") != -1 && mag == null &&
+            if (objectiveData[i].indexOf('x') != -1 && mag == null &&
               na == null)
             {
-              int xIndex = objectiveData[i].indexOf("x");
+              int xIndex = objectiveData[i].indexOf('x');
               mag = objectiveData[i].substring(0, xIndex).trim();
               na = objectiveData[i].substring(xIndex + 1).trim();
             }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -167,7 +167,7 @@ public class MetamorphHandler extends BaseHandler {
               freeformDescription += "\n";
             }
             else {
-              int colon = line.indexOf(":");
+              int colon = line.indexOf(':');
               if (colon != -1) {
                 k = line.substring(0, colon).trim();
                 v = line.substring(colon + 1).trim();
@@ -184,7 +184,7 @@ public class MetamorphHandler extends BaseHandler {
           }
         }
         else {
-          int colon = value.indexOf(":");
+          int colon = value.indexOf(':');
           while (colon != -1) {
             k = value.substring(0, colon);
             int space = value.lastIndexOf(" ", value.indexOf(":", colon + 1));
@@ -192,7 +192,7 @@ public class MetamorphHandler extends BaseHandler {
             v = value.substring(colon + 1, space).trim();
             if (metadata != null) metadata.put(k, v);
             value = value.substring(space).trim();
-            colon = value.indexOf(":");
+            colon = value.indexOf(':');
             checkKey(k, v);
           }
         }
@@ -252,7 +252,7 @@ public class MetamorphHandler extends BaseHandler {
       }
     }
     else if (key.equals("Speed")) {
-      int space = value.indexOf(" ");
+      int space = value.indexOf(' ');
       if (space > 0) {
         value = value.substring(0, space);
       }
@@ -262,8 +262,8 @@ public class MetamorphHandler extends BaseHandler {
       catch (NumberFormatException e) { }
     }
     else if (key.equals("Exposure")) {
-      if (value.indexOf(" ") != -1) {
-        value = value.substring(0, value.indexOf(" "));
+      if (value.indexOf(' ') != -1) {
+        value = value.substring(0, value.indexOf(' '));
       }
       // exposure times are stored in milliseconds, we want them in seconds
       try {

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -358,8 +358,8 @@ public class MetamorphReader extends BaseTiffReader {
       LOGGER.info("Looking for STK file in {}", parent.getAbsolutePath());
       String[] dirList = parent.list(true);
       for (String f : dirList) {
-        int underscore = f.indexOf("_");
-        if (underscore < 0) underscore = f.indexOf(".");
+        int underscore = f.indexOf('_');
+        if (underscore < 0) underscore = f.indexOf('.');
         if (underscore < 0) underscore = f.length();
         String prefix = f.substring(0, underscore);
 
@@ -390,7 +390,7 @@ public class MetamorphReader extends BaseTiffReader {
       String stkName = stk.getName();
       String stkPrefix = stkName;
       if (stkPrefix.indexOf('_') >= 0) {
-        stkPrefix = stkPrefix.substring(0, stkPrefix.indexOf("_") + 1);
+        stkPrefix = stkPrefix.substring(0, stkPrefix.indexOf('_') + 1);
       }
       Location parent = stk.getParentFile();
       String[] list = parent.list(true);
@@ -399,7 +399,7 @@ public class MetamorphReader extends BaseTiffReader {
         if (checkSuffix(f, ND_SUFFIX)) {
           String prefix = f.substring(0, f.lastIndexOf("."));
           if (prefix.indexOf('_') >= 0) {
-            prefix = prefix.substring(0, prefix.indexOf("_") + 1);
+            prefix = prefix.substring(0, prefix.indexOf('_') + 1);
           }
           if (stkName.startsWith(prefix) || prefix.equals(stkPrefix)) {
             int charCount = 0;
@@ -451,7 +451,7 @@ public class MetamorphReader extends BaseTiffReader {
       String key = "";
 
       for (String line : lines) {
-        int comma = line.indexOf(",");
+        int comma = line.indexOf(',');
         if (comma <= 0) {
           currentValue.append("\n");
           currentValue.append(line);
@@ -1232,7 +1232,7 @@ public class MetamorphReader extends BaseTiffReader {
           break;
         }
 
-        int colon = line.indexOf(":");
+        int colon = line.indexOf(':');
 
         if (colon < 0) {
           // normal line (not a key/value pair)
@@ -1267,10 +1267,10 @@ public class MetamorphReader extends BaseTiffReader {
           addSeriesMeta(key, value);
           if (key.equals("Exposure")) {
             if (value.indexOf('=') != -1) {
-              value = value.substring(value.indexOf("=") + 1).trim();
+              value = value.substring(value.indexOf('=') + 1).trim();
             }
             if (value.indexOf(' ') != -1) {
-              value = value.substring(0, value.indexOf(" "));
+              value = value.substring(0, value.indexOf(' '));
             }
             try {
               value = value.replace(',', '.');
@@ -1281,7 +1281,7 @@ public class MetamorphReader extends BaseTiffReader {
           }
           else if (key.equals("Bit Depth")) {
             if (value.indexOf('-') != -1) {
-              value = value.substring(0, value.indexOf("-"));
+              value = value.substring(0, value.indexOf('-'));
             }
             try {
               ms0.bitsPerPixel = Integer.parseInt(value);
@@ -1289,7 +1289,7 @@ public class MetamorphReader extends BaseTiffReader {
             catch (NumberFormatException e) { }
           }
           else if (key.equals("Gain")) {
-            int space = value.indexOf(" ");
+            int space = value.indexOf(' ');
             if (space != -1) {
               int nextSpace = value.indexOf(" ", space + 1);
               if (nextSpace < 0) {
@@ -1354,13 +1354,13 @@ public class MetamorphReader extends BaseTiffReader {
     String name = l.getName();
     String parent = l.getParent();
 
-    if (name.indexOf("_") > 0) {
-      String prefix = name.substring(0, name.indexOf("_"));
-      String suffix = name.substring(name.indexOf("_"));
+    if (name.indexOf('_') > 0) {
+      String prefix = name.substring(0, name.indexOf('_'));
+      String suffix = name.substring(name.indexOf('_'));
 
       String basePrefix = new Location(currentId).getName();
-      int end = basePrefix.indexOf("_");
-      if (end < 0) end = basePrefix.indexOf(".");
+      int end = basePrefix.indexOf('_');
+      if (end < 0) end = basePrefix.indexOf('.');
       basePrefix = basePrefix.substring(0, end);
 
       if (!basePrefix.equals(prefix)) {

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -193,7 +193,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
     CoreMetadata m = core.get(0);
 
     String filename = id.substring(id.lastIndexOf(File.separator) + 1);
-    filename = filename.substring(0, filename.indexOf("."));
+    filename = filename.substring(0, filename.indexOf('.'));
     boolean integerFilename = true;
     try {
       Integer.parseInt(filename);
@@ -528,7 +528,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
 
   private int getField(String stageLabel) {
     if (stageLabel.indexOf("Scan") < 0) return 0;
-    String index = stageLabel.substring(0, stageLabel.indexOf(":")).trim();
+    String index = stageLabel.substring(0, stageLabel.indexOf(':')).trim();
     return Integer.parseInt(index) - 1;
   }
 
@@ -559,7 +559,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
     for (String tiff : tiffs) {
       if (!new Location(tiff).exists()) {
         String base = tiff.substring(tiff.lastIndexOf(File.separator) + 1);
-        base = base.substring(0, base.indexOf("."));
+        base = base.substring(0, base.indexOf('.'));
         String suffix = tiff.substring(tiff.lastIndexOf("."));
         while (base.length() < 3) {
           base = "0" + base;
@@ -626,8 +626,8 @@ public class MetamorphTiffReader extends BaseTiffReader {
       String base1 = s1.substring(s1.lastIndexOf(File.separator) + 1);
       String base2 = s2.substring(s2.lastIndexOf(File.separator) + 1);
 
-      base1 = base1.substring(0, base1.indexOf("."));
-      base2 = base2.substring(0, base2.indexOf("."));
+      base1 = base1.substring(0, base1.indexOf('.'));
+      base2 = base2.substring(0, base2.indexOf('.'));
 
       try {
         int num1 = Integer.parseInt(base1);

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -186,7 +186,7 @@ public class ND2Handler extends BaseHandler {
 
         final StringBuilder sb = new StringBuilder();
         for (int i=0; i<points.length; i++) {
-          points[i] = points[i].substring(points[i].indexOf(":") + 1);
+          points[i] = points[i].substring(points[i].indexOf(':') + 1);
           sb.append(points[i]);
           if (i < points.length - 1) sb.append(" ");
         }
@@ -526,7 +526,7 @@ public class ND2Handler extends BaseHandler {
         metadata.put("Z position for position #" + posZ.size(), value);
       }
       else if (qName.startsWith("item_")) {
-        int v = Integer.parseInt(qName.substring(qName.indexOf("_") + 1));
+        int v = Integer.parseInt(qName.substring(qName.indexOf('_') + 1));
         if (v == numSeries) {
           numSeries++;
         }
@@ -677,7 +677,7 @@ public class ND2Handler extends BaseHandler {
         String[] tokens = value.split(" ");
         int magIndex = -1;
         for (int i=0; i<tokens.length; i++) {
-          if (tokens[i].indexOf("x") != -1) {
+          if (tokens[i].indexOf('x') != -1) {
             magIndex = i;
             break;
           }
@@ -689,7 +689,7 @@ public class ND2Handler extends BaseHandler {
         correction = s.toString();
         if (magIndex >= 0) {
           String m =
-            tokens[magIndex].substring(0, tokens[magIndex].indexOf("x"));
+            tokens[magIndex].substring(0, tokens[magIndex].indexOf('x'));
           m = DataTools.sanitizeDouble(m);
           if (m.length() > 0) {
             mag = new Double(m);
@@ -715,7 +715,7 @@ public class ND2Handler extends BaseHandler {
           if (runtype.endsWith("ZStackLoop")) {
             if (ms0.sizeZ == 0) {
               ms0.sizeZ = Integer.parseInt(value);
-              if (ms0.dimensionOrder.indexOf("Z") == -1) {
+              if (ms0.dimensionOrder.indexOf('Z') == -1) {
                 ms0.dimensionOrder = "Z" + ms0.dimensionOrder;
               }
             }
@@ -723,7 +723,7 @@ public class ND2Handler extends BaseHandler {
           else if (runtype.endsWith("TimeLoop")) {
             if (ms0.sizeT == 0) {
               ms0.sizeT = Integer.parseInt(value);
-              if (ms0.dimensionOrder.indexOf("T") == -1) {
+              if (ms0.dimensionOrder.indexOf('T') == -1) {
                 ms0.dimensionOrder = "T" + ms0.dimensionOrder;
               }
             }
@@ -743,7 +743,7 @@ public class ND2Handler extends BaseHandler {
       else if (key.equals("VirtualComponents")) {
         if (ms0.sizeC == 0) {
           ms0.sizeC = Integer.parseInt(value);
-          if (ms0.dimensionOrder.indexOf("C") == -1) {
+          if (ms0.dimensionOrder.indexOf('C') == -1) {
             ms0.dimensionOrder += "C" + ms0.dimensionOrder;
           }
         }
@@ -766,7 +766,7 @@ public class ND2Handler extends BaseHandler {
             parseKeyAndValue(v[0].trim(), v[1].trim(), runtype);
           }
           else if (v[0].equals("Line")) {
-            parseKeyAndValue(v[0], t.substring(t.indexOf(":") + 1).trim(), runtype);
+            parseKeyAndValue(v[0], t.substring(t.indexOf(':') + 1).trim(), runtype);
           }
           else if (v.length > 1) {
             v[0] = v[0].replace('{', ' ');
@@ -888,7 +888,7 @@ public class ND2Handler extends BaseHandler {
       else if (key.equals("Line")) {
         String[] values = value.split(";");
         for (int q=0; q<values.length; q++) {
-          int colon = values[q].indexOf(":");
+          int colon = values[q].indexOf(':');
           if (colon < 0) continue;
           String nextKey = values[q].substring(0, colon).trim();
           String nextValue = values[q].substring(colon + 1).trim();

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -446,7 +446,7 @@ public class NDPIReader extends BaseTiffReader {
     if (metadataTag != null) {
       String[] entries = metadataTag.split("\n");
       for (String entry : entries) {
-        int eq = entry.indexOf("=");
+        int eq = entry.indexOf('=');
         if (eq < 0) {
           continue;
         }

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -156,7 +156,7 @@ public class NDPISReader extends FormatReader {
     String[] lines = DataTools.readFile(currentId).split("\r\n");
 
     for (String line : lines) {
-      int eq = line.indexOf("=");
+      int eq = line.indexOf('=');
       if (eq < 0) {
         continue;
       }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -574,7 +574,7 @@ public class NativeND2Reader extends FormatReader {
                 xmlString =
                   xmlString.substring(0, xmlString.lastIndexOf(">") + 1);
                 if (xmlString.startsWith("<?xml")) {
-                  xmlString = xmlString.substring(xmlString.indexOf(">") + 1);
+                  xmlString = xmlString.substring(xmlString.indexOf('>') + 1);
                 }
                 if (!xmlString.endsWith("</variant>")) {
                   xmlString += "</variant>";
@@ -1115,15 +1115,15 @@ public class NativeND2Reader extends FormatReader {
         fieldIndex--;
       }
 
-      if (getSizeC() > 1 && getDimensionOrder().indexOf("C") == -1) {
+      if (getSizeC() > 1 && getDimensionOrder().indexOf('C') == -1) {
         core.get(0).dimensionOrder = "C" + getDimensionOrder();
         fieldIndex++;
       }
 
       core.get(0).dimensionOrder = "XY" + getDimensionOrder();
-      if (getDimensionOrder().indexOf("Z") == -1) core.get(0).dimensionOrder += "Z";
-      if (getDimensionOrder().indexOf("C") == -1) core.get(0).dimensionOrder += "C";
-      if (getDimensionOrder().indexOf("T") == -1) core.get(0).dimensionOrder += "T";
+      if (getDimensionOrder().indexOf('Z') == -1) core.get(0).dimensionOrder += "Z";
+      if (getDimensionOrder().indexOf('C') == -1) core.get(0).dimensionOrder += "C";
+      if (getDimensionOrder().indexOf('T') == -1) core.get(0).dimensionOrder += "T";
 
       if (getSizeZ() == 0) {
         core.get(0).sizeZ = 1;
@@ -1495,7 +1495,7 @@ public class NativeND2Reader extends FormatReader {
         }
         s = in.readString(blockLength);
         s = s.replaceAll("<!--.+?>", ""); // remove comments
-        int openBracket = s.indexOf("<");
+        int openBracket = s.indexOf('<');
         if (openBracket == -1) continue;
         int closedBracket = s.lastIndexOf(">") + 1;
         if (closedBracket < openBracket) continue;
@@ -1581,9 +1581,9 @@ public class NativeND2Reader extends FormatReader {
       fieldIndex++;
     }
 
-    if (getDimensionOrder().indexOf("Z") == -1) core.get(0).dimensionOrder += "Z";
-    if (getDimensionOrder().indexOf("C") == -1) core.get(0).dimensionOrder += "C";
-    if (getDimensionOrder().indexOf("T") == -1) core.get(0).dimensionOrder += "T";
+    if (getDimensionOrder().indexOf('Z') == -1) core.get(0).dimensionOrder += "Z";
+    if (getDimensionOrder().indexOf('C') == -1) core.get(0).dimensionOrder += "C";
+    if (getDimensionOrder().indexOf('T') == -1) core.get(0).dimensionOrder += "T";
     core.get(0).dimensionOrder = "XY" + getDimensionOrder();
 
     if (getImageCount() == 0) {
@@ -2137,7 +2137,7 @@ public class NativeND2Reader extends FormatReader {
     try {
       ND2Handler handler = new ND2Handler(core, offsetCount);
       String xmlString = XMLTools.sanitizeXML(textString);
-      int start = xmlString.indexOf("<");
+      int start = xmlString.indexOf('<');
       int end = xmlString.lastIndexOf(">");
       if (start >= 0 && end >= 0 && end >= start) {
         xmlString = xmlString.substring(start, end + 1);
@@ -2164,7 +2164,7 @@ public class NativeND2Reader extends FormatReader {
       String[] lines = textString.split("\n");
       ND2Handler handler = new ND2Handler(core, offsetCount);
       for (String line : lines) {
-        int separator = line.indexOf(":");
+        int separator = line.indexOf(':');
         if (separator >= 0) {
           String key = line.substring(0, separator).trim();
           String value = line.substring(separator + 1).trim();
@@ -2193,7 +2193,7 @@ public class NativeND2Reader extends FormatReader {
       lines = textString.split(" ");
       for (int i=0; i<lines.length; i++) {
         String key = lines[i++];
-        while (!key.endsWith(":") && key.indexOf("_") < 0 && i < lines.length) {
+        while (!key.endsWith(":") && key.indexOf('_') < 0 && i < lines.length) {
           key += " " + lines[i++];
           if (i >= lines.length) {
             break;

--- a/components/formats-gpl/src/loci/formats/in/NikonElementsTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonElementsTiffReader.java
@@ -104,7 +104,7 @@ public class NikonElementsTiffReader extends BaseTiffReader {
     if (xml.length() == 0) {
       xml = ifds.get(0).getIFDTextValue(NIKON_XML_TAG_2).trim();
     }
-    int open = xml.indexOf("<");
+    int open = xml.indexOf('<');
     if (open >= 0) {
       xml = xml.substring(open);
     }

--- a/components/formats-gpl/src/loci/formats/in/NikonTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonTiffReader.java
@@ -130,7 +130,7 @@ public class NikonTiffReader extends BaseTiffReader {
       int nTokensInKey = 0;
       for (String key : TOP_LEVEL_KEYS) {
         if (line.startsWith(key)) {
-          nTokensInKey = key.indexOf(" ") != -1 ? 3 : 2;
+          nTokensInKey = key.indexOf(' ') != -1 ? 3 : 2;
           break;
         }
       }
@@ -182,7 +182,7 @@ public class NikonTiffReader extends BaseTiffReader {
         gain.add(new Double(value));
       }
       else if (key.equals("history pinhole")) {
-        pinholeSize = new Double(value.substring(0, value.indexOf(" ")));
+        pinholeSize = new Double(value.substring(0, value.indexOf(' ')));
       }
       else if (key.startsWith("history laser") && key.endsWith("wavelength")) {
         wavelength.add(new Double(value.replaceAll("\\D", "")));

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1639,7 +1639,7 @@ public class ZeissCZIReader extends FormatReader {
           Element detector = getFirstNode(detectorSettings, "Detector");
           if (detector != null) {
             String detectorID = detector.getAttribute("Id");
-            if (detectorID.indexOf(" ") != -1) {
+            if (detectorID.indexOf(' ') != -1) {
               detectorID =
                 detectorID.substring(detectorID.lastIndexOf(" ") + 1);
             }
@@ -1767,7 +1767,7 @@ public class ZeissCZIReader extends FormatReader {
           String lotNumber = getFirstNodeValue(manufacturerNode, "LotNumber");
 
           String detectorID = detector.getAttribute("Id");
-          if (detectorID.indexOf(" ") != -1) {
+          if (detectorID.indexOf(' ') != -1) {
             detectorID = detectorID.substring(detectorID.lastIndexOf(" ") + 1);
           }
           if (!detectorID.startsWith("Detector:")) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -726,7 +726,7 @@ public class ZeissLSMReader extends FormatReader {
     int instrument = getEffectiveSeries(series);
 
     String imageName = getLSMFileFromSeries(series);
-    if (imageName.indexOf(".") != -1) {
+    if (imageName.indexOf('.') != -1) {
       imageName = imageName.substring(0, imageName.lastIndexOf("."));
     }
     if (imageName.indexOf(File.separator) != -1) {
@@ -1437,7 +1437,7 @@ public class ZeissLSMReader extends FormatReader {
         store.setFilterID(id, instrument, nextFilter);
         store.setFilterModel(channel.filter, instrument, nextFilter);
 
-        int space = channel.filter.indexOf(" ");
+        int space = channel.filter.indexOf(' ');
         if (space != -1) {
           String type = channel.filter.substring(0, space).trim();
           if (type.equals("BP")) type = "BandPass";
@@ -2339,7 +2339,7 @@ public class ZeissLSMReader extends FormatReader {
       description = getStringValue(RECORDING_DESCRIPTION);
       name = getStringValue(RECORDING_NAME);
       binning = getStringValue(RECORDING_CAMERA_BINNING);
-      if (binning != null && binning.indexOf("x") == -1) {
+      if (binning != null && binning.indexOf('x') == -1) {
         if (binning.equals("0")) binning = null;
         else binning += "x" + binning;
       }
@@ -2360,12 +2360,12 @@ public class ZeissLSMReader extends FormatReader {
       String[] tokens = objective.split(" ");
       int next = 0;
       for (; next<tokens.length; next++) {
-        if (tokens[next].indexOf("/") != -1) break;
+        if (tokens[next].indexOf('/') != -1) break;
         correction += tokens[next];
       }
       if (next < tokens.length) {
         String p = tokens[next++];
-        int slash = p.indexOf("/");
+        int slash = p.indexOf('/');
         if (slash > 0) {
           try {
             magnification = new Double(p.substring(0, slash - 1));

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
@@ -203,7 +203,7 @@ public class ZeissTIFFHandler extends DefaultHandler {
       d.angle = parseDouble(cdata);
     }
     else if (qName.startsWith("Matrix_")) {
-      String value = qName.substring(qName.indexOf("_") + 1);
+      String value = qName.substring(qName.indexOf('_') + 1);
       Integer index = Integer.parseInt(value);
       Double mval = parseDouble(cdata);
       current_scaling.matrix.put(index, mval);
@@ -648,7 +648,7 @@ public class ZeissTIFFHandler extends DefaultHandler {
     Dimension
     getDimension(String key)
     {
-      String value = key.substring(key.indexOf("_") + 1);
+      String value = key.substring(key.indexOf('_') + 1);
       Integer index = Integer.parseInt(value);
       Dimension d = dims.get(index);
       if (d == null)

--- a/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissZVIReader.java
@@ -399,8 +399,8 @@ public class ZeissZVIReader extends BaseZeissReader {
 
   private int getImageNumber(String dirName, int defaultNumber) {
     if (dirName.toUpperCase().indexOf("ITEM") != -1) {
-      int open = dirName.indexOf("(");
-      int close = dirName.indexOf(")");
+      int open = dirName.indexOf('(');
+      int close = dirName.indexOf(')');
       if (open < 0 || close < 0 || close < open) return defaultNumber;
       return Integer.parseInt(dirName.substring(open + 1, close));
     }


### PR DESCRIPTION
Inspired by https://github.com/openmicroscopy/bioformats/pull/2528#discussion_r76218340 -

> this is really just about switching to calling a method that can assume searching for a single character instead of having to care about search string length

this is a mechanical change so that a simpler library method can be used in our GPL reader code. It may not make much difference but sets a good example for others writing further code based on our existing code. https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/ suffices for testing.

This PR also adjusts a couple of common utility classes in the same way.