### PR TITLE
switch to String.indexOf(int) in various GPL-licensed readers (part two)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -571,7 +571,7 @@ public class BDReader extends FormatReader {
           while (!line.endsWith(".adf\"")) {
             line = s.readLine().trim();
           }
-          plateName = line.substring(line.indexOf(":")).trim();
+          plateName = line.substring(line.indexOf(':')).trim();
           plateName = plateName.replace('/', File.separatorChar);
           plateName = plateName.replace('\\', File.separatorChar);
           for (int i=0; i<3; i++) {
@@ -691,12 +691,12 @@ public class BDReader extends FormatReader {
 
       IniTable numerator = dye.getTable("Numerator");
       String em = numerator.get("Emission");
-      em = em.substring(0, em.indexOf(" "));
+      em = em.substring(0, em.indexOf(' '));
       emWave[c] = Double.parseDouble(em);
 
       String ex = numerator.get("Excitation");
       ex = ex.substring(0, ex.lastIndexOf(" "));
-      if (ex.indexOf(" ") != -1) {
+      if (ex.indexOf(' ') != -1) {
         ex = ex.substring(ex.lastIndexOf(" ") + 1);
       }
       exWave[c] = Double.parseDouble(ex);

--- a/components/formats-gpl/src/loci/formats/in/BrukerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BrukerReader.java
@@ -272,7 +272,7 @@ public class BrukerReader extends FormatReader {
 
       for (int i=0; i<lines.length; i++) {
         String line = lines[i];
-        int index = line.indexOf("=");
+        int index = line.indexOf('=');
         if (index >= 0) {
           String key = line.substring(0, index);
           String value = line.substring(index + 1);
@@ -330,7 +330,7 @@ public class BrukerReader extends FormatReader {
 
       for (int i=0; i<lines.length; i++) {
         String line = lines[i];
-        int index = line.indexOf("=");
+        int index = line.indexOf('=');
         if (index >= 0) {
           String key = line.substring(0, index);
           String value = line.substring(index + 1);

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -707,19 +707,19 @@ public class FV1000Reader extends FormatReader {
         if (axis == null) break;
         boolean addAxis = Integer.parseInt(axis.get("Number")) > 1;
         if (dim == 2) {
-          if (addAxis && getDimensionOrder().indexOf("C") == -1) {
+          if (addAxis && getDimensionOrder().indexOf('C') == -1) {
             ms0.dimensionOrder += "C";
           }
         }
         else if (dim == 3) {
-          if (addAxis && getDimensionOrder().indexOf("Z") == -1) {
+          if (addAxis && getDimensionOrder().indexOf('Z') == -1) {
             ms0.dimensionOrder += "Z";
           }
           final Double number = Double.valueOf(axis.get("AbsPositionValue"));
           plane.positionZ = new Length(number, UNITS.REFERENCEFRAME);
         }
         else if (dim == 4) {
-          if (addAxis && getDimensionOrder().indexOf("T") == -1) {
+          if (addAxis && getDimensionOrder().indexOf('T') == -1) {
             ms0.dimensionOrder += "T";
           }
           // divide by 1000, as the position is in milliseconds
@@ -888,12 +888,12 @@ public class FV1000Reader extends FormatReader {
     }
 
     if (getSizeC() > 1 && getSizeZ() == 1 && getSizeT() == 1) {
-      if (getDimensionOrder().indexOf("C") == -1) ms0.dimensionOrder += "C";
+      if (getDimensionOrder().indexOf('C') == -1) ms0.dimensionOrder += "C";
     }
 
-    if (getDimensionOrder().indexOf("Z") == -1) ms0.dimensionOrder += "Z";
-    if (getDimensionOrder().indexOf("C") == -1) ms0.dimensionOrder += "C";
-    if (getDimensionOrder().indexOf("T") == -1) ms0.dimensionOrder += "T";
+    if (getDimensionOrder().indexOf('Z') == -1) ms0.dimensionOrder += "Z";
+    if (getDimensionOrder().indexOf('C') == -1) ms0.dimensionOrder += "C";
+    if (getDimensionOrder().indexOf('T') == -1) ms0.dimensionOrder += "T";
 
     ms0.pixelType =
       FormatTools.pixelTypeFromBytes(imageDepth, false, false);
@@ -1102,7 +1102,7 @@ public class FV1000Reader extends FormatReader {
         store.setFilterID(filterID, 0, channelIndex);
         store.setFilterModel(channel.barrierFilter, 0, channelIndex);
 
-        if (channel.barrierFilter.indexOf("-") != -1) {
+        if (channel.barrierFilter.indexOf('-') != -1) {
           String[] emValues = channel.barrierFilter.split("-");
           for (int i=0; i<emValues.length; i++) {
             emValues[i] = emValues[i].replaceAll("\\D", "");
@@ -1478,12 +1478,12 @@ public class FV1000Reader extends FormatReader {
     parent = tmp.getAbsolutePath();
 
     baseFile = current.getName();
-    if (baseFile == null || baseFile.indexOf("_") == -1) return null;
+    if (baseFile == null || baseFile.indexOf('_') == -1) return null;
     baseFile = baseFile.substring(0, baseFile.lastIndexOf("_"));
     if (checkSuffix(current.getName(), new String[] {"roi", "lut"})) {
       if (!new Location(tmp, baseFile + ".oif").exists() &&
         !new Location(tmp, baseFile + ".OIF").exists() &&
-        baseFile.indexOf("_") >= 0)
+        baseFile.indexOf('_') >= 0)
       {
         // some metadata files have an extra underscore
         baseFile = baseFile.substring(0, baseFile.lastIndexOf("_"));
@@ -1556,9 +1556,9 @@ public class FV1000Reader extends FormatReader {
     String directoryKey = null, directoryValue = null, key = null, value = null;
     for (String line : lines) {
       line = line.trim();
-      if (line.indexOf("=") != -1) {
-        key = line.substring(0, line.indexOf("="));
-        value = line.substring(line.indexOf("=") + 1);
+      if (line.indexOf('=') != -1) {
+        key = line.substring(0, line.indexOf('='));
+        value = line.substring(line.indexOf('=') + 1);
 
         if (directoryKey != null && directoryValue != null) {
           value = value.replaceAll(directoryKey, directoryValue);
@@ -1756,7 +1756,7 @@ public class FV1000Reader extends FormatReader {
     RandomAccessInputStream stream = getFile(filename);
     String data = stream.readString((int) stream.length());
     if (!data.startsWith("[")) {
-      data = data.substring(data.indexOf("["), data.length());
+      data = data.substring(data.indexOf('['), data.length());
     }
     data = DataTools.stripString(data);
     BufferedReader reader = new BufferedReader(new StringReader(data));

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -2011,7 +2011,7 @@ public class FlexReader extends FormatReader {
     String[] lines = DataTools.readFile(configFile).split("[\r\n]");
     for (String line : lines) {
       LOGGER.trace(line);
-      int eq = line.indexOf("=");
+      int eq = line.indexOf('=');
       if (eq == -1 || line.startsWith("#")) continue;
       String alias = line.substring(0, eq).trim();
       String[] servers = line.substring(eq + 1).trim().split(";");

--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -310,7 +310,7 @@ public class FluoviewReader extends BaseTiffReader {
       }
       else if (name.equals("event")) {
         m.sizeZ *= size;
-        if (dimensionOrder.indexOf("Z") == -1) {
+        if (dimensionOrder.indexOf('Z') == -1) {
           dimensionOrder += "Z";
         }
         if (Double.compare(voxelZ, 1) == 0) {
@@ -319,7 +319,7 @@ public class FluoviewReader extends BaseTiffReader {
       }
       else if (name.equals("z")) {
         m.sizeZ *= size;
-        if (dimensionOrder.indexOf("Z") == -1) {
+        if (dimensionOrder.indexOf('Z') == -1) {
           dimensionOrder += "Z";
         }
         
@@ -350,7 +350,7 @@ public class FluoviewReader extends BaseTiffReader {
       }
       else if (name.equals("ch") || name.equals("wavelength")) {
         m.sizeC *= size;
-        if (dimensionOrder.indexOf("C") == -1) {
+        if (dimensionOrder.indexOf('C') == -1) {
           dimensionOrder += "C";
         }
         voxelC = voxel;
@@ -359,14 +359,14 @@ public class FluoviewReader extends BaseTiffReader {
         name.equals("animation"))
       {
         m.sizeT *= size;
-        if (dimensionOrder.indexOf("T") == -1) {
+        if (dimensionOrder.indexOf('T') == -1) {
           dimensionOrder += "T";
         }
         voxelT = voxel;
         timeIndex = i - 2;
       }
       else {
-        if (dimensionOrder.indexOf("S") == -1) dimensionOrder += "S";
+        if (dimensionOrder.indexOf('S') == -1) dimensionOrder += "S";
         seriesCount *= size;
 
         if (name.equals("montage")) montageIndex = i - 2;
@@ -374,10 +374,10 @@ public class FluoviewReader extends BaseTiffReader {
       }
     }
 
-    if (dimensionOrder.indexOf("Z") == -1) dimensionOrder += "Z";
-    if (dimensionOrder.indexOf("T") == -1) dimensionOrder += "T";
-    if (dimensionOrder.indexOf("C") == -1) dimensionOrder += "C";
-    if (dimensionOrder.indexOf("S") == -1) dimensionOrder += "S";
+    if (dimensionOrder.indexOf('Z') == -1) dimensionOrder += "Z";
+    if (dimensionOrder.indexOf('T') == -1) dimensionOrder += "T";
+    if (dimensionOrder.indexOf('C') == -1) dimensionOrder += "C";
+    if (dimensionOrder.indexOf('S') == -1) dimensionOrder += "S";
 
     m.imageCount = ifds.size() / seriesCount;
     if (getSizeZ() > getImageCount()) m.sizeZ = getImageCount();
@@ -755,7 +755,7 @@ public class FluoviewReader extends BaseTiffReader {
       String[] lines = comment.split("\n");
       for (String token : lines) {
         token = token.trim();
-        int eq = token.indexOf("=");
+        int eq = token.indexOf('=');
         if (eq != -1) {
           String key = token.substring(0, eq);
           String value = token.substring(eq + 1);
@@ -829,9 +829,9 @@ public class FluoviewReader extends BaseTiffReader {
         }
         else if (token.startsWith("Z") && token.indexOf(" um ") != -1) {
           // looking for "Z - x um in y planes"
-          String z = token.substring(token.indexOf("-") + 1);
+          String z = token.substring(token.indexOf('-') + 1);
           z = z.replaceAll("\\p{Alpha}", "").trim();
-          int firstSpace = z.indexOf(" ");
+          int firstSpace = z.indexOf(' ');
           double size = Double.parseDouble(z.substring(0, firstSpace));
           double nPlanes = Double.parseDouble(z.substring(firstSpace).trim());
           voxelZ = size / nPlanes;
@@ -859,7 +859,7 @@ public class FluoviewReader extends BaseTiffReader {
       int end = comment.indexOf("[Version Info End]");
       if (start != -1 && end != -1 && end > start) {
         comment = comment.substring(start + 14, end).trim();
-        start = comment.indexOf("=") + 1;
+        start = comment.indexOf('=') + 1;
         end = comment.indexOf("\n");
         if (end > start) comment = comment.substring(start, end).trim();
         else comment = comment.substring(start).trim();

--- a/components/formats-gpl/src/loci/formats/in/INRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/INRReader.java
@@ -105,7 +105,7 @@ public class INRReader extends FormatReader {
     CoreMetadata m = core.get(0);
 
     for (String line : lines) {
-      int index = line.indexOf("=");
+      int index = line.indexOf('=');
       if (index >= 0) {
         String key = line.substring(0, index);
         String value = line.substring(index + 1);
@@ -128,7 +128,7 @@ public class INRReader extends FormatReader {
           isSigned = value.toLowerCase().startsWith("signed");
         }
         else if (key.equals("PIXSIZE")) {
-          String bits = value.substring(0, value.indexOf(" "));
+          String bits = value.substring(0, value.indexOf(' '));
           nBits = Integer.parseInt(bits);
         }
         else if (key.equals("VX")) {

--- a/components/formats-gpl/src/loci/formats/in/IPWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IPWReader.java
@@ -244,9 +244,9 @@ public class IPWReader extends FormatReader {
           for (String token : tokens) {
             String label = "Timestamp";
             String data = token.trim();
-            if (token.indexOf("=") != -1) {
-              label = token.substring(0, token.indexOf("=")).trim();
-              data = token.substring(token.indexOf("=") + 1).trim();
+            if (token.indexOf('=') != -1) {
+              label = token.substring(0, token.indexOf('=')).trim();
+              data = token.substring(token.indexOf('=') + 1).trim();
             }
             addGlobalMeta(label, data);
             if (label.equals("frames")) m.sizeT = Integer.parseInt(data);

--- a/components/formats-gpl/src/loci/formats/in/ImaconReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImaconReader.java
@@ -150,7 +150,7 @@ public class ImaconReader extends BaseTiffReader {
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       String xml = firstIFD.getIFDTextValue(XML_TAG).trim();
-      xml = xml.substring(xml.indexOf("<"));
+      xml = xml.substring(xml.indexOf('<'));
       XMLTools.parseXML(xml, new ImaconHandler());
     }
 
@@ -198,7 +198,7 @@ public class ImaconReader extends BaseTiffReader {
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       if (experimenterName == null) experimenterName = "";
 
-      int nameSpace = experimenterName.indexOf(" ");
+      int nameSpace = experimenterName.indexOf(' ');
       String firstName =
         nameSpace == -1 ? "" : experimenterName.substring(0, nameSpace);
       String lastName = nameSpace == -1 ? experimenterName :

--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -168,7 +168,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
     if (comment != null) {
       String[] lines = comment.split("\n");
       for (String line : lines) {
-        int equals = line.indexOf("=");
+        int equals = line.indexOf('=');
         if (equals < 0) continue;
         String key = line.substring(0, equals);
         String value = line.substring(equals + 1);
@@ -222,7 +222,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
       String channelName = null;
       String[] lines = comment.split("\n");
       for (String line : lines) {
-        int equals = line.indexOf("=");
+        int equals = line.indexOf('=');
         if (equals < 0) continue;
         String key = line.substring(0, equals);
         String value = line.substring(equals + 1);
@@ -313,21 +313,21 @@ public class ImprovisionTiffReader extends BaseTiffReader {
       int cDiff = coords[i][1] - coords[i - 1][1];
       int tDiff = coords[i][2] - coords[i - 1][2];
 
-      if (zDiff > 0 && getDimensionOrder().indexOf("Z") < 0) {
+      if (zDiff > 0 && getDimensionOrder().indexOf('Z') < 0) {
         m.dimensionOrder += "Z";
       }
-      if (cDiff > 0 && getDimensionOrder().indexOf("C") < 0) {
+      if (cDiff > 0 && getDimensionOrder().indexOf('C') < 0) {
         m.dimensionOrder += "C";
       }
-      if (tDiff > 0 && getDimensionOrder().indexOf("T") < 0) {
+      if (tDiff > 0 && getDimensionOrder().indexOf('T') < 0) {
         m.dimensionOrder += "T";
       }
       if (m.dimensionOrder.length() == 5) break;
     }
 
-    if (getDimensionOrder().indexOf("Z") < 0) m.dimensionOrder += "Z";
-    if (getDimensionOrder().indexOf("C") < 0) m.dimensionOrder += "C";
-    if (getDimensionOrder().indexOf("T") < 0) m.dimensionOrder += "T";
+    if (getDimensionOrder().indexOf('Z') < 0) m.dimensionOrder += "Z";
+    if (getDimensionOrder().indexOf('C') < 0) m.dimensionOrder += "C";
+    if (getDimensionOrder().indexOf('T') < 0) m.dimensionOrder += "T";
   }
 
   /* @see BaseTiffReader#initMetadataStore() */
@@ -375,7 +375,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
     for (String line : lines) {
       line = line.trim();
       if (line.startsWith("SampleUUID=")) {
-        return line.substring(line.indexOf("=") + 1).trim();
+        return line.substring(line.indexOf('=') + 1).trim();
       }
     }
     return "";

--- a/components/formats-gpl/src/loci/formats/in/InveonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InveonReader.java
@@ -163,7 +163,7 @@ public class InveonReader extends FormatReader {
       line = line.trim();
 
       if (!line.startsWith("#")) {
-        int space = line.indexOf(" ");
+        int space = line.indexOf(' ');
         if (space < 0) {
           continue;
         }
@@ -248,13 +248,13 @@ public class InveonReader extends FormatReader {
           key.equals("ct_projection_center_offset") ||
           key.equals("ct_projection_horizontal_bed_offset"))
         {
-          space = value.indexOf(" ");
+          space = value.indexOf(' ');
           int index = Integer.parseInt(value.substring(0, space));
           value = value.substring(space + 1);
           key += " " + index;
         }
         else if (key.equals("user")) {
-          space = value.indexOf(" ");
+          space = value.indexOf(' ');
           key = value.substring(0, space);
           value = value.substring(space + 1);
         }
@@ -628,7 +628,7 @@ public class InveonReader extends FormatReader {
   }
 
   private String transformFilter(String value) {
-    int space = value.indexOf(" ");
+    int space = value.indexOf(' ');
     int filter = Integer.parseInt(value.substring(0, space));
     String cutoff = " (cutoff = " + value.substring(space + 1) + ")";
 

--- a/components/formats-gpl/src/loci/formats/in/IvisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IvisionReader.java
@@ -94,7 +94,7 @@ public class IvisionReader extends FormatReader {
     String version = stream.readString(3);
     try {
       Double.parseDouble(version);
-      return version.indexOf(".") != -1 && version.indexOf("-") == -1;
+      return version.indexOf('.') != -1 && version.indexOf('-') == -1;
     }
     catch (NumberFormatException e) { }
     return false;
@@ -248,7 +248,7 @@ public class IvisionReader extends FormatReader {
         in.seek(in.getFilePointer() - 5);
 
         String xml = in.readString((int) (in.length() - in.getFilePointer()));
-        xml = xml.substring(xml.indexOf("<"), xml.lastIndexOf("plist>") + 6);
+        xml = xml.substring(xml.indexOf('<'), xml.lastIndexOf("plist>") + 6);
         IvisionHandler handler = new IvisionHandler();
         try {
           XMLTools.parseXML(xml, handler);

--- a/components/formats-gpl/src/loci/formats/in/OxfordInstrumentsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OxfordInstrumentsReader.java
@@ -148,9 +148,9 @@ public class OxfordInstrumentsReader extends FormatReader {
       for (int i=0; i<nMetadataStrings; i++) {
         int length = in.readInt();
         String s = in.readString(length);
-        if (s.indexOf(":") != -1) {
-          String key = s.substring(0, s.indexOf(":")).trim();
-          String value = s.substring(s.indexOf(":") + 1).trim();
+        if (s.indexOf(':') != -1) {
+          String key = s.substring(0, s.indexOf(':')).trim();
+          String value = s.substring(s.indexOf(':') + 1).trim();
           if (!value.equals("-")) {
             addGlobalMeta(key, value);
           }

--- a/components/formats-gpl/src/loci/formats/in/SBIGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SBIGReader.java
@@ -146,7 +146,7 @@ public class SBIGReader extends FormatReader {
     String[] lines = DataTools.readFile(currentId).split("\n");
     for (String line : lines) {
       line = line.trim();
-      int eq = line.indexOf("=");
+      int eq = line.indexOf('=');
       if (eq != -1) {
         String key = line.substring(0, eq).trim();
         String value = line.substring(eq + 1).trim();

--- a/components/formats-gpl/src/loci/formats/in/SDTInfo.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTInfo.java
@@ -490,9 +490,9 @@ public class SDTInfo {
     String key = null, value = null;
     for (int i=1; i<count-1; i++) {
       String token = st.nextToken().trim();
-      if (token.indexOf(":") == -1) continue;
-      key = token.substring(0, token.indexOf(":")).trim();
-      value = token.substring(token.indexOf(":") + 1).trim();
+      if (token.indexOf(':') == -1) continue;
+      key = token.substring(0, token.indexOf(':')).trim();
+      value = token.substring(token.indexOf(':') + 1).trim();
       meta.put(key, value);
     }
 
@@ -520,13 +520,13 @@ public class SDTInfo {
       if (token.startsWith("#SP") || token.startsWith("#DI") ||
         token.startsWith("#PR") || token.startsWith("#MP"))
       {
-        int open = token.indexOf("[");
+        int open = token.indexOf('[');
         key = token.substring(open + 1, token.indexOf(",", open));
         value = token.substring(token.lastIndexOf(",") + 1, token.length() - 1);
       }
       else if (token.startsWith("#TR") || token.startsWith("#WI")) {
-        key = token.substring(0, token.indexOf("[")).trim();
-        value = token.substring(token.indexOf("[") + 1, token.indexOf("]"));
+        key = token.substring(0, token.indexOf('[')).trim();
+        value = token.substring(token.indexOf('[') + 1, token.indexOf(']'));
       }
 
       if (key != null && value != null) meta.put(key, value);

--- a/components/formats-gpl/src/loci/formats/in/SEQReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SEQReader.java
@@ -133,8 +133,8 @@ public class SEQReader extends BaseTiffReader {
       String[] lines = descr.split("\n");
       for (String token : lines) {
         token = token.trim();
-        int eq = token.indexOf("=");
-        if (eq == -1) eq = token.indexOf(":");
+        int eq = token.indexOf('=');
+        if (eq == -1) eq = token.indexOf(':');
         if (eq != -1) {
           String label = token.substring(0, eq);
           String data = token.substring(eq + 1);

--- a/components/formats-gpl/src/loci/formats/in/SPCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SPCReader.java
@@ -773,9 +773,9 @@ public class SPCReader extends FormatReader {
     
     int tagOffset = setup.indexOf(tag);
     String taggedString = setup.substring(tagOffset, tagOffset + 30);
-    tagOffset = taggedString.indexOf(",");
+    tagOffset = taggedString.indexOf(',');
     String tagType = taggedString.substring(tagOffset + 1, tagOffset + 2);
-    String valueTxt = taggedString.substring(tagOffset + 3, taggedString.indexOf("]"));
+    String valueTxt = taggedString.substring(tagOffset + 3, taggedString.indexOf(']'));
     double value = 0.0;
     if (tagType.matches("I")) {
       value = Integer.parseInt(valueTxt);

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -281,13 +281,13 @@ public class SVSReader extends BaseTiffReader {
         for (String line : lines) {
           tokens = line.split("[|]");
           for (String t : tokens) {
-            if (t.indexOf("=") == -1) {
+            if (t.indexOf('=') == -1) {
               addGlobalMeta("Comment", t);
               comments[i] = t;
             }
             else {
-              key = t.substring(0, t.indexOf("=")).trim();
-              value = t.substring(t.indexOf("=") + 1).trim();
+              key = t.substring(0, t.indexOf('=')).trim();
+              value = t.substring(t.indexOf('=') + 1).trim();
               addSeriesMeta(key, value);
               if (key.equals("MPP")) {
                 pixelSize[i] = FormatTools.getPhysicalSizeX(DataTools.parseDouble(value));

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -487,8 +487,8 @@ public class ScreenReader extends FormatReader {
   private String getRow(String well) {
     String wellName = well.substring(well.lastIndexOf(File.separator) + 1);
     char firstChar = Character.toUpperCase(wellName.charAt(0));
-    while (wellName.indexOf("_") > 0 && (firstChar < 'A' || firstChar > 'P')) {
-      wellName = wellName.substring(wellName.indexOf("_") + 1);
+    while (wellName.indexOf('_') > 0 && (firstChar < 'A' || firstChar > 'P')) {
+      wellName = wellName.substring(wellName.indexOf('_') + 1);
       firstChar = Character.toUpperCase(wellName.charAt(0));
     }
     return wellName.substring(0, 1).toUpperCase();
@@ -497,8 +497,8 @@ public class ScreenReader extends FormatReader {
   private String getColumn(String well) {
     String wellName = well.substring(well.lastIndexOf(File.separator) + 1);
     char firstChar = Character.toUpperCase(wellName.charAt(0));
-    while (wellName.indexOf("_") > 0 && (firstChar < 'A' || firstChar > 'P')) {
-      wellName = wellName.substring(wellName.indexOf("_") + 1);
+    while (wellName.indexOf('_') > 0 && (firstChar < 'A' || firstChar > 'P')) {
+      wellName = wellName.substring(wellName.indexOf('_') + 1);
       firstChar = Character.toUpperCase(wellName.charAt(0));
     }
     int end = wellName.lastIndexOf("_");

--- a/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SimplePCITiffReader.java
@@ -163,7 +163,7 @@ public class SimplePCITiffReader extends BaseTiffReader {
     IniTable microscopeTable = ini.getTable(" MICROSCOPE ");
     if (microscopeTable != null) {
       String objective = microscopeTable.get("Objective");
-      int space = objective.indexOf(" ");
+      int space = objective.indexOf(' ');
       if (space != -1) {
         magnification = new Double(objective.substring(0, space - 1));
         immersion = objective.substring(space + 1);

--- a/components/formats-gpl/src/loci/formats/in/SlidebookTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SlidebookTiffReader.java
@@ -226,11 +226,11 @@ public class SlidebookTiffReader extends BaseTiffReader {
         if (c < channelNames.size()) {
           String name = channelNames.get(c);
           if (name != null) {
-            if (name.indexOf(":") > 0) {
-              name = name.substring(name.indexOf(":") + 1);
+            if (name.indexOf(':') > 0) {
+              name = name.substring(name.indexOf(':') + 1);
             }
-            if (name.indexOf(";") > 0) {
-              name = name.substring(0, name.indexOf(";"));
+            if (name.indexOf(';') > 0) {
+              name = name.substring(0, name.indexOf(';'));
             }
 
             store.setChannelName(name.trim(), 0, c);


### PR DESCRIPTION
Inspired by https://github.com/openmicroscopy/bioformats/pull/2528#discussion_r76218340 -

> this is really just about switching to calling a method that can assume searching for a single character instead of having to care about search string length

this is a mechanical change so that a simpler library method can be used in our GPL reader code. It may not make much difference but sets a good example for others writing further code based on our existing code. https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/ suffices for testing.