### PR TITLE
switch to String.indexOf(int) in various GPL-licensed readers (part three)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -211,8 +211,8 @@ public class AFIReader extends FormatReader {
     for (int i=0; i<pixels.size(); i++) {
       String file = pixels.get(i);
 
-      int underscore = file.indexOf("_");
-      int fullStop = file.indexOf(".");
+      int underscore = file.indexOf('_');
+      int fullStop = file.indexOf('.');
       if (underscore >= 0 && fullStop > underscore) {
         channelNames[i] = file.substring(underscore + 1, fullStop);
       }

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -114,7 +114,7 @@ public class CellWorxReader extends FormatReader {
     Location parent = current.getParentFile();
 
     String htdName = current.getName();
-    while (htdName.indexOf("_") > 0) {
+    while (htdName.indexOf('_') > 0) {
       htdName = htdName.substring(0, htdName.lastIndexOf("_"));
       if (new Location(parent, htdName + ".htd").exists() ||
         new Location(parent, htdName + ".HTD").exists())
@@ -360,13 +360,13 @@ public class CellWorxReader extends FormatReader {
       String[] f = DataTools.readFile(plateLogFile).split("\n");
       for (String line : f) {
         if (line.trim().startsWith("Z Map File")) {
-          String file = line.substring(line.indexOf(":") + 1);
+          String file = line.substring(line.indexOf(':') + 1);
           file = file.substring(file.lastIndexOf("/") + 1).trim();
           String parent = new Location(id).getAbsoluteFile().getParent();
           zMapFile = new Location(parent, file).getAbsolutePath();
         }
         else if (line.trim().startsWith("Scanner SN")) {
-          serialNumber = line.substring(line.indexOf(":") + 1).trim();
+          serialNumber = line.substring(line.indexOf(':') + 1).trim();
         }
       }
     }
@@ -585,7 +585,7 @@ public class CellWorxReader extends FormatReader {
     String[] lines = data.split("\n");
     for (String line : lines) {
       line = line.trim();
-      int separator = line.indexOf(":");
+      int separator = line.indexOf(':');
       if (separator < 0) continue;
       String key = line.substring(0, separator).trim();
       String value = line.substring(separator + 1).trim();
@@ -623,7 +623,7 @@ public class CellWorxReader extends FormatReader {
         }
       }
       else if (key.equals("Scan Area")) {
-        int s = value.indexOf("x");
+        int s = value.indexOf('x');
         if (s > 0) {
           int end = value.indexOf(" ", s + 2);
           Double xSize = new Double(value.substring(0, s).trim());
@@ -644,7 +644,7 @@ public class CellWorxReader extends FormatReader {
         }
       }
       else if (key.startsWith("Channel")) {
-        int start = key.indexOf(" ") + 1;
+        int start = key.indexOf(' ') + 1;
         int end = key.indexOf(" ", start);
         if (end < 0) end = key.length();
         int index = Integer.parseInt(key.substring(start, end)) - 1;
@@ -668,16 +668,16 @@ public class CellWorxReader extends FormatReader {
             }
           }
           else if (token.startsWith("EX")) {
-            int slash = token.indexOf("/");
+            int slash = token.indexOf('/');
             if (slash > 0) {
               String ex = token.substring(0, slash).trim();
               String em = token.substring(slash + 1).trim();
 
-              if (ex.indexOf(" ") > 0) ex = ex.substring(ex.indexOf(" ") + 1);
-              if (em.indexOf(" ") > 0) {
-                em = em.substring(em.indexOf(" ") + 1);
-                if (em.indexOf(" ") > 0) {
-                  em = em.substring(0, em.indexOf(" "));
+              if (ex.indexOf(' ') > 0) ex = ex.substring(ex.indexOf(' ') + 1);
+              if (em.indexOf(' ') > 0) {
+                em = em.substring(em.indexOf(' ') + 1);
+                if (em.indexOf(' ') > 0) {
+                  em = em.substring(0, em.indexOf(' '));
                 }
               }
 

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -358,8 +358,8 @@ public class DeltavisionReader extends FormatReader {
           m.imageCount = sizeZ * sizeC;
         }
       }
-      else if (getDimensionOrder().indexOf("Z") <
-        getDimensionOrder().indexOf("T"))
+      else if (getDimensionOrder().indexOf('Z') <
+        getDimensionOrder().indexOf('T'))
       {
         sizeZ = realPlaneCount / (sizeC * sizeT);
         if (sizeZ == 0) {
@@ -982,7 +982,7 @@ public class DeltavisionReader extends FormatReader {
     List<Double> filters = new ArrayList<Double>();
 
     for (String line : lines) {
-      int colon = line.indexOf(":");
+      int colon = line.indexOf(':');
       if (colon != -1 && !line.startsWith("Created")) {
         key = line.substring(0, colon).trim();
 
@@ -993,7 +993,7 @@ public class DeltavisionReader extends FormatReader {
         // Objective properties
         if (key.equals("Objective")) {
           // assume first word is the manufacturer's name
-          int space = value.indexOf(" ");
+          int space = value.indexOf(' ');
           if (space != -1) {
             String manufacturer = value.substring(0, space);
             String extra = value.substring(space + 1);
@@ -1005,9 +1005,9 @@ public class DeltavisionReader extends FormatReader {
             String magnification = "", na = "";
 
             if (tokens.length >= 1) {
-              int end = tokens[0].indexOf("X");
+              int end = tokens[0].indexOf('X');
               if (end > 0) magnification = tokens[0].substring(0, end);
-              int start = tokens[0].indexOf("/");
+              int start = tokens[0].indexOf('/');
               if (start >= 0) na = tokens[0].substring(start + 1);
             }
 
@@ -1032,11 +1032,11 @@ public class DeltavisionReader extends FormatReader {
           }
         }
         else if (key.equalsIgnoreCase("Lens ID")) {
-          if (value.indexOf(",") != -1) {
-            value = value.substring(0, value.indexOf(","));
+          if (value.indexOf(',') != -1) {
+            value = value.substring(0, value.indexOf(','));
           }
-          if (value.indexOf(" ") != -1) {
-            value = value.substring(value.indexOf(" ") + 1);
+          if (value.indexOf(' ') != -1) {
+            value = value.substring(value.indexOf(' ') + 1);
           }
           if (!value.equals("null")) {
             String objectiveID = "Objective:" + value;
@@ -1340,7 +1340,7 @@ public class DeltavisionReader extends FormatReader {
         }
       }
 
-      if (line.length() > 0 && line.indexOf(".") == -1) previousLine = line;
+      if (line.length() > 0 && line.indexOf('.') == -1) previousLine = line;
 
       doStatistics = line.endsWith("- reading image data...");
     }

--- a/components/formats-gpl/src/loci/formats/in/HISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HISReader.java
@@ -187,7 +187,7 @@ public class HISReader extends FormatReader {
       if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
         String[] data = comment.split(";");
         for (String token : data) {
-          int eq = token.indexOf("=");
+          int eq = token.indexOf('=');
           if (eq != -1) {
             String key = token.substring(0, eq);
             String value = token.substring(eq + 1);

--- a/components/formats-gpl/src/loci/formats/in/HRDGDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HRDGDFReader.java
@@ -129,7 +129,7 @@ public class HRDGDFReader extends FormatReader {
 
     // size stored in kilometers
     String pixelSize =
-      data[1].substring(data[1].indexOf(" ") + 1, data[1].lastIndexOf(" "));
+      data[1].substring(data[1].indexOf(' ') + 1, data[1].lastIndexOf(" "));
     Double physicalSize = new Double(pixelSize) * 1000000000.0;
 
     // parse the center coordinates
@@ -145,8 +145,8 @@ public class HRDGDFReader extends FormatReader {
     while (!data[lineNumber++].startsWith("SURFACE WIND COMPONENTS"));
 
     String dims = data[lineNumber++].trim();
-    String x = dims.substring(0, dims.indexOf(" ")).trim();
-    String y = dims.substring(dims.indexOf(" ") + 1).trim();
+    String x = dims.substring(0, dims.indexOf(' ')).trim();
+    String y = dims.substring(dims.indexOf(' ') + 1).trim();
     surfaceWind = new double[2][Integer.parseInt(y) * Integer.parseInt(x)];
 
     int pixIndex = 0;
@@ -154,13 +154,13 @@ public class HRDGDFReader extends FormatReader {
     while (lineNumber < data.length) {
       String line = data[lineNumber++];
 
-      while (line.indexOf("(") != -1) {
-        int end = line.indexOf(")");
+      while (line.indexOf('(') != -1) {
+        int end = line.indexOf(')');
 
-        String pixel = line.substring(line.indexOf("(") + 1, end);
+        String pixel = line.substring(line.indexOf('(') + 1, end);
         line = line.substring(end + 1);
 
-        int comma = pixel.indexOf(",");
+        int comma = pixel.indexOf(',');
 
         surfaceWind[0][pixIndex] = new Double(pixel.substring(0, comma).trim());
         surfaceWind[1][pixIndex] =

--- a/components/formats-gpl/src/loci/formats/in/HitachiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HitachiReader.java
@@ -98,7 +98,7 @@ public class HitachiReader extends FormatReader {
     }
 
     String base = name;
-    if (base.indexOf(".") >= 0) {
+    if (base.indexOf('.') >= 0) {
       base = base.substring(0, base.lastIndexOf("."));
     }
 
@@ -183,7 +183,7 @@ public class HitachiReader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     if (!checkSuffix(id, "txt")) {
       String base = id;
-      if (base.indexOf(".") >= 0) {
+      if (base.indexOf('.') >= 0) {
         base = base.substring(0, base.lastIndexOf("."));
       }
 
@@ -293,7 +293,7 @@ public class HitachiReader extends FormatReader {
     }
 
     if (workingDistance != null) {
-      int end = workingDistance.indexOf(" ");
+      int end = workingDistance.indexOf(' ');
       if (end < 0) end = workingDistance.length();
 
       workingDistance = workingDistance.substring(0, end);

--- a/components/formats-gpl/src/loci/formats/in/KodakReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KodakReader.java
@@ -181,7 +181,7 @@ public class KodakReader extends FormatReader {
     String[] lines = metadata.split("\n");
 
     for (String line : lines) {
-      int index = line.indexOf(":");
+      int index = line.indexOf(':');
       if (index < 0 || line.startsWith("#") || line.startsWith("-")) {
         continue;
       }
@@ -204,15 +204,15 @@ public class KodakReader extends FormatReader {
         }
       }
       else if (key.equals("Exposure Time")) {
-        Double exposureTime = new Double(value.substring(0, value.indexOf(" ")));
+        Double exposureTime = new Double(value.substring(0, value.indexOf(' ')));
         if (exposureTime != null) {
           store.setPlaneExposureTime(new Time(exposureTime, UNITS.SECOND), 0, 0);
         }
       }
       else if (key.equals("Vertical Resolution")) {
         // resolution stored in pixels per inch
-        if (value.indexOf(" ") > 0) {
-          value = value.substring(0, value.indexOf(" "));
+        if (value.indexOf(' ') > 0) {
+          value = value.substring(0, value.indexOf(' '));
         }
         Double size = new Double(value);
         size = 1.0 / (size * (1.0 / 25400));
@@ -224,8 +224,8 @@ public class KodakReader extends FormatReader {
       }
       else if (key.equals("Horizontal Resolution")) {
         // resolution stored in pixels per inch
-        if (value.indexOf(" ") > 0) {
-          value = value.substring(0, value.indexOf(" "));
+        if (value.indexOf(' ') > 0) {
+          value = value.substring(0, value.indexOf(' '));
         }
         Double size = new Double(value);
         size = 1.0 / (size * (1.0 / 25400));
@@ -244,7 +244,7 @@ public class KodakReader extends FormatReader {
           LOGGER.debug("CCD temperature detected as {}; assumed to be invalid", temp);
         }
         else {
-          temp = new Double(value.substring(0, value.indexOf(" ")));
+          temp = new Double(value.substring(0, value.indexOf(' ')));
           store.setImagingEnvironmentTemperature(
                 new Temperature(temp, UNITS.CELSIUS), 0);
         }

--- a/components/formats-gpl/src/loci/formats/in/L2DReader.java
+++ b/components/formats-gpl/src/loci/formats/in/L2DReader.java
@@ -95,7 +95,7 @@ public class L2DReader extends FormatReader {
     Location parent = location.getAbsoluteFile().getParentFile();
 
     String scanName = location.getName();
-    if (scanName.indexOf("_") >= 0) {
+    if (scanName.indexOf('_') >= 0) {
       scanName = scanName.substring(0, scanName.lastIndexOf("_"));
     }
 
@@ -270,8 +270,8 @@ public class L2DReader extends FormatReader {
       String[] lines = scanData.split("\n");
       for (String line : lines) {
         if (!line.startsWith("#")) {
-          String key = line.substring(0, line.indexOf("="));
-          String value = line.substring(line.indexOf("=") + 1);
+          String key = line.substring(0, line.indexOf('='));
+          String value = line.substring(line.indexOf('=') + 1);
           addSeriesMeta(key, value);
 
           if (key.equals("ExperimentNames")) {
@@ -401,8 +401,8 @@ public class L2DReader extends FormatReader {
     String[] lines = data.split("\n");
     for (String line : lines) {
       if (!line.startsWith("#")) {
-        String key = line.substring(0, line.indexOf("=")).trim();
-        String value = line.substring(line.indexOf("=") + 1).trim();
+        String key = line.substring(0, line.indexOf('=')).trim();
+        String value = line.substring(line.indexOf('=') + 1).trim();
         addGlobalMeta(key, value);
 
         if (key.equals("ScanNames")) {

--- a/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LiFlimReader.java
@@ -333,7 +333,7 @@ public class LiFlimReader extends FormatReader {
             rois.put(index, roi);
           }
           else if (metaKey.equals("ExposureTime")) {
-            int space = value.indexOf(" ");
+            int space = value.indexOf(' ');
             double expTime = Double.parseDouble(value.substring(0, space));
             String units = value.substring(space + 1).toLowerCase();
             if (units.equals("ms")) {

--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -719,13 +719,13 @@ public class MIASReader extends FormatReader {
       ms.falseColor = readers[0][0].isFalseColor();
       ms.dimensionOrder = order[i];
 
-      if (ms.dimensionOrder.indexOf("Z") == -1) {
+      if (ms.dimensionOrder.indexOf('Z') == -1) {
         ms.dimensionOrder += "Z";
       }
-      if (ms.dimensionOrder.indexOf("C") == -1) {
+      if (ms.dimensionOrder.indexOf('C') == -1) {
         ms.dimensionOrder += "C";
       }
-      if (ms.dimensionOrder.indexOf("T") == -1) {
+      if (ms.dimensionOrder.indexOf('T') == -1) {
         ms.dimensionOrder += "T";
       }
 
@@ -850,7 +850,7 @@ public class MIASReader extends FormatReader {
 
       parseTemplateFile(store);
 
-      plateName = plateName.substring(plateName.indexOf("-") + 1);
+      plateName = plateName.substring(plateName.indexOf('-') + 1);
       store.setPlateName(plateName, 0);
       store.setPlateExternalIdentifier(plateName, 0);
 
@@ -984,7 +984,7 @@ public class MIASReader extends FormatReader {
     int[] position = new int[4];
 
     file = file.substring(file.lastIndexOf(File.separator) + 1);
-    String wellIndex = file.substring(4, file.indexOf("_"));
+    String wellIndex = file.substring(4, file.indexOf('_'));
     position[0] = Integer.parseInt(wellIndex) - 1;
 
     int tIndex = file.indexOf("_t") + 2;
@@ -1059,7 +1059,7 @@ public class MIASReader extends FormatReader {
     String[] lines = data.split("\r\n");
 
     for (String line : lines) {
-      int eq = line.indexOf("=");
+      int eq = line.indexOf('=');
       if (eq != -1) {
         String key = line.substring(0, eq);
         String value = line.substring(eq + 1);

--- a/components/formats-gpl/src/loci/formats/in/MolecularImagingReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MolecularImagingReader.java
@@ -112,7 +112,7 @@ public class MolecularImagingReader extends FormatReader {
     for (String line : lines) {
       line = line.trim();
 
-      int space = line.indexOf(" ");
+      int space = line.indexOf(' ');
       if (space != -1) {
         String key = line.substring(0, space).trim();
         String value = line.substring(space + 1).trim();

--- a/components/formats-gpl/src/loci/formats/in/PCIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCIReader.java
@@ -323,15 +323,15 @@ public class PCIReader extends FormatReader {
           String comments = stream.readString((int) stream.length());
           String[] lines = comments.split("\n");
           for (String line : lines) {
-            int eq = line.indexOf("=");
+            int eq = line.indexOf('=');
             if (eq != -1) {
               String key = line.substring(0, eq).trim();
               String value = line.substring(eq + 1).trim();
               addGlobalMeta(key, value);
 
               if (key.equals("factor")) {
-                if (value.indexOf(";") != -1) {
-                  value = value.substring(0, value.indexOf(";"));
+                if (value.indexOf(';') != -1) {
+                  value = value.substring(0, value.indexOf(';'));
                 }
                 scaleFactor = Double.parseDouble(value.trim());
               }

--- a/components/formats-gpl/src/loci/formats/in/PCORAWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PCORAWReader.java
@@ -195,7 +195,7 @@ public class PCORAWReader extends FormatReader {
       String[] lines = DataTools.readFile(paramFile).split("\n");
       for (int i=0; i<lines.length; i++) {
         String line = lines[i];
-        int sep = line.indexOf(":");
+        int sep = line.indexOf(':');
         if (sep < 0) {
           continue;
         }
@@ -208,7 +208,7 @@ public class PCORAWReader extends FormatReader {
         if (key.equals("Exposure / Delay")) {
           // set the exposure time
 
-          String exp = value.substring(0, value.indexOf(" "));
+          String exp = value.substring(0, value.indexOf(' '));
           Double parsedExp = new Double(exp);
           Time exposure = null;
           if (parsedExp != null) {

--- a/components/formats-gpl/src/loci/formats/in/PDSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PDSReader.java
@@ -206,9 +206,9 @@ public class PDSReader extends FormatReader {
     CoreMetadata m = core.get(0);
 
     for (String line : headerData) {
-      int eq = line.indexOf("=");
+      int eq = line.indexOf('=');
       if (eq < 0) continue;
-      int end = line.indexOf("/");
+      int end = line.indexOf('/');
       if (end < 0) end = line.length();
 
       String key = line.substring(0, eq).trim();

--- a/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PerkinElmerReader.java
@@ -128,7 +128,7 @@ public class PerkinElmerReader extends FormatReader {
     }
 
     String ext = name;
-    if (ext.indexOf(".") != -1) ext = ext.substring(ext.lastIndexOf(".") + 1);
+    if (ext.indexOf('.') != -1) ext = ext.substring(ext.lastIndexOf(".") + 1);
     boolean binFile = true;
     try {
       Integer.parseInt(ext, 16);
@@ -142,10 +142,10 @@ public class PerkinElmerReader extends FormatReader {
     String prefix = baseFile.getParent() + File.separator;
 
     String namePrefix = baseFile.getName();
-    if (namePrefix.indexOf(".") != -1) {
+    if (namePrefix.indexOf('.') != -1) {
       namePrefix = namePrefix.substring(0, namePrefix.lastIndexOf("."));
     }
-    if (namePrefix.indexOf("_") != -1 && binFile) {
+    if (namePrefix.indexOf('_') != -1 && binFile) {
       namePrefix = namePrefix.substring(0, namePrefix.lastIndexOf("_"));
     }
     prefix += namePrefix;
@@ -156,7 +156,7 @@ public class PerkinElmerReader extends FormatReader {
     }
     if (!htmlFile.exists()) {
       htmlFile = new Location(prefix + ".HTM");
-      while (!htmlFile.exists() && prefix.indexOf("_") != -1) {
+      while (!htmlFile.exists() && prefix.indexOf('_') != -1) {
         prefix = prefix.substring(0, prefix.lastIndexOf("_"));
         htmlFile = new Location(prefix + ".htm");
         if (!htmlFile.exists()) htmlFile = new Location(prefix + ".HTM");
@@ -476,7 +476,7 @@ public class PerkinElmerReader extends FormatReader {
       String[] tokens = DataTools.readFile(htmFile).split(HTML_REGEX);
 
       for (int j=0; j<tokens.length; j++) {
-        if (tokens[j].indexOf("<") != -1) tokens[j] = "";
+        if (tokens[j].indexOf('<') != -1) tokens[j] = "";
       }
 
       for (int j=0; j<tokens.length-1; j+=2) {

--- a/components/formats-gpl/src/loci/formats/in/PrairieMetadata.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieMetadata.java
@@ -299,7 +299,7 @@ public class PrairieMetadata {
       if (keyElement == null) continue;
       final String key = attr(keyElement, "key");
       final String value = attr(keyElement, "value");
-      final int underscore = key.indexOf("_");
+      final int underscore = key.indexOf('_');
       if (underscore < 0) {
         // single key/value pair
         table.put(key, new ValueItem(value, null));

--- a/components/formats-gpl/src/loci/formats/in/PrairieReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PrairieReader.java
@@ -150,7 +150,7 @@ public class PrairieReader extends FormatReader {
     Location parent = file.getParentFile();
 
     String prefix = file.getName();
-    if (prefix.indexOf(".") != -1) {
+    if (prefix.indexOf('.') != -1) {
       prefix = prefix.substring(0, prefix.lastIndexOf("."));
     }
 
@@ -162,7 +162,7 @@ public class PrairieReader extends FormatReader {
     // check for appropriately named XML file
 
     Location xml = new Location(parent, prefix + ".xml");
-    while (!xml.exists() && prefix.indexOf("_") != -1) {
+    while (!xml.exists() && prefix.indexOf('_') != -1) {
       prefix = prefix.substring(0, prefix.lastIndexOf("_"));
       xml = new Location(parent, prefix + ".xml");
     }

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -114,13 +114,13 @@ public class TCSReader extends FormatReader {
 
     // check that there is no LEI file
     String prefix = name;
-    if (prefix.indexOf(".") != -1) {
+    if (prefix.indexOf('.') != -1) {
       prefix = prefix.substring(0, prefix.lastIndexOf("."));
     }
     Location lei = new Location(prefix + ".lei");
     if (!lei.exists()) {
       lei = new Location(prefix + ".LEI");
-      while (!lei.exists() && prefix.indexOf("_") != -1) {
+      while (!lei.exists() && prefix.indexOf('_') != -1) {
         prefix = prefix.substring(0, prefix.lastIndexOf("_"));
         lei = new Location(prefix + ".lei");
         if (!lei.exists()) lei = new Location(prefix + ".LEI");
@@ -313,13 +313,13 @@ public class TCSReader extends FormatReader {
 
         for (int i=axisTypes.length-1; i>=0; i--) {
           if (axisTypes[i] == AxisGuesser.Z_AXIS) {
-            if (getDimensionOrder().indexOf("Z") == -1) {
+            if (getDimensionOrder().indexOf('Z') == -1) {
               ms0.dimensionOrder += "Z";
             }
             ms0.sizeZ *= count[i];
           }
           else if (axisTypes[i] == AxisGuesser.C_AXIS) {
-            if (getDimensionOrder().indexOf("C") == -1) {
+            if (getDimensionOrder().indexOf('C') == -1) {
               ms0.dimensionOrder += "C";
             }
             ms0.sizeC *= count[i];
@@ -361,24 +361,24 @@ public class TCSReader extends FormatReader {
       }
       if (unique) {
         ms0.sizeT++;
-        if (getDimensionOrder().indexOf("T") < 0) {
+        if (getDimensionOrder().indexOf('T') < 0) {
           ms0.dimensionOrder += "T";
         }
       }
       else if (i > 0) {
-        if ((ch[i] != ch[i - 1]) && getDimensionOrder().indexOf("C") < 0) {
+        if ((ch[i] != ch[i - 1]) && getDimensionOrder().indexOf('C') < 0) {
           ms0.dimensionOrder += "C";
         }
-        else if (getDimensionOrder().indexOf("Z") < 0) {
+        else if (getDimensionOrder().indexOf('Z') < 0) {
           ms0.dimensionOrder += "Z";
         }
       }
       unique = true;
     }
 
-    if (getDimensionOrder().indexOf("Z") < 0) ms0.dimensionOrder += "Z";
-    if (getDimensionOrder().indexOf("C") < 0) ms0.dimensionOrder += "C";
-    if (getDimensionOrder().indexOf("T") < 0) ms0.dimensionOrder += "T";
+    if (getDimensionOrder().indexOf('Z') < 0) ms0.dimensionOrder += "Z";
+    if (getDimensionOrder().indexOf('C') < 0) ms0.dimensionOrder += "C";
+    if (getDimensionOrder().indexOf('T') < 0) ms0.dimensionOrder += "T";
 
     if (getSizeC() == 0) ms0.sizeC = 1;
     if (getSizeT() == 0) ms0.sizeT = 1;
@@ -398,7 +398,7 @@ public class TCSReader extends FormatReader {
       String[] lines = comment.split("\n");
       for (String line : lines) {
         if (!line.startsWith("[")) {
-          int eq = line.indexOf("=");
+          int eq = line.indexOf('=');
           if (eq < 0) continue;
           String key = line.substring(0, eq).trim();
           String value = line.substring(eq + 1).trim();

--- a/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
@@ -111,7 +111,7 @@ public class TillVisionReader extends FormatReader {
       return true;
     }
     String pstFile = name;
-    if (name.indexOf(".") != -1) {
+    if (name.indexOf('.') != -1) {
       pstFile = pstFile.substring(0, pstFile.lastIndexOf("."));
     }
     pstFile += ".pst";
@@ -369,7 +369,7 @@ public class TillVisionReader extends FormatReader {
           String[] lines = description.split("[\r\n]");
           for (String line : lines) {
             line = line.trim();
-            int colon = line.indexOf(":");
+            int colon = line.indexOf(':');
             if (colon != -1 && !line.startsWith(";")) {
               String key = line.substring(0, colon).trim();
               String value = line.substring(colon + 1).trim();

--- a/components/formats-gpl/src/loci/formats/in/TrestleReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TrestleReader.java
@@ -219,7 +219,7 @@ public class TrestleReader extends BaseTiffReader {
     String comment = ifds.get(0).getComment();
     String[] values = comment.split(";");
     for (String v : values) {
-      int eq = v.indexOf("=");
+      int eq = v.indexOf('=');
       if (eq < 0) continue;
       String key = v.substring(0, eq).trim();
       String value = v.substring(eq + 1).trim();
@@ -284,8 +284,8 @@ public class TrestleReader extends BaseTiffReader {
     Location baseFile = new Location(currentId).getAbsoluteFile();
     Location parent = baseFile.getParentFile();
     String name = baseFile.getName();
-    if (name.indexOf(".") >= 0) {
-      name = name.substring(0, name.indexOf(".") + 1);
+    if (name.indexOf('.') >= 0) {
+      name = name.substring(0, name.indexOf('.') + 1);
     }
 
     roiFile = new Location(parent, name + "ROI").getAbsolutePath();

--- a/components/formats-gpl/src/loci/formats/in/UnisokuReader.java
+++ b/components/formats-gpl/src/loci/formats/in/UnisokuReader.java
@@ -75,7 +75,7 @@ public class UnisokuReader extends FormatReader {
       return super.isThisType(name, open);
     }
 
-    if (name.indexOf(".") < 0) {
+    if (name.indexOf('.') < 0) {
       return false;
     }
 
@@ -180,7 +180,7 @@ public class UnisokuReader extends FormatReader {
           date = DateTools.formatDate(value, "MM/dd/yy HH:mm:ss");
         }
         else if (key.startsWith(":ascii flag; data type")) {
-          value = value.substring(value.indexOf(" ") + 1);
+          value = value.substring(value.indexOf(' ') + 1);
           int type = Integer.parseInt(value);
           boolean signed = type % 2 == 1;
           int bytes = type / 2;

--- a/components/formats-gpl/src/loci/formats/in/VarianFDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VarianFDFReader.java
@@ -215,11 +215,11 @@ public class VarianFDFReader extends FormatReader {
       if (line.length() == 0) break;
       if (line.startsWith("#")) continue;
 
-      int space = line.indexOf(" ");
-      int eq = line.indexOf("=");
+      int space = line.indexOf(' ');
+      int eq = line.indexOf('=');
       String type = line.substring(0, space).trim();
       String var = line.substring(space, eq).trim();
-      String value = line.substring(eq + 1, line.indexOf(";")).trim();
+      String value = line.substring(eq + 1, line.indexOf(';')).trim();
 
       if (var.equals("*storage")) {
         storedFloats = value.equals("\"float\"");

--- a/components/formats-gpl/src/loci/formats/in/VisitechReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VisitechReader.java
@@ -92,7 +92,7 @@ public class VisitechReader extends FormatReader {
     if (checkSuffix(name, "xys")) return true;
 
     // verify that there is an .xys file in the same directory
-    if (name.indexOf(" ") == -1) return false;
+    if (name.indexOf(' ') == -1) return false;
     if (!open) return false;
     String prefix = name.substring(0, name.lastIndexOf(" "));
     Location xys = new Location(prefix + " 1.xys");
@@ -209,7 +209,7 @@ public class VisitechReader extends FormatReader {
         token.indexOf("pixels") != -1)
       {
         token = token.replaceAll("<.*?>", "");
-        int ndx = token.indexOf(":");
+        int ndx = token.indexOf(':');
 
         if (ndx != -1) {
           key = token.substring(0, ndx).trim();
@@ -226,7 +226,7 @@ public class VisitechReader extends FormatReader {
               FormatTools.pixelTypeFromBytes(bits, false, false);
           }
           else if (key.equals("Image dimensions")) {
-            int n = value.indexOf(",");
+            int n = value.indexOf(',');
             ms0.sizeX = Integer.parseInt(value.substring(1, n).trim());
             ms0.sizeY = Integer.parseInt(value.substring(n + 1,
               value.length() - 1).trim());
@@ -243,10 +243,10 @@ public class VisitechReader extends FormatReader {
         if (token.indexOf("pixels") != -1) {
           ms0.sizeC++;
           ms0.imageCount +=
-            Integer.parseInt(token.substring(0, token.indexOf(" ")));
+            Integer.parseInt(token.substring(0, token.indexOf(' ')));
         }
         else if (token.startsWith("Time Series")) {
-          int idx = token.indexOf(";") + 1;
+          int idx = token.indexOf(';') + 1;
           String ss = token.substring(idx, token.indexOf(" ", idx)).trim();
           ms0.sizeT = Integer.parseInt(ss);
         }


### PR DESCRIPTION
Inspired by https://github.com/openmicroscopy/bioformats/pull/2528#discussion_r76218340 -

> this is really just about switching to calling a method that can assume searching for a single character instead of having to care about search string length

this is a mechanical change so that a simpler library method can be used in our GPL reader code. It may not make much difference but sets a good example for others writing further code based on our existing code. https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-full-repository/ suffices for testing.