### PR TITLE
FormatReaderTestFactory: list files as returned by getCurrentFile

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Arrays;
 
 import loci.common.DataTools;
@@ -202,14 +202,14 @@ public class FormatReaderTestFactory {
     }
 
     // remove duplicates
-    Set<String> fileSet = new HashSet<String>(files);
-    Set<String> minimalFiles = new HashSet<String>();
+    Set<String> fileSet = new LinkedHashSet<String>(files);
+    Set<String> minimalFiles = new LinkedHashSet<String>();
     FileStitcher reader = new FileStitcher();
     while (!fileSet.isEmpty()) {
       String file = fileSet.iterator().next();
       try {
         reader.setId(file);
-        Set<String> auxFiles = new HashSet<String>(
+        Set<String> auxFiles = new LinkedHashSet<String>(
             Arrays.asList(reader.getUsedFiles())
         );
         fileSet.removeAll(auxFiles);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -29,6 +29,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import loci.common.DataTools;
 import loci.formats.FileStitcher;
@@ -70,7 +73,7 @@ public class FormatReaderTestFactory {
 
   @Factory
   public Object[] createInstances() {
-    List files = new ArrayList();
+    List<String> files = new ArrayList<String>();
 
     // parse explicit filename, if any
     final String nameProp = "testng.filename";
@@ -199,19 +202,18 @@ public class FormatReaderTestFactory {
     }
 
     // remove duplicates
-    int index = 0;
+    Set<String> minimalFiles = new HashSet<String>();
     FileStitcher reader = new FileStitcher();
-    while (index < files.size()) {
-      String file = (String) files.get(index);
+    for (String file: files) {
       try {
         reader.setId(file);
-        String[] usedFiles = reader.getUsedFiles();
-        for (int q=0; q<usedFiles.length; q++) {
-          if (files.indexOf(usedFiles[q]) > index) {
-            files.remove(usedFiles[q]);
-          }
-        }
-        files.set(index, reader.getCurrentFile());
+        Set<String> auxFiles = new HashSet<String>(
+            Arrays.asList(reader.getUsedFiles())
+        );
+        String masterFile = reader.getCurrentFile();
+        auxFiles.remove(masterFile);
+        minimalFiles.removeAll(auxFiles);
+        minimalFiles.add(masterFile);
       }
       catch (Exception e) { }
       finally {
@@ -220,9 +222,8 @@ public class FormatReaderTestFactory {
         }
         catch (IOException e) { }
       }
-
-      index++;
     }
+    files = new ArrayList(minimalFiles);
 
     // create test class instances
     System.out.println("Building list of tests...");

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -202,14 +202,17 @@ public class FormatReaderTestFactory {
     }
 
     // remove duplicates
+    Set<String> fileSet = new HashSet<String>(files);
     Set<String> minimalFiles = new HashSet<String>();
     FileStitcher reader = new FileStitcher();
-    for (String file: files) {
+    while (!fileSet.isEmpty()) {
+      String file = fileSet.iterator().next();
       try {
         reader.setId(file);
         Set<String> auxFiles = new HashSet<String>(
             Arrays.asList(reader.getUsedFiles())
         );
+        fileSet.removeAll(auxFiles);
         String masterFile = reader.getCurrentFile();
         auxFiles.remove(masterFile);
         minimalFiles.removeAll(auxFiles);
@@ -217,6 +220,7 @@ public class FormatReaderTestFactory {
       }
       catch (Exception e) { }
       finally {
+        fileSet.remove(file);
         try {
           reader.close();
         }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -211,6 +211,7 @@ public class FormatReaderTestFactory {
             files.remove(usedFiles[q]);
           }
         }
+        files.set(index, reader.getCurrentFile());
       }
       catch (Exception e) { }
       finally {

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -300,7 +300,7 @@ public class TestTools {
     catch (IOException exc) {
       LOGGER.debug("", exc);
     }
-    catch (Exception e) { }
+    catch (Throwable e) { }
 
     Arrays.sort(subs, new Comparator() {
       @Override


### PR DESCRIPTION
This PR addresses a problem I've encountered while building a test case based on a plate from `idr0009-simpson-secretion`. The dataset is structured as follows:

```
AcquisitionLog.dat
data/
.DS_Store
experiment_descriptor.dat
experiment_descriptor.xml
```

Where `data` contains the individual TIFF files. The configuration file generated with `gen-config` looked fine:

```
[experiment_descriptor.xml global]
...

[experiment_descriptor.xml series_0]
[experiment_descriptor.xml series_1]
...
```

However, the test failed, complaining about `AcquisitionLog.dat` not being configured. Here is a breakdown of what happens:

* To build the list of files to be tested, `FormatReaderTestFactory` walks the entire tree and builds an initial list with everything in it (almost everything, as .DS_Store is immediately discarded as a hidden file); then it walks down that list in order, and uses `getUsedFiles` to remove redundant files (i.e., those that are already taken into account by readers of files above them).

* Due to the black magic performed by `ScanrReader`, all files in the set are actually found by pointing `setId` to any of them. Since `AcquisitionLog.dat` is the first one, all other files are discarded.

* `FormatReaderTest` receives `AcquisitionLog.dat` as id, but uses `getCurrentFile` to write the config file. `ScanrReader`'s wisdom, however, ensures that no matter what was passed to `setId`, `getCurrentFile` always returns the path of the XML file in the set.

* Since the above list is rebuilt while running tests, the only file listed is, again, `AcquisitionLog.dat`. This is not mentioned in the config file, though, so the test fails.

This PR fixes (in this case, at least) the problem by using `getCurrentFile` to represent test targets in the list, so that there is no mismatch when this is compared with config contents. However, it seems weird to rebuild the list while running tests. A more long-term solution would be to change the code so that only what's written in the config file is considered while actually running tests.
