### PR TITLE
ZeissCZIReader : Fix imageCount for RGB images

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -715,7 +715,7 @@ public class ZeissCZIReader extends FormatReader {
       seriesCount *= mosaics;
     }
 
-    ms0.imageCount = getSizeZ() * (isRGB() ? 1 : getSizeC()) * getSizeT();
+    ms0.imageCount = getSizeZ() * (isRGB() ? getSizeC()/3 : getSizeC()) * getSizeT();
 
     LOGGER.trace("Size Z = {}", getSizeZ());
     LOGGER.trace("Size C = {}", getSizeC());


### PR DESCRIPTION
**Reference:** 
https://trac.openmicroscopy.org/ome/ticket/13239
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-May/006030.html

**Testing Instructions:** 
Open the following Image from QA17192 in ImageJ/Fiji,
Conv 2 3 colors.czi

and 
1) check if the image opens. (without this PR, you should get an exception: as shown in the ticket)
and
2) check if there are 9 channels.
and,
1) Split the image into three stacks (3 channels each),
2) And view the images in composite mode: [Image-->Color-->make Composite]

this will allow you to see the 3 channels as 3RGB images individually and these can be compared with Zen Lite.

@melissalinkert 