### PR TITLE
DataTools: remove internal usages of deprecated API

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -177,13 +177,13 @@ public class ImprovisionTiffReader extends BaseTiffReader {
         else if (key.equals("TotalChannels")) tc = value;
         else if (key.equals("TotalTimepoints")) tt = value;
         else if (key.equals("XCalibrationMicrons")) {
-          pixelSizeX = Double.parseDouble(DataTools.sanitizeDouble(value));
+          pixelSizeX = DataTools.parseDouble(value);
         }
         else if (key.equals("YCalibrationMicrons")) {
-          pixelSizeY = Double.parseDouble(DataTools.sanitizeDouble(value));
+          pixelSizeY = DataTools.parseDouble(value);
         }
         else if (key.equals("ZCalibrationMicrons")) {
-          pixelSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
+          pixelSizeZ = DataTools.parseDouble(value);
         }
       }
       metadata.remove("Comment");

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -511,17 +511,17 @@ public class ND2Handler extends BaseHandler {
         }
       }
       else if ("dPosX".equals(prevElement) && qName.startsWith("item_")) {
-        final Double number = Double.valueOf(DataTools.sanitizeDouble(value));
+        final Double number = DataTools.parseDouble(value);
         posX.add(new Length(number, UNITS.REFERENCEFRAME));
         metadata.put("X position for position #" + posX.size(), value);
       }
       else if ("dPosY".equals(prevElement) && qName.startsWith("item_")) {
-        final Double number = Double.valueOf(DataTools.sanitizeDouble(value));
+        final Double number = DataTools.parseDouble(value);
         posY.add(new Length(number, UNITS.REFERENCEFRAME));
         metadata.put("Y position for position #" + posY.size(), value);
       }
       else if ("dPosZ".equals(prevElement) && qName.startsWith("item_")) {
-        final Double number = Double.valueOf(DataTools.sanitizeDouble(value));
+        final Double number = DataTools.parseDouble(value);
         posZ.add(new Length(number, UNITS.REFERENCEFRAME));
         metadata.put("Z position for position #" + posZ.size(), value);
       }
@@ -563,7 +563,7 @@ public class ND2Handler extends BaseHandler {
         rois.add(roi);
       }
       else if (qName.equals("dPinholeRadius")) {
-        pinholeSize = new Double(DataTools.sanitizeDouble(value));
+        pinholeSize = DataTools.parseDouble(value);
         metadata.put("Pinhole size", value);
       }
       else if (qName.endsWith("ChannelColor")) {
@@ -647,29 +647,27 @@ public class ND2Handler extends BaseHandler {
 
     try {
       if (key.endsWith("dCalibration")) {
-        pixelSizeX = Double.parseDouble(DataTools.sanitizeDouble(value));
+        pixelSizeX = DataTools.parseDouble(value);
         pixelSizeY = pixelSizeX;
       }
       else if (key.endsWith("dZStep")) {
-        pixelSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
+        pixelSizeZ =  DataTools.parseDouble(value);
       }
       else if (key.endsWith("Gain")) {
-        value = DataTools.sanitizeDouble(value);
-        if (!value.equals("")) {
-          gain.add(new Double(value));
-        }
+        Double gainValue = DataTools.parseDouble(value);
+        if (gainValue != null) gain.add(gainValue);
       }
       else if (key.endsWith("dLampVoltage")) {
-        voltage = new Double(DataTools.sanitizeDouble(value));
+        voltage = DataTools.parseDouble(value);
       }
       else if (key.endsWith("dObjectiveMag") && mag == null) {
-        mag = new Double(DataTools.sanitizeDouble(value));
+        mag = DataTools.parseDouble(value);
       }
       else if (key.endsWith("dObjectiveNA")) {
-        na = new Double(DataTools.sanitizeDouble(value));
+        na = DataTools.parseDouble(value);
       }
       else if (key.endsWith("dRefractIndex1")) {
-        refractiveIndex = new Double(DataTools.sanitizeDouble(value));
+        refractiveIndex = DataTools.parseDouble(value);
       }
       else if (key.equals("sObjective") || key.equals("wsObjectiveName") ||
         key.equals("sOptics"))
@@ -690,25 +688,20 @@ public class ND2Handler extends BaseHandler {
         if (magIndex >= 0) {
           String m =
             tokens[magIndex].substring(0, tokens[magIndex].indexOf('x'));
-          m = DataTools.sanitizeDouble(m);
-          if (m.length() > 0) {
-            mag = new Double(m);
-          }
+          mag = DataTools.parseDouble(m);
         }
         if (magIndex + 1 < tokens.length) immersion = tokens[magIndex + 1];
       }
       else if (key.endsWith("dTimeMSec")) {
-        long v = (long) Double.parseDouble(DataTools.sanitizeDouble(value));
-        if (!ts.contains(new Long(v))) {
-          ts.add(new Long(v));
+        Long v = DataTools.parseLong(value);;
+        if (!ts.contains(v)) {
+          ts.add(v);
           metadata.put("number of timepoints", ts.size());
         }
       }
       else if (key.endsWith("dZPos")) {
-        long v = (long) Double.parseDouble(DataTools.sanitizeDouble(value));
-        if (!zs.contains(new Long(v))) {
-          zs.add(new Long(v));
-        }
+        Long v = DataTools.parseLong(value);
+        if (!zs.contains(v)) zs.add(v);
       }
       else if (key.endsWith("uiCount")) {
         if (runtype != null) {
@@ -847,17 +840,16 @@ public class ND2Handler extends BaseHandler {
       else if (key.equals("Readout Speed")) {
         int last = value.lastIndexOf(" ");
         if (last != -1) value = value.substring(0, last);
-        speed.add(new Double(DataTools.sanitizeDouble(value)));
+        speed.add(DataTools.parseDouble(value));
       }
       else if (key.equals("Temperature")) {
         String temp = value.replaceAll("[\\D&&[^-.]]", "");
-        temperature.add(new Double(DataTools.sanitizeDouble(temp)));
+        temperature.add(DataTools.parseDouble(temp));
       }
       else if (key.equals("Exposure")) {
         String[] s = value.trim().split(" ");
-        s[0] = DataTools.sanitizeDouble(s[0]);
-        if (s[0].trim().length() > 0) {
-          double time = Double.parseDouble(s[0]);
+        Double time = DataTools.parseDouble(s[0]);
+        if (time != null) {
           // TODO: check for other units
           if (s.length > 1) {
             if (s[1].equals("ms")) time /= 1000;
@@ -866,24 +858,18 @@ public class ND2Handler extends BaseHandler {
             // assume time is in milliseconds
             time /= 1000;
           }
-          exposureTime.add(new Double(time));
+          exposureTime.add(time);
         }
       }
       else if (key.equals("{Pinhole Size}")) {
-        pinholeSize = new Double(DataTools.sanitizeDouble(value));
+        pinholeSize = DataTools.parseDouble(value);
         metadata.put("Pinhole size", value);
       }
       else if (key.startsWith("- Step")) {
         int space = key.indexOf(" ", key.indexOf("Step") + 1);
         int last = key.indexOf(" ", space + 1);
         if (last == -1) last = key.length();
-        try {
-          pixelSizeZ = Double.parseDouble(
-            DataTools.sanitizeDouble(key.substring(space, last)));
-        }
-        catch (Exception e) {
-          LOGGER.trace("Could not parse Z step '{}'", key, e);
-        }
+        pixelSizeZ = DataTools.parseDouble(key.substring(space, last));
       }
       else if (key.equals("Line")) {
         String[] values = value.split(";");
@@ -904,8 +890,7 @@ public class ND2Handler extends BaseHandler {
         exWave.add(new Double(v[0]));
       }
       else if (key.equals("Power")) {
-        value = DataTools.sanitizeDouble(value);
-        power.add(new Integer((int) Double.parseDouble(value)));
+        power.add(DataTools.parseInteger(value));
       }
       else if (key.equals("CameraUniqueName")) {
         cameraModel = value;

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -867,9 +867,12 @@ public class ND2Handler extends BaseHandler {
       }
       else if (key.startsWith("- Step")) {
         int space = key.indexOf(" ", key.indexOf("Step") + 1);
-        int last = key.indexOf(" ", space + 1);
-        if (last == -1) last = key.length();
-        pixelSizeZ = DataTools.parseDouble(key.substring(space, last));
+        if (space != -1) {
+          int last = key.indexOf(" ", space + 1);
+          if (last == -1) last = key.length();
+          String pixelSizeZstring = key.substring(space, last);
+          pixelSizeZ = DataTools.parseDouble(pixelSizeZstring.trim());
+        }
       }
       else if (key.equals("Line")) {
         String[] values = value.split(";");

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -866,13 +866,8 @@ public class ND2Handler extends BaseHandler {
         metadata.put("Pinhole size", value);
       }
       else if (key.startsWith("- Step")) {
-        int space = key.indexOf(" ", key.indexOf("Step") + 1);
-        if (space != -1) {
-          int last = key.indexOf(" ", space + 1);
-          if (last == -1) last = key.length();
-          String pixelSizeZstring = key.substring(space, last);
-          pixelSizeZ = DataTools.parseDouble(pixelSizeZstring.trim());
-        }
+        Double step = parsePixelsSizeZFromKey(key);
+        if (step != null) pixelSizeZ = step;
       }
       else if (key.equals("Line")) {
         String[] values = value.split(";");
@@ -938,4 +933,12 @@ public class ND2Handler extends BaseHandler {
      return key.startsWith("Dimensions") || key.startsWith("Abmessungen");
   }
 
+  private Double parsePixelsSizeZFromKey(String key) {
+    int space = key.indexOf(" ", key.indexOf("Step") + 1);
+    if (space == -1) return null;
+
+    int last = key.indexOf(" ", space + 1);
+    if (last == -1) last = key.length();
+    return DataTools.parseDouble(key.substring(space, last).trim());
+  }
 }

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -693,7 +693,7 @@ public class ND2Handler extends BaseHandler {
         if (magIndex + 1 < tokens.length) immersion = tokens[magIndex + 1];
       }
       else if (key.endsWith("dTimeMSec")) {
-        Long v = DataTools.parseLong(value);;
+        Long v = DataTools.parseLong(value);
         if (!ts.contains(v)) {
           ts.add(v);
           metadata.put("number of timepoints", ts.size());
@@ -938,10 +938,10 @@ public class ND2Handler extends BaseHandler {
    * The expected format for the key is "- Step <value>".
    */
   private Double parsePixelsSizeZFromKey(String key) {
-    int space = key.indexOf(" ", key.indexOf("Step") + 1);
+    int space = key.indexOf(' ', key.indexOf("Step") + 1);
     if (space == -1) return null;
 
-    int last = key.indexOf(" ", space + 1);
+    int last = key.indexOf(' ', space + 1);
     if (last == -1) last = key.length();
     return DataTools.parseDouble(key.substring(space, last).trim());
   }

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -933,6 +933,10 @@ public class ND2Handler extends BaseHandler {
      return key.startsWith("Dimensions") || key.startsWith("Abmessungen");
   }
 
+  /**
+   * Parses the physical size from a key.
+   * The expected format for the key is "- Step <value>".
+   */
   private Double parsePixelsSizeZFromKey(String key) {
     int space = key.indexOf(" ", key.indexOf("Step") + 1);
     if (space == -1) return null;

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2226,12 +2226,7 @@ public class NativeND2Reader extends FormatReader {
             key = key.substring(0, 8);
           }
           if (trueSizeZ == null) {
-            try {
-              trueSizeZ = Double.parseDouble(DataTools.sanitizeDouble(value));
-            }
-            catch (NumberFormatException nfe) {
-              LOGGER.trace("Could not parse step", nfe);
-            }
+            trueSizeZ = DataTools.parseDouble(value);
           }
         }
         else if (key.equals("Name")) {
@@ -2244,22 +2239,13 @@ public class NativeND2Reader extends FormatReader {
             if (last-first < 0){
                 last = first + key.substring(first).indexOf(' ');
             }
-            try {
-              textEmissionWavelengths.add(
-                new Double(key.substring(first, last).trim()) + 20);
-            }
-            catch (NumberFormatException nfe) {
-              LOGGER.trace("Could not parse emission wavelength", nfe);
-            }
+            Double wavelength = DataTools.parseDouble(key.substring(
+              first, last).trim()) + 20;
+            if (wavelength != null) textEmissionWavelengths.add(wavelength);
           }
         }
         else if (key.equals("Refractive Index")) {
-          try {
-            refractiveIndex = Double.parseDouble(DataTools.sanitizeDouble(value));
-          }
-          catch (NumberFormatException nfe) {
-            LOGGER.trace("Could not parse refractive index", nfe);
-          }
+          refractiveIndex = DataTools.parseDouble(value);
         }
 
         if (metadata.containsKey(key)) {

--- a/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
@@ -32,7 +32,8 @@ import loci.formats.CoreMetadata;
 import loci.formats.in.ND2Handler;
 
 import static org.testng.Assert.assertEquals;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -40,19 +41,30 @@ import org.testng.annotations.Test;
  */
 public class ND2HandlerTest {
 
-  private List<CoreMetadata> coreList = new ArrayList<CoreMetadata>();
+  private List<CoreMetadata> coreList;
   private ND2Handler handler;
 
-  @BeforeClass
+  @BeforeMethod
   public void setUp() {
+    coreList = new ArrayList<CoreMetadata>();
     coreList.add(new CoreMetadata());
     handler = new ND2Handler(coreList, 1);
   }
 
-  @Test
-  public void testParsePixelsSizeZ()
+  @DataProvider(name = "pixelsSizeKey")
+  public Object[][] createPixelsSizeKey() {
+    return new Object[][] {
+      {"- Step .1 ", .1},
+      {"- Step .1", .1},
+      {"- Step ,1 ", .1},
+      {"- Step", 0.0},
+    };
+  }
+  
+  @Test(dataProvider="pixelsSizeKey")
+  public void testParsePixelsSizeZ(String key, double value)
   {
-    handler.parseKeyAndValue("- Step", "", "");
-    assertEquals(handler.getPixelSizeZ(), 0.0);
+    handler.parseKeyAndValue(key, "", "");
+    assertEquals(handler.getPixelSizeZ(), value);
   }
 }

--- a/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
@@ -32,6 +32,7 @@ import loci.formats.CoreMetadata;
 import loci.formats.in.ND2Handler;
 
 import static org.testng.Assert.assertEquals;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -39,13 +40,19 @@ import org.testng.annotations.Test;
  */
 public class ND2HandlerTest {
 
-  private List<CoreMetadata> core = new ArrayList<CoreMetadata>();
-  private ND2Handler handler = new ND2Handler(core, 1);
+  private List<CoreMetadata> coreList = new ArrayList<CoreMetadata>();
+  private ND2Handler handler;
+
+  @BeforeClass
+  public void setUp() {
+    coreList.add(new CoreMetadata());
+    handler = new ND2Handler(coreList, 1);
+  }
 
   @Test
-  public void testParsePhysicalSizeZ()
+  public void testParsePixelsSizeZ()
   {
     handler.parseKeyAndValue("- Step", "", "");
-    assertEquals(handler.getPixelSizeZ(), null);
+    assertEquals(handler.getPixelSizeZ(), 0.0);
   }
 }

--- a/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
@@ -54,17 +54,20 @@ public class ND2HandlerTest {
   @DataProvider(name = "pixelsSizeKey")
   public Object[][] createPixelsSizeKey() {
     return new Object[][] {
-      {"- Step .1 ", .1},
-      {"- Step .1", .1},
-      {"- Step ,1 ", .1},
-      {"- Step", 0.0},
+      {"dZStep", ".1", .1},
+      {"- Step .1 ", "", .1},
+      {"- Step .1", "", .1},
+      {"- Step ,1 ", "", .1},
+      {"- Step", "", 0.0},
+      {"- Step ", "", 0.0},
+      {"- Step d", "", 0.0},
     };
   }
   
   @Test(dataProvider="pixelsSizeKey")
-  public void testParsePixelsSizeZ(String key, double value)
+  public void testParsePixelsSizeZ(String key, String value, double pixelSizeZ)
   {
-    handler.parseKeyAndValue(key, "", "");
-    assertEquals(handler.getPixelSizeZ(), value);
+    handler.parseKeyAndValue(key, value, "");
+    assertEquals(handler.getPixelSizeZ(), pixelSizeZ);
   }
 }

--- a/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.utests.in;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import loci.formats.CoreMetadata;
+import loci.formats.in.ND2Handler;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link ND2Handler}.
+ */
+public class ND2HandlerTest {
+
+  private List<CoreMetadata> core = new ArrayList<CoreMetadata>();
+  private ND2Handler handler = new ND2Handler(core, 1);
+
+  @Test
+  public void testParsePhysicalSizeZ()
+  {
+    handler.parseKeyAndValue("- Step", "", "");
+    assertEquals(handler.getPixelSizeZ(), null);
+  }
+}


### PR DESCRIPTION
See https://trello.com/c/b4oDFIo4/21-remove-instances-of-deprecated-sanitizedouble

This PR completes the deprecation of the `DataTools.sanitizeDouble()` in https://github.com/openmicroscopy/bioformats/pull/2285 and updates the few places across the code still relying on the deprecated API to use `DataTools.parse*` instead.

This PR should have no functional effect mostly cleanup. To test it:
- check the build does not warn about these deprecated classes anymore
- check the automated tests are still passing with this PR included
- optionally open a couple of files from the two affected formats and check the metadata is unchanged without and with this PR e.g. by comparing the ouput of `showinf -omexml-only` 

Open questions:
- how to handle ND2 metadata where the value is -1?