### PR TITLE
ScanR: return blank planes instead of skipping missing wells (develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -519,7 +519,7 @@ public class ScanrReader extends FormatReader {
       if (next == originalIndex &&
         missingWellFiles == nSlices * nTimepoints * nChannels * nPos)
       {
-        wellNumbers.remove(well);
+        next += nSlices * nTimepoints * nChannels * nPos;
       }
     }
     nWells = wellNumbers.size();


### PR DESCRIPTION
Rebases #1995 onto develop.
