### PR TITLE
ScanR: read core metadata from first non-null TIFF file (develop)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -545,7 +545,12 @@ public class ScanrReader extends FormatReader {
     }
 
     reader = new MinimalTiffReader();
-    reader.setId(tiffs[0]);
+    for (String tiff : tiffs) {
+      if (tiff != null) {
+        reader.setId(tiff);
+	break;
+      }
+    }
     int sizeX = reader.getSizeX();
     int sizeY = reader.getSizeY();
     int pixelType = reader.getPixelType();


### PR DESCRIPTION
Rebases #2147 onto develop.

**NOTE:** the bug this PR fixes is triggered by #2588 (the `tiffs` array changes order so that a `null` entry appears at index 0), so we should merge that one first.
