### PR TITLE
Deltavision: use readUnsignedShort() to read time dimensions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -307,7 +307,7 @@ public class DeltavisionReader extends FormatReader {
     int filePixelType = in.readInt();
 
     in.seek(180);
-    int rawSizeT = in.readShort();
+    int rawSizeT = in.readUnsignedShort();
     int sizeT = rawSizeT == 0 ? 1 : rawSizeT;
 
     int sequence = in.readShort();


### PR DESCRIPTION
See  http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-September/006183.html and https://trac.openmicroscopy.org/ome/ticket/13261

For large dimensions (over 32767), using readShort() wraps the value to a negative. This commit explores using readUnsignedShort() instead to retrieve the  time dimension while remaining in agreement with the DV specification.