### PR TITLE
Use canonical paths in the test suite

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -209,9 +209,11 @@ public class FormatReaderTestFactory {
       String file = fileSet.iterator().next();
       try {
         reader.setId(file);
-        Set<String> auxFiles = new LinkedHashSet<String>(
-            Arrays.asList(reader.getUsedFiles())
-        );
+        String[] usedFiles = reader.getUsedFiles();
+        Set<String> auxFiles = new LinkedHashSet<String>();
+        for (String s: usedFiles) {
+          auxFiles.add((new File(s)).getCanonicalPath());
+        }
         fileSet.removeAll(auxFiles);
         String masterFile = reader.getCurrentFile();
         auxFiles.remove(masterFile);

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -352,7 +352,11 @@ public class TestTools {
                !subsList.get(i).endsWith("test_setup.ini")) {
         if (typeTester.isThisType(subsList.get(i))) {
           LOGGER.debug("\tOK");
-          files.add(file.getAbsolutePath());
+          try {
+            files.add(file.getCanonicalPath());
+          } catch (IOException e) {
+            files.add(file.getAbsolutePath());
+          }
         }
         else LOGGER.debug("\tunknown type");
       }


### PR DESCRIPTION
Although #2574 has simplified config file generation, the logic that removes files already being tested as part of a different set is not robust enough. openmicroscopy/data_repo_config#146 (see comments on `metamorph/chris`) is an example of how it can fail due to different path strings referring to the same file. This PR changes the above code to use canonical paths to resolve ambiguities. With this, I was able to regenerate the `metamorph/chris` config in a few seconds (see openmicroscopy/data_repo_config#147).

--breaking