### PR TITLE
Ant: remove the pdf generation from the top-level documentation target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,13 @@ jdk:
 env:
   - BUILD=maven_findbugs
   - BUILD=maven
-  - BUILD=sphinx_html
   - BUILD=ant
 
 matrix:
   fast_finish: true
 
 before_install:
-  - if [[ $BUILD == 'sphinx_html' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
+  - if [[ $BUILD == 'ant' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
 
 install:
   - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx_html' ]]; then git fetch --tags; fi

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -139,8 +139,6 @@ Type "ant -p" for a list of targets.
     description="generate the Sphinx HTML and PDF documentation">
     <echo>----------=========== Sphinx HTML ===========----------</echo>
     <ant dir="docs/sphinx" target="html"/>
-    <echo>----------=========== Sphinx PDF ===========----------</echo>
-    <ant dir="docs/sphinx" target="pdf"/>
     <echo>----------=========== Sphinx MAN ===========----------</echo>
     <ant dir="docs/sphinx" target="man"/>
   </target>

--- a/tools/test-build
+++ b/tools/test-build
@@ -48,24 +48,6 @@ flake()
     flake8 -v components cpp docs
 }
 
-# Test sphinx docs build
-sphinx()
-{
-    (
-        export SPHINXOPTS="-W"
-        ant -Dsphinx.warnopts=$SPHINXOPTS clean-docs-sphinx
-        ant -Dsphinx.warnopts=$SPHINXOPTS docs-sphinx
-    )
-}
-
-sphinx_html()
-{
-    (
-        cd docs/sphinx
-        ant -Dsphinx.warnopts=-W html
-     )
- }
-
 # Test Ant build targets
 antbuild()
 {
@@ -88,6 +70,7 @@ antbuild()
       ant clean compile-tests
       ant clean compile-turbojpeg
       ant clean utils
+      ant -Dsphinx.warnopts=$SPHINXOPTS clean-docs-sphinx docs-sphinx
     )
 }
 
@@ -104,10 +87,6 @@ do
             cpp ;;
         flake8)
             flake ;;
-        sphinx)
-            sphinx ;;
-        sphinx_html)
-            sphinx_html ;;
         ant)
             antbuild ;;
         all)


### PR DESCRIPTION
See https://trello.com/c/noU6gku8/14-review-docs-strategy

With this PR, the top-level `docs-sphinx` target used by the release jobs amongst others should no longer produce a PDF but still a zip containing the HTML sources /cc @hflynn 

While reviewing this we might want to make sure that the names of the Javadocs vs Sphinx docs zips are sensible/consistent as we will expose them in the downloads pages.