### PR TITLE
Add version number to Javadoc zip

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -131,7 +131,7 @@ Type "ant -p" for a list of targets.
   <target name="docs-zip" depends="docs"/>
 
   <target name="docs-sphinx"
-    description="generate the Sphinx HTML and PDF documentation">
+    description="generate the Sphinx HTML documentation">
     <echo>----------=========== Sphinx HTML ===========----------</echo>
     <ant dir="docs/sphinx" target="html"/>
     <echo>----------=========== Sphinx MAN ===========----------</echo>
@@ -139,7 +139,7 @@ Type "ant -p" for a list of targets.
   </target>
 
   <target name="clean-docs-sphinx"
-	description="remove build files for the Sphinx HTML and PDF documentation">
+	description="remove build files for the Sphinx HTML documentation">
     <ant dir="docs/sphinx" target="clean"/>
   </target>
 

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -12,7 +12,7 @@ Type "ant -p" for a list of targets.
   <import file="${root.dir}/ant/java.xml"/>
   <property file="build.properties"/>
 
-  <target name="docs" depends="javadoc-properties, mvn-init"
+  <target name="docs" depends="javadoc-properties, mvn-init, release-version"
     description="generate the Javadocs for most components">
     <echo>----------=========== Javadocs ===========----------</echo>
     <tstamp>
@@ -37,7 +37,7 @@ Type "ant -p" for a list of targets.
     </javadoc>
     <zip destfile="${artifact.dir}/bio-formats-javadocs-${release.version}.zip">
       <zipfileset dir="${merged-docs.dir}" prefix="bio-formats-javadocs-${release.version}"/>
-      </zip>
+    </zip>
   </target>
 
   <target name="bftools"

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -35,8 +35,9 @@ Type "ant -p" for a list of targets.
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
       <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->
     </javadoc>
-    <zip destfile="${artifact.dir}/bio-formats-javadocs.zip"
-      basedir="${merged-docs.dir}"/>
+    <zip destfile="${artifact.dir}/bio-formats-javadocs-${release.version}.zip">
+      <zipfileset dir="${merged-docs.dir}" prefix="bio-formats-javadocs-${release.version}"/>
+      </zip>
   </target>
 
   <target name="bftools"


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/pull/2609 where this was suggested. Once built, the javadoc zip should now be bio-formats-javadocs-VERSION.zip (likely 5.2.3-DEV).

I also tidied up a couple of pdf references not removed in the linked PR above.