### PR TITLE
Use ome-common 5.3.0 release from maven central

### DIFF
--- a/ant/global.properties
+++ b/ant/global.properties
@@ -26,3 +26,4 @@ objenesis.version = 2.1
 minlog.version = 1.2
 testng.version = 6.8
 guava.version = 17.0
+ome_common.version = 5.3.0

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-common</artifactId>
-      <version>5.3.0</version>
+      <version>${ome_common.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/components/forks/poi/pom.xml
+++ b/components/forks/poi/pom.xml
@@ -29,9 +29,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>formats-common</artifactId>
-      <version>5.2.3</version>
+      <groupId>org.openmicroscopy</groupId>
+      <artifactId>ome-common</artifactId>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-common</artifactId>
-      <version>5.3.0</version>
+      <version>${ome_common.version}</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -28,9 +28,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>formats-common</artifactId>
-      <version>5.2.3</version>
+      <groupId>org.openmicroscopy</groupId>
+      <artifactId>ome-common</artifactId>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-common</artifactId>
-      <version>5.3.0</version>
+      <version>${ome_common.version}</version>
     </dependency>
 
     <dependency>

--- a/components/ome-xml/pom.xml
+++ b/components/ome-xml/pom.xml
@@ -29,9 +29,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>formats-common</artifactId>
-      <version>5.2.3</version>
+      <groupId>org.openmicroscopy</groupId>
+      <artifactId>ome-common</artifactId>
+      <version>5.3.0</version>
     </dependency>
 
     <dependency>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -21,15 +21,33 @@ Type "ant -p" for a list of targets.
   <target name="init" depends="release-version">
     <property name="sphinx.release" value="${release.shortversion}"/>
     <property name="sphinx.version" value="${release.major}.${release.minor}"/>
-    <property name="sphinx.source.branch" value="develop"/>
-    <property name="sphinx.source.user" value="openmicroscopy"/>
+    <if>
+      <isset property="sphinx.source.branch"/>
+      <then>
+        <property name="sphinx.bioformats.source.branch" value="${sphinx.source.branch}"/>
+        <property name="sphinx.common_java.source.branch" value="${sphinx.source.branch}"/>
+      </then>
+    </if>
+    <property name="sphinx.bioformats.source.branch" value="develop"/>
+    <property name="sphinx.common_java.source.branch" value="master"/>
+    <if>
+      <isset property="sphinx.source.user"/>
+      <then>
+        <property name="sphinx.openmicroscopy_source.user" value="${sphinx.source.user}"/>
+        <property name="sphinx.ome_source.user" value="${sphinx.source.user}"/>
+      </then>
+    </if>
+    <property name="sphinx.openmicroscopy_source.user" value="openmicroscopy"/>
+    <property name="sphinx.ome_source.user" value="ome"/>
     <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
 
     <copy file="conf.py.in" tofile="conf.py" overwrite="true"/>
     <replace file="conf.py" token="@sphinx_srcdir@" value="."/>
     <replace file="conf.py" token="@sphinx_builddir@" value="."/>
-    <replace file="conf.py" token="@sphinx_source_branch@" value="${sphinx.source.branch}"/>
-    <replace file="conf.py" token="@sphinx_source_user@" value="${sphinx.source.user}"/>
+    <replace file="conf.py" token="@bioformats_source_branch@" value="${sphinx.bioformats.source.branch}"/>
+    <replace file="conf.py" token="@common_java_source_branch@" value="${sphinx.common_java.source.branch}"/>
+    <replace file="conf.py" token="@openmicroscopy_source_user@" value="${sphinx.openmicroscopy_source.user}"/>
+    <replace file="conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
     <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
   </target>
 

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -49,6 +49,7 @@ Type "ant -p" for a list of targets.
     <replace file="conf.py" token="@openmicroscopy_source_user@" value="${sphinx.openmicroscopy_source.user}"/>
     <replace file="conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
     <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
+    <replace file="conf.py" token="@ome_common_version@" value="${ome_common.version}"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -15,10 +15,10 @@
 srcdir = '@sphinx_srcdir@'
 builddir = '@sphinx_builddir@'
 bioformats_source_branch = '@bioformats_source_branch@'
-common_java_source_branch = '@common_java_source_branch@'
 openmicroscopy_source_user = '@openmicroscopy_source_user@'
 ome_source_user = '@ome_source_user@'
 omerodoc_uri = '@sphinx_omerodoc_uri@'
+ome_common_version = '@ome_common_version@'
 
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
@@ -114,9 +114,6 @@ bf_github_blob = bf_github_root + 'blob/' + bioformats_source_branch + '/'
 gpl_formats = bf_github_blob + 'components/formats-gpl/src/loci/formats/'
 bsd_formats = bf_github_blob + 'components/formats-bsd/src/loci/formats/'
 bf_cpp = bf_github_blob + 'cpp/'
-common_java_github_root = github_root + ome_source_user + '/ome-common-java/'
-common_java_github_tree = common_java_github_root + 'tree/' + common_java_source_branch + '/'
-common_java_github_blob = common_java_github_root + 'blob/' + common_java_source_branch + '/'
 
 # Variables used to define Jenkins extlinks
 jenkins_root = 'http://ci.openmicroscopy.org'
@@ -138,7 +135,6 @@ extlinks = {
     'report' : (trac_root + '/report/%s', ''),
     # Github links
     'source' : (bf_github_blob + '%s', ''),
-    'common_java_source' : (common_java_github_blob + '%s', ''),
     'sourcedir' : (bf_github_tree + '%s', ''),
     'bfreader' : (gpl_formats + 'in/%s', ''),
     'bsd-reader' : (bsd_formats + 'in/%s', ''),
@@ -165,6 +161,8 @@ extlinks = {
     # Downloads
     'downloads' : (downloads_root + '/latest/bio-formats5.2/%s', ''),
     'javadoc' : (downloads_root + '/latest/bio-formats5.2/api/%s', ''),
+    'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
+
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', '')

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -14,9 +14,11 @@
 # Substitutions from external build system.
 srcdir = '@sphinx_srcdir@'
 builddir = '@sphinx_builddir@'
-ext_source_branch = '@sphinx_source_branch@'
-ext_source_user = '@sphinx_source_user@'
-ext_omerodoc_uri = '@sphinx_omerodoc_uri@'
+bioformats_source_branch = '@bioformats_source_branch@'
+common_java_source_branch = '@common_java_source_branch@'
+openmicroscopy_source_user = '@openmicroscopy_source_user@'
+ome_source_user = '@ome_source_user@'
+omerodoc_uri = '@sphinx_omerodoc_uri@'
 
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
@@ -105,23 +107,16 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-# Variables used to define Github extlinks
-source_branch = 'develop'
-if (ext_source_branch is not None and len(ext_source_branch) > 0 and
-    ext_source_branch != "@%s@" % ('sphinx_source_branch')):
-    source_branch = ext_source_branch
-source_user = 'openmicroscopy'
-if (ext_source_user is not None and len(ext_source_user) > 0 and
-    ext_source_user != "@%s@" % ('sphinx_source_user}')):
-    source_user = ext_source_user
-
 github_root = 'https://github.com/'
-bf_github_root = github_root + source_user + '/bioformats/'
-bf_github_tree = bf_github_root + 'tree/' + source_branch + '/'
-bf_github_blob = bf_github_root + 'blob/' + source_branch + '/'
+bf_github_root = github_root + openmicroscopy_source_user + '/bioformats/'
+bf_github_tree = bf_github_root + 'tree/' + bioformats_source_branch + '/'
+bf_github_blob = bf_github_root + 'blob/' + bioformats_source_branch + '/'
 gpl_formats = bf_github_blob + 'components/formats-gpl/src/loci/formats/'
 bsd_formats = bf_github_blob + 'components/formats-bsd/src/loci/formats/'
 bf_cpp = bf_github_blob + 'cpp/'
+common_java_github_root = github_root + ome_source_user + '/ome-common-java/'
+common_java_github_tree = common_java_github_root + 'tree/' + common_java_source_branch + '/'
+common_java_github_blob = common_java_github_root + 'blob/' + common_java_source_branch + '/'
 
 # Variables used to define Jenkins extlinks
 jenkins_root = 'http://ci.openmicroscopy.org'
@@ -135,10 +130,6 @@ oo_root = 'http://www.openmicroscopy.org'
 oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
-omerodoc_uri = oo_site_root + '/support/omero5.1'
-if (ext_omerodoc_uri is not None and len(ext_omerodoc_uri) > 0 and
-    ext_omerodoc_uri != "@%s@" % ('sphinx_omerodoc_uri}')):
-    omerodoc_uri = ext_omerodoc_uri
 
 extlinks = {
     # Trac links
@@ -147,6 +138,7 @@ extlinks = {
     'report' : (trac_root + '/report/%s', ''),
     # Github links
     'source' : (bf_github_blob + '%s', ''),
+    'common_java_source' : (common_java_github_blob + '%s', ''),
     'sourcedir' : (bf_github_tree + '%s', ''),
     'bfreader' : (gpl_formats + 'in/%s', ''),
     'bsd-reader' : (bsd_formats + 'in/%s', ''),

--- a/docs/sphinx/developers/components.txt
+++ b/docs/sphinx/developers/components.txt
@@ -11,12 +11,31 @@ can also be built with Maven by running :command:`mvn` in the component's
 subdirectory.  The Maven module name for each component (as it is shown in
 most IDEs) is also noted in parenthesis.
 
+External components
+-------------------
+
+.. _ome-common:
+
+ome-common (Common):
+
+Provides I/O classes that unify reading from files on disk, streams or files
+in memory, compressed streams, and non-file URLs.  The primary entry points
+are :javadoc:`Location <loci/common/Location.html>`,
+:javadoc:`RandomAccessInputStream <loci/common/RandomAccessInputStream.html>`
+(for reading), and :javadoc:`RandomAccessOutputStream
+<loci/common/RandomAccessOutputStream.html>` (for writing).
+
+In addition to I/O, there are several classes to assist in working with XML
+(:javadoc:`XMLTools <loci/common/xml/XMLTools.html>`), date/timestamps
+(:javadoc:`DateTools <loci/common/DateTools.html>`), logging configuration
+(:javadoc:`DebugTools <loci/common/DebugTools.html>`), and byte arithmetic
+(:javadoc:`DataTools <loci/common/DataTools.html>`).
+
 Core components
 ---------------
 
 The most commonly used and actively modified components.
 
-- :ref:`formats-common <formats-common>`
 - :ref:`formats-api <formats-api>`
 - :ref:`formats-bsd <formats-bsd>`
 - :ref:`formats-gpl <formats-gpl>`
@@ -125,8 +144,8 @@ for large files.  There are no dependencies on other components.
 This is a fork of `Apache POI <http://poi.apache.org>`_, which allows reading
 of Microsoft OLE document files.  We have made substantial changes to support
 files larger than 2GB and reduce the amount of memory required to open a file.
-I/O is also handled by classes from :ref:`formats-common <formats-common>`,
-which allows OLE files to be read from memory.
+I/O is also handled by classes from :ref:`ome-common <ome-common>`, which
+allows OLE files to be read from memory.
 
 .. _forks-turbojpeg:
 
@@ -152,30 +171,8 @@ and writing files.  There are no file format readers or writers actually
 implemented in this component, but it does contain the majority of the API
 that defines Bio-Formats.  :ref:`formats-bsd <formats-bsd>` and
 :ref:`formats-gpl <formats-gpl>` implement this API to provide file format
-readers and writers. :ref:`formats-common <formats-common>` and
+readers and writers. :ref:`ome-common <ome-common>` and
 :ref:`ome-xml <ome-xml>` are both required as part of the interface definitions.
-
-.. _formats-common:
-
-:source:`formats-common (Common) <components/formats-common>`:
-
-`Ant: jar-formats-common`
-
-Provides I/O classes that unify reading from files on disk, streams or files
-in memory, compressed streams, and non-file URLs.  The primary entry points
-are :javadoc:`Location <loci/common/Location.html>`,
-:javadoc:`RandomAccessInputStream <loci/common/RandomAccessInputStream.html>`
-(for reading), and :javadoc:`RandomAccessOutputStream
-<loci/common/RandomAccessOutputStream.html>` (for writing).
-
-In addition to I/O, there are several classes to assist in working with XML
-(:javadoc:`XMLTools <loci/common/xml/XMLTools.html>`), date/timestamps
-(:javadoc:`DateTools <loci/common/DateTools.html>`), logging configuration
-(:javadoc:`DebugTools <loci/common/DebugTools.html>`), and byte arithmetic
-(:javadoc:`DataTools <loci/common/DataTools.html>`).
-
-This does not depend on any other components, so can be used anywhere
-independent of the rest of the Bio-Formats API.
 
 .. _formats-bsd:
 
@@ -207,7 +204,7 @@ available specification.
 
 Java implementation of the `Metakit database specification
 <http://equi4.com/metakit/>`_.  This uses classes from
-:ref:`formats-common <formats-common>` and is used by
+:ref:`ome-common <ome-common>` and is used by
 :ref:`formats-gpl <formats-gpl>`, but is otherwise independent of the main
 Bio-Formats API.
 

--- a/docs/sphinx/developers/components.txt
+++ b/docs/sphinx/developers/components.txt
@@ -20,16 +20,16 @@ ome-common (Common):
 
 Provides I/O classes that unify reading from files on disk, streams or files
 in memory, compressed streams, and non-file URLs.  The primary entry points
-are :javadoc:`Location <loci/common/Location.html>`,
-:javadoc:`RandomAccessInputStream <loci/common/RandomAccessInputStream.html>`
-(for reading), and :javadoc:`RandomAccessOutputStream
+are :common_javadoc:`Location <loci/common/Location.html>`,
+:common_javadoc:`RandomAccessInputStream <loci/common/RandomAccessInputStream.html>`
+(for reading), and :common_javadoc:`RandomAccessOutputStream
 <loci/common/RandomAccessOutputStream.html>` (for writing).
 
 In addition to I/O, there are several classes to assist in working with XML
-(:javadoc:`XMLTools <loci/common/xml/XMLTools.html>`), date/timestamps
-(:javadoc:`DateTools <loci/common/DateTools.html>`), logging configuration
-(:javadoc:`DebugTools <loci/common/DebugTools.html>`), and byte arithmetic
-(:javadoc:`DataTools <loci/common/DataTools.html>`).
+(:common_javadoc:`XMLTools <loci/common/xml/XMLTools.html>`), date/timestamps
+(:common_javadoc:`DateTools <loci/common/DateTools.html>`), logging configuration
+(:common_javadoc:`DebugTools <loci/common/DebugTools.html>`), and byte arithmetic
+(:common_javadoc:`DataTools <loci/common/DataTools.html>`).
 
 Core components
 ---------------

--- a/docs/sphinx/developers/service.txt
+++ b/docs/sphinx/developers/service.txt
@@ -108,10 +108,10 @@ Writing a service
        ...
 
 .. seealso::
-  :source:`loci.common.services.Service <components/formats-common/src/loci/common/services/Service.java>`.
+  :common_java_source:`loci.common.services.Service <src/main/java/loci/common/services/Service.java>`.
     Source code for ``loci.common.services.Service`` interface
 
-  :source:`loci.common.services.ServiceFactory <components/formats-common/src/loci/common/services/ServiceFactory.java>`
+  :common_java_source:`loci.common.services.ServiceFactory <src/main/java/loci/common/services/ServiceFactory.java>`
     Source code for ``loci.common.services.Service`` interface
 
 

--- a/docs/sphinx/developers/service.txt
+++ b/docs/sphinx/developers/service.txt
@@ -35,7 +35,7 @@ Writing a service
 -----------------
 
 -  **Interface** -- The basic form of a service is an interface which
-   inherits from :javadoc:`loci.common.services.Service <loci/common/services/Service.html>`.
+   inherits from :common_javadoc:`loci.common.services.Service <loci/common/services/Service.html>`.
    Here is a very basic example using the (now removed) ``OMENotesService``
 
    ::
@@ -96,7 +96,7 @@ Writing a service
 
 -  **Registration** -- A service's interface and implementation must
    finally be *registered* with the
-   :javadoc:`loci.common.services.ServiceFactory <loci/common/services/ServiceFactory.html>`
+   :common_javadoc:`loci.common.services.ServiceFactory <loci/common/services/ServiceFactory.html>`
    via the :file:`services.properties` file. Following the ``OMENotesService``
    again, here is an example registration:
 
@@ -106,14 +106,6 @@ Writing a service
        # OME notes service (implementation in legacy ome-notes component)
        loci.common.services.OMENotesService=loci.ome.notes.services.OMENotesServiceImpl
        ...
-
-.. seealso::
-  :common_java_source:`loci.common.services.Service <src/main/java/loci/common/services/Service.java>`.
-    Source code for ``loci.common.services.Service`` interface
-
-  :common_java_source:`loci.common.services.ServiceFactory <src/main/java/loci/common/services/ServiceFactory.java>`
-    Source code for ``loci.common.services.Service`` interface
-
 
 Using a service
 ---------------

--- a/docs/sphinx/users/fiji/index.txt
+++ b/docs/sphinx/users/fiji/index.txt
@@ -40,7 +40,7 @@ an earlier version using this guide if you need to.
 
    - jai_imageio.jar
    - formats-gpl.jar
-   - formats-common.jar
+   - ome-common.jar
    - turbojpeg.jar
    - ome-xml.jar
    - formats-bsd.jar
@@ -59,7 +59,7 @@ an earlier version using this guide if you need to.
 
    - jai_imageio.jar
    - formats-gpl.jar
-   - formats-common.jar
+   - ome-common.jar
    - turbojpeg.jar
    - ome-xml.jar
    - formats-bsd.jar

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
+    <ome_common.version>5.3.0</ome_common.version>
 
     <xsdfu.schemaver>2016-06</xsdfu.schemaver>
     <xsdfu.schemapath>components/specification/released-schema/${xsdfu.schemaver}</xsdfu.schemapath>


### PR DESCRIPTION
- Switch to using maven central or ome-common in place of the old formats-common.
- Update the documentation to use ome-common and replace links which are no longer valid in the source tree; handle the differences between the split repos when building the documentation

Testing: Check that the ant and maven builds continue to work.  Check the documentation links.

Will the javadoc links need fixing up to use a different location for the ome-common documentation; it's currently using the -latest doc links, but they might disappear after merging?

/cc @sbesson 