### PR TITLE
OME-TIFF: fix Plane population to preserve existing The* values

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1022,13 +1022,10 @@ public class OMETiffReader extends FormatReader {
 
     MetadataTools.populatePixels(metadataStore, this, false, false);
     for (int i=0; i<meta.getImageCount(); i++) {
-      setCoreIndex(i);
-
       // make sure that TheZ, TheC, and TheT are all set on any
       // existing Planes
       // missing Planes are not added, and exising TheZ, TheC, and
       // TheT values are not changed
-      ArrayList<Integer> populatedPlanes = new ArrayList<Integer>();
       for (int p=0; p<meta.getPlaneCount(i); p++) {
         NonNegativeInteger z = meta.getPlaneTheZ(i, p);
         NonNegativeInteger c = meta.getPlaneTheC(i, p);
@@ -1046,11 +1043,8 @@ public class OMETiffReader extends FormatReader {
           t = new NonNegativeInteger(0);
           metadataStore.setPlaneTheT(t, i, p);
         }
-
-        populatedPlanes.add(getIndex(z.getValue(), c.getValue(), t.getValue()));
       }
     }
-    setCoreIndex(0);
     for (int i=0; i<acquiredDates.length; i++) {
       if (acquiredDates[i] != null) {
         metadataStore.setImageAcquisitionDate(

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1020,7 +1020,37 @@ public class OMETiffReader extends FormatReader {
       }
     }
 
-    MetadataTools.populatePixels(metadataStore, this, true, false);
+    MetadataTools.populatePixels(metadataStore, this, false, false);
+    for (int i=0; i<meta.getImageCount(); i++) {
+      setCoreIndex(i);
+
+      // make sure that TheZ, TheC, and TheT are all set on any
+      // existing Planes
+      // missing Planes are not added, and exising TheZ, TheC, and
+      // TheT values are not changed
+      ArrayList<Integer> populatedPlanes = new ArrayList<Integer>();
+      for (int p=0; p<meta.getPlaneCount(i); p++) {
+        NonNegativeInteger z = meta.getPlaneTheZ(i, p);
+        NonNegativeInteger c = meta.getPlaneTheC(i, p);
+        NonNegativeInteger t = meta.getPlaneTheT(i, p);
+
+        if (z == null) {
+          z = new NonNegativeInteger(0);
+          metadataStore.setPlaneTheZ(z, i, p);
+        }
+        if (c == null) {
+          c = new NonNegativeInteger(0);
+          metadataStore.setPlaneTheC(c, i, p);
+        }
+        if (t == null) {
+          t = new NonNegativeInteger(0);
+          metadataStore.setPlaneTheT(t, i, p);
+        }
+
+        populatedPlanes.add(getIndex(z.getValue(), c.getValue(), t.getValue()));
+      }
+    }
+    setCoreIndex(0);
     for (int i=0; i<acquiredDates.length; i++) {
       if (acquiredDates[i] != null) {
         metadataStore.setImageAcquisitionDate(


### PR DESCRIPTION
See
https://trello.com/c/aTV56qEX/6-fix-ome-tiff-regression-plane-population

To test, check the output of ```showinf -nopix -omexml``` with the files from QA 17375 and 16996 and verify that the ```The*``` values on the ```Plane```s are correct and that there are no relevant validation errors.  For QA 16996, ```TheZ``` and ```TheT``` were set in the file, but ```TheC``` was missing.  For QA 17375, all three values are set, but the order does not necessarily match ```DimensionOrder``` and some planes do not have a ```Plane``` element at all.