### PR TITLE
Update redirecting ZEISS links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1764,7 +1764,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = PCXReader
-notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_.
+notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/int/downloads/lsm-5-series.html>`_.
 
 [PCORAW]
 extensions = .pcoraw, .rec
@@ -2396,7 +2396,7 @@ extensions = .xml, .tiff
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 bsd = no
-software = `Zeiss ZEN Lite <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen-lite.html>`_
+software = `Zeiss ZEN Lite <http://www.zeiss.com/microscopy/int/products/microscope-software/zen-lite.html>`_
 weHave = * many example datasets
 weWant = * an official specification document
 pixelsRating = Very good
@@ -2411,10 +2411,10 @@ mif = true
 pagename = zeiss-axiovision-zvi
 extensions = .zvi
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
-developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision.html>`_
+developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 bsd = no
 versions = 1.0, 2.0
-software = `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/en_de/downloads/axiovision.html>`_
+software = `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/int/downloads/axiovision.html>`_
 weHave = * a ZVI specification document (v2.0.5, from 2010 August, in PDF) \n
 * an older ZVI specification document (v2.0.2, from 2006 August 23, in PDF) \n
 * an older ZVI specification document (v2.0.1, from 2005 April 21, in PDF) \n
@@ -2441,7 +2441,7 @@ indexExtensions = .czi
 extensions = `.czi <http://www.zeiss.com/czi>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/czi>`_
 bsd = no
-software = `Zeiss ZEN <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen.html>`_
+software = `Zeiss ZEN <http://www.zeiss.com/microscopy/int/products/microscope-software/zen.html>`_
 weHave = * many example datasets \n
 * official specification documents
 pixelsRating = Outstanding
@@ -2460,7 +2460,7 @@ pagename = zeiss-lsm
 extensions = .lsm, .mdb
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 bsd = no
-software = `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_ \n
+software = `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/int/downloads/lsm-5-series.html>`_ \n
 `LSM Toolbox plugin for ImageJ <http://imagejdocu.tudor.lu/Members/ppirrotte/lsmtoolbox>`_ \n
 `LSM Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/lsm-reader.html>`_ \n
 `DIMIN <http://www.dimin.net/>`_

--- a/docs/sphinx/formats/pcx-pc-paintbrush.txt
+++ b/docs/sphinx/formats/pcx-pc-paintbrush.txt
@@ -47,4 +47,4 @@ Utility: |Fair|
 **Additional Information**
 
 
-Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_.
+Commercial applications that support PCX include `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/int/downloads/lsm-5-series.html>`_.

--- a/docs/sphinx/formats/zeiss-axiovision-tiff.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-tiff.txt
@@ -24,7 +24,7 @@ Reader: ZeissTIFFReader (:bfreader:`Source Code <ZeissTIFFReader.java>`, :doc:`S
 
 Freely Available Software:
 
-- `Zeiss ZEN Lite <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen-lite.html>`_
+- `Zeiss ZEN Lite <http://www.zeiss.com/microscopy/int/products/microscope-software/zen-lite.html>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/zeiss-axiovision-zvi.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-zvi.txt
@@ -6,7 +6,7 @@ Zeiss AxioVision ZVI (Zeiss Vision Image)
 
 Extensions: .zvi
 
-Developer: `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/en_de/products/microscope-software/axiovision.html>`_
+Developer: `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 
 Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
 
@@ -24,7 +24,7 @@ Reader: ZeissZVIReader (:bfreader:`Source Code <ZeissZVIReader.java>`, :doc:`Sup
 
 Freely Available Software:
 
-- `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/en_de/downloads/axiovision.html>`_
+- `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/int/downloads/axiovision.html>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/zeiss-czi.txt
+++ b/docs/sphinx/formats/zeiss-czi.txt
@@ -23,7 +23,7 @@ Reader: ZeissCZIReader (:bfreader:`Source Code <ZeissCZIReader.java>`, :doc:`Sup
 
 Freely Available Software:
 
-- `Zeiss ZEN <http://www.zeiss.com/microscopy/en_de/products/microscope-software/zen.html>`_
+- `Zeiss ZEN <http://www.zeiss.com/microscopy/int/products/microscope-software/zen.html>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/zeiss-lsm.txt
+++ b/docs/sphinx/formats/zeiss-lsm.txt
@@ -23,7 +23,7 @@ Reader: ZeissLSMReader (:bfreader:`Source Code <ZeissLSMReader.java>`, :doc:`Sup
 
 Freely Available Software:
 
-- `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/en_de/downloads/lsm-5-series.html>`_ 
+- `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/int/downloads/lsm-5-series.html>`_ 
 - `LSM Toolbox plugin for ImageJ <http://imagejdocu.tudor.lu/Members/ppirrotte/lsmtoolbox>`_ 
 - `LSM Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/lsm-reader.html>`_ 
 - `DIMIN <http://www.dimin.net/>`_


### PR DESCRIPTION
These ZEISS links were making the build unstable (see https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/440/warnings3Result/) and although the new build is green, they are still redirecting so this PR updates them.