### PR TITLE
Remove findbugs from Travis and simplify the yml configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,12 @@ cache:
 addons:
   apt_packages:
     - git
-    - cmake
-    - build-essential
-    - libboost-all-dev
 
 jdk:
   - oraclejdk8
   - openjdk7
 
 env:
-  - BUILD=maven_findbugs
   - BUILD=maven
   - BUILD=ant
 
@@ -33,17 +29,7 @@ before_install:
   - if [[ $BUILD == 'ant' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
 
 install:
-  - if [[ $BUILD != 'ant' ]] && [[ $BUILD != 'sphinx_html' ]]; then git fetch --tags; fi
-  - if [[ $BUILD == 'maven_findbugs' ]]; then mvn install -DskipTests=true; fi
+  - if [[ $BUILD != 'ant' ]]; then git fetch --tags; fi
 
 script:
   - ./tools/test-build $BUILD
-
-matrix:
-  exclude:
-    - jdk: openjdk7
-      env: BUILD=sphinx_html
-    - jdk: openjdk7
-      env: BUILD=maven_findbugs
-    - jdk: oraclejdk8
-      env: BUILD=maven

--- a/tools/test-build
+++ b/tools/test-build
@@ -17,11 +17,6 @@ maven()
     mvn
 }
 
-maven_findbugs()
-{
-    mvn findbugs:findbugs -Dfindbugs.threshold=medium
-}
-
 cpp()
 {
     (
@@ -80,8 +75,6 @@ do
             clean ;;
         maven)
             maven ;;
-        maven_findbugs)
-            maven_findbugs ;;
         cpp)
             cpp ;;
         flake8)


### PR DESCRIPTION
The `findbugs:findbugs` Maven phase was added to the Travis test script as a way to flag errors. However this is generated a report while the command to fail the build is `findbugs:check`. The latter generates many warnings across components which cannot be fixed in the main Bio-Formats source code without significant work. Instead these should be fixed and activated in each decoupled component.

This commit removes `findbugs:findbugs:` from the Travis test and simplifies the YML file to clarify the fact we are testing a 2x2 matrix (Ant/Maven with JDK 7/8).

To test this PR, check Travis is green and the time of  `oraclejdk8/maven` component is reduced to match roughly the time of the `openjdk8/maven` component.