### PR TITLE
Fix other ZEISS links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2377,8 +2377,8 @@ writer = WlzWriter
 
 [Zeiss Axio CSM]
 extensions = .lms
-owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
-developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
+developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 bsd = no
 weHave = * one example dataset
 pixelsRating = Good
@@ -2393,8 +2393,8 @@ the only one which saves files in the .lms format. \n
 
 [Zeiss AxioVision TIFF]
 extensions = .xml, .tiff
-owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
-developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
+developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 bsd = no
 software = `Zeiss ZEN Lite <http://www.zeiss.com/microscopy/int/products/microscope-software/zen-lite.html>`_
 weHave = * many example datasets
@@ -2410,7 +2410,7 @@ mif = true
 [Zeiss AxioVision ZVI (Zeiss Vision Image)]
 pagename = zeiss-axiovision-zvi
 extensions = .zvi
-owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 bsd = no
 versions = 1.0, 2.0
@@ -2438,8 +2438,8 @@ Commercial applications that support ZVI include `Bitplane Imaris <http://www.bi
 
 [Zeiss CZI]
 indexExtensions = .czi
-extensions = `.czi <http://www.zeiss.com/czi>`_
-developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/czi>`_
+extensions = `.czi <http://www.zeiss.com/microscopy/int/products/microscope-software/zen/czi.html>`_
+developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 bsd = no
 software = `Zeiss ZEN <http://www.zeiss.com/microscopy/int/products/microscope-software/zen.html>`_
 weHave = * many example datasets \n
@@ -2458,7 +2458,7 @@ notes = Bio-Formats does not support CZI files generated using JPEG-XR compressi
 [Zeiss LSM (Laser Scanning Microscope) 510/710]
 pagename = zeiss-lsm
 extensions = .lsm, .mdb
-owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 bsd = no
 software = `Zeiss LSM Image Browser <http://www.zeiss.com/microscopy/int/downloads/lsm-5-series.html>`_ \n
 `LSM Toolbox plugin for ImageJ <http://imagejdocu.tudor.lu/Members/ppirrotte/lsmtoolbox>`_ \n

--- a/docs/sphinx/formats/zeiss-axio-csm.txt
+++ b/docs/sphinx/formats/zeiss-axio-csm.txt
@@ -6,9 +6,9 @@ Zeiss Axio CSM
 
 Extensions: .lms
 
-Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
-Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
 **Support**
 

--- a/docs/sphinx/formats/zeiss-axiovision-tiff.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-tiff.txt
@@ -6,9 +6,9 @@ Zeiss AxioVision TIFF
 
 Extensions: .xml, .tiff
 
-Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
-Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
 **Support**
 

--- a/docs/sphinx/formats/zeiss-axiovision-zvi.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-zvi.txt
@@ -8,7 +8,7 @@ Extensions: .zvi
 
 Developer: `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 
-Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
 **Support**
 

--- a/docs/sphinx/formats/zeiss-czi.txt
+++ b/docs/sphinx/formats/zeiss-czi.txt
@@ -4,9 +4,9 @@
 Zeiss CZI
 ===============================================================================
 
-Extensions: `.czi <http://www.zeiss.com/czi>`_
+Extensions: `.czi <http://www.zeiss.com/microscopy/int/products/microscope-software/zen/czi.html>`_
 
-Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/czi>`_
+Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
 
 **Support**

--- a/docs/sphinx/formats/zeiss-lsm.txt
+++ b/docs/sphinx/formats/zeiss-lsm.txt
@@ -7,7 +7,7 @@ Zeiss LSM (Laser Scanning Microscope) 510/710
 Extensions: .lsm, .mdb
 
 
-Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/>`_
+Owner: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 
 **Support**
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1590,7 +1590,7 @@ Supported Formats
      - |no|
      - |no|
    * - :doc:`formats/zeiss-czi`
-     - `.czi <http://www.zeiss.com/czi>`_
+     - `.czi <http://www.zeiss.com/microscopy/int/products/microscope-software/zen/czi.html>`_
      - |Outstanding|
      - |Outstanding|
      - |Very good|


### PR DESCRIPTION
Fixes up the ZEISS links which may be redirected but are still upsetting the build -https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/443/warnings3Result/

(I also fixed up the CZI links while I was at it, given that was redirecting too, and linking to the CZI specific page twice was inconsistent with the other pages where the ZEISS developer link goes just to the homepage)

Should make the merge build green again.