### PR TITLE
Update ome-poi to 5.3.0

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-poi</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -384,10 +384,6 @@
     <repository>
       <id>ome.snapshots</id>
       <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-    </repository>
-    <repository>
-      <id>ome.snapshots.test</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/openmicroscopy/bioformats/pull/2624

The ome-poi version has been changed to 5.3.0 from 5.3.0-SNAPSHOT.
The repository previously used for the snapshot has been removed in favour of Maven central.

To test: Verify that builds remain green