### PR TITLE
Revert changes to handle symlinks with external configuration

### DIFF
--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -98,19 +98,9 @@ public class ConfigurationTree {
     if (rootDir == null) {
       throw new IllegalArgumentException("rootDir cannot be null.");
     }
-
+    this.rootDir = new File(rootDir).getAbsolutePath();
     if (configDir != null) {
-      Location rootLocation = new Location(rootDir);
-      Location configLocation = new Location(configDir);
-      while (rootLocation.getName().equals(configLocation.getName())) {
-        rootLocation = rootLocation.getParentFile();
-        configLocation = configLocation.getParentFile();
-      }
-
-      this.rootDir = rootLocation.getAbsolutePath();
-      this.configDir = configLocation.getAbsolutePath();
-    } else {
-      this.rootDir = new File(rootDir).getAbsolutePath();
+        this.configDir = new File(configDir).getAbsolutePath();
     }
     root = new DefaultMutableTreeNode();
   }
@@ -135,7 +125,6 @@ public class ConfigurationTree {
    *  Relocate a path from an base directory into a target directory
    */
   public String relocate(String path, String oldRoot, String newRoot) {
-
     String subPath = path.substring((int) Math.min(
       oldRoot.length() + 1, path.length()));
     if (subPath.length() == 0) {

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -195,6 +195,48 @@ public class TestTools {
     getFiles(root, files, config, toplevelConfig, subdirs, "");
   }
 
+  /**
+   * Retrieve an external configuration file given a root directory and test
+   * configuration.
+   * @deprecated No replacement.
+   */
+  @Deprecated
+  public static String getExternalConfigFile(String root,
+    final ConfigurationTree config)
+  {
+    // Look for a configuration file under the configuration directory
+    String configRoot = config.relocateToConfig(root);
+    Location configFile = new Location(configRoot, baseConfigName);
+    if (configFile.exists()) {
+      return configFile.getAbsolutePath();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Retrieve an external symlinked configuration file given a root directory
+   * and a test configuration.
+   * @deprecated No replacement.
+   */
+  @Deprecated
+  public static String getExternalSymlinkConfigFile(String root,
+    final ConfigurationTree config)
+  {
+    // Look for a configuration file under the configuration directory
+    try {
+      String canonicalRoot = new Location(root).getCanonicalPath();
+      if (!root.equals(canonicalRoot)) {
+        String configCanonicalRoot = config.relocateToConfig(canonicalRoot);
+        Location configFile = new Location(configCanonicalRoot, baseConfigName);
+        if (configFile.exists()) {
+          return configFile.getAbsolutePath();
+        }
+      }
+    } catch (IOException e) {};
+    return null;
+  }
+
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig, String[] subdirs,


### PR DESCRIPTION
Reverts #1912.

Discussed with @sbesson: these changes were needed to support the peculiar link structure in `test_images_good` and should not be needed anymore now that we're moving to a "proper" subset. On one hand, this revert simplifies the code; on the other hand, I've found out that the path relocation feature added in #1912 was generating wrong paths with the new subset layout.
