### PR TITLE
Restore no-poi ant test

### DIFF
--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -14,7 +14,7 @@ Type "ant -p" for a list of targets.
   <property file="build.properties"/>
 
   <target name="test" depends="jar,compile-tests,test-no-mdb,test-no-netcdf,
-    test-no-jhdf"
+    test-no-poi,test-no-jhdf"
     description="run tests">
     <!-- NOTE: Overrides default "test" target from java.xml -->
     <copy tofile="${build.dir}/testng.xml" overwrite="true"
@@ -79,6 +79,31 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-mx${testng.memory}"/>
     </testng>
     <fail if="failedTest"/>
+  </target>
+
+<target name="test-no-poi" depends="compile-tests"    
+    description="run missing POI JAR tests" if="doTests">   
+    <copy tofile="${build.dir}/testng.xml" overwrite="true"   
+      file="${tests.dir}/loci/formats/utests/testng-no-poi.xml"/>   
+    <path id="test-no-poi.classpath">   
+      <restrict>    
+        <path refid="test.classpath"/>    
+        <rsel:not>    
+          <rsel:name name="ome-poi*.jar"/>    
+        </rsel:not>   
+      </restrict>   
+    </path>   
+    <testng failureProperty="failedTest">   
+      <classpath refid="test-no-poi.classpath"/>    
+      <classpath>   
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->    
+        <pathelement location="${test-classes.dir}"/>   
+        <pathelement location="${classes.dir}"/>    
+      </classpath>    
+      <xmlfileset file="${build.dir}/testng.xml"/>    
+      <jvmarg value="-mx${testng.memory}"/>   
+    </testng>   
+    <fail if="failedTest"/>   
   </target>
 
   <target name="test-no-jhdf" depends="compile-tests"


### PR DESCRIPTION
This PR is a follow up to https://github.com/openmicroscopy/bioformats/pull/2624

This test was incorrectly removed in https://github.com/openmicroscopy/bioformats/pull/2624/commits/1e7a361d0705686f6ffaff588621eee324deebb7

The test-no-poi target has been restored.

To test:
- Verify that the builds and tests remain green
- Use ant test locally to verify that the test-no-poi runs successfully 