### PR TITLE
All component versions are defined in root pom

### DIFF
--- a/ant/global.properties
+++ b/ant/global.properties
@@ -15,15 +15,3 @@ artifact.dir = ${root.dir}/artifacts
 # copyright strings to use when generating javadocs
 copyright.begin = <i>Copyright &#169;
 copyright.end   = Open Microscopy Environment</i>
-
-domain.prefix = org.openmicroscopy
-
-log4j.version = 1.2.17
-logback.version = 1.1.1
-slf4j.version = 1.7.6
-kryo.version = 2.24.0
-objenesis.version = 2.1
-minlog.version = 1.2
-testng.version = 6.8
-guava.version = 17.0
-ome_common.version = 5.3.0

--- a/ant/global.xml
+++ b/ant/global.xml
@@ -10,6 +10,7 @@ Type "ant -p" for a list of targets.
 <project>
   <property file="${user.home}/.ant-global.properties"/>
   <property file="${root.dir}/ant/global.properties"/>
+  <xmlproperty file="${root.dir}/pom.xml" prefix="maven" keepRoot="false"/>
 
   <!-- Convenient JDK version properties -->
 
@@ -79,6 +80,14 @@ Type "ant -p" for a list of targets.
   <!-- ProGuard: http://proguard.sourceforge.net/ -->
   <!--<taskdef resource="proguard/ant/task.properties"
     classpath="${lib.dir}/proguard.jar"/>-->
+
+  <!-- Version properties from maven -->
+  <propertyselector property="mavenproperties" match="maven\.properties\.(.*\.version)" select="\1"/>
+  <for list="${mavenproperties}" param="mavenproperty">
+    <sequential>
+      <property name="@{mavenproperty}" value="${maven.properties.@{mavenproperty}}"/>
+    </sequential>
+  </for>
 
   <!-- Internal build targets -->
 

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-xml.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-xml.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-xml.version}</version>
     </dependency>
 
     <dependency>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -41,12 +41,12 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-xml.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>specification</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${specification.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-xml.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-poi</artifactId>
-      <version>5.3.0</version>
+      <version>${ome-poi.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/metakit/pom.xml
+++ b/components/metakit/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-common</artifactId>
-      <version>${ome_common.version}</version>
+      <version>${ome-common.version}</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-xml.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -49,7 +49,8 @@ Type "ant -p" for a list of targets.
     <replace file="conf.py" token="@openmicroscopy_source_user@" value="${sphinx.openmicroscopy_source.user}"/>
     <replace file="conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
     <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
-    <replace file="conf.py" token="@ome_common_version@" value="${ome_common.version}"/>
+    <replace file="conf.py" token="@ome_common_version@" value="${ome-common.version}"/>
+    <replace file="conf.py" token="@ome_xml_version@" value="${ome-xml.version}"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -19,6 +19,8 @@ openmicroscopy_source_user = '@openmicroscopy_source_user@'
 ome_source_user = '@ome_source_user@'
 omerodoc_uri = '@sphinx_omerodoc_uri@'
 ome_common_version = '@ome_common_version@'
+ome_xml_version = '@ome_xml_version@'
+ome_specification_version = '@ome_specification_version@'
 
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
@@ -162,6 +164,8 @@ extlinks = {
     'downloads' : (downloads_root + '/latest/bio-formats5.2/%s', ''),
     'javadoc' : (downloads_root + '/latest/bio-formats5.2/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
+    'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_xml_version + '/' + '%s', ''),
+    'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_specification_version + '/' + '%s', ''),
 
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),

--- a/docs/sphinx/developers/matlab-dev.txt
+++ b/docs/sphinx/developers/matlab-dev.txt
@@ -167,7 +167,7 @@ To access physical voxel and stack sizes of the data:
   :end-before: read-ome-metadata-end
 
 For more information about the methods to retrieve the metadata, see the
-:javadoc:`MetadataRetrieve <loci/formats/meta/MetadataRetrieve.html>` Javadoc
+:xml_javadoc:`MetadataRetrieve <ome/xml/meta/MetadataRetrieve.html>` Javadoc
 page.
 
 To convert the OME metadata into a string, use the ``dumpXML()`` method:
@@ -266,7 +266,7 @@ metadata and pass this object directly to ``bfsave``:
   :end-before: bfsave-metadata-end
 
 For more information about the methods to store the metadata, see the
-:javadoc:`MetadataStore <loci/formats/meta/MetadataStore.html>` Javadoc page.
+:xml_javadoc:`MetadataStore <ome/xml/meta/MetadataStore.html>` Javadoc page.
 
 .. _reader_performance:
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,10 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome_common.version>5.3.0</ome_common.version>
+    <ome-common.version>5.3.0</ome-common.version>
+    <specification.version>5.3.0</specification.version>
+    <ome-xml.version>5.3.0</ome-xml.version>
+    <ome-poi.version>5.3.0</ome-poi.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Also fix up doc links to use versioned ome-xml javadocs, as for ome-common.

Testing: Check and and maven builds continue to work and that jobs remain green.  Check matlab links for MetadataStore/Retrieve.