### PR TITLE
Bump ome-mdbtools version to 5.3.0

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-mdbtools</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>${ome-mdbtools.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -384,10 +384,6 @@
     <repository>
       <id>ome.snapshots</id>
       <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-    </repository>
-    <repository>
-      <id>ome.snapshots.test</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <specification.version>5.3.0</specification.version>
     <ome-xml.version>5.3.0</ome-xml.version>
     <ome-poi.version>5.3.0</ome-poi.version>
+    <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Bumps the version of ome-mdbtools from 5.3.0-SNAPSHOT to 5.3.0
- Removes the test repo as jar is now located on maven central
- Uses the new versioning as introduced in https://github.com/openmicroscopy/bioformats/pull/2637