### PR TITLE
Fix Axiovision download link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2414,7 +2414,7 @@ owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.ht
 developer = `Carl Zeiss Microscopy GmbH (AxioVision) <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 bsd = no
 versions = 1.0, 2.0
-software = `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/int/downloads/axiovision.html>`_
+software = `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 weHave = * a ZVI specification document (v2.0.5, from 2010 August, in PDF) \n
 * an older ZVI specification document (v2.0.2, from 2006 August 23, in PDF) \n
 * an older ZVI specification document (v2.0.1, from 2005 April 21, in PDF) \n

--- a/docs/sphinx/formats/zeiss-axiovision-zvi.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-zvi.txt
@@ -24,7 +24,7 @@ Reader: ZeissZVIReader (:bfreader:`Source Code <ZeissZVIReader.java>`, :doc:`Sup
 
 Freely Available Software:
 
-- `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/int/downloads/axiovision.html>`_
+- `Zeiss Axiovision LE <http://www.zeiss.com/microscopy/int/products/microscope-software/axiovision.html>`_
 
 
 We currently have:


### PR DESCRIPTION
Fixes https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/454/warnings3Result/

Download link is now at the bottom of the product page because you have to give your personal details to get the free version.

Should make the build green again. 
Staged at http://www.openmicroscopy.org/site/support/bio-formats5.3-staging/formats/zeiss-axiovision-zvi.html