### PR TITLE
Improve Ant jar and bundle target to honor maven.repo.local variable

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -176,7 +176,9 @@ your FindBugs installation's lib directory. E.g.:
       </manifest>
     </jar>
     <artifact:install file="${artifact.dir}/${component.jar}">
-        <pom refid="maven.pom"/>
+      <artifact:localRepository id="local.repository"
+        path="${maven.repo.local}"/>
+      <pom refid="maven.pom"/>
     </artifact:install>
   </target>
 
@@ -189,7 +191,9 @@ your FindBugs installation's lib directory. E.g.:
       </manifest>
     </jar>
     <artifact:install file="${artifact.dir}/${bundle.jar}">
-        <pom refid="maven.pom"/>
+      <pom refid="maven.pom"/>
+      <artifact:localRepository id="local.repository"
+        path="${maven.repo.local}"/>
     </artifact:install>
   </target>
 


### PR DESCRIPTION
## Background

See https://trello.com/c/MeIS9tyf/21-test-jobs-rearchitecture. The migration of the Ant build system to use `Maven Ant Tasks` in https://github.com/openmicroscopy/bioformats/pull/2622 greatly improved the build system and dependency management.

Prior to 5.3.0-m1, the Ant build was fully contained within the source code directory using embedded dependencies and generating all artifacts under `artifacts`. With the change above, the build logic now uses the Maven repository both for the project dependencies but also the individual components.

One downside of this approach has been reported in the CI environment where builds were previously implicitly relying on the build containment and are now failing due to race conditions and/or overwriting SNAPSHOT artifacts which could be used by other jobs.
## Changes

Similar to Maven, a property was introduced in https://github.com/openmicroscopy/bioformats/commit/f948bc1ad9aa6020c8d7c7d0878c087b2ce2707c allowing to override the local repository. However as it was only introduced for the dependency resolution, it made its usage incomplete.

This commit should restore the symmetry with the `mvn-init` task and use the repository defined by `maven.repo.local` if set for installing the component or bundle JAR.
## Testing

To test this PR, it should be possible to build Bio-Formats from the top-level directory using a custom repository and the Ant build system:

```
$ ant clean jars -Dmaven.repo.local=/tmp/bf_ant_repo
```
## Application

In the context of the CI testing, using this property should allow to differentiate the jobs which need to share artifacts using the default Maven repository under  `~/.m2` e.g. the build job and the integration/repository jobs from standalone job. An immediate candidate for the latter are the [repository subset jobs](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-repository-subset/) which are used to test PRs against subset of the data repository and should remain runnable at anytime without impacting the daily jobs like [the full repository job](https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-full-repository/) /cc @simleo 
