### PR TITLE
update developer docs

### DIFF
--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -62,26 +62,6 @@ If you are interested in working on the Bio-Formats source code itself,
 you can load it into your favorite IDE, or develop with your favorite
 text editor.
 
-Prerequisites
-^^^^^^^^^^^^^
-
-In addition to the Bio-Formats source code, the following programs and
-packages are also required:
-
-- `Python 2 <http://python.org>`_, version 2.6 or later (note: not
-  version 3)
-- `Genshi <http://genshi.edgewall.org>`_ 0.5 or later (0.7 recommended)
-
-.. note::
-
-    Genshi may be installed (in order of decreasing preference) with
-    some Linux distributions' package managers, :program:`pip` (``pip
-    install genshi``), by downloading a compatible :file:`.egg` for
-    your system from the `Genshi download page
-    <http://genshi.edgewall.org/wiki/Download>`_, or from source.  If
-    using a :file:`.egg`, make sure it is added to your
-    :envvar:`PYTHONPATH` environment variable.
-
 NetBeans
 ^^^^^^^^
 
@@ -124,13 +104,6 @@ and browsing to the top-level folder of your Bio-Formats working copy.
 Alternatively, run the Eclipse Maven target with :command:`mvn
 eclipse:eclipse` to create the Eclipse project files, then use
 :menuselection:`File --> Import --> Existing Projects into Workspace`.
-
-To remove post-import errors, either close the ``ome-xml`` project or run::
-
-  ant jars && mvn generate-sources
-
-.. seealso::
-   `[ome-devel] Importing source into eclipse <http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2014-March/002719.html>`_
 
 Command line
 ^^^^^^^^^^^^

--- a/docs/sphinx/developers/building-bioformats.txt
+++ b/docs/sphinx/developers/building-bioformats.txt
@@ -103,7 +103,7 @@ You can import the Bio-Formats source by choosing
 and browsing to the top-level folder of your Bio-Formats working copy.
 Alternatively, run the Eclipse Maven target with :command:`mvn
 eclipse:eclipse` to create the Eclipse project files, then use
-:menuselection:`File --> Import --> Existing Projects into Workspace`.
+:menuselection:`File --> Import --> Existing Maven Projects`.
 
 Command line
 ^^^^^^^^^^^^

--- a/docs/sphinx/developers/components.txt
+++ b/docs/sphinx/developers/components.txt
@@ -131,7 +131,7 @@ readers and writers. :ref:`ome-common <ome-common>` and
 
 :source:`formats-bsd (BSD Bio-Formats readers and writers) <components/formats-bsd>`:
 
-`Ant: jar-formats-bsd, jar-formats-bsd-tests`
+`Ant: jar-formats-bsd`
 
 This contains readers and writers for formats which have a publicly available
 specification, e.g. TIFF.  Everything in the component is BSD-licensed.

--- a/docs/sphinx/developers/overview.txt
+++ b/docs/sphinx/developers/overview.txt
@@ -40,8 +40,8 @@ OME data model.
 Implementation
 --------------
 
-Bio-Formats is primarily a Java project. It can be used from MATLAB, and
-there are C++ bindings and an ongoing C++ implementation effort. The
+Bio-Formats is primarily a Java project. It can be used from MATLAB and
+there is also a separate C++ implementation (OME Files C++). The
 source code is available for download and sometimes the user community
 contributes code back into Bio-Formats by opening a pull request on
 GitHub. Bio-Formats is built from source with Ant or Maven and some of


### PR DESCRIPTION
See https://trello.com/c/phPRO185/34-developer-documentation-updates

As well as reviewing the staging pages https://www.openmicroscopy.org/site/support/bio-formats5.3-staging/developers/overview.html etc, the tester needs to check that the decoupling of ome-xml means there are no post-import errors when importing the BF source into Eclipse - import 5.3.0-m1 to test.