### PR TITLE
Add JPEG-XR support for CZI data

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
@@ -32,6 +32,7 @@ import java.awt.Panel;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Arrays;
+import java.nio.channels.ClosedByInterruptException;
 
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -80,13 +81,8 @@ public class ThumbLoader implements Runnable {
     if (loader == null) return;
     stop = true;
     BF.status(false, "Canceling thumbnail generation");
-    try {
-      loader.join();
-      loader = null;
-    }
-    catch (InterruptedException exc) {
-      exc.printStackTrace();
-    }
+    loader.interrupt();
+    loader = null;
     BF.status(false, "");
   }
 
@@ -138,7 +134,7 @@ public class ThumbLoader implements Runnable {
     }
     catch (FormatException e) { exc = e; }
     catch (IOException e) { exc = e; }
-    if (exc != null) {
+    if (exc != null && !(exc instanceof ClosedByInterruptException)) {
       BF.warn(quiet, "Error loading thumbnail for series #" + (series + 1));
       BF.debug(DebugTools.getStackTrace(exc));
     }

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1264,7 +1264,7 @@ public final class FormatTools {
     if (bytes.length == 1) return bytes[0];
     int rgbChannelCount = reader.getRGBChannelCount();
     byte[] rtn = new byte[rgbChannelCount * bytes[0].length];
-    
+
     if (!reader.isInterleaved()) {
       for (int i=0; i<rgbChannelCount; i++) {
         System.arraycopy(bytes[i], 0, rtn, bytes[0].length * i, bytes[i].length);
@@ -1273,7 +1273,7 @@ public final class FormatTools {
     else {
       int bpp = FormatTools.getBytesPerPixel(reader.getPixelType());
 
-      for (int i=0; i<bytes[0].length/bpp; i+=bpp) {
+      for (int i=0; i<bytes[0].length; i+=bpp) {
         for (int j=0; j<rgbChannelCount; j++) {
           System.arraycopy(bytes[j], i, rtn, (i * rgbChannelCount) + j * bpp, bpp);
         }

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -303,8 +303,8 @@ public class ChannelSeparator extends ReaderWrapper {
     MetadataTools.populatePixelsOnly(store, this);
     if (store instanceof MetadataRetrieve) {
       MetadataRetrieve retrieve = (MetadataRetrieve) store;
-      for (int s=0; s<getCoreMetadataList().size(); s++) {
-        setCoreIndex(s);
+      for (int s=0; s<getSeriesCount(); s++) {
+        setSeries(s);
         int rgbChannels = getSizeC() / reader.getEffectiveSizeC();
         for (int c=0; c<reader.getEffectiveSizeC(); c++) {
           String originalChannelName = retrieve.getChannelName(s, c * rgbChannels);
@@ -313,7 +313,7 @@ public class ChannelSeparator extends ReaderWrapper {
           }
         }
       }
-      setCoreIndex(0);
+      setSeries(0);
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -35,6 +35,8 @@ package loci.formats;
 import java.io.IOException;
 
 import loci.common.DataTools;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.meta.MetadataStore;
 
 /**
  * Logic to automatically separate the channels in a file.
@@ -296,6 +298,23 @@ public class ChannelSeparator extends ReaderWrapper {
     lastImageY = -1;
     lastImageWidth = -1;
     lastImageHeight = -1;
+
+    MetadataStore store = getMetadataStore();
+    MetadataTools.populatePixelsOnly(store, this);
+    if (store instanceof MetadataRetrieve) {
+      MetadataRetrieve retrieve = (MetadataRetrieve) store;
+      for (int s=0; s<getCoreMetadataList().size(); s++) {
+        setCoreIndex(s);
+        int rgbChannels = getSizeC() / reader.getEffectiveSizeC();
+        for (int c=0; c<reader.getEffectiveSizeC(); c++) {
+          String originalChannelName = retrieve.getChannelName(s, c * rgbChannels);
+          for (int i=1; i<rgbChannels; i++) {
+            store.setChannelName(originalChannelName, s, c * rgbChannels + i);
+          }
+        }
+      }
+      setCoreIndex(0);
+    }
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -237,7 +237,7 @@ public class ChannelSeparator extends ReaderWrapper {
     int channel = no % c;
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
 
-    return ImageTools.splitChannels(thumb, channel, c, bpp, false, false);
+    return ImageTools.splitChannels(thumb, channel, c, bpp, false, reader.isInterleaved());
   }
 
   /* @see IFormatReader#close(boolean) */

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -300,14 +300,24 @@ public class ChannelSeparator extends ReaderWrapper {
     lastImageHeight = -1;
 
     MetadataStore store = getMetadataStore();
-    MetadataTools.populatePixelsOnly(store, this);
+    boolean pixelsPopulated = false;
     if (store instanceof MetadataRetrieve) {
       MetadataRetrieve retrieve = (MetadataRetrieve) store;
       for (int s=0; s<getSeriesCount(); s++) {
         setSeries(s);
         int rgbChannels = getSizeC() / reader.getEffectiveSizeC();
+        if (rgbChannels == 1) {
+          continue;
+        }
         for (int c=0; c<reader.getEffectiveSizeC(); c++) {
           String originalChannelName = retrieve.getChannelName(s, c * rgbChannels);
+          if (originalChannelName == null) {
+            continue;
+          }
+          if (!pixelsPopulated) {
+            MetadataTools.populatePixelsOnly(store, this);
+            pixelsPopulated = true;
+          }
           for (int i=1; i<rgbChannels; i++) {
             store.setChannelName(originalChannelName, s, c * rgbChannels + i);
           }

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -310,6 +310,9 @@ public class ChannelSeparator extends ReaderWrapper {
           continue;
         }
         for (int c=0; c<reader.getEffectiveSizeC(); c++) {
+          if (c * rgbChannels >= retrieve.getChannelCount(s)) {
+            break;
+          }
           String originalChannelName = retrieve.getChannelName(s, c * rgbChannels);
           if (originalChannelName == null) {
             continue;

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -60,7 +60,7 @@
     </dependency>
     <dependency>
       <groupId>ome</groupId>
-      <artifactId>jxrlib</artifactId>
+      <artifactId>jxrlib-all</artifactId>
       <version>${jxrlib.version}</version>
     </dependency>
     <dependency>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -59,6 +59,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>ome</groupId>
+      <artifactId>jxrlib</artifactId>
+      <version>${jxrlib.version}</version>
+    </dependency>
+    <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>netcdf</artifactId>
       <version>4.3.19</version>

--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -1,0 +1,82 @@
+/*
+ */
+
+package loci.formats.codec;
+
+import java.io.IOException;
+
+import loci.common.RandomAccessInputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.MissingLibraryException;
+import loci.formats.UnsupportedCompressionException;
+import loci.formats.services.JPEGXRService;
+
+/**
+ */
+public class JPEGXRCodec extends BaseCodec {
+
+  // -- Fields --
+
+  private JPEGXRService service;
+
+  // -- Codec API methods --
+
+  /* @see Codec#compress(byte[], CodecOptions) */
+  @Override
+  public byte[] compress(byte[] data, CodecOptions options)
+    throws FormatException
+  {
+    throw new UnsupportedCompressionException(
+      "JPEG-XR compression not supported");
+  }
+
+  /* @see Codec#decompress(RandomAccessInputStream, CodecOptions) */
+  @Override
+  public byte[] decompress(RandomAccessInputStream in, CodecOptions options)
+    throws FormatException, IOException
+  {
+    byte[] buf = new byte[(int) in.length()];
+    in.read(buf);
+    return decompress(buf, options);
+  }
+
+  /**
+   * The CodecOptions parameter should have the following fields set:
+   *  {@link CodecOptions#maxBytes maxBytes}
+   *
+   * @see Codec#decompress(byte[], CodecOptions)
+   */
+  @Override
+  public byte[] decompress(byte[] buf, CodecOptions options)
+    throws FormatException
+  {
+    initialize();
+
+    return service.decompress(buf);
+  }
+
+  // -- Helper methods --
+
+  /**
+   * Initializes the JPEG-XR dependency service. This is called at the
+   * beginning of the {@link #decompress} method to avoid having the
+   * constructor's method definition contain a checked exception.
+   *
+   * @throws FormatException If there is an error initializing JPEG-XR
+   * services.
+   */
+  private void initialize() throws FormatException {
+    if (service != null) return;
+    try {
+      ServiceFactory factory = new ServiceFactory();
+      service = factory.getInstance(JPEGXRService.class);
+    }
+    catch (DependencyException e) {
+      throw new MissingLibraryException("JPEG-XR library not available", e);
+    }
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -77,7 +77,7 @@ public class JPEGXRCodec extends BaseCodec {
   {
     initialize();
 
-    return service.decompress(buf);
+    return service.decompress(buf, options.maxBytes);
   }
 
   // -- Helper methods --

--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -1,4 +1,26 @@
 /*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
  */
 
 package loci.formats.codec;

--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -77,7 +77,7 @@ public class JPEGXRCodec extends BaseCodec {
   {
     initialize();
 
-    return service.decompress(buf, options.maxBytes);
+    return service.decompress(buf);
   }
 
   // -- Helper methods --

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -608,13 +608,14 @@ public class ZeissCZIReader extends FormatReader {
     int fullResBlockCount = planes.size();
     for (int i=0; i<planes.size(); i++) {
       long planeSize = (long) planes.get(i).x * planes.get(i).y * bpp;
-      if (planes.get(i).directoryEntry.compression == UNCOMPRESSED) {
+      int compression = planes.get(i).directoryEntry.compression;
+      if (compression == UNCOMPRESSED || compression == JPEGXR) {
         long size = planes.get(i).dataSize;
         if (size < planeSize || planeSize >= Integer.MAX_VALUE || size < 0) {
           // check for reduced resolution in the pyramid
           DimensionEntry[] entries = planes.get(i).directoryEntry.dimensionEntries;
           if (planes.get(i).directoryEntry.pyramidType == 2 &&
-            size == entries[0].storedSize * entries[1].storedSize * bpp &&
+            (compression == JPEGXR || size == entries[0].storedSize * entries[1].storedSize * bpp) &&
             (planes.get(i).x % entries[0].storedSize) == 0 &&
             (planes.get(i).y % entries[1].storedSize) == 0)
           {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -887,6 +887,7 @@ public class ZeissCZIReader extends FormatReader {
           int minCol = Integer.MAX_VALUE;
           int maxCol = Integer.MIN_VALUE;
           int x = 0, y = 0;
+          int lastX = 0, lastY = 0;
           for (SubBlock plane : planes) {
             if (plane.coreIndex != s) {
               continue;
@@ -913,12 +914,16 @@ public class ZeissCZIReader extends FormatReader {
             if (plane.y > tileHeight[s]) {
               tileHeight[s] = plane.y;
             }
+            if (plane.row == maxRow && plane.col == maxCol) {
+              lastX = plane.x;
+              lastY = plane.y;
+            }
           }
 
           // don't overwrite the dimensions if stitching already occurred
           if (core.get(s).sizeX == x && core.get(s).sizeY == y) {
-            core.get(s).sizeX = (core.get(s).sizeX + maxCol) - minCol;
-            core.get(s).sizeY = (core.get(s).sizeY + maxRow) - minRow;
+            core.get(s).sizeX = (lastX + maxCol) - minCol;
+            core.get(s).sizeY = (lastY + maxRow) - minRow;
           }
         }
         for (int r=0; r<core.get(s).resolutionCount; r++) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -509,7 +509,7 @@ public class ZeissCZIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
-    if (maxResolution > 0 && getCoreIndex() < core.size() - 2) {
+    if (maxResolution > 0 && getCoreIndex() < core.size() - extraImages.size()) {
       return (int) Math.min(1024, getSizeX());
     }
     if (tileWidth != null && getCoreIndex() < tileWidth.length) {
@@ -525,7 +525,7 @@ public class ZeissCZIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
-    if (maxResolution > 0 && getCoreIndex() < core.size() - 2) {
+    if (maxResolution > 0 && getCoreIndex() < core.size() - extraImages.size()) {
       return (int) Math.min(1024, getSizeY());
     }
     if (tileHeight != null && getCoreIndex() < tileHeight.length) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -972,23 +972,6 @@ public class ZeissCZIReader extends FormatReader {
       segment.close();
     }
 
-    if (seriesCount * pixelTypes.size() > 1) {
-      core.clear();
-      for (int j=0; j<pixelTypes.size(); j++) {
-        for (int i=0; i<seriesCount; i++) {
-          CoreMetadata add = new CoreMetadata(ms0);
-          if (pixelTypes.size() > 1) {
-            int newC = originalC / pixelTypes.size();
-            add.sizeC = newC;
-            add.imageCount = add.sizeZ * add.sizeT;
-            add.rgb = false;
-            convertPixelType(add, pixelTypes.get(j));
-          }
-          core.add(add);
-        }
-      }
-    }
-
     // populate the OME metadata
 
     store = makeFilterMetadata();

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3304,6 +3304,9 @@ public class ZeissCZIReader extends FormatReader {
           data = new LZWCodec().decompress(data, options);
           break;
         case JPEGXR:
+          options.maxBytes = directoryEntry.dimensionEntries[0].storedSize *
+            directoryEntry.dimensionEntries[1].storedSize *
+            getRGBChannelCount() * FormatTools.getBytesPerPixel(getPixelType());
           data = new JPEGXRCodec().decompress(data, options);
           break;
         case 104: // camera-specific packed pixels

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -52,6 +52,7 @@ import loci.formats.MetadataTools;
 import loci.formats.UnsupportedCompressionException;
 import loci.formats.codec.CodecOptions;
 import loci.formats.codec.JPEGCodec;
+import loci.formats.codec.JPEGXRCodec;
 import loci.formats.codec.LZWCodec;
 import loci.formats.meta.MetadataStore;
 
@@ -3303,8 +3304,8 @@ public class ZeissCZIReader extends FormatReader {
           data = new LZWCodec().decompress(data, options);
           break;
         case JPEGXR:
-          throw new UnsupportedCompressionException(
-            "JPEG-XR not yet supported");
+          data = new JPEGXRCodec().decompress(data, options);
+          break;
         case 104: // camera-specific packed pixels
           data = decode12BitCamera(data, options.maxBytes);
           // reverse column ordering

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -772,7 +772,10 @@ public class ZeissCZIReader extends FormatReader {
           break;
         }
       }
-      if (getSizeX() > planes.get(0).x && !equalTiles) {
+      if ((getSizeX() > planes.get(0).x ||
+        (getSizeX() == planes.get(0).x &&
+        calculatedSeries == seriesCount * mosaics * positions)) && !equalTiles)
+      {
         // image was fused; treat the mosaics as a single image
         seriesCount = 1;
         positions = 1;

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -305,7 +305,15 @@ public class ZeissCZIReader extends FormatReader {
       // thumbnail, label, or preview image stored as an attachment
 
       int index = getCoreIndex() - (core.size() - extraImages.size());
-      return extraImages.get(index).attachmentData;
+      byte[] fullPlane = extraImages.get(index).attachmentData;
+      RandomAccessInputStream s = new RandomAccessInputStream(fullPlane);
+      try {
+        readPlane(s, x, y, w, h, buf);
+      }
+      finally {
+        s.close();
+      }
+      return buf;
     }
 
     previousChannel = getZCTCoords(no)[1];

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -357,10 +357,11 @@ public class ZeissCZIReader extends FormatReader {
           (plane.planeIndex == previousChannel && validScanDim))
         {
           int res = (int) Math.pow(scaleFactor, plane.resolutionIndex);
-          if ((prestitched != null && prestitched) || validScanDim) {
-            int realX = plane.x / res;
-            int realY = plane.y / res;
 
+          int realX = plane.x / res;
+          int realY = plane.y / res;
+
+          if ((prestitched != null && prestitched) || validScanDim) {
             Region tile = new Region(plane.col, plane.row, realX, realY);
             if (validScanDim) {
               tile.y += (no / getSizeC());
@@ -412,7 +413,7 @@ public class ZeissCZIReader extends FormatReader {
             byte[] rawData = new SubBlock(plane).readPixelData();
             RandomAccessInputStream s = new RandomAccessInputStream(rawData);
             try {
-              readPlane(s, x, y, w, h, buf);
+              readPlane(s, x, y, w, h, realX - getSizeX(), buf);
               emptyTile = false;
             }
             finally {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -330,9 +330,10 @@ public class ZeissCZIReader extends FormatReader {
     boolean emptyTile = true;
     try {
       int minTileX = Integer.MAX_VALUE, minTileY = Integer.MAX_VALUE;
+      int baseResolution = (maxResolution + 1) * (currentIndex / (maxResolution + 1));
       for (SubBlock plane : planes) {
-        if ((plane.planeIndex == no && (plane.coreIndex == currentIndex ||
-          (maxResolution > 0 && plane.coreIndex == (currentIndex / maxResolution)))) ||
+        if ((plane.planeIndex == no && ((maxResolution == 0 && plane.coreIndex == currentIndex) ||
+          (maxResolution > 0 && plane.coreIndex == baseResolution))) ||
           (plane.planeIndex == previousChannel && validScanDim))
         {
           if (plane.row < minTileY) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -794,7 +794,7 @@ public class ZeissCZIReader extends FormatReader {
           mosaics = 1;
         }
         else {
-          prestitched = false;
+          prestitched = maxResolution > 0;
         }
         ms0.sizeX = newX;
         ms0.sizeY = newY;
@@ -1534,7 +1534,9 @@ public class ZeissCZIReader extends FormatReader {
             break;
           case 'M':
             if (dimension.start > prevM) {
-              if (!extraDimOrder.contains('M') && mosaics <= getSeriesCount()) {
+              if (!extraDimOrder.contains('M') && mosaics <= getSeriesCount() &&
+                (prestitched == null || !prestitched))
+              {
                 extraLengths[extraDimOrder.size()] = mosaics;
                 extraDimOrder.add('M');
               }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1251,7 +1251,7 @@ public class ZeissCZIReader extends FormatReader {
           }
 
           String color = channels.get(c).color;
-          if (color != null) {
+          if (color != null && !isRGB()) {
             color = color.replaceAll("#", "");
             if (color.length() > 6) {
               color = color.substring(2, color.length());

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -496,6 +496,9 @@ public class ZeissCZIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
+    if (maxResolution > 0 && getCoreIndex() < core.size() - 2) {
+      return (int) Math.min(1024, getSizeX());
+    }
     if (tileWidth != null && getCoreIndex() < tileWidth.length) {
       int width = tileWidth[getCoreIndex()];
       if (width == 0 && getCoreIndex() > 0) {
@@ -509,6 +512,9 @@ public class ZeissCZIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
+    if (maxResolution > 0 && getCoreIndex() < core.size() - 2) {
+      return (int) Math.min(1024, getSizeY());
+    }
     if (tileHeight != null && getCoreIndex() < tileHeight.length) {
       int height = tileHeight[getCoreIndex()];
       if (height == 0 && getCoreIndex() > 0) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -398,6 +398,10 @@ public class ZeissCZIReader extends FormatReader {
               if (rawData.length < realX * realY * pixel) {
                 realX = rawData.length / (realY * pixel);
               }
+              else if (rawData.length == (realX + 1) * (realY + 1) * pixel) {
+                realX++;
+                realY++;
+              }
 
               int rowLen = pixel * (int) Math.min(intersection.width, realX);
               int outputOffset = outputRow * outputRowLen + outputCol;
@@ -650,7 +654,8 @@ public class ZeissCZIReader extends FormatReader {
         if (size < planeSize || planeSize >= Integer.MAX_VALUE || size < 0) {
           // check for reduced resolution in the pyramid
           DimensionEntry[] entries = planes.get(i).directoryEntry.dimensionEntries;
-          if ((planes.get(i).directoryEntry.pyramidType == 2 || compression == JPEGXR) &&
+          int pyramidType = planes.get(i).directoryEntry.pyramidType;
+          if ((pyramidType == 1 || pyramidType == 2 || compression == JPEGXR) &&
             (compression == JPEGXR || size == entries[0].storedSize * entries[1].storedSize * bpp))
           {
             int scale = planes.get(i).x / entries[0].storedSize;
@@ -749,6 +754,9 @@ public class ZeissCZIReader extends FormatReader {
     int originalMosaicCount = mosaics;
     if (maxResolution == 0) {
       seriesCount *= mosaics;
+    }
+    else {
+      prestitched = true;
     }
 
     ms0.imageCount = getSizeZ() * (isRGB() ? getSizeC()/3 : getSizeC()) * getSizeT();

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -395,6 +395,10 @@ public class ZeissCZIReader extends FormatReader {
                 outputRow -= tile.y;
               }
 
+              if (rawData.length < realX * realY * pixel) {
+                realX = rawData.length / (realY * pixel);
+              }
+
               int rowLen = pixel * (int) Math.min(intersection.width, realX);
               int outputOffset = outputRow * outputRowLen + outputCol;
               for (int trow=0; trow<intersection.height; trow++) {
@@ -647,9 +651,7 @@ public class ZeissCZIReader extends FormatReader {
           // check for reduced resolution in the pyramid
           DimensionEntry[] entries = planes.get(i).directoryEntry.dimensionEntries;
           if ((planes.get(i).directoryEntry.pyramidType == 2 || compression == JPEGXR) &&
-            (compression == JPEGXR || size == entries[0].storedSize * entries[1].storedSize * bpp) &&
-            (planes.get(i).x % entries[0].storedSize) == 0 &&
-            (planes.get(i).y % entries[1].storedSize) == 0)
+            (compression == JPEGXR || size == entries[0].storedSize * entries[1].storedSize * bpp))
           {
             int scale = planes.get(i).x / entries[0].storedSize;
             if (scale == 1 || (scale % 2) == 0 || (scale % 3) == 0) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -791,6 +791,33 @@ public class ZeissCZIReader extends FormatReader {
     ms0.dimensionOrder = "XYCZT";
 
     ArrayList<Integer> pixelTypes = new ArrayList<Integer>();
+    pixelTypes.add(planes.get(0).directoryEntry.pixelType);
+    if (maxResolution == 0) {
+      for (SubBlock plane : planes) {
+        if (!pixelTypes.contains(plane.directoryEntry.pixelType)) {
+          pixelTypes.add(plane.directoryEntry.pixelType);
+        }
+        plane.pixelTypeIndex = pixelTypes.indexOf(plane.directoryEntry.pixelType);
+      }
+
+      if (seriesCount * pixelTypes.size() > 1) {
+        core.clear();
+        for (int j=0; j<pixelTypes.size(); j++) {
+          for (int i=0; i<seriesCount; i++) {
+            CoreMetadata add = new CoreMetadata(ms0);
+            if (pixelTypes.size() > 1) {
+              int newC = originalC / pixelTypes.size();
+              add.sizeC = newC;
+              add.imageCount = add.sizeZ * add.sizeT;
+              add.rgb = false;
+              convertPixelType(add, pixelTypes.get(j));
+            }
+            core.add(add);
+          }
+        }
+      }
+    }
+
     if (seriesCount > 1 || maxResolution > 0) {
       core.clear();
       for (int i=0; i<seriesCount; i++) {
@@ -802,17 +829,6 @@ public class ZeissCZIReader extends FormatReader {
           resolution.resolutionCount = 1;
           core.add(resolution);
         }
-      }
-    }
-    else {
-      // check for case where each channel has a different pixel type
-
-      pixelTypes.add(planes.get(0).directoryEntry.pixelType);
-      for (SubBlock plane : planes) {
-        if (!pixelTypes.contains(plane.directoryEntry.pixelType)) {
-          pixelTypes.add(plane.directoryEntry.pixelType);
-        }
-        plane.pixelTypeIndex = pixelTypes.indexOf(plane.directoryEntry.pixelType);
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -331,15 +331,15 @@ public class ZeissCZIReader extends FormatReader {
     try {
       int minTileX = Integer.MAX_VALUE, minTileY = Integer.MAX_VALUE;
       for (SubBlock plane : planes) {
-        if ((plane.coreIndex == currentIndex && plane.planeIndex == no) ||
+        if ((plane.planeIndex == no && (plane.coreIndex == currentIndex ||
+          (maxResolution > 0 && plane.coreIndex == (currentIndex / maxResolution)))) ||
           (plane.planeIndex == previousChannel && validScanDim))
         {
-          int res = (int) Math.pow(scaleFactor, plane.resolutionIndex);
-          if ((plane.row / res) < minTileY) {
-            minTileY = plane.row / res;
+          if (plane.row < minTileY) {
+            minTileY = plane.row;
           }
-          if ((plane.col / res) < minTileX) {
-            minTileX = plane.col / res;
+          if (plane.col < minTileX) {
+            minTileX = plane.col;
           }
         }
       }
@@ -352,7 +352,7 @@ public class ZeissCZIReader extends FormatReader {
             int realX = plane.x / res;
             int realY = plane.y / res;
 
-            Region tile = new Region(plane.col / res, plane.row / res, realX, realY);
+            Region tile = new Region(plane.col, plane.row, realX, realY);
             if (validScanDim) {
               tile.y += (no / getSizeC());
               image.height = scanDim;
@@ -366,6 +366,8 @@ public class ZeissCZIReader extends FormatReader {
               tile.x -= minTileX;
               tile.y -= minTileY;
             }
+            tile.x /= res;
+            tile.y /= res;
 
             if (tile.intersects(image)) {
               emptyTile = false;

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRService.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRService.java
@@ -38,10 +38,9 @@ public interface JPEGXRService extends Service {
    * Opening and closing of decoders and streams is handled internally.
    *
    * @param compressed the complete JPEG-XR compressed data
-   * @param outputSize the number of expected decompressed bytes
    * @return raw decompressed bytes
    * @throws FormatException if an error occurs during decompression
    */
-  byte[] decompress(byte[] compressed, int outputSize) throws FormatException;
+  byte[] decompress(byte[] compressed) throws FormatException;
 
 }

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRService.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRService.java
@@ -38,9 +38,10 @@ public interface JPEGXRService extends Service {
    * Opening and closing of decoders and streams is handled internally.
    *
    * @param compressed the complete JPEG-XR compressed data
+   * @param outputSize the number of expected decompressed bytes
    * @return raw decompressed bytes
    * @throws FormatException if an error occurs during decompression
    */
-  byte[] decompress(byte[] compressed) throws FormatException;
+  byte[] decompress(byte[] compressed, int outputSize) throws FormatException;
 
 }

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRService.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRService.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.services;
+
+import loci.common.services.Service;
+import loci.formats.FormatException;
+
+/**
+ * Interface defining methods for working with JPEG-XR data
+ */
+public interface JPEGXRService extends Service {
+
+  /**
+   * Decompress the given JPEG-XR compressed byte array and return as a byte array.
+   * Opening and closing of decoders and streams is handled internally.
+   *
+   * @param compressed the complete JPEG-XR compressed data
+   * @return raw decompressed bytes
+   * @throws FormatException if an error occurs during decompression
+   */
+  byte[] decompress(byte[] compressed) throws FormatException;
+
+}

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
@@ -25,6 +25,10 @@
 
 package loci.formats.services;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
 import loci.common.services.AbstractService;
 import loci.common.services.Service;
 import loci.formats.FormatException;
@@ -44,13 +48,24 @@ public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService 
    * @see JPEGXRServiceImpl#decompress(byte[])
    */
   public byte[] decompress(byte[] compressed) throws FormatException {
-    Decode decoder = new Decode(compressed);
+    String outFile = null;
+    try {
+      outFile = File.createTempFile(String.valueOf(System.currentTimeMillis()), ".jxr").getAbsolutePath();
+      FileOutputStream out = new FileOutputStream(outFile);
+      out.write(compressed);
+      out.close();
+    }
+    catch (IOException e) {
+      throw new FormatException("Could not write input bytes to temporary file", e);
+    }
+    Decode decoder = new Decode(new File(outFile));
     byte[] decompressed = null;
     try {
       decompressed = decoder.toBytes();
     }
     finally {
       decoder.close();
+      new File(outFile).delete();
     }
     return decompressed;
   }

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
@@ -26,7 +26,6 @@
 package loci.formats.services;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import loci.common.services.AbstractService;
 import loci.common.services.Service;
@@ -54,23 +53,10 @@ public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService 
    * @see JPEGXRServiceImpl#decompress(byte[], int)
    */
   public byte[] decompress(byte[] compressed, int outputSize) throws FormatException {
-    try {
       LOGGER.trace("begin tile decode; compressed size = {}, expected decompressed size = {}", compressed.length, outputSize);
-      Decode decoder = new Decode(compressed);
-      LOGGER.trace("constructed Decode");
-      ByteBuffer output = ByteBuffer.allocateDirect(outputSize);
-      LOGGER.trace("allocated output ByteBuffer");
-      decoder.toBytes(output);
+      byte[] raw = Decode.decodeFirstFrame(compressed, 0, compressed.length, outputSize);
       LOGGER.trace("retrieved decompressed bytes");
-      byte[] raw = new byte[outputSize];
-      output.get(raw);
-      output = null;
-      LOGGER.trace("copied decompressed bytes");
       return raw;
-    }
-    catch (DecodeException e) {
-      throw new FormatException(e);
-    }
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.services;
+
+import loci.common.services.AbstractService;
+import loci.common.services.Service;
+import loci.formats.FormatException;
+
+import ome.jxrlib.Decode;
+
+/**
+ * Interface defining methods for working with JPEG-XR data
+ */
+public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService {
+
+  public JPEGXRServiceImpl() {
+    checkClassDependency(ome.jxrlib.Decode.class);
+  }
+
+  /**
+   * @see JPEGXRServiceImpl#decompress(byte[])
+   */
+  public byte[] decompress(byte[] compressed) throws FormatException {
+    Decode decoder = new Decode(compressed);
+    byte[] decompressed = null;
+    try {
+      decompressed = decoder.toBytes();
+    }
+    finally {
+      decoder.close();
+    }
+    return decompressed;
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
@@ -50,12 +50,12 @@ public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService 
   }
 
   /**
-   * @see JPEGXRServiceImpl#decompress(byte[], int)
+   * @see JPEGXRServiceImpl#decompress(byte[])
    */
-  public byte[] decompress(byte[] compressed, int outputSize) throws FormatException {
-      LOGGER.trace("begin tile decode; compressed size = {}, expected decompressed size = {}", compressed.length, outputSize);
-      byte[] raw = Decode.decodeFirstFrame(compressed, 0, compressed.length, outputSize);
-      LOGGER.trace("retrieved decompressed bytes");
+  public byte[] decompress(byte[] compressed) throws FormatException {
+      LOGGER.trace("begin tile decode; compressed size = {}", compressed.length);
+      byte[] raw = Decode.decodeFirstFrame(compressed, 0, compressed.length);
+      LOGGER.trace("retrieved decompressed bytes size = {}", raw.length);
       return raw;
   }
 

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
@@ -35,10 +35,16 @@ import loci.formats.FormatException;
 import ome.jxrlib.Decode;
 import ome.jxrlib.DecodeException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Interface defining methods for working with JPEG-XR data
  */
 public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService {
+
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(JPEGXRServiceImpl.class);
 
   public JPEGXRServiceImpl() {
     checkClassDependency(ome.jxrlib.Decode.class);
@@ -49,12 +55,17 @@ public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService 
    */
   public byte[] decompress(byte[] compressed, int outputSize) throws FormatException {
     try {
+      LOGGER.trace("begin tile decode; compressed size = {}, expected decompressed size = {}", compressed.length, outputSize);
       Decode decoder = new Decode(compressed);
+      LOGGER.trace("constructed Decode");
       ByteBuffer output = ByteBuffer.allocateDirect(outputSize);
+      LOGGER.trace("allocated output ByteBuffer");
       decoder.toBytes(output);
+      LOGGER.trace("retrieved decompressed bytes");
       byte[] raw = new byte[outputSize];
       output.get(raw);
       output = null;
+      LOGGER.trace("copied decompressed bytes");
       return raw;
     }
     catch (DecodeException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <ome-xml.version>5.3.0</ome-xml.version>
     <ome-poi.version>5.3.0</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
-    <jxrlib.version>0.1.0-SNAPSHOT</jxrlib.version>
+    <jxrlib.version>0.2.0-SNAPSHOT</jxrlib.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <ome-xml.version>5.3.0</ome-xml.version>
     <ome-poi.version>5.3.0</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
+    <jxrlib.version>0.1.0-SNAPSHOT</jxrlib.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,10 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome-common.version>5.3.1-SNAPSHOT</ome-common.version>
-    <specification.version>5.3.1-SNAPSHOT</specification.version>
-    <ome-xml.version>5.3.1-SNAPSHOT</ome-xml.version>
-    <ome-poi.version>5.3.1-SNAPSHOT</ome-poi.version>
+    <ome-common.version>5.3.1</ome-common.version>
+    <specification.version>5.3.1</specification.version>
+    <ome-xml.version>5.3.1</ome-xml.version>
+    <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <jxrlib.version>0.2.0-SNAPSHOT</jxrlib.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <ome-xml.version>5.3.1</ome-xml.version>
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
-    <jxrlib.version>0.2.0-SNAPSHOT</jxrlib.version>
+    <jxrlib.version>0.2.0</jxrlib.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.1-SNAPSHOT</ome-common.version>
-    <specification.version>5.3.0</specification.version>
-    <ome-xml.version>5.3.0</ome-xml.version>
-    <ome-poi.version>5.3.0</ome-poi.version>
+    <specification.version>5.3.1-SNAPSHOT</specification.version>
+    <ome-xml.version>5.3.1-SNAPSHOT</ome-xml.version>
+    <ome-poi.version>5.3.1-SNAPSHOT</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <jxrlib.version>0.2.0-SNAPSHOT</jxrlib.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome-common.version>5.3.0</ome-common.version>
+    <ome-common.version>5.3.1-SNAPSHOT</ome-common.version>
     <specification.version>5.3.0</specification.version>
     <ome-xml.version>5.3.0</ome-xml.version>
     <ome-poi.version>5.3.0</ome-poi.version>


### PR DESCRIPTION
Requires https://github.com/ome/ome-common-java/pull/8

This is a port of work done on private 5.1-based branches to support JPEG-XR-compressed .czi data.  There are also a few changes in the ImageJ plugin to fix obvious problems with reading and displaying RGB thumbnails.  JPEG-XR decoding is provided by an additional dependency on:

https://github.com/glencoesoftware/jxrlib

Relevant data for testing is listed in https://trello.com/c/OHKk0BiI/41-jpeg-xr.  A configuration PR for the public datasets on that card is forthcoming; the private datasets can be reviewed and tested as a follow-up to this PR.  All of the test files contain larger pyramids, so testing in ImageJ/showinf is a little tricky.  The last 2 series in each file are label/macro images which should open easily.  Remaining series are pyramids, so you may only be able to open smaller tiles and not the full image.  Note that the brightfield files (anything with ```BF``` in the name) will show black pixels for missing tiles, where Zen shows white.  This is intentional and expected, but just something to be aware of.  