### PR TITLE
ND2HandlerTest - Update package to match location

### DIFF
--- a/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/ND2HandlerTest.java
@@ -23,7 +23,7 @@
  * #L%
  */
 
-package loci.formats.utests.in;
+package loci.formats.utests;
 
 import java.util.List;
 import java.util.ArrayList;


### PR DESCRIPTION
I discovered while testing https://github.com/openmicroscopy/bioformats/pull/2647 that when importing a fresh copy of Bio-Formats into Eclipse that I would see an error due to ND2HandlerTest having a mismatch between its package and location. I have updated the package to match the file location.

To reproduce:
- In Eclipse, do File -> Import -> Existing Maven projects and import Bio-Formats without the PR, verify that an error is shown

To test:
- With the PR, reimport the project as before and verify that no error is present