### PR TITLE
Fix test-suite targets to use TestNG

### DIFF
--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -26,6 +26,7 @@ Type "ant -p" for a list of targets.
   <target name="test-file-handles" depends="compile"
     description="run tests for leaking file handles">
     <exec executable="${basedir}/target-test-runner">
+      <!-- FileHandleTest is single-threaded -->
       <arg value="-t1"/>
       <arg value="-f${testng.filename}"/>
       <arg value="loci.tests.testng.FileHandleTest"/>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -11,6 +11,11 @@ Type "ant -p" for a list of targets.
   <property name="root.dir" location="../.."/>
   <import file="${root.dir}/ant/java.xml"/>
   <property file="build.properties"/>
+  <condition property="testng.threadCount" value="1">
+    <not>
+      <isset property="testng.threadCount"/>
+    </not>
+  </condition>
 
   <!-- overrides 'clean' target in common.xml -->
   <target name="clean" >
@@ -21,17 +26,37 @@ Type "ant -p" for a list of targets.
   <target name="test-file-handles" depends="compile"
     description="run tests for leaking file handles">
     <exec executable="${basedir}/target-test-runner">
+      <arg value="--hudson"/>
+      <arg value="-t${testng.threadCount}"/>
+      <arg value="-f${testng.filename}"/>
       <arg value="loci.tests.testng.FileHandleTest"/>
-      <arg value="${filename}"/>
     </exec>
+    <testng failureProperty="failedTest">
+      <classpath>
+        <pathelement location="${classes.dir}"/>
+      </classpath>
+      <classpath refid="test.classpath"/>
+      <xmlfileset file="testng.xml"/>
+      <jvmarg value="-Dlogback.configurationFile=logback-target-test-runner.xml"/>
+    </testng>
   </target>
 
   <target name="test-open-bytes-performance" depends="compile"
     description="run tests for open bytes performance">
     <exec executable="${basedir}/target-test-runner">
-      <arg value="loci.tests.testng.OpenBytesPerformanceTest"/>
-      <arg value="${filename}"/>
+        <arg value="--hudson"/>
+        <arg value="-t${testng.threadCount}"/>
+        <arg value="-f${testng.filename}"/>
+        <arg value="loci.tests.testng.FileHandleTest"/>
     </exec>
+    <testng failureProperty="failedTest">
+      <classpath>
+        <pathelement location="${classes.dir}"/>
+      </classpath>
+      <classpath refid="test.classpath"/>
+      <xmlfileset file="testng.xml"/>
+      <jvmarg value="-Dlogback.configurationFile=logback-target-test-runner.xml"/>
+    </testng>
   </target>
 
   <target name="test-tiff-writer" depends="compile"
@@ -126,12 +151,6 @@ Type "ant -p" for a list of targets.
 
   <target name="test-automated" depends="compile"
     description="run automated tests in group 'automated'">
-
-    <condition property="testng.threadCount" value="1">
-      <not>
-        <isset property="testng.threadCount"/>
-      </not>
-    </condition>
 
     <testng groups="automated" testname="Automated tests"
       listeners="loci.tests.testng.OrderingListener"

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -27,7 +27,7 @@ Type "ant -p" for a list of targets.
     description="run tests for leaking file handles">
     <exec executable="${basedir}/target-test-runner">
       <arg value="--hudson"/>
-      <arg value="-t${testng.threadCount}"/>
+      <arg value="-t1"/>
       <arg value="-f${testng.filename}"/>
       <arg value="loci.tests.testng.FileHandleTest"/>
     </exec>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -39,6 +39,7 @@ Type "ant -p" for a list of targets.
       <xmlfileset file="testng.xml"/>
       <jvmarg value="-Dlogback.configurationFile=logback-target-test-runner.xml"/>
     </testng>
+    <fail if="failedTest"/>
   </target>
 
   <target name="test-open-bytes-performance" depends="compile"
@@ -57,6 +58,7 @@ Type "ant -p" for a list of targets.
       <xmlfileset file="testng.xml"/>
       <jvmarg value="-Dlogback.configurationFile=logback-target-test-runner.xml"/>
     </testng>
+    <fail if="failedTest"/>
   </target>
 
   <target name="test-tiff-writer" depends="compile"

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -26,7 +26,6 @@ Type "ant -p" for a list of targets.
   <target name="test-file-handles" depends="compile"
     description="run tests for leaking file handles">
     <exec executable="${basedir}/target-test-runner">
-      <arg value="--hudson"/>
       <arg value="-t1"/>
       <arg value="-f${testng.filename}"/>
       <arg value="loci.tests.testng.FileHandleTest"/>
@@ -45,7 +44,6 @@ Type "ant -p" for a list of targets.
   <target name="test-open-bytes-performance" depends="compile"
     description="run tests for open bytes performance">
     <exec executable="${basedir}/target-test-runner">
-        <arg value="--hudson"/>
         <arg value="-t${testng.threadCount}"/>
         <arg value="-f${testng.filename}"/>
         <arg value="loci.tests.testng.OpenBytesPerformanceTest"/>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -47,7 +47,7 @@ Type "ant -p" for a list of targets.
         <arg value="--hudson"/>
         <arg value="-t${testng.threadCount}"/>
         <arg value="-f${testng.filename}"/>
-        <arg value="loci.tests.testng.FileHandleTest"/>
+        <arg value="loci.tests.testng.OpenBytesPerformanceTest"/>
     </exec>
     <testng failureProperty="failedTest">
       <classpath>

--- a/components/test-suite/logback-target-test-runner.xml
+++ b/components/test-suite/logback-target-test-runner.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="true">
   <appender name="performance" class="loci.tests.testng.TimestampedLogFileAppender">
-    <File>target-test-runner-performance.log</File>
+    <File>target/target-test-runner-performance.log</File>
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c %x - %m%n</pattern>
     </layout>
   </appender>
   <appender name="default" class="loci.tests.testng.TimestampedLogFileAppender">
-    <File>target-test-runner.log</File>
+    <File>target/target-test-runner.log</File>
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c %x - %m%n</pattern>
     </layout>

--- a/components/test-suite/target-test-runner
+++ b/components/test-suite/target-test-runner
@@ -4,7 +4,7 @@
 Generate TestNG XML files and run test cases.
 """
 
-#  
+#
 #  Copyright (C) 2009 - 2016 Open Microscopy Environment. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -28,10 +28,8 @@ Generate TestNG XML files and run test cases.
 #  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 #  SUCH DAMAGE.
 
-import glob
 import sys
 import os
-import re
 
 from xml.sax.saxutils import escape
 from tempfile import NamedTemporaryFile
@@ -39,15 +37,16 @@ from getopt import getopt, GetoptError
 
 # Handle Python 2.5 built-in ElementTree
 try:
-        from xml.etree.ElementTree import XML, Element, SubElement, ElementTree, dump
+    from xml.etree.ElementTree import Element, ElementTree
 except ImportError:
-        from elementtree.ElementTree import XML, Element, SubElement, ElementTree, dump
+    from elementtree.ElementTree import Element, ElementTree
 
 
 # Configuration options
 JAVA_ARGS = "-Xmx2048M"
 START_CLASS = "org.testng.TestNG"
 DOCTYPE = '<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">'
+
 
 def usage(error):
     """Prints usage so that we don't have to. :)"""
@@ -69,17 +68,12 @@ Examples:
 Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd, cmd)
     sys.exit(2)
 
-def create_testng_xml_file(test_class, targets, revision, hudson, thread_count, in_memory):
+def create_testng_xml_file(test_class, targets, hudson, thread_count, in_memory):
     """Creates a temporary file with TestNG XML content for each target."""
     root = Element("suite")
     root.set("name", "targets")
     root.set("parallel", "tests")
     root.set("thread-count", str(thread_count))
-    if revision is not None:
-        parameter = Element("parameter")
-        parameter.set("name", "bioformats_revision")
-        parameter.set("value", revision)
-        root.append(parameter)
     # Add each target to the TestNG XML file
     for target in targets:
         target = target.strip().lstrip()
@@ -158,30 +152,6 @@ if __name__ == '__main__':
     program_dir = os.path.dirname(sys.argv[0])
     os.chdir(program_dir)
 
-    classpath = ""
-    try:
-        classpath = os.environ['CLASSPATH']
-    except KeyError:
-        pass
-    classpath = "%s:./build/classes" % classpath
-    for f in glob.glob("../../artifacts/*.jar"):
-        if not f.endswith("bioformats_package.jar") and not f.endswith("loci_tools.jar") and f.find("log4j") == -1:
-            classpath += ":%s" % f
-
-    revision = None
-    try:
-        revision = os.environ['SVN_REVISION']
-    except:
-        pass
-
-    xml_file = create_testng_xml_file(test_class, targets, revision,
+    xml_file = create_testng_xml_file(test_class, targets,
                                       hudson, thread_count, in_memory)
-    log_props = 'logback-target-test-runner.xml'
-    log_props = os.path.join(os.path.dirname(__file__), log_props)
-    log_props = os.path.abspath(log_props)
-    log_props = '-Dlogback.configurationFile=file:///%s' % log_props
-    cmd = 'java %s -cp "%s" %s %s %s' % (JAVA_ARGS, classpath, log_props, \
-                                         START_CLASS, xml_file.name)
-    print cmd
-    os.system(cmd)
     xml_file.close()

--- a/components/test-suite/target-test-runner
+++ b/components/test-suite/target-test-runner
@@ -107,12 +107,13 @@ def create_testng_xml_file(test_class, targets, thread_count, in_memory):
         root.append(test)
 
     # Write TestNG file to disk
-    xml_file = open('testng.xml', 'w')
-    xml_file.write(DOCTYPE)
-    ElementTree(root).write(xml_file)
-    xml_file.write("\n")
-    xml_file.flush()
-    return xml_file
+    program_dir = os.path.dirname(sys.argv[0])
+    testng_file = os.path.join(program_dir, 'testng.xml')
+    with open(testng_file, 'w') as xml_file:
+        xml_file.write(DOCTYPE)
+        ElementTree(root).write(xml_file)
+        xml_file.write("\n")
+        xml_file.flush()
 
 if __name__ == '__main__':
     try:
@@ -144,9 +145,4 @@ if __name__ == '__main__':
     if len(targets) == 0:
         usage("Expecting at least one target from file or argument")
 
-    program_dir = os.path.dirname(sys.argv[0])
-    os.chdir(program_dir)
-
-    xml_file = create_testng_xml_file(
-        test_class, targets, thread_count, in_memory)
-    xml_file.close()
+    create_testng_xml_file(test_class, targets, thread_count, in_memory)

--- a/components/test-suite/target-test-runner
+++ b/components/test-suite/target-test-runner
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-Generate TestNG XML files and run test cases.
+Generate TestNG XML files
 """
 
 #
@@ -53,13 +53,12 @@ def usage(error):
     cmd = sys.argv[0]
     print """%s
 Usage: %s [-f file] <test_class> [target...]
-Runs a test on a given set of targets.
+Generates a TestNG XML file against a given set of targets.
 
 Options:
   -f            Reads targets from a file ("-" reads from STDIN)
   -t            Number of parallel threads for TestNG to use (default 2)
   -m            Memory-map files whenever possible
-  --hudson      Prepares the TestNG XML for use by Hudson
 
 Examples:
   %s -f ~/regular_test_files loci.tests.testng.OpenBytesPerformanceTest ~/testimages/foo.tiff
@@ -68,7 +67,7 @@ Examples:
 Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd, cmd)
     sys.exit(2)
 
-def create_testng_xml_file(test_class, targets, hudson, thread_count, in_memory):
+def create_testng_xml_file(test_class, targets, thread_count, in_memory):
     """Creates a temporary file with TestNG XML content for each target."""
     root = Element("suite")
     root.set("name", "targets")
@@ -106,10 +105,9 @@ def create_testng_xml_file(test_class, targets, hudson, thread_count, in_memory)
         test.append(groups)
         test.append(klasses)
         root.append(test)
-    if hudson:
-        xml_file = open('testng.xml', 'w')
-    else:
-        xml_file = NamedTemporaryFile(suffix=".xml")
+
+    # Write TestNG file to disk
+    xml_file = open('testng.xml', 'w')
     xml_file.write(DOCTYPE)
     ElementTree(root).write(xml_file)
     xml_file.write("\n")
@@ -118,12 +116,11 @@ def create_testng_xml_file(test_class, targets, hudson, thread_count, in_memory)
 
 if __name__ == '__main__':
     try:
-        options, args = getopt(sys.argv[1:], "mf:t:", ['hudson'])
+        options, args = getopt(sys.argv[1:], "mf:t:", [])
     except GetoptError, (msg, opt):
         usage(msg)
 
     targets = list()
-    hudson = False
     thread_count = 1
     test_class = None
     in_memory = False
@@ -136,8 +133,6 @@ if __name__ == '__main__':
             targets += f.readlines()
         if option == "-t":
             thread_count = int(argument)
-        if option == "--hudson":
-            hudson = True
         if option == "-m":
             in_memory = True
 
@@ -152,6 +147,6 @@ if __name__ == '__main__':
     program_dir = os.path.dirname(sys.argv[0])
     os.chdir(program_dir)
 
-    xml_file = create_testng_xml_file(test_class, targets,
-                                      hudson, thread_count, in_memory)
+    xml_file = create_testng_xml_file(
+        test_class, targets, thread_count, in_memory)
     xml_file.close()

--- a/components/test-suite/target-test-runner
+++ b/components/test-suite/target-test-runner
@@ -32,7 +32,6 @@ import sys
 import os
 
 from xml.sax.saxutils import escape
-from tempfile import NamedTemporaryFile
 from getopt import getopt, GetoptError
 
 # Handle Python 2.5 built-in ElementTree
@@ -66,6 +65,7 @@ Examples:
 
 Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd, cmd)
     sys.exit(2)
+
 
 def create_testng_xml_file(test_class, targets, thread_count, in_memory):
     """Creates a temporary file with TestNG XML content for each target."""


### PR DESCRIPTION
Addresses https://trello.com/c/jGrPs6c9/16-fix-integration-tests

Following the build changes in https://github.com/openmicroscopy/bioformats/pull/2622, the `test-file-handles` and `test-openbytes-performance` targets of the `test-suite` component ended up broken. Historically these targets were relying on the `target-test-runner` Python script to generate a TestNG XML file from a test class, a series of target files and run the tests. With the removal of the JARs from the source code, reconstructing the CLASSPATH necessary to run the tests cannot be simply achieved in `target-test-runner`.

Instead this PR reduces the `target-test-runnner` scope to only generating the TestNG file and uses the Ant `testng` target to run the tests using the generated XML file. The single-threaded nature of the `FileHandlesTest` class is also captured in the `test-files-handles` target.

This PR should be tested via the https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-performance/ job wich runs both targets against a unified series of target files.