### PR TITLE
Fix test-metadata and move it to test-suite

### DIFF
--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -133,7 +133,7 @@ Type "ant -p" for a list of targets.
 
   <target name="test-metadata" depends="compile-tests"
     description="test metadata level support for a single file" if="doTests">
-    <testng sourcedir="${test.dir}" testname="Metadata tests" failureProperty="failedTest">
+    <testng testname="Metadata tests" failureProperty="failedTest">
       <classpath>
         <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>

--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -131,19 +131,4 @@ Type "ant -p" for a list of targets.
     <fail if="failedTest"/>
   </target>
 
-  <target name="test-metadata" depends="compile-tests"
-    description="test metadata level support for a single file" if="doTests">
-    <testng testname="Metadata tests" failureProperty="failedTest">
-      <classpath>
-        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
-        <pathelement location="${test-classes.dir}"/>
-        <pathelement location="${classes.dir}"/>
-      </classpath>
-      <classpath refid="test.classpath"/>
-      <classfileset file="${test-classes.dir}/loci/formats/utests/MetadataConfigurableTest.class"/>
-      <sysproperty key="testng.filename" value="${testng.filename}"/>
-      <jvmarg value="-mx${testng.memory}"/>
-    </testng>
-    <fail if="failedTest"/>
-  </target>
 </project>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -312,4 +312,19 @@ Type "ant -p" for a list of targets.
   </target>
   <target name="test-config-xml" depends="gen-config-xml"/>
 
+  <target name="test-metadata" depends="compile"
+    description="test metadata level support for a single file">
+    <testng testname="Metadata tests" failureProperty="failedTest">
+      <classpath>
+        <pathelement location="${basedir}"/><!-- logback.xml -->
+        <pathelement location="${classes.dir}"/>
+      </classpath>
+      <classpath refid="test.classpath"/>
+      <classfileset file="${classes.dir}/loci/tests/testng/MetadataConfigurableTest.class"/>
+      <sysproperty key="testng.filename" value="${testng.filename}"/>
+      <jvmarg value="-mx${testng.memory}"/>
+    </testng>
+    <fail if="failedTest"/>
+  </target>
+
 </project>

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -42,6 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Factory;
 
+import static loci.tests.testng.TestTools.getProperty;
+
 /**
  * Factory for scanning a directory structure and generating instances of
  * {@link FormatReaderTest} based on the image files found.
@@ -61,17 +63,6 @@ public class FormatReaderTestFactory {
     LoggerFactory.getLogger(FormatReaderTestFactory.class);
 
   // -- TestNG factory methods --
-
-  /**
-   * Safely return a system property by key excluding default Ant values
-   */
-  public String getProperty(String key) {
-    String value = System.getProperty(key);
-    if (value == null || value.equals("${" + key + "}")) {
-      return null;
-    }
-    return value;
-  }
 
   @Factory
   public Object[] createInstances() {

--- a/components/test-suite/src/loci/tests/testng/MetadataConfigurableTest.java
+++ b/components/test-suite/src/loci/tests/testng/MetadataConfigurableTest.java
@@ -23,7 +23,7 @@
  * #L%
  */
 
-package loci.formats.utests;
+package loci.tests.testng;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;

--- a/components/test-suite/src/loci/tests/testng/MetadataConfigurableTest.java
+++ b/components/test-suite/src/loci/tests/testng/MetadataConfigurableTest.java
@@ -45,12 +45,21 @@ import loci.formats.services.OMEXMLService;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static loci.tests.testng.TestTools.getProperty;
 
 /**
  */
 public class MetadataConfigurableTest {
 
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(MetadataConfigurableTest.class);
   private static final String FILENAME_PROPERTY = "testng.filename";
+  private static final String SKIP_MESSAGE = "No image file specified";
 
   private ImageReader pixelsOnly;
   private ImageReader all;
@@ -67,7 +76,11 @@ public class MetadataConfigurableTest {
     noOverlays = new ImageReader();
     noOverlays.setMetadataOptions(
       new DefaultMetadataOptions(MetadataLevel.NO_OVERLAYS));
-    id = System.getProperty(FILENAME_PROPERTY);
+    id = getProperty(FILENAME_PROPERTY);
+    if (null == id) {
+      LOGGER.error(SKIP_MESSAGE);
+      throw new SkipException(SKIP_MESSAGE);
+    }
   }
 
   @Test

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -67,6 +67,17 @@ public class TestTools {
 
   public static final String baseConfigName = ".bioformats";
 
+  /**
+   * Safely return a system property by key excluding default Ant values
+   */
+  public static String getProperty(String key) {
+    String value = System.getProperty(key);
+    if (value == null || value.equals("${" + key + "}")) {
+      return null;
+    }
+    return value;
+  }
+
   /** Calculate the SHA-1 of a byte array. */
   public static String sha1(byte[] b, int offset, int len) {
     try {


### PR DESCRIPTION
The `test-metadata` target in `components/formats-gpl/build.xml` was broken due to an obsolete TestNG option (`sourcedir`). This PR fixes the target and moves it (along with the test it refers to) to `test-suite`, since it's actually not a unit test and it's not formats-gpl-specific. Rather, it tests metadata levels on a single user-specified file:

```
ant -f components/test-suite/build.xml test-metadata -Dtestng.filename=/path/to/image.ext
```