### PR TITLE
Test build cleanup

### DIFF
--- a/.classpath-template
+++ b/.classpath-template
@@ -9,16 +9,8 @@
         <classpathentry kind="src" path="components/formats-gpl/src"/>
         <classpathentry kind="src" path="components/forks/jai/build/src"/>
         <classpathentry kind="src" path="components/forks/jai/src"/>
-        <classpathentry kind="src" path="components/legacy/ome-editor/src"/>
-        <classpathentry kind="src" path="components/legacy/ome-notes/src"/>
-        <classpathentry kind="src" path="components/loci-plugins/build/src"/>
-        <classpathentry kind="src" path="components/loci-plugins/src"/>
         <classpathentry kind="src" path="components/metakit/build/src"/>
         <classpathentry kind="src" path="components/metakit/src"/>
-        <classpathentry kind="src" path="components/ome-xml/build/src"/>
-        <classpathentry kind="src" path="components/ome-xml/src"/>
-        <classpathentry kind="src" path="components/impl-bsd/build/src"/>
-        <classpathentry kind="src" path="components/impl-bsd/src"/>
         <classpathentry kind="src" path="components/stubs/lwf-stubs/build/src"/>
         <classpathentry kind="src" path="components/stubs/lwf-stubs/src"/>
         <classpathentry kind="src" path="components/test-suite/build/src"/>
@@ -26,11 +18,8 @@
         <classpathentry kind="src" path="components/formats-api/test"/>
         <classpathentry kind="src" path="components/formats-bsd/test"/>
         <classpathentry kind="src" path="components/formats-gpl/test"/>
-        <classpathentry kind="src" path="components/loci-plugins/test"/>
         <classpathentry kind="src" path="components/metakit/test"/>
         <classpathentry kind="src" path="components/ome-xml/test"/>
-        <classpathentry kind="src" path="components/impl-bsd/test"/>
-        <classpathentry kind="src" path="target/generated/src"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/eclipse-bin"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -2,17 +2,6 @@
 .project
 .settings
 .DS_Store
-BioFormats Unit Tests
-IO_Tests
-Missing JAI ImageIO Service Tests
-Missing LuraWave Service Tests
-Missing MDB Service Tests
-Missing NetCDF Service Tests
-Missing OME ReaderWriter Service Tests
-Missing OME-XML Service Tests
-Missing POI Service Tests
-OME ReaderWriter Service Tests
-OMEXMLTests
 artifacts
 build
 components/*/utils/*.class
@@ -25,6 +14,3 @@ testng.css
 tools/*.jar
 *.log
 *.xpr
-
-# For Fiji #
-loci_tools.jar

--- a/docs/sphinx/developers/useful-scripts.txt
+++ b/docs/sphinx/developers/useful-scripts.txt
@@ -26,8 +26,6 @@ to the arguments specified.  Valid arguments are:
 
   * `clean`: cleans the Maven build directories
   * `maven`: builds all Java components using Maven and runs unit tests
-  * `cpp`: builds the native C++ code alone
-  * `sphinx`: builds the Sphinx documentation alone
   * `ant`: builds all Java components using Ant and runs unit tests
   * `all`: equivalent of `clean maven sphinx ant`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-exclude=cpp/ext,docs/sphinx

--- a/tools/test-build
+++ b/tools/test-build
@@ -49,7 +49,7 @@ do
         ant)
             antbuild ;;
         all)
-            clean && maven_findbugs && antbuild;;
+            clean && maven && antbuild;;
         *)
             echo "Invalid argument: \"$arg\"" >&2
             exit 1

--- a/tools/test-build
+++ b/tools/test-build
@@ -17,32 +17,6 @@ maven()
     mvn
 }
 
-cpp()
-{
-    (
-        cd cpp
-        mkdir build
-        cd build
-        (
-            mkdir gtest
-            cd gtest
-            cmake /usr/src/gtest
-            make
-        )
-        CXX="g++ -std=gnu++98" GTEST_ROOT="$(pwd)/gtest" cmake -Dcxxstd-autodetect=OFF -Dextended-tests=OFF ../.. || cat CMakeFiles/CMakeError.log
-        make
-        make test
-        make DESTDIR=../install install
-        make doc
-    )
-}
-
-# Check python sources with flake8
-flake()
-{
-    flake8 -v components cpp docs
-}
-
 # Test Ant build targets
 antbuild()
 {
@@ -72,14 +46,10 @@ do
             clean ;;
         maven)
             maven ;;
-        cpp)
-            cpp ;;
-        flake8)
-            flake ;;
         ant)
             antbuild ;;
         all)
-            clean && maven_findbugs && sphinx && antbuild;;
+            clean && maven_findbugs && antbuild;;
         *)
             echo "Invalid argument: \"$arg\"" >&2
             exit 1


### PR DESCRIPTION
Following the 5.3.0-m1 decoupling, this cleans up a couple of additional files in the top-level:

- setup.cfg is removed as all Python components have been migrated away
- the `test-build` script is reviewed to remove the obsolete `cpp` and `flake8` targets as well as the documentation
- the `.classpath-template` and `.gitignore` files are reviewed to removed decoupled/obsolete components and folders which should be ignored by the top-level `target`, `test-output`.... folders generated by the build system