### PR TITLE
Update volocity links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2298,7 +2298,7 @@ mif = true
 
 [Volocity Library Clipping]
 extensions = .acff
-developer = `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
+developer = `PerkinElmer <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/>`_
 bsd = no
 weHave = * several Volocity library clipping datasets
 weWant = * any datasets that do not open correctly \n
@@ -2313,7 +2313,7 @@ notes = RGB .acff files are not yet supported.  See :ticket:`6413`.
 
 [Volocity]
 extensions = .mvd2
-developer = `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
+developer = `PerkinElmer <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/>`_
 bsd = no
 samples = `PerkinElmer Downloads <http://cellularimaging.perkinelmer.com/downloads/>`_
 weHave = * many example Volocity datasets

--- a/docs/sphinx/formats/volocity-library-clipping.txt
+++ b/docs/sphinx/formats/volocity-library-clipping.txt
@@ -6,7 +6,7 @@ Volocity Library Clipping
 
 Extensions: .acff
 
-Developer: `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
+Developer: `PerkinElmer <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/>`_
 
 
 **Support**

--- a/docs/sphinx/formats/volocity.txt
+++ b/docs/sphinx/formats/volocity.txt
@@ -6,7 +6,7 @@ Volocity
 
 Extensions: .mvd2
 
-Developer: `PerkinElmer <http://www.perkinelmer.com/cellular-imaging/>`_
+Developer: `PerkinElmer <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/>`_
 
 
 **Support**


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-docs/478/warnings3Result/ - PerkinElmer seem to be in the process of re-organizing their website, this is the replacement equivalent link. Should make the build green again.