### PR TITLE
Tiling API and Tiff Writer implementation

### DIFF
--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -293,6 +293,38 @@ public abstract class FormatWriter extends FormatHandler
     this.sequential = sequential;
   }
 
+  /* @see IFormatWriter#getTileSizeX() */
+  @Override
+  public int getTileSizeX() {
+    int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
+    return width;
+  }
+
+  /* @see IFormatWriter#setTileSizeX(int) */
+  @Override
+  public int setTileSizeX(int tileSize) throws FormatException {
+    int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
+    if (tileSize < 0) throw new FormatException("Tile size must be > 0.");
+    if (tileSize > width) throw new FormatException("Tile size must not be > width - " + width);
+    return width;
+  }
+
+  /* @see IFormatWriter#getTileSizeY() */
+  @Override
+  public int getTileSizeY() {
+    int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
+    return height;
+  }
+
+  /* @see IFormatWriter#setTileSizeY(int) */
+  @Override
+  public int setTileSizeY(int tileSize) throws FormatException {
+    int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
+    if (tileSize < 0) throw new FormatException("Tile size must be > 0.");
+    if (tileSize > height) throw new FormatException("Tile size must not be > height - " + height);
+    return height;
+  }
+
   // -- IFormatHandler API methods --
 
   /**

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -343,7 +343,7 @@ public abstract class FormatWriter extends FormatHandler
     if (out != null) {
       out.close();
     }
-    out = new RandomAccessOutputStream(currentId);
+    out = createOutputStream();
 
     MetadataRetrieve r = getMetadataRetrieve();
     initialized = new boolean[r.getImageCount()][];
@@ -485,6 +485,10 @@ public abstract class FormatWriter extends FormatHandler
     int c = r.getPixelsSizeC(series).getValue().intValue();
     c /= r.getChannelSamplesPerPixel(series, 0).getValue().intValue();
     return z * c * t;
+  }
+
+  protected RandomAccessOutputStream createOutputStream() throws IOException {
+    return new RandomAccessOutputStream(currentId);
   }
 
 }

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -296,32 +296,30 @@ public abstract class FormatWriter extends FormatHandler
   /* @see IFormatWriter#getTileSizeX() */
   @Override
   public int getTileSizeX() {
-    int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
-    return width;
+    return metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
   }
 
   /* @see IFormatWriter#setTileSizeX(int) */
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
     int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
-    if (tileSize < 0) throw new FormatException("Tile size must be > 0.");
-    if (tileSize > width) throw new FormatException("Tile size must not be > width - " + width);
+    if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
+    if (tileSize > width) throw new FormatException("Tile width must be <= image width (" + width + ")");
     return width;
   }
 
   /* @see IFormatWriter#getTileSizeY() */
   @Override
   public int getTileSizeY() {
-    int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
-    return height;
+    return metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
   }
 
   /* @see IFormatWriter#setTileSizeY(int) */
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
     int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
-    if (tileSize < 0) throw new FormatException("Tile size must be > 0.");
-    if (tileSize > height) throw new FormatException("Tile size must not be > height - " + height);
+    if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
+    if (tileSize > height) throw new FormatException("Tile height must be <= image height (" + height + ")");
     return height;
   }
 

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -295,32 +295,38 @@ public abstract class FormatWriter extends FormatHandler
 
   /* @see IFormatWriter#getTileSizeX() */
   @Override
-  public int getTileSizeX() {
-    return metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
+  public int getTileSizeX() throws FormatException {
+    PositiveInteger width = metadataRetrieve.getPixelsSizeX(getSeries());
+    if (width == null) throw new FormatException("Pixels Size X must not be null when attempting to get tile size.");
+    return width.getValue();
   }
 
   /* @see IFormatWriter#setTileSizeX(int) */
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
-    int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
+    PositiveInteger width = metadataRetrieve.getPixelsSizeX(getSeries());
+    if (width == null) throw new FormatException("Pixels Size X must not be null when attempting to set tile size.");
     if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
-    if (tileSize > width) throw new FormatException("Tile width must be <= image width (" + width + ")");
-    return width;
+    if (tileSize > width.getValue()) throw new FormatException("Tile width must be <= image width (" + width.getValue() + ")");
+    return width.getValue();
   }
 
   /* @see IFormatWriter#getTileSizeY() */
   @Override
-  public int getTileSizeY() {
-    return metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
+  public int getTileSizeY() throws FormatException {
+    PositiveInteger height = metadataRetrieve.getPixelsSizeY(getSeries());
+    if (height == null) throw new FormatException("Pixels Size Y must not be null when attempting to get tile size.");
+    return height.getValue();
   }
 
   /* @see IFormatWriter#setTileSizeY(int) */
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
-    int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
+    PositiveInteger height = metadataRetrieve.getPixelsSizeY(getSeries());
+    if (height == null) throw new FormatException("Pixels Size Y must not be null when attempting to set tile size.");
     if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
-    if (tileSize > height) throw new FormatException("Tile height must be <= image height (" + height + ")");
-    return height;
+    if (tileSize > height.getValue()) throw new FormatException("Tile height must be <= image height (" + height.getValue() + ")");
+    return height.getValue();
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -307,7 +307,6 @@ public abstract class FormatWriter extends FormatHandler
     PositiveInteger width = metadataRetrieve.getPixelsSizeX(getSeries());
     if (width == null) throw new FormatException("Pixels Size X must not be null when attempting to set tile size.");
     if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
-    if (tileSize > width.getValue()) throw new FormatException("Tile width must be <= image width (" + width.getValue() + ")");
     return width.getValue();
   }
 
@@ -325,7 +324,6 @@ public abstract class FormatWriter extends FormatHandler
     PositiveInteger height = metadataRetrieve.getPixelsSizeY(getSeries());
     if (height == null) throw new FormatException("Pixels Size Y must not be null when attempting to set tile size.");
     if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
-    if (tileSize > height.getValue()) throw new FormatException("Tile height must be <= image height (" + height.getValue() + ")");
     return height.getValue();
   }
 

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -212,7 +212,8 @@ public interface IFormatWriter extends IFormatHandler {
   /**
    * Will attempt to set the tile width to the desired value and return the actual value which will be used
    * @param tileSize The tile width you wish to use
-   * @return The tile width which will actually be used, this may differ from the value attempted to set
+   * @return The tile width which will actually be used, this may differ from the value requested.
+   *         If the requested value is not supported the writer will return and use the closest appropriate value.
    * @throws FormatException Tile size must be greater than 0 and less than the image width
    */
   int setTileSizeX(int tileSize) throws FormatException;
@@ -228,7 +229,8 @@ public interface IFormatWriter extends IFormatHandler {
   /**
    * Will attempt to set the tile height to the desired value and return the actual value which will be used
    * @param tileSize The tile height you wish to use
-   * @return The tile height which will actually be used, this may differ from the value attempted to set
+   * @return The tile height which will actually be used, this may differ from the value requested.
+   *         If the requested value is not supported the writer will return and use the closest appropriate value.
    * @throws FormatException Tile size must be greater than 0 and less than the image height
    */
   int setTileSizeY(int tileSize) throws FormatException;

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -205,14 +205,15 @@ public interface IFormatWriter extends IFormatHandler {
    * Retrieves the current tile width
    * Defaults to full image width if not supported
    * @return The current tile width being used
+   * @throws FormatException Image metadata including Pixels Size X must be set prior to calling getTileSizeX()
    */
-  int getTileSizeX();
+  int getTileSizeX() throws FormatException;
 
   /**
    * Will attempt to set the tile width to the desired value and return the actual value which will be used
-   * @param tileSize - The tile width you wish to use
+   * @param tileSize The tile width you wish to use
    * @return The tile width which will actually be used, this may differ from the value attempted to set
-   * @throws FormatException - Tile size must be greater than 0 and less than the image width
+   * @throws FormatException Tile size must be greater than 0 and less than the image width
    */
   int setTileSizeX(int tileSize) throws FormatException;
 
@@ -220,14 +221,15 @@ public interface IFormatWriter extends IFormatHandler {
    * Retrieves the current tile height
    * Defaults to full image height if not supported
    * @return The current tile height being used
+   * @throws FormatException Image metadata including Pixels Size Y must be set prior to calling getTileSizeY()
    */
-  int getTileSizeY();
+  int getTileSizeY() throws FormatException;
 
   /**
    * Will attempt to set the tile height to the desired value and return the actual value which will be used
-   * @param tileSize - The tile height you wish to use
+   * @param tileSize The tile height you wish to use
    * @return The tile height which will actually be used, this may differ from the value attempted to set
-   * @throws FormatException - Tile size must be greater than 0 and less than the image height
+   * @throws FormatException Tile size must be greater than 0 and less than the image height
    */
   int setTileSizeY(int tileSize) throws FormatException;
 

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -201,4 +201,34 @@ public interface IFormatWriter extends IFormatHandler {
    */
   void setWriteSequentially(boolean sequential);
 
+  /**
+   * Retrieves the current tile width
+   * Defaults to full image width if not supported
+   * @return The current tile width being used
+   */
+  int getTileSizeX();
+
+  /**
+   * Will attempt to set the tile width to the desired value and return the actual value which will be used
+   * @param tileSize - The tile width you wish to use
+   * @return The tile width which will actually be used, this may differ from the value attempted to set
+   * @throws FormatException - Tile size must be greater than 0 and less than the image width
+   */
+  int setTileSizeX(int tileSize) throws FormatException;
+
+  /**
+   * Retrieves the current tile height
+   * Defaults to full image height if not supported
+   * @return The current tile height being used
+   */
+  int getTileSizeY();
+
+  /**
+   * Will attempt to set the tile height to the desired value and return the actual value which will be used
+   * @param tileSize - The tile height you wish to use
+   * @return The tile height which will actually be used, this may differ from the value attempted to set
+   * @throws FormatException - Tile size must be greater than 0 and less than the image height
+   */
+  int setTileSizeY(int tileSize) throws FormatException;
+
 }

--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -187,43 +187,21 @@ public class ImageWriter implements IFormatWriter {
     return w;
   }
   
-  /**
-   * Retrieves the current tile width
-   * Defaults to full image width if not supported
-   * @return The current tile width being used
-   */
   @Override
   public int getTileSizeX() {
     return getWriter().getTileSizeX();
   }
 
-  /**
-   * Will attempt to set the tile width to the desired value and return the actual value which will be used
-   * @param tileSize - The tile width you wish to use
-   * @return The tile width which will actually be used, this may differ from the value attempted to set
-   * @throws FormatException - Tile size must be greater than 0 and less than the image width
-   */
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
     return getWriter().setTileSizeX(tileSize);
   }
 
-  /**
-   * Retrieves the current tile height
-   * Defaults to full image height if not supported
-   * @return The current tile height being used
-   */
   @Override
   public int getTileSizeY() {
     return getWriter().getTileSizeY();
   }
 
-  /**
-   * Will attempt to set the tile height to the desired value and return the actual value which will be used
-   * @param tileSize - The tile height you wish to use
-   * @return The tile height which will actually be used, this may differ from the value attempted to set
-   * @throws FormatException - Tile size must be greater than 0 and less than the image width
-   */
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
     return getWriter().setTileSizeY(tileSize);

--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -187,6 +187,48 @@ public class ImageWriter implements IFormatWriter {
     return w;
   }
   
+  /**
+   * Retrieves the current tile width
+   * Defaults to full image width if not supported
+   * @return The current tile width being used
+   */
+  @Override
+  public int getTileSizeX() {
+    return getWriter().getTileSizeX();
+  }
+
+  /**
+   * Will attempt to set the tile width to the desired value and return the actual value which will be used
+   * @param tileSize - The tile width you wish to use
+   * @return The tile width which will actually be used, this may differ from the value attempted to set
+   * @throws FormatException - Tile size must be greater than 0 and less than the image width
+   */
+  @Override
+  public int setTileSizeX(int tileSize) throws FormatException {
+    return getWriter().setTileSizeX(tileSize);
+  }
+
+  /**
+   * Retrieves the current tile height
+   * Defaults to full image height if not supported
+   * @return The current tile height being used
+   */
+  @Override
+  public int getTileSizeY() {
+    return getWriter().getTileSizeY();
+  }
+
+  /**
+   * Will attempt to set the tile height to the desired value and return the actual value which will be used
+   * @param tileSize - The tile height you wish to use
+   * @return The tile height which will actually be used, this may differ from the value attempted to set
+   * @throws FormatException - Tile size must be greater than 0 and less than the image width
+   */
+  @Override
+  public int setTileSizeY(int tileSize) throws FormatException {
+    return getWriter().setTileSizeY(tileSize);
+  }
+
   // -- IMetadataConfigurable API methods --
 
   /* @see loci.formats.IMetadataConfigurable#getSupportedMetadataLevels() */

--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -188,7 +188,7 @@ public class ImageWriter implements IFormatWriter {
   }
   
   @Override
-  public int getTileSizeX() {
+  public int getTileSizeX() throws FormatException {
     return getWriter().getTileSizeX();
   }
 
@@ -198,7 +198,7 @@ public class ImageWriter implements IFormatWriter {
   }
 
   @Override
-  public int getTileSizeY() {
+  public int getTileSizeY() throws FormatException {
     return getWriter().getTileSizeY();
   }
 

--- a/components/formats-api/src/loci/formats/WriterWrapper.java
+++ b/components/formats-api/src/loci/formats/WriterWrapper.java
@@ -328,7 +328,7 @@ public abstract class WriterWrapper implements IFormatWriter {
   
   /* @see IFormatWriter#getTileSizeX() */
   @Override
-  public int getTileSizeX() {
+  public int getTileSizeX() throws FormatException {
     return writer.getTileSizeX();
   }
 
@@ -340,7 +340,7 @@ public abstract class WriterWrapper implements IFormatWriter {
 
   /* @see IFormatWriter#getTileSizeY() */
   @Override
-  public int getTileSizeY() {
+  public int getTileSizeY() throws FormatException {
     return writer.getTileSizeY();
   }
 

--- a/components/formats-api/src/loci/formats/WriterWrapper.java
+++ b/components/formats-api/src/loci/formats/WriterWrapper.java
@@ -140,10 +140,14 @@ public abstract class WriterWrapper implements IFormatWriter {
     ColorModel cm = getColorModel();
     int rate = getFramesPerSecond();
     String compress = getCompression();
+    int tileSizeX = getTileSizeX();
+    int tileSizeY = getTileSizeY();
     wrapperCopy.setInterleaved(interleaved);
     wrapperCopy.setColorModel(cm);
     wrapperCopy.setFramesPerSecond(rate);
     wrapperCopy.setCompression(compress);
+    wrapperCopy.setTileSizeX(tileSizeX);
+    wrapperCopy.setTileSizeY(tileSizeY);
     return wrapperCopy;
   }
 
@@ -320,6 +324,30 @@ public abstract class WriterWrapper implements IFormatWriter {
   @Override
   public void setWriteSequentially(boolean sequential) {
     writer.setWriteSequentially(sequential);
+  }
+  
+  /* @see IFormatWriter#getTileSizeX() */
+  @Override
+  public int getTileSizeX() {
+    return writer.getTileSizeX();
+  }
+
+  /* @see IFormatWriter#setTileSizeX(int) */
+  @Override
+  public int setTileSizeX(int tileSize) throws FormatException {
+    return writer.setTileSizeX(tileSize);
+  }
+
+  /* @see IFormatWriter#getTileSizeY() */
+  @Override
+  public int getTileSizeY() {
+    return writer.getTileSizeY();
+  }
+
+  /* @see IFormatWriter#setTileSizeY(int) */
+  @Override
+  public int setTileSizeY(int tileSize) throws FormatException {
+    return writer.setTileSizeY(tileSize);
   }
 
   // -- IFormatHandler API methods --

--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -28,6 +28,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <sysproperty key="testng.runWriterTilingTests" value="${testng.runWriterTilingTests}"/>
+    	<sysproperty key="testng.runWriterTilingTests" value="${testng.runWriterTilingTests}"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-Dlurawave.license=XXX"/>
     </testng>

--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -27,6 +27,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
       </classpath>
+      <sysproperty key="testng.runWriterTilingTests" value="${testng.runWriterTilingTests}"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-Dlurawave.license=XXX"/>
     </testng>

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -298,7 +298,7 @@ public class TiffWriter extends FormatWriter {
       if (no < initialized[series].length && !initialized[series][no]) {
         initialized[series][no] = true;
 
-        RandomAccessInputStream tmp = new RandomAccessInputStream(currentId);
+        RandomAccessInputStream tmp = createInputStream();
         if (tmp.length() == 0) {
           synchronized (this) {
             // write TIFF header
@@ -527,8 +527,8 @@ public class TiffWriter extends FormatWriter {
 
   protected void setupTiffSaver() throws IOException {
     out.close();
-    out = new RandomAccessOutputStream(currentId);
-    tiffSaver = new TiffSaver(out, currentId);
+    out = createOutputStream();
+    tiffSaver = createTiffSaver();
 
     MetadataRetrieve retrieve = getMetadataRetrieve();
     boolean littleEndian = false;
@@ -605,6 +605,14 @@ public class TiffWriter extends FormatWriter {
       }
     }
     return returnBuf;
+  }
+  
+  protected RandomAccessInputStream createInputStream() throws IOException {
+    return new RandomAccessInputStream(currentId);
+  }
+  
+  protected TiffSaver createTiffSaver() {
+    return new TiffSaver(out, currentId);
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -571,7 +571,7 @@ public class TiffWriter extends FormatWriter {
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
     tileSizeY = super.setTileSizeY(tileSize);
-    tileSizeY = Math.round(tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
+    tileSizeY = Math.round((float)tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
     return tileSizeY;
   }
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -178,7 +178,7 @@ public class TiffWriter extends FormatWriter {
           int type = FormatTools.pixelTypeFromString(
             retrieve.getPixelsType(i).toString());
           long bpp = FormatTools.getBytesPerPixel(type);
-          totalBytes += sizeX * sizeY * sizeZ * sizeC * sizeT * bpp;
+          totalBytes += (long)sizeX * (long)sizeY * (long)sizeZ * (long)sizeC * (long)sizeT * bpp;
         }
 
         if (totalBytes >= BIG_TIFF_CUTOFF) {

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -552,7 +552,12 @@ public class TiffWriter extends FormatWriter {
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
     tileSizeX = super.setTileSizeX(tileSize);
-    tileSizeX = Math.round((float)tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
+    if (tileSize < TILE_GRANULARITY) {
+      tileSizeX = TILE_GRANULARITY;
+    }
+    else {
+      tileSizeX = Math.round((float)tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
+    }
     return tileSizeX;
   }
 
@@ -567,7 +572,12 @@ public class TiffWriter extends FormatWriter {
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
     tileSizeY = super.setTileSizeY(tileSize);
-    tileSizeY = Math.round((float)tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
+    if (tileSize < TILE_GRANULARITY) {
+      tileSizeY = TILE_GRANULARITY;
+    }
+    else {
+      tileSizeY = Math.round((float)tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
+    }
     return tileSizeY;
   }
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -233,15 +233,15 @@ public class TiffWriter extends FormatWriter {
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(tileSizeY));
     }
     if (tileSizeX < w || tileSizeY < h) {
-      int nXTiles = (w + tileSizeX - 1) / tileSizeX;
-      int nYTiles = (h + tileSizeY - 1)  / tileSizeY;
+      int nXTiles = (w + (x % tileSizeX) + tileSizeX - 1) / tileSizeX;
+      int nYTiles = (h + (y % tileSizeY) + tileSizeY - 1)  / tileSizeY;
       for (int yTileIndex=0; yTileIndex<nYTiles; yTileIndex++) {
         for (int xTileIndex=0; xTileIndex<nXTiles; xTileIndex++) {
-          int effectiveTileSizeX = xTileIndex < nXTiles - 1 ? tileSizeX : w - (tileSizeX * xTileIndex);
-          int effectiveTileSizeY = yTileIndex < nYTiles - 1 ? tileSizeY : h - (tileSizeY * yTileIndex);
+          int effectiveTileSizeX = xTileIndex < nXTiles - 1 ? tileSizeX - (x % tileSizeX) : w - (tileSizeX * xTileIndex);
+          int effectiveTileSizeY = yTileIndex < nYTiles - 1 ? tileSizeY - (y % tileSizeY) : h - (tileSizeY * yTileIndex);
           byte [] tileBuf = getTile(buf, xTileIndex, yTileIndex, x, y, w, h);
-          int tileX = x + (xTileIndex * tileSizeX);
-          int tileY = y + (yTileIndex * tileSizeY);
+          int tileX = x + (xTileIndex * tileSizeX) - (xTileIndex > 0 ? (x % tileSizeX) : 0);
+          int tileY = y + (yTileIndex * tileSizeY) - (yTileIndex > 0 ? (y % tileSizeY) : 0);
 
           // This operation is synchronized
           synchronized (this) {
@@ -577,12 +577,12 @@ public class TiffWriter extends FormatWriter {
   }
 
   private byte[] getTile(byte[] buf, int xTileIndex, int yTileIndex, int x, int y, int w, int h) {
-    int nXTiles = (w + tileSizeX - 1) / tileSizeX;
-    int nYTiles = (h + tileSizeY - 1)  / tileSizeY;
-    int tileX = x + (xTileIndex * tileSizeX);
-    int tileY = y + (yTileIndex * tileSizeY);
-    int effectiveTileSizeX = xTileIndex < nXTiles - 1 ? tileSizeX : w - (tileSizeX * xTileIndex);
-    int effectiveTileSizeY = yTileIndex < nYTiles - 1 ? tileSizeY : h - (tileSizeY * yTileIndex);
+    int nXTiles = (w + (x % tileSizeX) + tileSizeX - 1) / tileSizeX;
+    int nYTiles = (h + (y % tileSizeY) + tileSizeY - 1)  / tileSizeY;
+    int tileX = x + (xTileIndex * tileSizeX) - (xTileIndex > 0 ? (x % tileSizeX) : 0);
+    int tileY = y + (yTileIndex * tileSizeY) - (yTileIndex > 0 ? (y % tileSizeY) : 0);
+    int effectiveTileSizeX = xTileIndex < nXTiles - 1 ? tileSizeX - (x % tileSizeX) : w - (tileSizeX * xTileIndex);
+    int effectiveTileSizeY = yTileIndex < nYTiles - 1 ? tileSizeY - (y % tileSizeY) : h - (tileSizeY * yTileIndex);
     MetadataRetrieve retrieve = getMetadataRetrieve();
     int type = FormatTools.pixelTypeFromString(retrieve.getPixelsType(series).toString());
     int channel_count = getSamplesPerPixel();

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -227,6 +227,7 @@ public class TiffWriter extends FormatWriter {
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(tileSizeY));
     }
     if (tileSizeX < w || tileSizeY < h) {
+      int tileNo = no;
       int numTilesX = (w + (x % tileSizeX) + tileSizeX - 1) / tileSizeX;
       int numTilesY = (h + (y % tileSizeY) + tileSizeY - 1) / tileSizeY;
       for (int yTileIndex = 0; yTileIndex < numTilesY; yTileIndex++) {
@@ -242,12 +243,12 @@ public class TiffWriter extends FormatWriter {
           synchronized (this) {
             // This operation is synchronized against the TIFF saver.
             synchronized (tiffSaver) {
-              index = prepareToWriteImage(no+1, tileBuf, ifd, tileParams.x, tileParams.y, tileParams.width, tileParams.height);
+              index = prepareToWriteImage(tileNo++, tileBuf, ifd, tileParams.x, tileParams.y, tileParams.width, tileParams.height);
               if (index == -1) {
                 return;
               }
             }
-          }     
+          }
 
           tiffSaver.writeImage(tileBuf, ifd, index, type, tileParams.x, tileParams.y, tileParams.width, tileParams.height,
           no == getPlaneCount() - 1 && getSeries() == retrieve.getImageCount() - 1);
@@ -264,10 +265,10 @@ public class TiffWriter extends FormatWriter {
             return;
           }
         }
-      }     
+      }
 
       tiffSaver.writeImage(buf, ifd, index, type, x, y, w, h,
-      no == getPlaneCount() && getSeries() == retrieve.getImageCount() - 1);
+      no == getPlaneCount() -1 && getSeries() == retrieve.getImageCount() - 1);
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -556,7 +556,7 @@ public class TiffWriter extends FormatWriter {
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
     tileSizeX = super.setTileSizeX(tileSize);
-    tileSizeX = Math.round(tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
+    tileSizeX = Math.round((float)tileSize/TILE_GRANULARITY) * TILE_GRANULARITY;
     return tileSizeX;
   }
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -222,7 +222,7 @@ public class TiffWriter extends FormatWriter {
     int imageHeight = retrieve.getPixelsSizeY(series).getValue().intValue();
     tileSizeX = getTileSizeX();
     tileSizeY = getTileSizeY();
-    if (tileSizeX < imageWidth || tileSizeY < imageHeight) {
+    if (tileSizeX != imageWidth || tileSizeY != imageHeight) {
       ifd.put(new Integer(IFD.TILE_WIDTH), new Long(tileSizeX));
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(tileSizeY));
     }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -226,10 +226,13 @@ public class TiffWriter extends FormatWriter {
     int type = FormatTools.pixelTypeFromString(
         retrieve.getPixelsType(series).toString());
     int index = no;
-    if (tileSizeX < w || tileSizeY < h) {
+    int imageWidth = retrieve.getPixelsSizeX(series).getValue().intValue();
+    int imageHeight = retrieve.getPixelsSizeY(series).getValue().intValue();
+    if (tileSizeX < imageWidth || tileSizeY < imageHeight) {
       ifd.put(new Integer(IFD.TILE_WIDTH), new Long(tileSizeX));
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(tileSizeY));
-
+    }
+    if (tileSizeX < w || tileSizeY < h) {
       int nXTiles = w / tileSizeX;
       int nYTiles = h / tileSizeY;
    

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -546,7 +546,7 @@ public class TiffWriter extends FormatWriter {
   }
 
   @Override
-  public int getTileSizeX() {
+  public int getTileSizeX() throws FormatException {
     if (tileSizeX == 0) {
       tileSizeX = super.getTileSizeX();
     }
@@ -561,7 +561,7 @@ public class TiffWriter extends FormatWriter {
   }
 
   @Override
-  public int getTileSizeY() {
+  public int getTileSizeY() throws FormatException {
     if (tileSizeY == 0) {
       tileSizeY = super.getTileSizeY();
     }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -183,9 +183,6 @@ public class TiffWriter extends FormatWriter {
       }
     }
 
-    tileSizeX = super.getTileSizeX();
-    tileSizeY = super.getTileSizeY();
-
     synchronized (this) {
       setupTiffSaver();
     }
@@ -223,13 +220,15 @@ public class TiffWriter extends FormatWriter {
     int index = no;
     int imageWidth = retrieve.getPixelsSizeX(series).getValue().intValue();
     int imageHeight = retrieve.getPixelsSizeY(series).getValue().intValue();
+    tileSizeX = getTileSizeX();
+    tileSizeY = getTileSizeY();
     if (tileSizeX < imageWidth || tileSizeY < imageHeight) {
       ifd.put(new Integer(IFD.TILE_WIDTH), new Long(tileSizeX));
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(tileSizeY));
     }
     if (tileSizeX < w || tileSizeY < h) {
       int numTilesX = (w + (x % tileSizeX) + tileSizeX - 1) / tileSizeX;
-      int numTilesY = (h + (y % tileSizeY) + tileSizeY - 1)  / tileSizeY;
+      int numTilesY = (h + (y % tileSizeY) + tileSizeY - 1) / tileSizeY;
       for (int yTileIndex = 0; yTileIndex < numTilesY; yTileIndex++) {
         for (int xTileIndex = 0; xTileIndex < numTilesX; xTileIndex++) {
           Rectangle tileParams = new Rectangle();
@@ -249,7 +248,7 @@ public class TiffWriter extends FormatWriter {
               }
             }
           }     
-  
+
           tiffSaver.writeImage(tileBuf, ifd, index, type, tileParams.x, tileParams.y, tileParams.width, tileParams.height,
           no == getPlaneCount() - 1 && getSeries() == retrieve.getImageCount() - 1);
         }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -32,9 +32,9 @@
 
 package loci.formats.out;
 
-import java.awt.Rectangle;
 import java.io.IOException;
 import loci.common.RandomAccessInputStream;
+import loci.common.Region;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.FormatWriter;
@@ -231,12 +231,12 @@ public class TiffWriter extends FormatWriter {
       int numTilesY = (h + (y % tileSizeY) + tileSizeY - 1) / tileSizeY;
       for (int yTileIndex = 0; yTileIndex < numTilesY; yTileIndex++) {
         for (int xTileIndex = 0; xTileIndex < numTilesX; xTileIndex++) {
-          Rectangle tileParams = new Rectangle();
+          Region tileParams = new Region();
           tileParams.width = xTileIndex < numTilesX - 1 ? tileSizeX - (x % tileSizeX) : w - (tileSizeX * xTileIndex);
           tileParams.height = yTileIndex < numTilesY - 1 ? tileSizeY - (y % tileSizeY) : h - (tileSizeY * yTileIndex);
           tileParams.x = x + (xTileIndex * tileSizeX) - (xTileIndex > 0 ? (x % tileSizeX) : 0);
           tileParams.y = y + (yTileIndex * tileSizeY) - (yTileIndex > 0 ? (y % tileSizeY) : 0);
-          byte [] tileBuf = getTile(buf, tileParams, new Rectangle(x, y, w, h));
+          byte [] tileBuf = getTile(buf, tileParams, new Region(x, y, w, h));
 
           // This operation is synchronized
           synchronized (this) {
@@ -581,7 +581,7 @@ public class TiffWriter extends FormatWriter {
     return tileSizeY;
   }
 
-  private byte[] getTile(byte[] buf, Rectangle tileParams, Rectangle srcParams) {
+  private byte[] getTile(byte[] buf, Region tileParams, Region srcParams) {
     MetadataRetrieve retrieve = getMetadataRetrieve();
     int type = FormatTools.pixelTypeFromString(retrieve.getPixelsType(series).toString());
     int channel_count = getSamplesPerPixel();

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -35,11 +35,9 @@ package loci.formats.utests.out;
 import static org.testng.AssertJUnit.assertEquals;
 import java.io.IOException;
 import org.junit.Assert;
-import loci.common.ByteArrayHandle;
 import loci.common.services.ServiceFactory;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
-import loci.formats.ImageReader;
 import loci.formats.codec.CompressionType;
 import loci.formats.meta.IMetadata;
 import loci.formats.out.TiffWriter;
@@ -55,7 +53,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Tests the functionality of BaseTiffReader
+ * Tests the functionality of TiffWriter
  */
 public class TiffWriterTest {
 

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -456,8 +456,6 @@ public class TiffWriterTest {
     if (tilingProp == null || Integer.valueOf(System.getProperty("testng.runWriterTilingTests")) == 0) {
       return;
     }
-    boolean runTilingTests = Boolean.valueOf(System.getProperty("testng.runWriterTilingTests"));
-    org.junit.Assume.assumeTrue(runTilingTests);
 
     File tmp = File.createTempFile("tiffWriterTest_Tiling", ".tiff");
     tmp.deleteOnExit();

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -1,0 +1,294 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests.out;
+
+import static org.testng.AssertJUnit.assertEquals;
+import java.io.IOException;
+import org.junit.Assert;
+import loci.common.ByteArrayHandle;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.ImageReader;
+import loci.formats.codec.CompressionType;
+import loci.formats.meta.IMetadata;
+import loci.formats.out.TiffWriter;
+import loci.formats.services.OMEXMLService;
+import loci.formats.tiff.IFD;
+import loci.formats.utests.tiff.TiffWriterMock;
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.PositiveInteger;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the functionality of BaseTiffReader
+ */
+public class TiffWriterTest {
+
+  private IFD ifd;
+  private TiffWriter writer;
+  private IMetadata metadata;
+  
+  final long BIG_TIFF_CUTOFF = (long) 1024 * 1024 * 3990;
+  private static final int SIZE_X = 1024;
+  private static final int SIZE_Y = 1024;
+  private static final int SIZE_Z = 4;
+  private static final int SIZE_C = 1;
+  private static final int SIZE_T = 20;
+  private static final byte[] buf = new byte[1024*1024];
+  private static final String COMPRESSION_UNCOMPRESSED = CompressionType.UNCOMPRESSED.getCompression();
+  private static final String COMPRESSION_LZW = CompressionType.LZW.getCompression();
+  private static final String COMPRESSION_J2K = CompressionType.J2K.getCompression();
+  private static final String COMPRESSION_J2K_LOSSY = CompressionType.J2K_LOSSY.getCompression();
+  private static final String COMPRESSION_JPEG = CompressionType.JPEG.getCompression();
+  private static final int[] pixelTypesJPEG = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16, FormatTools.UINT16};
+  private static final int[] pixelTypesJ2K = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16,FormatTools.UINT16, 
+      FormatTools.INT32, FormatTools.UINT32, FormatTools.FLOAT};
+  private static final int[] pixelTypesOther = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16,
+      FormatTools.UINT16, FormatTools.INT32, FormatTools.UINT32, FormatTools.FLOAT, FormatTools.DOUBLE};
+
+  @DataProvider(name = "bigTiffSuffixes")
+  public Object[][] createSuffixes() {
+    return new Object[][] {{"tf2"}, {"tf8"}, {"btf"}, {"tif"}, {"tiff"}};
+  }
+
+  @DataProvider(name = "codecs")
+  public Object[][] createCodecs() {
+    return new Object[][] {{null, pixelTypesOther}, {COMPRESSION_UNCOMPRESSED, pixelTypesOther}, {COMPRESSION_LZW, pixelTypesOther}, 
+      {COMPRESSION_J2K, pixelTypesJ2K}, {COMPRESSION_J2K_LOSSY, pixelTypesOther}, {COMPRESSION_JPEG, pixelTypesJPEG}};
+  }
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    ifd = new IFD();
+    writer = new TiffWriterMock();
+    ServiceFactory sf = new ServiceFactory();
+    OMEXMLService service = sf.getInstance(OMEXMLService.class);
+    metadata = service.createOMEXMLMetadata();
+    metadata.setPixelsDimensionOrder(DimensionOrder.XYZCT, 0);
+    metadata.setPixelsSizeX(new PositiveInteger(SIZE_X), 0);
+    metadata.setPixelsSizeY(new PositiveInteger(SIZE_Y), 0);
+    metadata.setPixelsSizeT(new PositiveInteger(SIZE_T), 0);
+    metadata.setPixelsSizeZ(new PositiveInteger(SIZE_Z), 0);
+    metadata.setPixelsSizeC(new PositiveInteger(SIZE_C), 0);
+    metadata.setPixelsType(PixelType.UINT8, 0);
+    metadata.setPixelsBinDataBigEndian(true, 0, 0);
+    metadata.setImageID("Image:1", 0);
+    metadata.setPixelsID("Pixels:1", 0);
+    metadata.setChannelID("Channel:1", 0, 0);
+    metadata.setChannelSamplesPerPixel(new PositiveInteger(1), 0, 0);
+    for (int i = 0; i < 1024 *1024; i++) {
+      buf[i] = (byte)(i%255);
+    }
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    writer.close();
+  }
+
+  @Test
+  public void testSetBigTiffFileTooLarge() throws IOException, FormatException {
+    // Test that no exception is thrown while below the big tiff limit (2147483648L)
+    // Exception is thrown when size is out.length() + 2 * (width * height * c * bytesPerPixel)
+    writer.setMetadataRetrieve(metadata);
+    ((TiffWriterMock)writer).createOutputBuffer(true);
+    long length = 4294967296L - (buf.length * 4);
+    ((TiffWriterMock)writer).setBufferLength(length);
+    writer.setId("test.tiff");
+    writer.saveBytes(0, buf, ifd);
+
+    //Test format exception is thrown after the big tiff limit (2147483648L)
+    boolean thrown = false;
+    try {
+      writer.saveBytes(1, buf, ifd);
+    }
+    catch(FormatException e) {
+      System.out.println("Caught Exception " + e);
+      if (e.getMessage().contains("File is too large; call setBigTiff(true)")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+  }
+  
+  @Test
+  public void testSetBigTiff() throws IOException, FormatException {
+    //Test that no exception is thrown after setting big tiff
+    writer.setMetadataRetrieve(metadata);
+    ((TiffWriterMock)writer).createOutputBuffer(true);
+    long length = 4294967296L - (buf.length * 2);
+    ((TiffWriterMock)writer).setBufferLength(length);
+    writer.setBigTiff(true);
+    writer.setId("test.tiff");
+    writer.saveBytes(0, buf, ifd);
+  }
+
+  @Test
+  public void testSetBigTiffAutomatic() throws IOException, FormatException {
+    //Test that no exception is thrown when bigTiff is set automatically due to size
+    metadata.setPixelsSizeT(new PositiveInteger(1000), 0);
+    writer.setMetadataRetrieve(metadata);
+    ((TiffWriterMock)writer).createOutputBuffer(true);
+    long length = 4294967296L;
+    ((TiffWriterMock)writer).setBufferLength(length);
+    writer.setId("test.tiff");
+    writer.saveBytes(0, buf, ifd);
+  }
+
+  @Test(dataProvider = "bigTiffSuffixes")
+  public void testSetBigTiffSuffixes(String suffix) throws IOException, FormatException {
+    //Test that no exception is thrown when bigTiff is set automatically due to size
+    writer.setMetadataRetrieve(metadata);
+    ((TiffWriterMock)writer).createOutputBuffer(true);
+    long length = 4294967296L;
+    ((TiffWriterMock)writer).setBufferLength(length);
+    writer.setId("test." + suffix);
+    boolean thrown = false;
+    try {
+      writer.saveBytes(0, buf, ifd);
+    }
+    catch(FormatException e) {
+      thrown = true;
+    }
+    if (suffix.contains("tif")) {
+      assertEquals(true,thrown);
+    }
+    else {
+      assertEquals(false,thrown);
+    }
+  }
+
+  @Test(dataProvider = "codecs")
+  public void testgetPixelTypes(String codec, int[] pixelTypes) {
+    Assert.assertArrayEquals(pixelTypes, writer.getPixelTypes(codec));
+  }
+
+  @Test
+  public void testGetPlaneCount() throws IOException, FormatException {
+    writer.setMetadataRetrieve(metadata);
+    writer.setSeries(0);
+    assertEquals(SIZE_T * SIZE_Z * SIZE_C, writer.getPlaneCount());
+    metadata.setPixelsSizeC(new PositiveInteger(4), 0);
+    metadata.setPixelsType(PixelType.INT16, 0);
+    writer.setMetadataRetrieve(metadata);
+    assertEquals(SIZE_T * SIZE_Z * 4, writer.getPlaneCount());
+  }
+
+  @Test
+  public void testGetTileSizeX() throws IOException {
+    writer.setMetadataRetrieve(metadata);
+    assertEquals(SIZE_X, writer.getTileSizeX());
+    writer.close();
+    writer = new TiffWriter();
+    metadata.setPixelsSizeX(new PositiveInteger(100), 0);
+    writer.setMetadataRetrieve(metadata);
+    assertEquals(100, writer.getTileSizeX());
+  }
+
+  @Test
+  public void testSetTileSizeX() {
+    writer.setMetadataRetrieve(metadata);
+    try {
+      writer.setTileSizeX(0);
+      assertEquals(SIZE_X, writer.getTileSizeX());
+      for (int i = 16; i < SIZE_X; i+=16) {
+        writer.setTileSizeX(i);
+        assertEquals(i, writer.getTileSizeX());
+      }
+      writer.setTileSizeX(SIZE_X);
+      assertEquals(SIZE_X, writer.getTileSizeX());
+      for (int i = 0; i < 8; i++) {
+        writer.setTileSizeX(i);
+        assertEquals(SIZE_X, writer.getTileSizeX());
+      }
+      for (int i = 8; i < 24; i++) {
+        writer.setTileSizeX(i);
+        assertEquals(16, writer.getTileSizeX());
+      }
+      for (int i = 24; i < 40; i++) {
+        writer.setTileSizeX(i);
+        assertEquals(32, writer.getTileSizeX());
+      }
+    }
+    catch(FormatException fe) {
+      assert(false);
+    }
+  }
+
+  @Test
+  public void testGetTileSizeY() throws IOException {
+    writer.setMetadataRetrieve(metadata);
+    assertEquals(SIZE_Y, writer.getTileSizeY());
+    writer.close();
+    writer = new TiffWriter();
+    metadata.setPixelsSizeY(new PositiveInteger(100), 0);
+    writer.setMetadataRetrieve(metadata);
+    assertEquals(100, writer.getTileSizeY());
+  }
+
+  @Test
+  public void testSetTileSizeY() {
+    writer.setMetadataRetrieve(metadata);
+    try {
+      writer.setTileSizeY(0);
+      assertEquals(SIZE_Y, writer.getTileSizeY());
+      for (int i = 16; i < SIZE_Y; i+=16) {
+        writer.setTileSizeY(i);
+        assertEquals(i, writer.getTileSizeY());
+      }
+      writer.setTileSizeY(SIZE_Y);
+      assertEquals(SIZE_Y, writer.getTileSizeY());
+      for (int i = 0; i < 8; i++) {
+        writer.setTileSizeY(i);
+        assertEquals(SIZE_Y, writer.getTileSizeY());
+      }
+      for (int i = 8; i < 24; i++) {
+        writer.setTileSizeY(i);
+        assertEquals(16, writer.getTileSizeY());
+      }
+      for (int i = 24; i < 40; i++) {
+        writer.setTileSizeY(i);
+        assertEquals(32, writer.getTileSizeY());
+      }
+    }
+    catch(FormatException fe) {
+      assert(false);
+    }
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -361,21 +361,17 @@ public class TiffWriterTest {
       writer.setTileSizeX(SIZE_X + 16);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Tile width must be <= image width")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
     thrown = false;
     try {
       writer.setTileSizeY(SIZE_Y + 16);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Tile height must be <= image height")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -136,7 +136,6 @@ public class TiffWriterTest {
       writer.saveBytes(1, buf, ifd);
     }
     catch(FormatException e) {
-      System.out.println("Caught Exception " + e);
       if (e.getMessage().contains("File is too large; call setBigTiff(true)")) {
         thrown = true;
       }
@@ -208,7 +207,7 @@ public class TiffWriterTest {
   }
 
   @Test
-  public void testGetTileSizeX() throws IOException {
+  public void testGetTileSizeX() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
     assertEquals(SIZE_X, writer.getTileSizeX());
     writer.close();
@@ -222,18 +221,12 @@ public class TiffWriterTest {
   public void testSetTileSizeX() {
     writer.setMetadataRetrieve(metadata);
     try {
-      writer.setTileSizeX(0);
-      assertEquals(SIZE_X, writer.getTileSizeX());
       for (int i = 16; i < SIZE_X; i+=16) {
         writer.setTileSizeX(i);
         assertEquals(i, writer.getTileSizeX());
       }
       writer.setTileSizeX(SIZE_X);
       assertEquals(SIZE_X, writer.getTileSizeX());
-      for (int i = 0; i < 8; i++) {
-        writer.setTileSizeX(i);
-        assertEquals(SIZE_X, writer.getTileSizeX());
-      }
       for (int i = 8; i < 24; i++) {
         writer.setTileSizeX(i);
         assertEquals(16, writer.getTileSizeX());
@@ -249,7 +242,7 @@ public class TiffWriterTest {
   }
 
   @Test
-  public void testGetTileSizeY() throws IOException {
+  public void testGetTileSizeY() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
     assertEquals(SIZE_Y, writer.getTileSizeY());
     writer.close();
@@ -263,18 +256,12 @@ public class TiffWriterTest {
   public void testSetTileSizeY() {
     writer.setMetadataRetrieve(metadata);
     try {
-      writer.setTileSizeY(0);
-      assertEquals(SIZE_Y, writer.getTileSizeY());
       for (int i = 16; i < SIZE_Y; i+=16) {
         writer.setTileSizeY(i);
         assertEquals(i, writer.getTileSizeY());
       }
       writer.setTileSizeY(SIZE_Y);
       assertEquals(SIZE_Y, writer.getTileSizeY());
-      for (int i = 0; i < 8; i++) {
-        writer.setTileSizeY(i);
-        assertEquals(SIZE_Y, writer.getTileSizeY());
-      }
       for (int i = 8; i < 24; i++) {
         writer.setTileSizeY(i);
         assertEquals(16, writer.getTileSizeY());
@@ -287,6 +274,108 @@ public class TiffWriterTest {
     catch(FormatException fe) {
       assert(false);
     }
+  }
+  
+  @Test
+  public void testTileFormatExceptions() {
+    boolean thrown = false;
+    int tile_size = 16;
+    try {
+      writer.setTileSizeY(tile_size);
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Pixels Size Y must not be null when attempting to set tile size")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    thrown = false;
+    try {
+      writer.setTileSizeX(tile_size);
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Pixels Size X must not be null when attempting to set tile size")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    thrown = false;
+    try {
+      writer.getTileSizeX();
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Pixels Size X must not be null when attempting to get tile size")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    thrown = false;
+    try {
+      writer.getTileSizeY();
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Pixels Size Y must not be null when attempting to get tile size")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    writer.setMetadataRetrieve(metadata);
+    thrown = false;
+    try {
+      writer.setTileSizeX(0);
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Tile size must be > 0")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    thrown = false;
+    try {
+      writer.setTileSizeY(0);
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Tile size must be > 0")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    thrown = false;
+    try {
+      writer.setTileSizeX(SIZE_X);
+    }
+    catch(FormatException e) {
+        thrown = true;
+    }
+    assert(!thrown);
+    thrown = false;
+    try {
+      writer.setTileSizeY(SIZE_Y);
+    }
+    catch(FormatException e) {
+        thrown = true;
+    }
+    assert(!thrown);
+    thrown = false;
+    try {
+      writer.setTileSizeX(SIZE_X + 16);
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Tile width must be <= image width")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
+    thrown = false;
+    try {
+      writer.setTileSizeY(SIZE_Y + 16);
+    }
+    catch(FormatException e) {
+      if (e.getMessage().contains("Tile height must be <= image height")) {
+        thrown = true;
+      }
+    }
+    assert(thrown);
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -227,7 +227,7 @@ public class TiffWriterTest {
       }
       writer.setTileSizeX(SIZE_X);
       assertEquals(SIZE_X, writer.getTileSizeX());
-      for (int i = 8; i < 24; i++) {
+      for (int i = 1; i < 24; i++) {
         writer.setTileSizeX(i);
         assertEquals(16, writer.getTileSizeX());
       }
@@ -262,7 +262,7 @@ public class TiffWriterTest {
       }
       writer.setTileSizeY(SIZE_Y);
       assertEquals(SIZE_Y, writer.getTileSizeY());
-      for (int i = 8; i < 24; i++) {
+      for (int i = 1; i < 24; i++) {
         writer.setTileSizeY(i);
         assertEquals(16, writer.getTileSizeY());
       }

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -105,7 +105,7 @@ public class TiffWriterTest {
   @DataProvider(name = "tiling")
   public Object[][] createTiling() {
     String tilingProp = System.getProperty("testng.runWriterTilingTests");
-    if (tilingProp == null|| !Boolean.valueOf(System.getProperty("testng.runWriterTilingTests"))) {
+    if (tilingProp == null || Integer.valueOf(System.getProperty("testng.runWriterTilingTests")) == 0) {
       return new Object[][] {{0, false, false, 0, 0, null, 0}};
     }
     int[] tileSize = {1, 32, 43, 64};
@@ -151,9 +151,8 @@ public class TiffWriterTest {
         }
       }
     }
-    String tilingSubsetProp = System.getProperty("testng.runSubsetTilingTests");
-    if (tilingSubsetProp != null) {
-      int percentageOfTests = Integer.parseInt(tilingSubsetProp);
+    if (tilingProp != null && Integer.valueOf(System.getProperty("testng.runWriterTilingTests")) < 100) {
+      int percentageOfTests = Integer.parseInt(tilingProp);
       int numTests = (paramSize / 100) * percentageOfTests;
       Object[][] returnSubset = new Object[numTests][];
       for (int i = 0; i < numTests; i++) {
@@ -454,7 +453,7 @@ public class TiffWriterTest {
   public void testSaveBytesTiling(int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
       int seriesCount, String compression, int pixelType) throws Exception {
     String tilingProp = System.getProperty("testng.runWriterTilingTests");
-    if (tilingProp == null || !Boolean.valueOf(System.getProperty("testng.runWriterTilingTests"))) {
+    if (tilingProp == null || Integer.valueOf(System.getProperty("testng.runWriterTilingTests")) == 0) {
       return;
     }
     boolean runTilingTests = Boolean.valueOf(System.getProperty("testng.runWriterTilingTests"));

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -66,6 +66,12 @@
             <class name="loci.formats.utests.tiff.TiffParserTest"/>
         </classes>
     </test>
+    <test name="TiffWriterTest">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.out.TiffWriterTest"/>
+      </classes>
+    </test>
     <test name="ReaderWrapper">
       <groups/>
       <classes>

--- a/components/formats-bsd/test/loci/formats/utests/tiff/ByteArrayHandleMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/ByteArrayHandleMock.java
@@ -1,0 +1,46 @@
+package loci.formats.utests.tiff;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import loci.common.ByteArrayHandle;
+
+public class ByteArrayHandleMock extends ByteArrayHandle {
+  
+  private long mockCapacity;
+  
+  public ByteArrayHandleMock(int capacity) {
+    buffer = ByteBuffer.allocate(INITIAL_LENGTH);
+    buffer.limit(INITIAL_LENGTH);
+    mockCapacity = capacity;
+  }
+  
+  @Override
+  public void setLength(long length) throws IOException {
+    mockCapacity = length;
+  }
+  
+  @Override
+  public long length() {
+    System.out.println("Getting length " + mockCapacity);
+    return mockCapacity;
+  }
+  
+  @Override
+  public void seek(long pos) throws IOException {
+    if (pos > length()) {
+      setLength(pos);
+    }
+    if (pos > INITIAL_LENGTH) {
+      buffer.position((int) INITIAL_LENGTH);
+    }
+    else {
+      buffer.position((int) pos);
+    }
+  }
+  
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    mockCapacity += b.length;
+  }
+}

--- a/components/formats-bsd/test/loci/formats/utests/tiff/ByteArrayHandleMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/ByteArrayHandleMock.java
@@ -22,7 +22,6 @@ public class ByteArrayHandleMock extends ByteArrayHandle {
   
   @Override
   public long length() {
-    System.out.println("Getting length " + mockCapacity);
     return mockCapacity;
   }
   

--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffWriterMock.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffWriterMock.java
@@ -1,0 +1,55 @@
+package loci.formats.utests.tiff;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import loci.common.ByteArrayHandle;
+import loci.common.RandomAccessInputStream;
+import loci.common.RandomAccessOutputStream;
+import loci.formats.out.TiffWriter;
+import loci.formats.tiff.TiffSaver;
+
+public class TiffWriterMock extends TiffWriter {
+  
+  private static final int INITIAL_CAPACITY = 1024 * 1024;
+  private ByteArrayHandle handle;
+  
+  public TiffWriterMock() {
+    super();
+    handle = new ByteArrayHandle(INITIAL_CAPACITY);
+  }
+  
+  public TiffWriterMock(String format, String[] exts) {
+    super(format, exts);
+    handle = new ByteArrayHandle(INITIAL_CAPACITY);
+  }
+  
+  @Override
+  protected RandomAccessOutputStream createOutputStream() throws IOException {
+    return new RandomAccessOutputStream(handle);
+  }
+  
+  @Override
+  protected RandomAccessInputStream createInputStream() throws IOException {
+    return new RandomAccessInputStream(handle);
+  }
+  
+  @Override
+  protected TiffSaver createTiffSaver() {
+    return new TiffSaver(out, handle);
+  }
+  
+  public void createOutputBuffer(boolean mock) throws IOException {
+    if (mock) {
+      handle = new ByteArrayHandleMock(INITIAL_CAPACITY);
+    }
+    else {
+      handle = new ByteArrayHandle(INITIAL_CAPACITY);
+    }
+  }
+  
+  public void setBufferLength(long length) throws IOException {
+    handle.setLength(length);
+  }
+
+}


### PR DESCRIPTION
Adds the following new API functions:
public int getTileSizeX()
public int getTileSizeY()
int setTileSizeX(int tileSize) throws FormatException
int setTileSizeY(int tileSize) throws FormatException 

The base implemenattion of these functions will default to full image height and width and return these values when you try to set to any other tiling size.

Any writer that uses the TiffWriter will have its own implementation which will allow any multiple of 16 to be used as a tile size. If a non multiple of 16 is provided then the tileSize will round to the nearest 16 and return this value to the caller.

For the TiffWriter, if a tile size has been set when saveBytes is called then the provided byte array will be written out in tiles of this size.

For testing the following combinations of Tiff images should be written out and verify that the tile sizes are correct using "tiffinfo -s" (should display for example '3072 Tiles, as opposed to '3072 strips') and verifying that the images display correctly:

- Single channel, multi time and z frames
- Single channel
- Multi channel interleaved image
- Multi channel non interleaved image
- Varying pixel formats
- Existing tiled image, verify that it can be resaved with different tile size
- Images with height and width which are not a multiple of 16
- Tiling with X and Y values which will overlap tile boundaries

Unit test contains framework for using mock writers to allow for unit testing of format writers withoutout outputting large filesets. I have included tests for basic TiffWriter functionality as well as the new API functions included for getting and setting tiling sizes. I have removed the incomplete tests for saveBytes which had been in progress, this functionality could be re-added later or covered with test-suite coverage.