### PR TITLE
Bundle cleanup

### DIFF
--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -57,6 +57,7 @@
       <groupId>net.imagej</groupId>
       <artifactId>ij</artifactId>
       <version>${imagej1.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -57,7 +57,6 @@
       <groupId>net.imagej</groupId>
       <artifactId>ij</artifactId>
       <version>${imagej1.version}</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/components/bundles/bioformats_package/assembly.xml
+++ b/components/bundles/bioformats_package/assembly.xml
@@ -11,6 +11,7 @@
     <dependencySet>
       <excludes>
         <exclude>gov.nih.imagej:imagej</exclude>
+        <exclude>net.imagej:ij</exclude>
         <exclude>org.springframework:spring*</exclude>
         <exclude>aopalliance:aopalliance</exclude>
         <exclude>org.aspectj:aspectj*</exclude>

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -71,7 +71,14 @@
           <archive>
             <manifest>
               <mainClass>loci.formats.gui.ImageViewer</mainClass>
+              <addClasspath>true</addClasspath>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestEntries>
+              <Implementation-Date>${maven.build.timestamp}</Implementation-Date>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
           </archive>
         </configuration>
         <executions>

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -53,6 +53,13 @@
       <version>${mipav-stubs.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>net.imagej</groupId>
+      <artifactId>ij</artifactId>
+      <version>${imagej1.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/components/bundles/loci_tools/assembly.xml
+++ b/components/bundles/loci_tools/assembly.xml
@@ -11,6 +11,7 @@
     <dependencySet>
       <excludes>
         <exclude>gov.nih.imagej:imagej</exclude>
+        <exclude>net.imagej:ij</exclude>
         <!-- exclude testing dependencies -->
         <exclude>org.testng:testng</exclude>
         <exclude>com.beust:jcommander</exclude>

--- a/components/bundles/loci_tools/pom.xml
+++ b/components/bundles/loci_tools/pom.xml
@@ -67,7 +67,14 @@
           <archive>
             <manifest>
               <mainClass>loci.formats.gui.ImageViewer</mainClass>
+              <addClasspath>true</addClasspath>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+            <manifestEntries>
+              <Implementation-Date>${maven.build.timestamp}</Implementation-Date>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
           </archive>
         </configuration>
         <executions>

--- a/components/bundles/loci_tools/pom.xml
+++ b/components/bundles/loci_tools/pom.xml
@@ -49,6 +49,12 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j.version}</version>
      </dependency>
+     <dependency>
+      <groupId>net.imagej</groupId>
+      <artifactId>ij</artifactId>
+      <version>${imagej1.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
See https://trello.com/c/i1XLwx3M/29-review-bundles

This adds version information to the manifest of Maven-built bundles and excludes ImageJ (```net.imagej:ij```) from bundles built with both Maven and Ant.

To test, build ```bioformats_package.jar``` and ```loci_tools.jar``` with both Ant (```ant clean jars tools```) and Maven (```mvn clean package install```).  Check the ```META-INF/MANIFEST.MF``` in all jars, and verify that all have matching information, including version number, git commit, and build date.  Also check that ImageJ is no longer included in any of the jars - each should be ~15MB smaller.