### PR TITLE
Test suite: don't exclude files that cause setId failures

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -219,13 +219,16 @@ public class FormatReaderTestFactory {
     }
     Set<String> minimalFiles = new LinkedHashSet<String>();
     FileStitcher reader = new FileStitcher();
+    Set<String> failingIds = new LinkedHashSet<String>();
     while (!fileSet.isEmpty()) {
       String file = fileSet.iterator().next();
       try {
         reader.setId(file);
       } catch (Exception e) {
-        LOGGER.error("setId({}) failed", file, e);
-        throw new RuntimeException(e);
+        LOGGER.error("setId(\"{}\") failed", file, e);
+        failingIds.add(file);
+        fileSet.remove(file);
+        continue;
       }
       try {
         String[] usedFiles = reader.getUsedFiles();
@@ -250,6 +253,11 @@ public class FormatReaderTestFactory {
         }
         catch (IOException e) { }
       }
+    }
+    if (!failingIds.isEmpty()) {
+      String msg = String.format("setId failed on %s", failingIds);
+      LOGGER.error(msg);
+      throw new RuntimeException(msg);
     }
     files = new ArrayList<String>();
     for (String s: minimalFiles) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -223,6 +223,11 @@ public class FormatReaderTestFactory {
       String file = fileSet.iterator().next();
       try {
         reader.setId(file);
+      } catch (Exception e) {
+        LOGGER.error("setId({}) failed", file, e);
+        throw new RuntimeException(e);
+      }
+      try {
         String[] usedFiles = reader.getUsedFiles();
         Set<String> auxFiles = new LinkedHashSet<String>();
         for (String s: usedFiles) {
@@ -234,7 +239,10 @@ public class FormatReaderTestFactory {
         minimalFiles.removeAll(auxFiles);
         minimalFiles.add(masterFile);
       }
-      catch (Exception e) { }
+      catch (Exception e) {
+        LOGGER.warn("Could not determine duplicate status for {}", file, e);
+        minimalFiles.add(file);
+      }
       finally {
         fileSet.remove(file);
         try {


### PR DESCRIPTION
In the "remove duplicates" phase, `FormatReaderTestFactory` ignores `setId` failures, effectively preventing files that would fail the test right at `setId` from being tested at all.

With this PR:

1. If `setId` fails in the remove duplicate phase, the method breaks immediately (we have to catch, print error and rethrow because testng swallows exceptions thrown by factory methods)
2. If anything else goes wrong in the remove duplicate phase the file is kept in the list, so that it gets tested later
