### PR TITLE
Options API: memoizer propagation

### DIFF
--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -830,6 +830,7 @@ public class ImageReader implements IFormatReader {
   @Override
   public void setId(String id) throws FormatException, IOException {
     IFormatReader currentReader = getReader(id);
+    currentReader.setMetadataOptions(getMetadataOptions());
     LOGGER.info("{} initializing {}",
       currentReader.getClass().getSimpleName(), id);
     currentReader.setId(id);

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -49,7 +49,6 @@ import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.formats.in.DefaultMetadataOptions;
 import loci.formats.in.MetadataLevel;
-import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataStore;
 import loci.formats.Memoizer;
 
@@ -918,9 +917,9 @@ public class FileStitcher extends ReaderWrapper {
     if (patterns.length == 0) patterns = new String[] {id};
     externals = new ExternalSeries[patterns.length];
 
+    DefaultMetadataOptions opt = (DefaultMetadataOptions) getMetadataOptions();
     for (int i=0; i<externals.length; i++) {
-      externals[i] = new ExternalSeries(new FilePattern(patterns[i]),
-                                        getMetadataOptions());
+      externals[i] = new ExternalSeries(new FilePattern(patterns[i]), opt);
     }
     fp = new FilePattern(patterns[0]);
 
@@ -1248,7 +1247,7 @@ public class FileStitcher extends ReaderWrapper {
     private AxisGuesser ag;
     private int imagesPerFile;
 
-    public ExternalSeries(FilePattern pattern, MetadataOptions opt)
+    public ExternalSeries(FilePattern pattern, DefaultMetadataOptions opt)
       throws FormatException, IOException
     {
       this.pattern = pattern;

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -917,9 +917,8 @@ public class FileStitcher extends ReaderWrapper {
     if (patterns.length == 0) patterns = new String[] {id};
     externals = new ExternalSeries[patterns.length];
 
-    DefaultMetadataOptions opt = (DefaultMetadataOptions) getMetadataOptions();
     for (int i=0; i<externals.length; i++) {
-      externals[i] = new ExternalSeries(new FilePattern(patterns[i]), opt);
+      externals[i] = new ExternalSeries(new FilePattern(patterns[i]));
     }
     fp = new FilePattern(patterns[0]);
 
@@ -1247,7 +1246,7 @@ public class FileStitcher extends ReaderWrapper {
     private AxisGuesser ag;
     private int imagesPerFile;
 
-    public ExternalSeries(FilePattern pattern, DefaultMetadataOptions opt)
+    public ExternalSeries(FilePattern pattern)
       throws FormatException, IOException
     {
       this.pattern = pattern;
@@ -1255,6 +1254,8 @@ public class FileStitcher extends ReaderWrapper {
 
       int nReaders = files.length > MAX_READERS ? 1 : files.length;
       readers = new DimensionSwapper[nReaders];
+      DefaultMetadataOptions opt =
+        (DefaultMetadataOptions) getMetadataOptions();
       boolean memoize = opt.getBoolean(Memoizer.PROPAGATE_KEY, false);
       for (int i=0; i<readers.length; i++) {
         if (classList != null) {
@@ -1270,7 +1271,7 @@ public class FileStitcher extends ReaderWrapper {
             readers[i] = new DimensionSwapper();
           }
         }
-        readers[i].setMetadataOptions(getMetadataOptions());
+        readers[i].setMetadataOptions(opt);
         readers[i].setGroupFiles(false);
       }
       readers[0].setId(files[0]);

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -51,6 +51,7 @@ import loci.formats.in.DefaultMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataStore;
+import loci.formats.Memoizer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -918,7 +919,8 @@ public class FileStitcher extends ReaderWrapper {
     externals = new ExternalSeries[patterns.length];
 
     for (int i=0; i<externals.length; i++) {
-      externals[i] = new ExternalSeries(new FilePattern(patterns[i]));
+      externals[i] = new ExternalSeries(new FilePattern(patterns[i]),
+                                        getMetadataOptions());
     }
     fp = new FilePattern(patterns[0]);
 
@@ -1246,7 +1248,7 @@ public class FileStitcher extends ReaderWrapper {
     private AxisGuesser ag;
     private int imagesPerFile;
 
-    public ExternalSeries(FilePattern pattern)
+    public ExternalSeries(FilePattern pattern, MetadataOptions opt)
       throws FormatException, IOException
     {
       this.pattern = pattern;
@@ -1254,11 +1256,22 @@ public class FileStitcher extends ReaderWrapper {
 
       int nReaders = files.length > MAX_READERS ? 1 : files.length;
       readers = new DimensionSwapper[nReaders];
+      boolean memoize = opt.getBoolean(Memoizer.PROPAGATE_KEY, false);
       for (int i=0; i<readers.length; i++) {
         if (classList != null) {
-          readers[i] = new DimensionSwapper(new ImageReader(classList));
+          IFormatReader subReader = new ImageReader(classList);
+          if (memoize) {
+            subReader = new Memoizer(subReader);
+          }
+          readers[i] = new DimensionSwapper(subReader);
+        } else {
+          if (memoize) {
+            readers[i] = new DimensionSwapper(new Memoizer());
+          } else {
+            readers[i] = new DimensionSwapper();
+          }
         }
-        else readers[i] = new DimensionSwapper();
+        readers[i].setMetadataOptions(getMetadataOptions());
         readers[i].setGroupFiles(false);
       }
       readers[0].setId(files[0]);

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -355,6 +355,17 @@ public class Memoizer extends ReaderWrapper {
   public static final String DIRECTORY_KEY = "memoizer.directory";
 
   /**
+   * Whether memoization should be propagated to underlying readers.
+   * Defaults to {@link #DEFAULT_PROPAGATE}.
+   */
+  public static final String PROPAGATE_KEY = "memoizer.propagate";
+
+  /**
+   * Default value for {@link #PROPAGATE_KEY}.
+   */
+  public static final boolean DEFAULT_PROPAGATE = true;
+
+  /**
    * Default {@link org.slf4j.Logger} for the memoizer class
    */
   private static final Logger LOGGER =
@@ -454,6 +465,7 @@ public class Memoizer extends ReaderWrapper {
     super();
     this.getMetadataOptions().setLong(MINIMUM_ELAPSED_KEY, minimumElapsed);
     this.getMetadataOptions().setFile(DIRECTORY_KEY, directory);
+    this.getMetadataOptions().setBoolean(PROPAGATE_KEY, true);
   }
 
   /**
@@ -500,6 +512,7 @@ public class Memoizer extends ReaderWrapper {
     super(r);
     this.getMetadataOptions().setLong(MINIMUM_ELAPSED_KEY, minimumElapsed);
     this.getMetadataOptions().setFile(DIRECTORY_KEY, directory);
+    this.getMetadataOptions().setBoolean(PROPAGATE_KEY, true);
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -50,6 +50,7 @@ import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.OMEXMLServiceImpl;
+import loci.formats.in.DefaultMetadataOptions;
 
 import org.perf4j.StopWatch;
 import org.perf4j.slf4j.Slf4JStopWatch;
@@ -463,9 +464,10 @@ public class Memoizer extends ReaderWrapper {
    */
   public Memoizer(long minimumElapsed, File directory) {
     super();
-    this.getMetadataOptions().setLong(MINIMUM_ELAPSED_KEY, minimumElapsed);
-    this.getMetadataOptions().setFile(DIRECTORY_KEY, directory);
-    this.getMetadataOptions().setBoolean(PROPAGATE_KEY, true);
+    DefaultMetadataOptions opt = (DefaultMetadataOptions) getMetadataOptions();
+    opt.setLong(MINIMUM_ELAPSED_KEY, minimumElapsed);
+    opt.setFile(DIRECTORY_KEY, directory);
+    opt.setBoolean(PROPAGATE_KEY, true);
   }
 
   /**
@@ -510,16 +512,17 @@ public class Memoizer extends ReaderWrapper {
    */
   public Memoizer(IFormatReader r, long minimumElapsed, File directory) {
     super(r);
-    this.getMetadataOptions().setLong(MINIMUM_ELAPSED_KEY, minimumElapsed);
-    this.getMetadataOptions().setFile(DIRECTORY_KEY, directory);
-    this.getMetadataOptions().setBoolean(PROPAGATE_KEY, true);
+    DefaultMetadataOptions opt = (DefaultMetadataOptions) getMetadataOptions();
+    opt.setLong(MINIMUM_ELAPSED_KEY, minimumElapsed);
+    opt.setFile(DIRECTORY_KEY, directory);
+    opt.setBoolean(PROPAGATE_KEY, true);
   }
 
   /**
    * Returns the current value of {@link #MINIMUM_ELAPSED_KEY}.
    */
   public long getMinimumElapsed() {
-    return getMetadataOptions().getLong(
+    return ((DefaultMetadataOptions) getMetadataOptions()).getLong(
         MINIMUM_ELAPSED_KEY, DEFAULT_MINIMUM_ELAPSED
     );
   }
@@ -529,7 +532,9 @@ public class Memoizer extends ReaderWrapper {
    * the option is not set.
    */
   public File getDirectory() {
-    return getMetadataOptions().getFile(DIRECTORY_KEY, null);
+    return ((DefaultMetadataOptions) getMetadataOptions()).getFile(
+        DIRECTORY_KEY, null
+    );
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -65,7 +65,7 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /**
  * {@link ReaderWrapper} implementation which caches the state of the
- * delegate (including and other {@link ReaderWrapper} instances)
+ * delegate (including other {@link ReaderWrapper} instances)
  * after {@link #setId(String)} has been called.
  *
  * Initializing a Bio-Formats reader can consume substantial time and memory.
@@ -74,7 +74,7 @@ import org.objenesis.strategy.StdInstantiatorStrategy;
  * size, the amount of metadata in the image and also the file format itself.
  *
  * With the {@link Memoizer} reader wrapper, if the time required to call the
- * {@link #setId(String)} method is larger than {@link #minimumElapsed}, the
+ * {@link #setId(String)} method is larger than a configurable minimum, the
  * initialized reader including all reader wrappers will be cached in a memo
  * file via {@link #saveMemo()}.
  * Any subsequent call to {@link #setId(String)} with a reader decorated by
@@ -516,7 +516,7 @@ public class Memoizer extends ReaderWrapper {
   }
 
   /**
-   * Returns the current value of {@link MINIMUM_ELAPSED_KEY}.
+   * Returns the current value of {@link #MINIMUM_ELAPSED_KEY}.
    */
   public long getMinimumElapsed() {
     return getMetadataOptions().getLong(
@@ -525,7 +525,7 @@ public class Memoizer extends ReaderWrapper {
   }
 
   /**
-   * Returns the current value of {@link DIRECTORY_KEY}, or {@null} if
+   * Returns the current value of {@link #DIRECTORY_KEY}, or {@code null} if
    * the option is not set.
    */
   public File getDirectory() {

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -777,7 +777,7 @@ public class Memoizer extends ReaderWrapper {
     File origFile = new File(id);
     File memoDir = getDirectory();
     if (null == memoDir) {
-      memoDir = origFile.getParentFile();
+      memoDir = origFile.getAbsoluteFile().getParentFile();
     }
     if (!memoDir.exists() && !memoDir.mkdirs()) {
       LOGGER.warn("skipping memo: can't create {}", memoDir);

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -521,6 +521,7 @@ public class FilePatternReader extends FormatReader {
 
     helper.setUsingPatternIds(true);
     helper.setCanChangePattern(false);
+    helper.setMetadataOptions(getMetadataOptions());
     helper.setId(pattern);
     core = helper.getCoreMetadataList();
   }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -284,6 +284,20 @@ public class MemoizerTest {
   }
 
   @Test
+  public void testGetMemoFileBasenameInPlace() {
+    memoizer = new Memoizer(0);
+    String basename = "foo";
+    File expMemoDir = new File(basename).getAbsoluteFile().getParentFile();
+    File memoFile = memoizer.getMemoFile(basename);
+    if (expMemoDir.canWrite()) {
+      File expMemoFile = new File(expMemoDir, "." + basename + ".bfmemo");
+      assertEquals(memoFile.getAbsolutePath(), expMemoFile.getAbsolutePath());
+    } else {
+      assertNull(memoFile);
+    }
+  }
+
+  @Test
   public void testRelocate() throws Exception {
     // Create an in-place memo file
     memoizer = new Memoizer(reader, 0);


### PR DESCRIPTION
Uses #2659 to get propagation of memoizing behaviour across a stack of wrappers and sub-readers. This is basically the same use case encountered in #2013, but here I've worked on `FilePatternReader` rather than `ScreenReader` because changes to the latter have not been ported to the mainline yet. Both readers rely on `FileStitcher` to group files together though, the main difference being that `ScreenReader` uses multiple stitchers whereas `FilePatternReader` uses only one.

These changes can be tested with a small ad-hoc program:

```java
import java.io.File;
import loci.formats.IFormatReader;
import loci.formats.ImageReader;
import loci.formats.Memoizer;

public final class TryPropagation {

  public static final long MIN_ELAPSED = 0L;
  public static final String DIR_PATH = "/tmp";

  public static void main(String[] args) throws Exception {
    String id = args[0];
    File dir = new File(DIR_PATH);
    IFormatReader reader = new Memoizer(new ImageReader(), MIN_ELAPSED, dir);
    reader.setId(id);
    for (int c = 0; c < reader.getSizeC(); c++) {
      reader.openBytes(reader.getIndex(0, c, 0));
    }
  }
}
```

You can get a minimal test setup starting from [multi-channel.ome.tiff](http://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/bioformats-artificial/multi-channel.ome.tiff):

```
bfconvert multi-channel.ome.tif multi-channel-C%c.tif
echo 'multi-channel-C<0-2>.tif' >multi-channel.pattern
```

Then run the program with `multi-channel.pattern` as its argument. After running the program once you should get memo files (under `/tmp`) corresponding to the pattern file and to all individual image files:

```
.multi-channel-C0.tif.bfmemo
.multi-channel-C1.tif.bfmemo
.multi-channel-C2.tif.bfmemo
.multi-channel.pattern.bfmemo
```

Now run the program again. Looking at the logs (with level set to `DEBUG`) you should see that:

* In the first run, readers are initialized from scratch and saved to memo. Since `FileStitcher` does a bit of closing and reopening on its sub-readers (see also: #2428), you should also see memo loads from `.multi-channel-C{0,1,2}.tif.bfmemo`
* In the second run, *all* readers are always loaded from their memo files

--breaking