### PR TITLE
octave: use usejava() instead of deprecated octave_config_info()

### DIFF
--- a/components/formats-gpl/octave/PKG_ADD
+++ b/components/formats-gpl/octave/PKG_ADD
@@ -2,8 +2,7 @@
 ## work properly in Octave.  We must error loading the package if not.
 
 ## First check if Octave was even built with Java support
-
-if (! octave_config_info ("features").JAVA)
+if (! usejava ("jvm"))
   error ("bioformats: support for java was disabled when Octave was built");
 endif
 

--- a/docs/sphinx/users/octave/index.txt
+++ b/docs/sphinx/users/octave/index.txt
@@ -21,7 +21,7 @@ support for java::
     $ octave
     >> OCTAVE_VERSION
     ans = 4.0.0
-    >> octave_config_info ("features").JAVA
+    >> usejava ("jvm")
     ans =  1
 
 Installation


### PR DESCRIPTION
This function has been deprecated in Octave. Replacing by the recommended alternative which works since Octave 3.8 and is not a problem for the bioformats package which already requires Octave 4.0.0.