### PR TITLE
Increase specificity of the artifactId version replacement

### DIFF
--- a/tools/bump_maven_version.py
+++ b/tools/bump_maven_version.py
@@ -13,6 +13,11 @@ def check_version_format(version):
     return re.match(pattern, version) is not None
 
 
+BIO_FORMATS_ARTIFACT = (
+    r"(<groupId>%s</groupId>\n"
+    ".*<artifactId>pom-bio-formats</artifactId>\n"
+    ".*<version>).*(</version>)")
+
 class Replacer(object):
 
     def __init__(self, old_group="ome", new_group="ome"):
@@ -21,9 +26,7 @@ class Replacer(object):
         self.group_pattern = \
             r"(<groupId>)%s(</groupId>)" % \
             old_group
-        self.artifact_pattern = \
-            r"(<groupId>%s</groupId>\n.*\n.*<version>).*(</version>)" % \
-            old_group
+        self.artifact_pattern = BIO_FORMATS_ARTIFACT % old_group
         self.release_version_pattern = \
             r"(<release.version>).*(</release.version>)"
         self.stableversion_pattern = \


### PR DESCRIPTION
See https://trello.com/c/3R8rGfYV/54-fix-version-bump-script

The introduction of `jxrlib` in 5.3.0-m2 broke the script used to bump versions - see https://github.com/openmicroscopy/bioformats/pull/2667 

This PR reduces the scope of the script by restricting the version bump to the `pom-bio-formats` artifact. This modified has been used to produce #2668 and #2671 but should be retested independently using e.g.

```
./tools/bump_maven_version.py 5.4.0
./tools/bump_maven_version.py 5.4.0-SNAPSHOT
```

It should also  work with the option allowing to switch the `groupId` /cc @joshmoore 
