### PR TITLE
Update EMAN link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -666,7 +666,7 @@ owner = `Gatan <http://www.gatan.com/>`_
 bsd = no
 versions = 3, 4
 software = `DM3 Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/DM3_Reader.html>`_ \n
-`EMAN <http://blake.bcm.edu/EMAN/>`_
+`EMAN <http://blake.bcm.edu/emanwiki/EMAN2>`_
 weHave = * Gatan's ImageReader2003 code (from 2003, in C++) \n
 * numerous DM3 datasets
 weWant = * a DM3 specification document

--- a/docs/sphinx/formats/gatan-digital-micrograph.txt
+++ b/docs/sphinx/formats/gatan-digital-micrograph.txt
@@ -24,7 +24,7 @@ Reader: GatanReader (:bfreader:`Source Code <GatanReader.java>`, :doc:`Supported
 Freely Available Software:
 
 - `DM3 Reader plugin for ImageJ <http://rsb.info.nih.gov/ij/plugins/DM3_Reader.html>`_ 
-- `EMAN <http://blake.bcm.edu/EMAN/>`_
+- `EMAN <http://blake.bcm.edu/emanwiki/EMAN2>`_
 
 
 We currently have:


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-latest-docs/261/warnings3Result/ - looks like they are updating their website but this will hopefully remain a valid link since their EMAN wiki home link in the top left goes to this URL.

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.3-staging/formats/gatan-digital-micrograph.html