### PR TITLE
MemoizerTest refactor

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -204,15 +204,7 @@ public class MemoizerTest {
   @Test
   public void testGetMemoFilePermissionsDirectory() throws Exception {
     File directory = createTempDir();
-    directory.delete();
     Memoizer memoizer = new Memoizer(reader, 0, directory);
-
-    // Check non-existing memo directory returns null
-    assertNull(memoizer.getMemoFile(id));
-
-    // Create memoizer directory and memoizer reader
-    directory.mkdirs();
-    memoizer = new Memoizer(reader, 0, directory);
 
     // Check existing non-writeable memo directory returns null
     if (File.separator.equals("/")) {
@@ -220,13 +212,6 @@ public class MemoizerTest {
       directory.setWritable(false);
       assertNull(memoizer.getMemoFile(id));
     }
-
-    // Check existing writeable memo diretory returns a memo file
-    directory.setWritable(true);
-    String memoDir = idDir.getAbsolutePath();
-    memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
-    recursiveDeleteOnExit(directory);
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -32,9 +32,10 @@
 
 package loci.formats.utests;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNull;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -151,7 +152,7 @@ public class MemoizerTest {
     Memoizer memoizer = new Memoizer(0, directory);
 
     // Check non-existing memo directory returns null
-    assertEquals(memoizer.getMemoFile(id), null);
+    assertNull(memoizer.getMemoFile(id));
 
     // Create memoizer directory and memoizer reader
     directory.mkdirs();
@@ -168,7 +169,7 @@ public class MemoizerTest {
     Memoizer memoizer = new Memoizer(0, null);
 
     // Check null memo directory returns null
-    assertEquals(memoizer.getMemoFile(id), null);
+    assertNull(memoizer.getMemoFile(id));
     checkNoMemo(memoizer, id);
   }
 
@@ -179,7 +180,7 @@ public class MemoizerTest {
     Memoizer memoizer = new Memoizer(reader, 0, directory);
 
     // Check non-existing memo directory returns null
-    assertEquals(memoizer.getMemoFile(id), null);
+    assertNull(memoizer.getMemoFile(id));
 
     // Create memoizer directory and memoizer reader
     directory.mkdirs();
@@ -196,7 +197,7 @@ public class MemoizerTest {
     Memoizer memoizer = new Memoizer(reader, 0, null);
 
     // Check null memo directory returns null
-    assertEquals(memoizer.getMemoFile(id), null);
+    assertNull(memoizer.getMemoFile(id));
     checkNoMemo(memoizer, id);
   }
 
@@ -207,7 +208,7 @@ public class MemoizerTest {
     Memoizer memoizer = new Memoizer(reader, 0, directory);
 
     // Check non-existing memo directory returns null
-    assertEquals(memoizer.getMemoFile(id), null);
+    assertNull(memoizer.getMemoFile(id));
 
     // Create memoizer directory and memoizer reader
     directory.mkdirs();
@@ -217,7 +218,7 @@ public class MemoizerTest {
     if (File.separator.equals("/")) {
       // File.setWritable() does not work properly on Windows
       directory.setWritable(false);
-      assertEquals(memoizer.getMemoFile(id), null);
+      assertNull(memoizer.getMemoFile(id));
     }
 
     // Check existing writeable memo diretory returns a memo file
@@ -237,7 +238,7 @@ public class MemoizerTest {
     if (File.separator.equals("/")) {
       // File.setWritable() does not work properly on Windows
       idDir.setWritable(false);
-      assertEquals(memoizer.getMemoFile(id), null);
+      assertNull(memoizer.getMemoFile(id));
     }
 
     // Check writeable file directory returns memo file beside file
@@ -253,7 +254,7 @@ public class MemoizerTest {
     if (File.separator.equals("/")) {
       // File.setWritable() does not work properly on Windows
       idDir.setWritable(false);
-      assertEquals(memoizer.getMemoFile(id), null);
+      assertNull(memoizer.getMemoFile(id));
     }
     // Check writeable file directory returns memo file beside file
     idDir.setWritable(true);

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -78,22 +78,6 @@ public class MemoizerTest {
     reader.close();
   }
 
-  @Test
-  public void testSimple() throws Exception {
-      memoizer = new Memoizer(reader);
-      File f = memoizer.getMemoFile(id);
-      if (f != null && f.exists()) {
-        f.delete();
-      }
-      // At this point we're sure that there's no memo file.
-      reader.setId(id);
-      reader.close();
-      memoizer.setId(id);
-      memoizer.close();
-      memoizer.setId(id);
-      memoizer.close();
-  }
-
   public void testDefaultConstructor() throws Exception {
       memoizer = new Memoizer();
       File f = memoizer.getMemoFile(id);

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -63,18 +63,12 @@ public class MemoizerTest {
 
   @BeforeMethod
   public void setUp() throws Exception {
-    reader = new FakeReader();
-    try {
-      String uuid = UUID.randomUUID().toString();
-      idDir = new File(System.getProperty("java.io.tmpdir"), uuid);
-      idDir.mkdirs();
-      File tempFile = new File(idDir, TEST_FILE);
-      tempFile.createNewFile();
-      id = tempFile.getAbsolutePath();
-      reader.setId(id);
-    } finally {
-      reader.close();
-    }
+    String uuid = UUID.randomUUID().toString();
+    idDir = new File(System.getProperty("java.io.tmpdir"), uuid);
+    idDir.mkdirs();
+    File tempFile = new File(idDir, TEST_FILE);
+    tempFile.createNewFile();
+    id = tempFile.getAbsolutePath();
     reader = new FakeReader(); // No setId !
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -55,7 +55,6 @@ public class MemoizerTest {
   private File idDir;
   private String id;
   private FakeReader reader;
-  private Memoizer memoizer;
 
   @BeforeMethod
   public void setUp() throws Exception {
@@ -70,12 +69,11 @@ public class MemoizerTest {
 
   @AfterMethod
   public void tearDown() throws Exception {
-    memoizer.close();
     reader.close();
   }
 
   public void testDefaultConstructor() throws Exception {
-    memoizer = new Memoizer();
+    Memoizer memoizer = new Memoizer();
     File f = memoizer.getMemoFile(id);
     File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
@@ -83,7 +81,7 @@ public class MemoizerTest {
 
   @Test
   public void testConstructorTimeElapsed() throws Exception {
-    memoizer = new Memoizer(0);
+    Memoizer memoizer = new Memoizer(0);
     File f = memoizer.getMemoFile(id);
     File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
@@ -101,7 +99,7 @@ public class MemoizerTest {
 
   @Test
   public void testConstructorReader() throws Exception {
-    memoizer = new Memoizer(reader);
+    Memoizer memoizer = new Memoizer(reader);
     File f = memoizer.getMemoFile(id);
     File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
@@ -109,7 +107,7 @@ public class MemoizerTest {
 
   @Test
   public void testConstructorReaderTimeElapsed() throws Exception {
-    memoizer = new Memoizer(reader, 0);
+    Memoizer memoizer = new Memoizer(reader, 0);
     File f = memoizer.getMemoFile(id);
     File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
@@ -129,7 +127,7 @@ public class MemoizerTest {
   public void testConstructorTimeElapsedDirectory() throws Exception {
     String uuid = UUID.randomUUID().toString();
     File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
-    memoizer = new Memoizer(0, directory);
+    Memoizer memoizer = new Memoizer(0, directory);
 
     // Check non-existing memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
@@ -157,7 +155,7 @@ public class MemoizerTest {
 
   @Test
   public void testConstructorTimeElapsedNull() throws Exception {
-    memoizer = new Memoizer(0, null);
+    Memoizer memoizer = new Memoizer(0, null);
 
     // Check null memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
@@ -173,7 +171,7 @@ public class MemoizerTest {
   public void testConstructorReaderTimeElapsedDirectory() throws Exception {
     String uuid = UUID.randomUUID().toString();
     File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
-    memoizer = new Memoizer(reader, 0, directory);
+    Memoizer memoizer = new Memoizer(reader, 0, directory);
 
     // Check non-existing memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
@@ -201,7 +199,7 @@ public class MemoizerTest {
 
   @Test
   public void testConstructorReaderTimeElapsedNull() throws Exception {
-    memoizer = new Memoizer(reader, 0, null);
+    Memoizer memoizer = new Memoizer(reader, 0, null);
 
     // Check null memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
@@ -217,7 +215,7 @@ public class MemoizerTest {
   public void testGetMemoFilePermissionsDirectory() throws Exception {
     String uuid = UUID.randomUUID().toString();
     File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
-    memoizer = new Memoizer(reader, 0, directory);
+    Memoizer memoizer = new Memoizer(reader, 0, directory);
 
     // Check non-existing memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
@@ -246,7 +244,7 @@ public class MemoizerTest {
   @Test
   public void testGetMemoFilePermissionsInPlaceDirectory() throws Exception {
     String rootPath = id.substring(0, id.indexOf(File.separator) + 1);
-    memoizer = new Memoizer(reader, 0, new File(rootPath));
+    Memoizer memoizer = new Memoizer(reader, 0, new File(rootPath));
 
     // Check non-writeable file directory returns null for in-place caching
     if (File.separator.equals("/")) {
@@ -264,7 +262,7 @@ public class MemoizerTest {
 
   @Test
   public void testGetMemoFilePermissionsInPlace() throws Exception {
-    memoizer = new Memoizer(reader);
+    Memoizer memoizer = new Memoizer(reader);
 
     // Check non-writeable file directory returns null for in-place caching
     if (File.separator.equals("/")) {
@@ -282,7 +280,7 @@ public class MemoizerTest {
   @Test
   public void testRelocate() throws Exception {
     // Create an in-place memo file
-    memoizer = new Memoizer(reader, 0);
+    Memoizer memoizer = new Memoizer(reader, 0);
     memoizer.setId(id);
     memoizer.close();
     assertFalse(memoizer.isLoadedFromMemo());

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -76,6 +76,15 @@ public class MemoizerTest {
     memoizer.close();
   }
 
+  private void checkMemoFile(File memoFile) {
+    checkMemoFile(memoFile, idDir);
+  }
+
+  private void checkMemoFile(File memoFile, File memoDir) {
+    File expMemoFile = new File(memoDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(memoFile.getAbsolutePath(), expMemoFile.getAbsolutePath());
+  }
+
   @BeforeMethod
   public void setUp() throws Exception {
     String uuid = UUID.randomUUID().toString();
@@ -94,34 +103,26 @@ public class MemoizerTest {
 
   public void testDefaultConstructor() throws Exception {
     Memoizer memoizer = new Memoizer();
-    File f = memoizer.getMemoFile(id);
-    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id));
   }
 
   @Test
   public void testConstructorTimeElapsed() throws Exception {
     Memoizer memoizer = new Memoizer(0);
-    File f = memoizer.getMemoFile(id);
-    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id));
     checkMemo(memoizer, id);
   }
 
   @Test
   public void testConstructorReader() throws Exception {
     Memoizer memoizer = new Memoizer(reader);
-    File f = memoizer.getMemoFile(id);
-    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id));
   }
 
   @Test
   public void testConstructorReaderTimeElapsed() throws Exception {
     Memoizer memoizer = new Memoizer(reader, 0);
-    File f = memoizer.getMemoFile(id);
-    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id));
     checkMemo(memoizer, id);
   }
 
@@ -139,10 +140,7 @@ public class MemoizerTest {
 
     String memoDir = idDir.getAbsolutePath();
     memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    File memoFile = new File(directory, memoDir);
-    memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
-    File f = memoizer.getMemoFile(id);
-    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
     checkMemo(memoizer, id);
   }
 
@@ -169,10 +167,7 @@ public class MemoizerTest {
 
     String memoDir = idDir.getAbsolutePath();
     memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    File memoFile = new File(directory, memoDir);
-    memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
-    File f = memoizer.getMemoFile(id);
-    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
     checkMemo(memoizer, id);
   }
 
@@ -209,10 +204,7 @@ public class MemoizerTest {
     directory.setWritable(true);
     String memoDir = idDir.getAbsolutePath();
     memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-    File memoFile = new File(directory, memoDir);
-    memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
-    assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
-                 memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
   }
 
   @Test
@@ -229,9 +221,7 @@ public class MemoizerTest {
 
     // Check writeable file directory returns memo file beside file
     idDir.setWritable(true);
-    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-    assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
-                 memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id));
   }
 
   @Test
@@ -246,9 +236,7 @@ public class MemoizerTest {
     }
     // Check writeable file directory returns memo file beside file
     idDir.setWritable(true);
-    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-    assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
-                 memoFile.getAbsolutePath());
+    checkMemoFile(memoizer.getMemoFile(id));
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -150,13 +150,9 @@ public class MemoizerTest {
     File directory = createTempDir();
     directory.delete();
     Memoizer memoizer = new Memoizer(0, directory);
-
     // Check non-existing memo directory returns null
     assertNull(memoizer.getMemoFile(id));
-
-    // Create memoizer directory and memoizer reader
     directory.mkdirs();
-
     String memoDir = idDir.getAbsolutePath();
     memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
     checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
@@ -167,7 +163,6 @@ public class MemoizerTest {
   @Test
   public void testConstructorTimeElapsedNull() throws Exception {
     Memoizer memoizer = new Memoizer(0, null);
-
     // Check null memo directory returns null
     assertNull(memoizer.getMemoFile(id));
     checkNoMemo(memoizer, id);
@@ -178,13 +173,9 @@ public class MemoizerTest {
     File directory = createTempDir();
     directory.delete();
     Memoizer memoizer = new Memoizer(reader, 0, directory);
-
     // Check non-existing memo directory returns null
     assertNull(memoizer.getMemoFile(id));
-
-    // Create memoizer directory and memoizer reader
     directory.mkdirs();
-
     String memoDir = idDir.getAbsolutePath();
     memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
     checkMemoFile(memoizer.getMemoFile(id), new File(directory, memoDir));
@@ -195,7 +186,6 @@ public class MemoizerTest {
   @Test
   public void testConstructorReaderTimeElapsedNull() throws Exception {
     Memoizer memoizer = new Memoizer(reader, 0, null);
-
     // Check null memo directory returns null
     assertNull(memoizer.getMemoFile(id));
     checkNoMemo(memoizer, id);

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -9,13 +9,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -46,19 +46,15 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-/**
- */
+
 public class MemoizerTest {
 
   private static final String TEST_FILE =
     "test&pixelType=int8&sizeX=20&sizeY=20&sizeC=1&sizeZ=1&sizeT=1.fake";
 
   private File idDir;
-
   private String id;
-
   private FakeReader reader;
-
   private Memoizer memoizer;
 
   @BeforeMethod
@@ -79,59 +75,58 @@ public class MemoizerTest {
   }
 
   public void testDefaultConstructor() throws Exception {
-      memoizer = new Memoizer();
-      File f = memoizer.getMemoFile(id);
-      File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-      assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    memoizer = new Memoizer();
+    File f = memoizer.getMemoFile(id);
+    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
   }
 
   @Test
   public void testConstructorTimeElapsed() throws Exception {
-      memoizer = new Memoizer(0);
-      File f = memoizer.getMemoFile(id);
-      File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-      assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    memoizer = new Memoizer(0);
+    File f = memoizer.getMemoFile(id);
+    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
 
-      // Test multiple setId invocations
-      memoizer.setId(id);
-      assertFalse(memoizer.isLoadedFromMemo());
-      assertTrue(memoizer.isSavedToMemo());
-      memoizer.close();
-      memoizer.setId(id);
-      assertTrue(memoizer.isLoadedFromMemo());
-      assertFalse(memoizer.isSavedToMemo());
-      memoizer.close();
+    // Test multiple setId invocations
+    memoizer.setId(id);
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertTrue(memoizer.isSavedToMemo());
+    memoizer.close();
+    memoizer.setId(id);
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertFalse(memoizer.isSavedToMemo());
+    memoizer.close();
   }
 
   @Test
   public void testConstructorReader() throws Exception {
-      memoizer = new Memoizer(reader);
-      File f = memoizer.getMemoFile(id);
-      File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-      assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    memoizer = new Memoizer(reader);
+    File f = memoizer.getMemoFile(id);
+    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
   }
 
   @Test
   public void testConstructorReaderTimeElapsed() throws Exception {
-      memoizer = new Memoizer(reader, 0);
-      File f = memoizer.getMemoFile(id);
-      File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-      assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
+    memoizer = new Memoizer(reader, 0);
+    File f = memoizer.getMemoFile(id);
+    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
 
-      // Test multiple setId invocations
-      memoizer.setId(id);
-      assertFalse(memoizer.isLoadedFromMemo());
-      assertTrue(memoizer.isSavedToMemo());
-      memoizer.close();
-      memoizer.setId(id);
-      assertTrue(memoizer.isLoadedFromMemo());
-      assertFalse(memoizer.isSavedToMemo());
-      memoizer.close();
+    // Test multiple setId invocations
+    memoizer.setId(id);
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertTrue(memoizer.isSavedToMemo());
+    memoizer.close();
+    memoizer.setId(id);
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertFalse(memoizer.isSavedToMemo());
+    memoizer.close();
   }
 
   @Test
   public void testConstructorTimeElapsedDirectory() throws Exception {
-
     String uuid = UUID.randomUUID().toString();
     File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
     memoizer = new Memoizer(0, directory);
@@ -162,7 +157,6 @@ public class MemoizerTest {
 
   @Test
   public void testConstructorTimeElapsedNull() throws Exception {
-
     memoizer = new Memoizer(0, null);
 
     // Check null memo directory returns null
@@ -173,12 +167,10 @@ public class MemoizerTest {
     assertFalse(memoizer.isLoadedFromMemo());
     assertFalse(memoizer.isSavedToMemo());
     memoizer.close();
-
   }
 
   @Test
   public void testConstructorReaderTimeElapsedDirectory() throws Exception {
-
     String uuid = UUID.randomUUID().toString();
     File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
     memoizer = new Memoizer(reader, 0, directory);
@@ -207,10 +199,8 @@ public class MemoizerTest {
     memoizer.close();
   }
 
-
   @Test
   public void testConstructorReaderTimeElapsedNull() throws Exception {
-
     memoizer = new Memoizer(reader, 0, null);
 
     // Check null memo directory returns null
@@ -225,68 +215,68 @@ public class MemoizerTest {
 
   @Test
   public void testGetMemoFilePermissionsDirectory() throws Exception {
-      String uuid = UUID.randomUUID().toString();
-      File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
-      memoizer = new Memoizer(reader, 0, directory);
+    String uuid = UUID.randomUUID().toString();
+    File directory = new File(System.getProperty("java.io.tmpdir"), uuid);
+    memoizer = new Memoizer(reader, 0, directory);
 
-      // Check non-existing memo directory returns null
+    // Check non-existing memo directory returns null
+    assertEquals(memoizer.getMemoFile(id), null);
+
+    // Create memoizer directory and memoizer reader
+    directory.mkdirs();
+    memoizer = new Memoizer(reader, 0, directory);
+
+    // Check existing non-writeable memo directory returns null
+    if (File.separator.equals("/")) {
+      // File.setWritable() does not work properly on Windows
+      directory.setWritable(false);
       assertEquals(memoizer.getMemoFile(id), null);
+    }
 
-      // Create memoizer directory and memoizer reader
-      directory.mkdirs();
-      memoizer = new Memoizer(reader, 0, directory);
-
-      // Check existing non-writeable memo directory returns null
-      if (File.separator.equals("/")) {
-        // File.setWritable() does not work properly on Windows
-        directory.setWritable(false);
-        assertEquals(memoizer.getMemoFile(id), null);
-      }
-
-      // Check existing writeable memo diretory returns a memo file
-      directory.setWritable(true);
-      String memoDir = idDir.getAbsolutePath();
-      memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
-      File memoFile = new File(directory, memoDir);
-      memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
-      assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
-                   memoFile.getAbsolutePath());
+    // Check existing writeable memo diretory returns a memo file
+    directory.setWritable(true);
+    String memoDir = idDir.getAbsolutePath();
+    memoDir = memoDir.substring(memoDir.indexOf(File.separator) + 1);
+    File memoFile = new File(directory, memoDir);
+    memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
+    assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
+                 memoFile.getAbsolutePath());
   }
 
   @Test
   public void testGetMemoFilePermissionsInPlaceDirectory() throws Exception {
-      String rootPath = id.substring(0, id.indexOf(File.separator) + 1);
-      memoizer = new Memoizer(reader, 0, new File(rootPath));
+    String rootPath = id.substring(0, id.indexOf(File.separator) + 1);
+    memoizer = new Memoizer(reader, 0, new File(rootPath));
 
-      // Check non-writeable file directory returns null for in-place caching
-      if (File.separator.equals("/")) {
-        // File.setWritable() does not work properly on Windows
-        idDir.setWritable(false);
-        assertEquals(memoizer.getMemoFile(id), null);
-      }
+    // Check non-writeable file directory returns null for in-place caching
+    if (File.separator.equals("/")) {
+      // File.setWritable() does not work properly on Windows
+      idDir.setWritable(false);
+      assertEquals(memoizer.getMemoFile(id), null);
+    }
 
-      // Check writeable file directory returns memo file beside file
-      idDir.setWritable(true);
-      File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-      assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
-        memoFile.getAbsolutePath());
+    // Check writeable file directory returns memo file beside file
+    idDir.setWritable(true);
+    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
+                 memoFile.getAbsolutePath());
   }
 
   @Test
   public void testGetMemoFilePermissionsInPlace() throws Exception {
-      memoizer = new Memoizer(reader);
+    memoizer = new Memoizer(reader);
 
-      // Check non-writeable file directory returns null for in-place caching
-      if (File.separator.equals("/")) {
-        // File.setWritable() does not work properly on Windows
-        idDir.setWritable(false);
-        assertEquals(memoizer.getMemoFile(id), null);
-      }
-      // Check writeable file directory returns memo file beside file
-      idDir.setWritable(true);
-      File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
-      assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
-        memoFile.getAbsolutePath());
+    // Check non-writeable file directory returns null for in-place caching
+    if (File.separator.equals("/")) {
+      // File.setWritable() does not work properly on Windows
+      idDir.setWritable(false);
+      assertEquals(memoizer.getMemoFile(id), null);
+    }
+    // Check writeable file directory returns memo file beside file
+    idDir.setWritable(true);
+    File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
+    assertEquals(memoizer.getMemoFile(id).getAbsolutePath(),
+                 memoFile.getAbsolutePath());
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -56,6 +56,26 @@ public class MemoizerTest {
   private String id;
   private FakeReader reader;
 
+  private static void checkMemo(Memoizer memoizer, String id)
+      throws Exception {
+    memoizer.setId(id);
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertTrue(memoizer.isSavedToMemo());
+    memoizer.close();
+    memoizer.setId(id);
+    assertTrue(memoizer.isLoadedFromMemo());
+    assertFalse(memoizer.isSavedToMemo());
+    memoizer.close();
+  }
+
+  private static void checkNoMemo(Memoizer memoizer, String id)
+      throws Exception {
+    memoizer.setId(id);
+    assertFalse(memoizer.isLoadedFromMemo());
+    assertFalse(memoizer.isSavedToMemo());
+    memoizer.close();
+  }
+
   @BeforeMethod
   public void setUp() throws Exception {
     String uuid = UUID.randomUUID().toString();
@@ -85,16 +105,7 @@ public class MemoizerTest {
     File f = memoizer.getMemoFile(id);
     File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
-
-    // Test multiple setId invocations
-    memoizer.setId(id);
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
-    memoizer.close();
-    memoizer.setId(id);
-    assertTrue(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    memoizer.close();
+    checkMemo(memoizer, id);
   }
 
   @Test
@@ -111,16 +122,7 @@ public class MemoizerTest {
     File f = memoizer.getMemoFile(id);
     File memoFile = new File(idDir, "." + TEST_FILE + ".bfmemo");
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
-
-    // Test multiple setId invocations
-    memoizer.setId(id);
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
-    memoizer.close();
-    memoizer.setId(id);
-    assertTrue(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    memoizer.close();
+    checkMemo(memoizer, id);
   }
 
   @Test
@@ -141,16 +143,7 @@ public class MemoizerTest {
     memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
     File f = memoizer.getMemoFile(id);
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
-
-    // Test multiple setId invocations
-    memoizer.setId(id);
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
-    memoizer.close();
-    memoizer.setId(id);
-    assertTrue(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    memoizer.close();
+    checkMemo(memoizer, id);
   }
 
   @Test
@@ -159,12 +152,7 @@ public class MemoizerTest {
 
     // Check null memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
-
-    // Test setId invocation
-    memoizer.setId(id);
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    memoizer.close();
+    checkNoMemo(memoizer, id);
   }
 
   @Test
@@ -185,16 +173,7 @@ public class MemoizerTest {
     memoFile = new File(memoFile, "." + TEST_FILE + ".bfmemo");
     File f = memoizer.getMemoFile(id);
     assertEquals(f.getAbsolutePath(), memoFile.getAbsolutePath());
-
-    // Test multiple setId invocations
-    memoizer.setId(id);
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertTrue(memoizer.isSavedToMemo());
-    memoizer.close();
-    memoizer.setId(id);
-    assertTrue(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    memoizer.close();
+    checkMemo(memoizer, id);
   }
 
   @Test
@@ -203,12 +182,7 @@ public class MemoizerTest {
 
     // Check null memo directory returns null
     assertEquals(memoizer.getMemoFile(id), null);
-
-    // Test setId invocation
-    memoizer.setId(id);
-    assertFalse(memoizer.isLoadedFromMemo());
-    assertFalse(memoizer.isSavedToMemo());
-    memoizer.close();
+    checkNoMemo(memoizer, id);
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -39,7 +39,6 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.File;
 import java.util.UUID;
 
-import loci.formats.FormatTools;
 import loci.formats.Memoizer;
 import loci.formats.in.FakeReader;
 
@@ -62,21 +61,8 @@ public class MemoizerTest {
 
   private Memoizer memoizer;
 
-  private static int fullPlaneCallIndex;
-
-  private int sizeX;
-
-  private int sizeY;
-
-  private int bpp;
-
-  private int planeSize;
-
   @BeforeMethod
   public void setUp() throws Exception {
-    fullPlaneCallIndex = 1;
-    // No mapping.
-    // Location.mapId(TEST_FILE, TEST_FILE);
     reader = new FakeReader();
     try {
       String uuid = UUID.randomUUID().toString();
@@ -86,10 +72,6 @@ public class MemoizerTest {
       tempFile.createNewFile();
       id = tempFile.getAbsolutePath();
       reader.setId(id);
-      sizeX = reader.getSizeX();
-      sizeY = reader.getSizeY();
-      bpp = FormatTools.getBytesPerPixel(reader.getPixelType());
-      planeSize = sizeY * sizeY * bpp;
     } finally {
       reader.close();
     }
@@ -352,13 +334,4 @@ public class MemoizerTest {
     assertFalse(memoizer.isSavedToMemo());
   }
 
-  public static void main(String[] args) throws Exception {
-    MemoizerTest t = new MemoizerTest();
-    t.setUp();
-    try {
-      t.testSimple();
-    } finally {
-      t.tearDown();
-    }
-  }
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -239,4 +239,15 @@ public class MemoizerTest {
     recursiveDeleteOnExit(newidDir);
   }
 
+  @Test
+  public void testWrappedReader() throws Exception {
+    Memoizer memoizer = new Memoizer(reader, 0);
+    File memoFile = memoizer.getMemoFile(id);
+    assertFalse(memoFile.exists());
+    reader.setId(id);
+    assertFalse(memoFile.exists());
+    reader.close();
+    checkMemo(memoizer, id);
+  }
+
 }

--- a/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/MemoizerTest.java
@@ -205,45 +205,25 @@ public class MemoizerTest {
   public void testGetMemoFilePermissionsDirectory() throws Exception {
     File directory = createTempDir();
     Memoizer memoizer = new Memoizer(reader, 0, directory);
-
-    // Check existing non-writeable memo directory returns null
-    if (File.separator.equals("/")) {
-      // File.setWritable() does not work properly on Windows
-      directory.setWritable(false);
+    if (directory.setWritable(false)) {
       assertNull(memoizer.getMemoFile(id));
     }
   }
 
   @Test
   public void testGetMemoFilePermissionsInPlaceDirectory() throws Exception {
-    String rootPath = id.substring(0, id.indexOf(File.separator) + 1);
-    Memoizer memoizer = new Memoizer(reader, 0, new File(rootPath));
-
-    // Check non-writeable file directory returns null for in-place caching
-    if (File.separator.equals("/")) {
-      // File.setWritable() does not work properly on Windows
-      idDir.setWritable(false);
+    Memoizer memoizer = new Memoizer(reader, 0, idDir);
+    if (idDir.setWritable(false)) {
       assertNull(memoizer.getMemoFile(id));
     }
-
-    // Check writeable file directory returns memo file beside file
-    idDir.setWritable(true);
-    checkMemoFile(memoizer.getMemoFile(id));
   }
 
   @Test
   public void testGetMemoFilePermissionsInPlace() throws Exception {
     Memoizer memoizer = new Memoizer(reader);
-
-    // Check non-writeable file directory returns null for in-place caching
-    if (File.separator.equals("/")) {
-      // File.setWritable() does not work properly on Windows
-      idDir.setWritable(false);
+    if (idDir.setWritable(false)) {
       assertNull(memoizer.getMemoFile(id));
     }
-    // Check writeable file directory returns memo file beside file
-    idDir.setWritable(true);
-    checkMemoFile(memoizer.getMemoFile(id));
   }
 
   @Test


### PR DESCRIPTION
Addresses several issues with `MemoizerTest`, mostly unused / redundant / duplicate code and the fact that temporary files were not being removed.

Since this PR contains whitespace changes, and to ensure no critical check has been inadvertently removed, it's best to review it one commit at a time, in order.

Functional checks include verifying that all tests pass and do not leave temporary files and directories around.

Some commit-specific additional notes:
 * b975b61b3d57677f4ae1aca0b122d9ce5f446a90: `testng.Assert{JUnit,}` have opposite conventions on tested vs expected argument ordering. Existing tests were using the `testng.Assert` convention.
 * 332f17bc5386865b769ef385ea8147c014907f82: uses `File.setWritable`'s return value to simplify the check and to take into account failures due to other reasons. If we want to be more explicit we can throw a `SkipException`.