### PR TITLE
build: Unify specification and ome-xml versions

### DIFF
--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>${ome-xml.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>${ome-xml.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>${ome-xml.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
 
     <dependency>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -41,12 +41,12 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>${ome-xml.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>specification</artifactId>
-      <version>${specification.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>${ome-xml.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openmicroscopy</groupId>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>${ome-xml.version}</version>
+      <version>${ome-model.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -53,8 +53,7 @@ Type "ant -p" for a list of targets.
     <replace file="conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
     <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
     <replace file="conf.py" token="@ome_common_version@" value="${ome-common.version}"/>
-    <replace file="conf.py" token="@ome_xml_version@" value="${ome-xml.version}"/>
-    <replace file="conf.py" token="@specification_version@" value="${specification.version}"/>
+    <replace file="conf.py" token="@ome_model_version@" value="${ome-model.version}"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -19,8 +19,7 @@ openmicroscopy_source_user = '@openmicroscopy_source_user@'
 ome_source_user = '@ome_source_user@'
 omerodoc_uri = '@sphinx_omerodoc_uri@'
 ome_common_version = '@ome_common_version@'
-ome_xml_version = '@ome_xml_version@'
-ome_specification_version = '@ome_specification_version@'
+ome_model_version = '@ome_model_version@'
 
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
@@ -164,8 +163,8 @@ extlinks = {
     'downloads' : (downloads_root + '/latest/bio-formats5.2/%s', ''),
     'javadoc' : (downloads_root + '/latest/bio-formats5.2/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
-    'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_xml_version + '/' + '%s', ''),
-    'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_specification_version + '/' + '%s', ''),
+    'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_model_version + '/' + '%s', ''),
+    'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_model_version + '/' + '%s', ''),
 
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.1</ome-common.version>
-    <specification.version>5.3.1</specification.version>
-    <ome-xml.version>5.3.1</ome-xml.version>
+    <ome-model.version>5.3.1</ome-model.version>
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <jxrlib.version>0.2.0</jxrlib.version>


### PR DESCRIPTION
Simplify the specification of these component versions.  Since they are coupled, use a single `ome-model.version` property for both.