### PR TITLE
OMEXMLReader: Handle BinData in non-Pixels elements such as Mask

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -347,7 +347,7 @@ public class OMEXMLReader extends FormatReader {
 
     @Override
     public void characters(char[] ch, int start, int length) {
-      if (currentQName.indexOf("BinData") < 0 || inPixels == false) {
+      if (!inPixels || currentQName.indexOf("BinData") < 0) {
         xmlBuffer.append(new String(ch, start, length));
       }
     }
@@ -373,7 +373,7 @@ public class OMEXMLReader extends FormatReader {
         inPixels = true;
       }
 
-      if (qName.indexOf("BinData") != -1 && inPixels == true) {
+      if (inPixels && qName.indexOf("BinData") != -1) {
         binData.add(
           new BinData(locator.getLineNumber(), locator.getColumnNumber()));
         String compress = attributes.getValue("Compression");


### PR DESCRIPTION
The reader made the assumption that `BinData` was only found inside `Pixels`.  However, it's also contained within `Mask`, and the reader was stripping out all `BinData` content when initially reading the OME-XML (it pre-processes it with a custom SAX parser before creating the `MetadataStore`).  This change makes the stripping selective, so it only occurs for `BinData` elements contained within Pixels.

This is related to https://github.com/ome/ome-model/pull/14 but is not coupled to it (it's useful for testing #14 with the sample in https://github.com/ome/ome-model/pull/13), but can be merged independently.  If you test these without this PR, you'll see that the ROI sample gets the `BinData` stripped out of the `Mask` ROI, and with this PR, it's correctly retained.

Testing: Check builds remain green.  Check that reading OME-XML with `Mask` `BinData` works with `showinf`.  The `specification/samples/2016-06/ROI.ome.xml` sample from https://github.com/ome/ome-model/pull/13 is useful for this purpose.
