### PR TITLE
Bump jxrlib to version 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-model.version>5.3.1</ome-model.version>
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
-    <jxrlib.version>0.2.0</jxrlib.version>
+    <jxrlib.version>0.2.1</jxrlib.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
See https://trello.com/c/pUrwD3HA/55-jxrlib-0-2-1-os-x-10-10-and-later for related reading 

As per https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/, a new
patch release of jxrlib was cut with a reduced but maintainable OSX version
support matrix. This commit update the jxrlib dependency shipped with
Bio-Formats accordingly.

This bump should have no functional impact. All CI jobs should remain green. With regard to testing support, JPEG-XR compressed CZI file should open under both OSX 10.10 or more recent versions.