### PR TITLE
ImageReader: ensure options reflect those of the actual reader

### DIFF
--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -45,6 +45,7 @@ import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.formats.in.MetadataLevel;
 import loci.formats.in.MetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.MetadataStore;
 
 import org.slf4j.Logger;
@@ -120,10 +121,13 @@ public class ImageReader implements IFormatReader {
     // add readers to the list
     List<IFormatReader> list = new ArrayList<IFormatReader>();
     Class<? extends IFormatReader>[] c = classList.getClasses();
+    // assign the same options instance to all readers
+    MetadataOptions opt = new DynamicMetadataOptions();
     for (int i=0; i<c.length; i++) {
       IFormatReader reader = null;
       try {
         reader = c[i].newInstance();
+        reader.setMetadataOptions(opt);
       }
       catch (IllegalAccessException exc) { }
       catch (InstantiationException exc) { }

--- a/components/formats-bsd/test/loci/formats/utests/ImageReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ImageReaderTest.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests;
+
+import loci.formats.ImageReader;
+import loci.formats.in.MetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.in.MetadataLevel;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class ImageReaderTest {
+
+  public static final String KEY = "test.option";
+  public static final String VALUE = "foo";
+
+  @DataProvider(name = "levels")
+  public Object[][] createLevels() {
+    return new Object[][] {
+      {MetadataLevel.MINIMUM},
+      {MetadataLevel.NO_OVERLAYS},
+      {MetadataLevel.ALL}
+    };
+  }
+
+  @Test
+  public void testOptionsExplicit() throws Exception {
+    DynamicMetadataOptions opt = new DynamicMetadataOptions();
+    opt.set(KEY, VALUE);
+    ImageReader reader = new ImageReader();
+    reader.setMetadataOptions(opt);
+    reader.setId("test.fake");
+    MetadataOptions rOpt = reader.getReader().getMetadataOptions();
+    assertTrue(rOpt instanceof DynamicMetadataOptions);
+    String v = ((DynamicMetadataOptions) rOpt).get(KEY);
+    assertNotNull(v);
+    assertEquals(v, VALUE);
+  }
+
+  @Test(dataProvider = "levels")
+  public void testOptionsImplicit(MetadataLevel level) throws Exception {
+    ImageReader reader = new ImageReader();
+    reader.getMetadataOptions().setMetadataLevel(level);
+    reader.setId("test.fake");
+    MetadataLevel rLevel =
+      reader.getReader().getMetadataOptions().getMetadataLevel();
+    assertEquals(rLevel, level);
+  }
+
+}

--- a/components/formats-bsd/test/loci/formats/utests/ImageReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/ImageReaderTest.java
@@ -71,6 +71,7 @@ public class ImageReaderTest {
     String v = ((DynamicMetadataOptions) rOpt).get(KEY);
     assertNotNull(v);
     assertEquals(v, VALUE);
+    reader.close();
   }
 
   @Test(dataProvider = "levels")
@@ -81,6 +82,7 @@ public class ImageReaderTest {
     MetadataLevel rLevel =
       reader.getReader().getMetadataOptions().getMetadataLevel();
     assertEquals(rLevel, level);
+    reader.close();
   }
 
 }

--- a/components/formats-bsd/test/loci/formats/utests/testng.xml
+++ b/components/formats-bsd/test/loci/formats/utests/testng.xml
@@ -175,4 +175,10 @@
         <class name="loci.formats.utests.CompressDecompressTest"/>
       </classes>
     </test>
+    <test name="ImageReaderTest">
+      <groups/>
+      <classes>
+        <class name="loci.formats.utests.ImageReaderTest"/>
+      </classes>
+    </test>
 </suite>


### PR DESCRIPTION
This is a porting of https://github.com/openmicroscopy/bioformats/pull/2013/commits/f0d58c2cd9b8db921aa5886916e3f7ec8a42aa0e to the current state. Without this, a call to `reader.getMetadataOptions().set*` on an `ImageReader` instance won't be reflected in the actual reader (unless it's the first one in the list).

More specifically, **without** this PR, `testOptionsImplicit` is expected to fail, while `testOptionsExplicit` should pass because `ImageReader.setMetadataOptions` already assigns the provided instance to all readers. I've added the test anyway to prevent regressions on this front. **With** this PR, both tests should pass.

Note that I couldn't place the unit test under `formats-api` because it wouldn't work there (no concrete readers). Although this may look weird, we currently have several other unit tests in `formats-bsd` that use `ImageReader` (e.g., `EightBitLosslessJPEG2000Test`). Perhaps we should move `FakeReader` to `formats-api` as a default "dummy" reader.