### PR TITLE
Options propagation: FileStitcher

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -835,6 +835,9 @@ public class FileStitcher extends ReaderWrapper {
   /* @see IFormatReader#getUnderlyingReaders() */
   @Override
   public IFormatReader[] getUnderlyingReaders() {
+    if (null == externals) {
+      return super.getUnderlyingReaders();
+    }
     List<IFormatReader> list = new ArrayList<IFormatReader>();
     for (ExternalSeries s : externals) {
       for (DimensionSwapper r : s.getReaders()) {

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1256,6 +1256,7 @@ public class FileStitcher extends ReaderWrapper {
           readers[i] = new DimensionSwapper(new ImageReader(classList));
         }
         else readers[i] = new DimensionSwapper();
+        readers[i].setMetadataOptions(getMetadataOptions());
         readers[i].setGroupFiles(false);
       }
       readers[0].setId(files[0]);

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -47,6 +47,7 @@ import java.util.Vector;
 import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
+import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataStore;
 
 import org.slf4j.Logger;
@@ -623,6 +624,19 @@ public class FileStitcher extends ReaderWrapper {
   @Override
   public boolean isGroupFiles() {
     return group;
+  }
+
+  /* @see IFormatReader#setMetadataOptions(MetadataOptions) */
+  @Override
+  public void setMetadataOptions(MetadataOptions options) {
+    super.setMetadataOptions(options);
+    if (externals != null) {
+      for (ExternalSeries s : externals) {
+        for (DimensionSwapper r : s.getReaders()) {
+          r.setMetadataOptions(options);
+        }
+      }
+    }
   }
 
   /* @see IFormatReader#setNormalized(boolean) */

--- a/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
@@ -219,6 +219,7 @@ public class FileStitcherTest {
     assertNotNull(fs.getUnderlyingReaders());
     fs.setId("test_z<0-2>.fake");
     assertNotNull(fs.getUnderlyingReaders());
+    fs.close();
   }
 
   @Test

--- a/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
@@ -65,6 +65,20 @@ public class FileStitcherTest {
   public static final String KEY = "test.option";
   public static final String VALUE = "foo";
 
+  public static void checkKV(IFormatReader r, String k, String expv) {
+    MetadataOptions rOpt = r.getMetadataOptions();
+    assertTrue(rOpt instanceof DynamicMetadataOptions);
+    String v = ((DynamicMetadataOptions) rOpt).get(k);
+    assertNotNull(v);
+    assertEquals(v, expv);
+  }
+
+  public static void checkKV(IFormatReader[] readers, String k, String expv) {  
+    for (IFormatReader r: readers) {
+      checkKV(r, k, expv);
+    }
+  }
+
   // expected core metadata for the final stitched image
   private static final int PIXEL_TYPE = FormatTools.UINT8;
   private static final int SIZE_X = 128;
@@ -229,13 +243,12 @@ public class FileStitcherTest {
     FileStitcher fs = new FileStitcher();
     fs.setMetadataOptions(opt);
     fs.setId("test_z<0-2>.fake");
-    for (IFormatReader r: fs.getUnderlyingReaders()) {
-      MetadataOptions rOpt = r.getMetadataOptions();
-      assertTrue(rOpt instanceof DynamicMetadataOptions);
-      String v = ((DynamicMetadataOptions) rOpt).get(KEY);
-      assertNotNull(v);
-      assertEquals(v, VALUE);
-    }
+    checkKV(fs.getUnderlyingReaders(), KEY, VALUE);
+    DynamicMetadataOptions newOpt = new DynamicMetadataOptions();
+    String newValue = VALUE + "_";
+    newOpt.set(KEY, newValue);
+    fs.setMetadataOptions(newOpt);
+    checkKV(fs.getUnderlyingReaders(), KEY, newValue);
     fs.close();
   }
 

--- a/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
@@ -213,6 +213,15 @@ public class FileStitcherTest {
   }
 
   @Test
+  public void testUnderlyingReaders() throws IOException, FormatException {
+    FakeReader reader = new FakeReader();
+    FileStitcher fs = new FileStitcher(reader);
+    assertNotNull(fs.getUnderlyingReaders());
+    fs.setId("test_z<0-2>.fake");
+    assertNotNull(fs.getUnderlyingReaders());
+  }
+
+  @Test
   public void testOptionsExplicit() throws IOException, FormatException {
     DynamicMetadataOptions opt = new DynamicMetadataOptions();
     opt.set(KEY, VALUE);

--- a/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FileStitcherTest.java
@@ -131,6 +131,7 @@ public class FileStitcherTest {
     assertEquals(fs.getPixelType(), PIXEL_TYPE);
     assertEqualsNoOrder(mkBasenames(fs.getUsedFiles()), filenames);
     checkPlanes(fs, dims);
+    fs.close();
   }
 
   // FakeReader encodes 5 integers at the start of each image plane: s idx,
@@ -225,6 +226,7 @@ public class FileStitcherTest {
       assertNotNull(v);
       assertEquals(v, VALUE);
     }
+    fs.close();
   }
 
   @Test(dataProvider = "levels")
@@ -236,6 +238,7 @@ public class FileStitcherTest {
     for (IFormatReader r: fs.getUnderlyingReaders()) {
       assertEquals(r.getMetadataOptions().getMetadataLevel(), level);
     }
+    fs.close();
   }
 
 }


### PR DESCRIPTION
In most cases, there is no need to do anything to propagate options in reader wrappers. This is due to the fact that they do not have their own options instance, but rather refer to that of their wrapped reader.

`FileStitcher` is an exception though, since it uses several external readers to do its job, while the "standard" `ReaderWrapper` contract assumes there is only one wrapped reader, whose behaviour will be somehow modified by the wrapper. In practice, `FileStitcher` has two main states:

1. **before calling setId** the file pattern hasn't been seen yet, so `FileStitcher` does not have enough info to even decide *how many* subreaders it needs. Options consistency is guaranteed in this state, but the only subreader is a placeholder;

2. **after calling setId** concrete subreaders are in place, and they should have the same options as the `FileStitcher` itself. This PR ensures this by getting the options object from the placeholder reader and assign it to all external readers right after they are constructed.

Speaking of subreaders, I've also fixed a NPE that could be triggered by calling `getUnderlyingReaders` in state no. 1. I've chosen to fall back to the generic `ReaderWrapper` behaviour and return the placeholder, but returning `null` might also make sense (i.e., "there are no *real* subreaders"). Throwing an `IllegalStateException` (directly or via `assertId`) might also make sense.

However, the docs are not clear enough on what we mean by "underlying readers". For instance, `ImageReader` returns its list of "candidate" readers, while `FileStitcher` returns a list of readers that are actually being used as delegates to do its job. Finally, unless I've missed something, no concrete reader overrides the method, although it should make sense for any reader that uses one or more other readers (e.g., `ScanrReader`). Since `ImageReader`, in mos respects, acts as a "mutant" reader that becomes a concrete reader once `setId` has been called, perhaps it would be more appropriate to return `getReader().getUnderlyingReaders()`, at least after `setId`.

In the future, if we want to get rid of `FileStitcher`'s dual nature, we might make it something different from a `ReaderWrapper`. We could have a `ReaderAggregator` (or similar) abstract class that formalizes a one-to-many relationship. Of course, external readers would still be created after `setId`, so the best option for `getUnderlyingReaders` would probably be to return an empty array.
