### PR TITLE
ImageJ: preserve original pixel values when exporting signed data

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -435,11 +435,23 @@ public class Exporter {
                 store.setPixelsID(MetadataTools.createLSID("Pixels", 0), 0);
             }
 
-            // always reset the pixel type
+            // reset the pixel type, unless the only change is signedness
             // this prevents problems if the user changed the bit depth of the image
+            boolean applyCalibrationFunction = false;
             try {
-                store.setPixelsType(PixelType.fromString(
-                        FormatTools.getPixelTypeString(ptype)), 0);
+                int originalType = FormatTools.pixelTypeFromString(
+                  store.getPixelsType(0).toString());
+                if (ptype != originalType &&
+                  (!FormatTools.isSigned(originalType) ||
+                  FormatTools.getBytesPerPixel(originalType) !=
+                  FormatTools.getBytesPerPixel(ptype)))
+                {
+                  store.setPixelsType(PixelType.fromString(
+                    FormatTools.getPixelTypeString(ptype)), 0);
+                }
+                else if (FormatTools.isSigned(originalType)) {
+                  applyCalibrationFunction = true;
+                }
             }
             catch (EnumerationException e) { }
 
@@ -692,11 +704,36 @@ public class Exporter {
                 int y = proc.getHeight();
 
                 if (proc instanceof ByteProcessor) {
-                    plane = (byte[]) proc.getPixels();
+                    if (applyCalibrationFunction) {
+                      // don't alter 'pixels' directly as that will
+                      // affect the open ImagePlus
+                      byte[] pixels = (byte[]) proc.getPixels();
+                      plane = new byte[pixels.length];
+                      float[] calibration = proc.getCalibrationTable();
+                      for (int pixel=0; pixel<pixels.length; pixel++) {
+                        plane[pixel] = (byte) calibration[pixels[pixel] & 0xff];
+                      }
+                    }
+                    else {
+                      plane = (byte[]) proc.getPixels();
+                    }
                 }
                 else if (proc instanceof ShortProcessor) {
-                    plane = DataTools.shortsToBytes(
-                            (short[]) proc.getPixels(), littleEndian);
+                    short[] pixels = (short[]) proc.getPixels();
+                    if (applyCalibrationFunction) {
+                      // don't alter 'pixels' directly as that will
+                      // affect the open ImagePlus
+                      plane = new byte[pixels.length * 2];
+                      float[] calibration = proc.getCalibrationTable();
+                      for (int pixel=0; pixel<pixels.length; pixel++) {
+                        short v = (short) calibration[pixels[pixel] & 0xffff];
+                        DataTools.unpackBytes(
+                          v, plane, pixel * 2, 2, littleEndian);
+                      }
+                    }
+                    else {
+                      plane = DataTools.shortsToBytes(pixels, littleEndian);
+                    }
                 }
                 else if (proc instanceof FloatProcessor) {
                     plane = DataTools.floatsToBytes(


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-December/006286.html

This should resolve some strange behavior when exporting from an
ImagePlus that represents signed data.  There are two parts to the fix:

1. don't overwrite the MetadataStore's pixel type from int* to uint*
2. when filling the byte[] to pass to saveBytes, use the ImageProcessor's calibration table to determine the real pixel values

To test, use QA 17471 and the ImageJ macro at the end of the above thread (adjusting the file paths as needed).  Without this change, run the macro in ImageJ and verify that the two histograms have different min/max values but the same overall shape.  Verify that ```showinf -minmax -range 1 1``` on the original .dv shows that the pixel type is int16, and that ```showinf -minmax``` on the saved TIFF shows that the pixel type is uint16.  Min/max values in both cases should match the corresponding ImageJ histogram.

With this change, re-run the ImageJ macro and confirm that both histograms are identical.  ```showinf -minmax``` on the saved TIFF should now show pixel type int16, and the min/max values should match the ImageJ histogram.

It would probably also be a good idea to do the same test with one of our existing int8 samples (or a fake file), perhaps as well as one or two unsigned datasets just to double-check that nothing was broken by this change.