### PR TITLE
TiffWriter - fix for incorrect last IFD and new unit test

### DIFF
--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -28,6 +28,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <sysproperty key="testng.runWriterTilingTests" value="${testng.runWriterTilingTests}"/>
+    	<sysproperty key="testng.runWriterSaveBytesTests" value="${testng.runWriterSaveBytesTests}"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-Dlurawave.license=XXX"/>
     </testng>

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -260,7 +260,7 @@ public class TiffWriter extends FormatWriter {
       synchronized (this) {
         // This operation is synchronized against the TIFF saver.
         synchronized (tiffSaver) {
-          index = prepareToWriteImage(no++, buf, ifd, x, y, w, h);
+          index = prepareToWriteImage(no, buf, ifd, x, y, w, h);
           if (index == -1) {
             return;
           }

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -112,7 +112,7 @@ public class TiffWriterTest {
   @DataProvider(name = "tiling")
   public Object[][] createTiling() {
     if (percentageOfTilingTests == 0) {
-      return new Object[][] {{0, false, false, 0, 0, null, 0}};
+      return new Object[][] {{0, false, false, 0, 0, 0, null, 0}};
     }
 
     int[] tileSizes = {1, 32, 43, 64};
@@ -126,7 +126,7 @@ public class TiffWriterTest {
   @DataProvider(name = "nonTiling")
   public Object[][] createNonTiling() {
     if (percentageOfTilingTests == 0) {
-      return new Object[][] {{0, false, false, 0, 0, null, 0}};
+      return new Object[][] {{0, false, false, 0, 0, 0, null, 0}};
     }
     int[] tileSizes = {PLANE_WIDTH};
     int[] channelCounts = {1, 3};

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -96,6 +96,7 @@ public class TiffWriterTest {
 
   /* Percentage of tiling tests to be executed */
   private static int percentageOfTilingTests = 0;
+  private static int percentageOfSaveBytesTests = 0;
 
   @DataProvider(name = "bigTiffSuffixes")
   public Object[][] createSuffixes() {
@@ -115,12 +116,30 @@ public class TiffWriterTest {
     }
 
     int[] tileSizes = {1, 32, 43, 64};
-    boolean[] booleanValues = {true, false};
     int[] channelCounts = {1, 3};
     int[] seriesCounts = {1, 5};
+    int[] timeCounts = {1};
     String[] compressions = {COMPRESSION_UNCOMPRESSED, COMPRESSION_LZW, COMPRESSION_J2K, COMPRESSION_J2K_LOSSY, COMPRESSION_JPEG};
+    return getData(tileSizes, channelCounts, seriesCounts, timeCounts, compressions);
+  }
+  
+  @DataProvider(name = "nonTiling")
+  public Object[][] createNonTiling() {
+    if (percentageOfTilingTests == 0) {
+      return new Object[][] {{0, false, false, 0, 0, null, 0}};
+    }
+    int[] tileSizes = {PLANE_WIDTH};
+    int[] channelCounts = {1, 3};
+    int[] seriesCounts = {1};
+    int[] timeCounts = {1, 5};
+    String[] compressions = {COMPRESSION_UNCOMPRESSED, COMPRESSION_LZW, COMPRESSION_J2K, COMPRESSION_J2K_LOSSY, COMPRESSION_JPEG};
+    return getData(tileSizes, channelCounts, seriesCounts, timeCounts, compressions);
+  }
+
+  private Object[][] getData(int[] tileSizes, int[] channelCounts, int[] seriesCounts, int[] timeCounts, String[] compressions) {
+    boolean[] booleanValues = {true, false};
     int compressionPixelTypeSizes = (2 * pixelTypesOther.length) + pixelTypesOther.length - 1 + pixelTypesJ2K.length + 2;
-    int paramSize = tileSizes.length * compressionPixelTypeSizes * 4 * channelCounts.length * seriesCounts.length;
+    int paramSize = tileSizes.length * compressionPixelTypeSizes * 4 * channelCounts.length * seriesCounts.length * timeCounts.length;
     Object[][] data = new Object[paramSize][];
     int index = 0;
     for (int tileSize : tileSizes) {
@@ -128,28 +147,30 @@ public class TiffWriterTest {
         for (boolean interleaved : booleanValues) {
           for (int channelCount : channelCounts) {
             for (int seriesCount : seriesCounts) {
-              for (String compression : compressions) {
-                int[] pixelTypes = pixelTypesOther;
-                if (compression.equals(COMPRESSION_J2K)) {
-                  pixelTypes = pixelTypesJ2K;
-                }
-                if (compression.equals(COMPRESSION_J2K_LOSSY)) {
-                  // Should also allow for double but JPEG 2K compression codec throws null pointer for 64 bitsPerSample
-                  pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16,
-                      FormatTools.UINT16, FormatTools.INT32, FormatTools.UINT32, FormatTools.FLOAT};
-                }
-                else if (compression.equals(COMPRESSION_JPEG)) {
-                  // Should be using pixelTypesJPEG however JPEGCodec throws exception: > 8 bit data cannot be compressed with JPEG
-                  pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8};
-                }
-                for (int pixelType : pixelTypes) {
-                  if (FormatTools.getBytesPerPixel(pixelType) > 2 &&
-                      (compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY))) {
-                    data[index] = new Object[] {tileSize, endianness, false, channelCount, seriesCount, compression, pixelType};
-                  } else {
-                    data[index] = new Object[] {tileSize, endianness, interleaved, channelCount, seriesCount, compression, pixelType};
+              for (int timeCount : timeCounts) {
+                for (String compression : compressions) {
+                  int[] pixelTypes = pixelTypesOther;
+                  if (compression.equals(COMPRESSION_J2K)) {
+                    pixelTypes = pixelTypesJ2K;
                   }
-                  index ++;
+                  if (compression.equals(COMPRESSION_J2K_LOSSY)) {
+                    // Should also allow for double but JPEG 2K compression codec throws null pointer for 64 bitsPerSample
+                    pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16,
+                        FormatTools.UINT16, FormatTools.INT32, FormatTools.UINT32, FormatTools.FLOAT};
+                  }
+                  else if (compression.equals(COMPRESSION_JPEG)) {
+                    // Should be using pixelTypesJPEG however JPEGCodec throws exception: > 8 bit data cannot be compressed with JPEG
+                    pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8};
+                  }
+                  for (int pixelType : pixelTypes) {
+                    if (FormatTools.getBytesPerPixel(pixelType) > 2 &&
+                        (compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY))) {
+                      data[index] = new Object[] {tileSize, endianness, false, channelCount, seriesCount, timeCount, compression, pixelType};
+                    } else {
+                      data[index] = new Object[] {tileSize, endianness, interleaved, channelCount, seriesCount, timeCount, compression, pixelType};
+                    }
+                    index ++;
+                  }
                 }
               }
             }
@@ -174,13 +195,19 @@ public class TiffWriterTest {
 
   @BeforeClass
   public void readProperty() throws Exception {
-      String tilingProp = System.getProperty("testng.runWriterTilingTests");
-      if (tilingProp == null ||
-          tilingProp.equals("${testng.runWriterTilingTests}")) return;
-      if (DataTools.parseInteger(tilingProp) == null) return;
-      percentageOfTilingTests = DataTools.parseInteger(tilingProp);
-      if (percentageOfTilingTests < 0) percentageOfTilingTests = 0;
-      if (percentageOfTilingTests > 100) percentageOfTilingTests = 100;
+    percentageOfTilingTests = getPropValue("testng.runWriterTilingTests");
+    percentageOfSaveBytesTests = getPropValue("testng.runWriterSaveBytesTests");
+  }
+  
+  private int getPropValue(String propertyName) {
+    String prop = System.getProperty(propertyName);
+    if (prop == null ||
+        prop.equals("${"+ propertyName + "}")) return 0;
+    if (DataTools.parseInteger(prop) == null) return 0;
+    int propertyValue = DataTools.parseInteger(prop);
+    if (propertyValue < 0) propertyValue = 0;
+    if (propertyValue > 100) propertyValue = 100;
+    return propertyValue;
   }
 
   @BeforeMethod
@@ -469,14 +496,14 @@ public class TiffWriterTest {
 
   @Test(dataProvider = "tiling")
   public void testSaveBytesTiling(int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
-      int seriesCount, String compression, int pixelType) throws Exception {
+      int seriesCount, int sizeT, String compression, int pixelType) throws Exception {
     if (percentageOfTilingTests == 0) return;
 
     File tmp = File.createTempFile("tiffWriterTest_Tiling", ".tiff");
     tmp.deleteOnExit();
     TiffWriter writer = new TiffWriter();
     String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
-    writer.setMetadataRetrieve(createMetadata(pixelTypeString, rgbChannels, seriesCount, littleEndian));
+    writer.setMetadataRetrieve(createMetadata(pixelTypeString, rgbChannels, seriesCount, littleEndian, sizeT));
     writer.setCompression(compression);
     writer.setInterleaved(interleaved);
     writer.setTileSizeX(tileSize);
@@ -490,7 +517,9 @@ public class TiffWriterTest {
 
     for (int s=0; s<seriesCount; s++) {
       writer.setSeries(s);
-      writer.saveBytes(0, plane);
+      for (int t=0; t<sizeT; t++) {
+        writer.saveBytes(t, plane);
+      }
     }
 
     writer.close();
@@ -510,21 +539,78 @@ public class TiffWriterTest {
     assertEquals(tileIFd.getIFDIntValue(IFD.TILE_LENGTH), expectedTileSize);
     assertEquals(tileIFd.getIFDIntValue(IFD.TILE_WIDTH), expectedTileSize);
 
-    assertEquals(reader.getImageCount(), reader.isRGB() ? seriesCount : rgbChannels * seriesCount );
-    assertEquals(reader.getSizeC(), rgbChannels);
+    for (int s=0; s<reader.getSeriesCount(); s++) {
+      reader.setSeries(s);
+      assertEquals(reader.getSizeC(), rgbChannels);
+      int imageCount = reader.isRGB() ? seriesCount * sizeT : rgbChannels * sizeT * seriesCount;
+      assertEquals(reader.getImageCount(), imageCount);
+      for (int image=0; image<reader.getImageCount(); image++) {
+        byte[] readPlane = reader.openBytes(image);
+        boolean lossy = compression.equals(COMPRESSION_JPEG) || compression.equals(COMPRESSION_J2K_LOSSY);
+        boolean isJ2K = compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY);
+        boolean interleavedDiffs = interleaved || (isJ2K && !interleaved);
+        if (!(lossy || interleavedDiffs)) {
+          Plane newPlane = new Plane(readPlane, reader.isLittleEndian(),
+            !reader.isInterleaved(), reader.getRGBChannelCount(),
+            FormatTools.getPixelTypeString(reader.getPixelType()));
+
+          assert(originalPlane.equals(newPlane));
+        }
+      }
+    }
+
+    tmp.delete();
+    reader.close();
+  }
+
+  @Test(dataProvider = "nonTiling")
+  public void testSaveBytes(int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
+      int seriesCount, int sizeT, String compression, int pixelType) throws Exception {
+    if (percentageOfSaveBytesTests == 0) return;
+
+    File tmp = File.createTempFile("tiffWriterTest", ".tiff");
+    tmp.deleteOnExit();
+    TiffWriter writer = new TiffWriter();
+    String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
+    writer.setMetadataRetrieve(createMetadata(pixelTypeString, rgbChannels, seriesCount, littleEndian, sizeT));
+    writer.setCompression(compression);
+    writer.setInterleaved(interleaved);
+    writer.setId(tmp.getAbsolutePath());
+
+    int bytes = FormatTools.getBytesPerPixel(pixelType);
+    byte[] plane = getPlane(PLANE_WIDTH, PLANE_HEIGHT, bytes * rgbChannels);
+    Plane originalPlane = new Plane(plane, littleEndian,
+      !writer.isInterleaved(), rgbChannels, FormatTools.getPixelTypeString(pixelType));
+
+    for (int s=0; s<seriesCount; s++) {
+      writer.setSeries(s);
+      for (int t=0; t<sizeT; t++) {
+        writer.saveBytes(t, plane);
+      }
+    }
+
+    writer.close();
+
+    TiffReader reader = new TiffReader();
+    reader.setId(tmp.getAbsolutePath());
 
     for (int s=0; s<reader.getSeriesCount(); s++) {
       reader.setSeries(s);
-      byte[] readPlane = reader.openBytes(0);
-      boolean lossy = compression.equals(COMPRESSION_JPEG) || compression.equals(COMPRESSION_J2K_LOSSY);
-      boolean interleavedDiffs = interleaved || 
-          ((compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY)) && !interleaved);
-      if (!(lossy || interleavedDiffs)) {
-        Plane newPlane = new Plane(readPlane, reader.isLittleEndian(),
-          !reader.isInterleaved(), reader.getRGBChannelCount(),
-          FormatTools.getPixelTypeString(reader.getPixelType()));
+      assertEquals(reader.getSizeC(), rgbChannels);
+      int imageCount = reader.isRGB() ? seriesCount * sizeT : rgbChannels * sizeT * seriesCount;
+      assertEquals(reader.getImageCount(), imageCount);
+      for (int image=0; image<reader.getImageCount(); image++) {
+        byte[] readPlane = reader.openBytes(image);
+        boolean lossy = compression.equals(COMPRESSION_JPEG) || compression.equals(COMPRESSION_J2K_LOSSY);
+        boolean isJ2K = compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY);
+        boolean interleavedDiffs = interleaved || (isJ2K && !interleaved);
+        if (!(lossy || interleavedDiffs)) {
+          Plane newPlane = new Plane(readPlane, reader.isLittleEndian(),
+            !reader.isInterleaved(), reader.getRGBChannelCount(),
+            FormatTools.getPixelTypeString(reader.getPixelType()));
 
-        assert(originalPlane.equals(newPlane));
+          assert(originalPlane.equals(newPlane));
+        }
       }
     }
 
@@ -541,7 +627,7 @@ public class TiffWriterTest {
   }
 
   private IMetadata createMetadata(String pixelType, int rgbChannels,
-      int seriesCount, boolean littleEndian) throws Exception {
+      int seriesCount, boolean littleEndian, int sizeT) throws Exception {
     IMetadata metadata;
 
     try {
@@ -558,7 +644,7 @@ public class TiffWriterTest {
 
     for (int i=0; i<seriesCount; i++) {
       MetadataTools.populateMetadata(metadata, i, "image #" + i, littleEndian,
-        "XYCZT", pixelType, 160, 160, 1, rgbChannels, 1, rgbChannels);
+        "XYCZT", pixelType, 160, 160, 1, rgbChannels, sizeT, rgbChannels);
     }
 
     return metadata;


### PR DESCRIPTION
This is a bug fix for an issue reported in https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8179&p=17776#p17776

The lastIFD was being written incorrectly due to https://github.com/openmicroscopy/bioformats/pull/2663/commits/4d48e1144da4c1035ff3a79ddcd556bd2c46582d which was part of https://github.com/openmicroscopy/bioformats/pull/2663

With this PR all non tiled behaviour should be identical as to prior to 5.3.0

This PR also introduces a new unit test to help ensure that such an issue will be caught in future:
- The new saveBytes test is largely similar to the tiled writing unit tests which had been added previously
- A new system prop has been added to enable the test in the same way as for the tiling test
- The tiling and saveBytes tests have both then refactored to reduce duplication in the unit tests

**To reproduce the original issue:**
- See the forum thread and using the sample files mentioned follow the bfconvert step
- Verify that the image opens with 49 frames as opposed to 2 channels of 25 frames
- Also, run the new unit test provided while excluding commit https://github.com/openmicroscopy/bioformats/commit/cdae6d17e9bc52788556413ea85b6582c38c0de5. This should fail with incorrect image counts for saveBytes tests

**To verify:**
- With the PR included perform the same bfconvert and verify that it correctly has 2 channels of 25 frames
- Verify that the new unit test runs without error

Note: To run the new unit test you must set the system property as below:
`-Dtestng.runWriterSaveBytesTests=100`