### PR TITLE
Remove tabularcolumns from docs

### DIFF
--- a/components/autogen/src/MakeDatasetStructureTable.java
+++ b/components/autogen/src/MakeDatasetStructureTable.java
@@ -60,11 +60,7 @@ public class MakeDatasetStructureTable {
     out.println("choose if you want");
     out.println("to open/import a dataset in a particular format.");
     out.println();
-    out.println(".. only:: html");
-    out.println();
-    out.println("    You can sort this table by clicking on any of the headings.");
-    out.println();
-    out.println(".. tabularcolumns:: |p{4cm}|p{3cm}|p{8cm}|");
+    out.println("You can sort this table by clicking on any of the headings.");
     out.println();
     out.println(".. list-table::");
     out.println("   :class: sortable");

--- a/components/autogen/src/doc/FormatTable.vm
+++ b/components/autogen/src/doc/FormatTable.vm
@@ -3,11 +3,7 @@ Supported Formats
 
 :term:`Ratings legend and definitions`
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{3cm}|p{2cm}|c|c|c|c|c|c|c|c|c|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable

--- a/components/autogen/src/doc/meta-summary.vm
+++ b/components/autogen/src/doc/meta-summary.vm
@@ -4,11 +4,7 @@ Summary of supported metadata fields
 Format readers
 --------------
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{3cm}|c|c|c|c|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable
@@ -42,11 +38,7 @@ Format readers
 Metadata fields
 ---------------
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{3cm}|c|c|c|c|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable

--- a/docs/sphinx/developers/conversion.txt
+++ b/docs/sphinx/developers/conversion.txt
@@ -4,12 +4,11 @@ Converting files from FV1000 OIB/OIF to OME-TIFF
 This document explains how to convert a file from FV1000 OIB/OIF to OME-TIFF
 using Bio-Formats version 4.2 and later.
 
-.. only:: html
-
-   Working example code is provided in    
-   :download:`FileConvert.java <examples/FileConvert.java>` - code from that class is
-   referenced here in part. You will need to have **bioformats_package.jar** in your 
-   Java CLASSPATH in order to compile FileConvert.java.
+Working example code is provided in
+:download:`FileConvert.java <examples/FileConvert.java>` - code from that
+class is referenced here in part. You will need to have
+**bioformats_package.jar** in your Java CLASSPATH in order to compile
+FileConvert.java.
 
 The first thing that must happen is we must create the object that stores
 OME-XML metadata.  This is done as follows:

--- a/docs/sphinx/developers/export2.txt
+++ b/docs/sphinx/developers/export2.txt
@@ -6,12 +6,10 @@ Further details on exporting raw pixel data to OME-TIFF files
 This document explains how to export pixel data to OME-TIFF using Bio-Formats
 version 4.2 and later.
 
-.. only:: html
-
-   Working example code is provided in    
-   :download:`FileExport.java <examples/FileExport.java>` - code from that class is
-   referenced here in part. You will need to have bioformats_package.jar in your Java
-   CLASSPATH in order to compile FileExport.java.
+Working example code is provided in
+:download:`FileExport.java <examples/FileExport.java>` - code from that class
+is referenced here in part. You will need to have bioformats_package.jar in
+your Java CLASSPATH in order to compile FileExport.java.
 
 The first thing that must happen is we must create the object that stores
 OME-XML metadata.  This is done as follows:

--- a/docs/sphinx/developers/file-reader.txt
+++ b/docs/sphinx/developers/file-reader.txt
@@ -33,8 +33,6 @@ Core metadata is the general term for anything that might be needed to work
 with the planes in a file. A list of core metadata fields is given in the
 table below together with the appropriate accessor method:
 
-.. tabularcolumns:: |l|c|
-
 .. list-table::
   :header-rows: 1
 
@@ -121,8 +119,6 @@ Bio-Formats provides a few extras to make file reading more flexible.
   by nesting the wrappers.
 
   The table below summarizes a few wrapper readers of interest:
-
-  .. tabularcolumns:: |l|c|
 
   .. list-table::
     :header-rows: 1

--- a/docs/sphinx/developers/generating-test-images.txt
+++ b/docs/sphinx/developers/generating-test-images.txt
@@ -110,8 +110,6 @@ Key-value pairs
 There are several other keys that can be added, a complete list of these,
 with their default values, is shown below.
 
-.. tabularcolumns:: |p{3cm}|p{11cm}|p{2cm}|
-
 .. list-table::
     :header-rows: 1
     :widths: 30, 60, 10

--- a/docs/sphinx/developers/java-library.txt
+++ b/docs/sphinx/developers/java-library.txt
@@ -50,8 +50,6 @@ Dependencies
 
 The complete list of current dependencies is as follows:
 
-.. tabularcolumns:: |l|l|l|
-
 .. list-table::
     :header-rows: 1
 

--- a/docs/sphinx/formats/dataset-table.txt
+++ b/docs/sphinx/formats/dataset-table.txt
@@ -10,11 +10,7 @@ Dataset Structure Table
 This table shows the extension of the file that you should choose if you want
 to open/import a dataset in a particular format.
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{4cm}|p{3cm}|p{8cm}|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable

--- a/docs/sphinx/formats/index.txt
+++ b/docs/sphinx/formats/index.txt
@@ -9,10 +9,8 @@ Bio-Formats can write, as well as read, each format.  The
 :doc:`/metadata-summary` table shows an overview of the :doc:`OME data model
 </about/index>` fields populated for each format.
 
-.. only:: html
-
-    Further information on each individual format is also provided (click on
-    the entries in the supported formats table).
+Further information on each individual format is also provided (click on
+the entries in the supported formats table).
 
 **We are always looking for examples of files to help us provide better
 support for different formats.** If you would like to help, you can upload

--- a/docs/sphinx/index.txt
+++ b/docs/sphinx/index.txt
@@ -13,22 +13,20 @@ Bio-Formats as a Java library and how to interface from non-Java codes.
 Finally, :doc:`formats/index` is a guide to all the file formats currently
 supported by Bio-Formats.
 
-.. only:: html
+- :doc:`about/index`
+- :doc:`users/index`
+- :doc:`developers/index`
+- :doc:`formats/index`
 
-    - :doc:`about/index`
-    - :doc:`users/index`
-    - :doc:`developers/index`
-    - :doc:`formats/index`
-
-    Bio-Formats |release| uses the *June 2016* release of the
-    :model_doc:`OME Model <>`.
+Bio-Formats |release| uses the *June 2016* release of the
+:model_doc:`OME Model <>`.
     
-    **Bio-Formats is a community project and we welcome your input.** You can
-    find guidance on :doc:`about/bug-reporting`, upload files to our
-    `QA system <http://qa.openmicroscopy.org.uk/qa/upload/>`_ for testing, and
-    :community_plone:`contact us <>` via our mailing lists or forums. Further
-    information about how the OME team works and how you can contribute to our
-    projects is in the :devs_doc:`Contributing Developer Documentation <>`.
+**Bio-Formats is a community project and we welcome your input.** You can
+find guidance on :doc:`about/bug-reporting`, upload files to our
+`QA system <http://qa.openmicroscopy.org.uk/qa/upload/>`_ for testing, and
+:community_plone:`contact us <>` via our mailing lists or forums. Further
+information about how the OME team works and how you can contribute to our
+projects is in the :devs_doc:`Contributing Developer Documentation <>`.
 
 
 .. toctree::

--- a/docs/sphinx/metadata-summary.txt
+++ b/docs/sphinx/metadata-summary.txt
@@ -4,11 +4,7 @@ Summary of supported metadata fields
 Format readers
 --------------
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{3cm}|c|c|c|c|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable
@@ -870,11 +866,7 @@ Format readers
 Metadata fields
 ---------------
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{3cm}|c|c|c|c|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -3,11 +3,7 @@ Supported Formats
 
 :term:`Ratings legend and definitions`
 
-.. only:: html
-
-    You can sort this table by clicking on any of the headings.
-
-.. tabularcolumns:: |p{3cm}|p{2cm}|c|c|c|c|c|c|c|c|c|
+You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable

--- a/docs/sphinx/users/index.txt
+++ b/docs/sphinx/users/index.txt
@@ -50,20 +50,8 @@ OMERO 5 uses Bio-Formats to read original files from over 140 file formats.
 Please refer to the :omerodoc:`OMERO documentation <>` for further
 information.
 
-.. only:: latex
-
-    |
-
-    .. image:: /images/bf_omero.png
-        :align: center
-
-
-|
-
-.. only:: html
-
-    Many other software packages can use Bio-Formats to read and write
-    microscopy formats (click on the package for further details):
+Many other software packages can use Bio-Formats to read and write
+microscopy formats (click on the package for further details):
 
 Image server applications
 =========================


### PR DESCRIPTION
See https://trello.com/c/SnUesylG/505-ditching-docs-pdfs this cleans up the now unused latex directions for tables.

@rleigh-codelibre not sure if there is also more build clean up that could happen in this repo too