### PR TITLE
Build Sphinx docs with maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
   fast_finish: true
 
 before_install:
-  - if [[ $BUILD == 'ant' ]]; then pip install --user flake8 Sphinx==1.2.3; fi
+  - pip install --user -r requirements.txt
 
 script:
   - ./tools/test-build $BUILD

--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -100,8 +100,6 @@ Type "ant -p" for a list of targets.
     description="generate the Sphinx HTML documentation">
     <echo>----------=========== Sphinx HTML ===========----------</echo>
     <ant dir="docs/sphinx" target="html"/>
-    <echo>----------=========== Sphinx MAN ===========----------</echo>
-    <ant dir="docs/sphinx" target="man"/>
   </target>
 
   <target name="clean-docs-sphinx"

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -1,36 +1,39 @@
 # Delegate all make targets directly to ant
 
-ifdef SPHINXOPTS
-ANT_SPHINXOPTS := -Dsphinx.opts="$(SPHINXOPTS)"
-endif
-
 ifdef BF_RELEASE
-ANT_BF_RELEASE := -Drelease.version="$(BF_RELEASE)"
+MVN_BF_RELEASE := -Drelease.version="$(BF_RELEASE)"
 endif
 
 ifdef RELEASE
-ANT_RELEASE := -Dsphinx.release="$(RELEASE)"
+MVN_RELEASE := -Dsphinx.release="$(RELEASE)"
 endif
 
 ifdef VERSION
-ANT_VERSION := -Dsphinx.version="$(VERSION)"
+MVN_VERSION := -Dsphinx.version="$(VERSION)"
 endif
 
 ifdef SOURCE_BRANCH
-ANT_SOURCE_BRANCH := -Dsphinx.source.branch="$(SOURCE_BRANCH)"
+MVN_SOURCE_BRANCH := -Dsphinx.source.branch="$(SOURCE_BRANCH)"
 endif
 
 ifdef SOURCE_USER
-ANT_SOURCE_USER := -Dsphinx.source.user="$(SOURCE_USER)"
+MVN_SOURCE_USER := -Dsphinx.source.user="$(SOURCE_USER)"
 endif
 
 ifdef OMERODOC_URI_JOB
-ANT_OMERODOC_URI_JOB := -Dsphinx.omerodoc.uri="$(OMERODOC_URI_JOB)"
+MVN_OMERODOC_URI_JOB := -Dsphinx.omerodoc.uri="$(OMERODOC_URI_JOB)"
+endif
+
+ifdef SPHINX_THEME
+MVN_SPHINX_THEME := -Dsphinx.html.theme="$(SPHINX_THEME)"
 endif
 
 default: html
 
 %:
-	ant $@ $(ANT_SPHINXOPTS) $(ANT_BF_RELEASE) $(ANT_RELEASE) $(ANT_VERSION) $(ANT_SOURCE_BRANCH) $(ANT_SOURCE_USER) $(ANT_JENKINS_JOB) $(ANT_JENKINS_CPP_JOB) $(ANT_OMERODOC_URI_JOB)
+	mvn -Dsphinx.builder=$@ $(MVN_BF_RELEASE) $(MVN_RELEASE) $(MVN_VERSION) $(MVN_SOURCE_BRANCH) $(MVN_SOURCE_USER) $(MVN_OMERODOC_URI_JOB) $(MVN_SPHINX_THEME)
 
-.PHONY: default
+clean:
+	mvn clean
+
+.PHONY: default clean

--- a/docs/sphinx/assembly.xml
+++ b/docs/sphinx/assembly.xml
@@ -1,0 +1,15 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>manual</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/sphinx/html</directory>
+      <outputDirectory/>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -14,11 +14,11 @@ Type "ant -p" for a list of targets.
   <property name="sphinx.build" value="sphinx-build"/>
   <property name="sphinx.warnopts" value=""/>
   <property name="sphinx.opts" value=""/>
+  <property name="sphinx.srcdir" location="."/>
   <property name="sphinx.builddir" location="_build"/>
-  <property name="latex.opts" value=""/>
 
   <target name="init">
-    <property name="release.version.regex" value="v([0-9]+)[.]([0-9]+)[.]([0-9]+)(.*)"/>
+    <property name="release.version.regex" value="v?([0-9]+)[.]([0-9]+)[.]([0-9]+)(.*)"/>
     <propertyregex property="release.major" input="${release.version}" regexp="${release.version.regex}" select="\1"/>
     <propertyregex property="release.minor" input="${release.version}" regexp="${release.version.regex}" select="\2"/>
 
@@ -42,18 +42,19 @@ Type "ant -p" for a list of targets.
     </if>
     <property name="sphinx.openmicroscopy_source.user" value="openmicroscopy"/>
     <property name="sphinx.ome_source.user" value="ome"/>
-    <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
+    <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.2"/>
 
-    <copy file="conf.py.in" tofile="conf.py" overwrite="true"/>
-    <replace file="conf.py" token="@sphinx_srcdir@" value="."/>
-    <replace file="conf.py" token="@sphinx_builddir@" value="."/>
-    <replace file="conf.py" token="@bioformats_source_branch@" value="${sphinx.bioformats.source.branch}"/>
-    <replace file="conf.py" token="@common_java_source_branch@" value="${sphinx.common_java.source.branch}"/>
-    <replace file="conf.py" token="@openmicroscopy_source_user@" value="${sphinx.openmicroscopy_source.user}"/>
-    <replace file="conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
-    <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
-    <replace file="conf.py" token="@ome_common_version@" value="${ome-common.version}"/>
-    <replace file="conf.py" token="@ome_model_version@" value="${ome-model.version}"/>
+    <mkdir dir="${sphinx.builddir}"/>
+    <copy file="conf.py" tofile="${sphinx.builddir}/conf.py" overwrite="true"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@sphinx_srcdir@" value="${sphinx.srcdir}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@sphinx_builddir@" value="${sphinx.builddir}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@bioformats_source_branch@" value="${sphinx.bioformats.source.branch}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@common_java_source_branch@" value="${sphinx.common_java.source.branch}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@openmicroscopy_source_user@" value="${sphinx.openmicroscopy_source.user}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@ome_common_version@" value="${ome-common.version}"/>
+    <replace file="${sphinx.builddir}/conf.py" token="@ome_model_version@" value="${ome-model.version}"/>
   </target>
 
   <macrodef name="sphinx" description="Run sphinx-build">
@@ -70,6 +71,8 @@ Type "ant -p" for a list of targets.
         <arg value="version=${sphinx.version}"/>
         <arg value="-b"/>
         <arg value="@{buildtype}"/>
+        <arg value="-c"/>
+        <arg value="${sphinx.builddir}"/>
         <arg line="@{opts}"/>
         <arg line="@{warnopts}"/>
         <arg value="@{srcdir}"/>
@@ -80,7 +83,7 @@ Type "ant -p" for a list of targets.
 
   <target name="html" depends="init">
     <sphinx buildtype="html"
-            srcdir="."
+            srcdir="${sphinx.srcdir}"
             destdir="${sphinx.builddir}/html"
             opts="${sphinx.opts}"
             warnopts="${sphinx.warnopts}"/>
@@ -89,80 +92,13 @@ Type "ant -p" for a list of targets.
       <!--
         include (none) to prevent problems if component.resources-bin is empty
       -->
-      <fileset dir="_build/html"/>
+      <fileset dir="${sphinx.builddir}/html"/>
     </copy>
     <zip destfile="${artifact.dir}/bio-formats-doc-${sphinx.release}.zip">
-      <zipfileset dir="_build/html" includes="**/*" prefix="bio-formats-doc-${sphinx.release}"/>
+      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="bio-formats-doc-${sphinx.release}"/>
     </zip>
     <delete dir="${artifact.dir}/bio-formats-doc-${sphinx.release}"/>
   </target>
-
-  <target name="man" depends="init">
-    <sphinx buildtype="man"
-            srcdir="."
-            destdir="${sphinx.builddir}/man"
-            opts="${sphinx.opts}"/>
-  </target>
-
-  <macrodef name="xelatex" description="Run XeLaTeX">
-    <attribute name="file" default=""/>
-    <sequential>
-      <basename property="file.basename" file="@{file}"/>
-      <dirname property="file.dirname" file="@{file}"/>
-      <exec executable="xelatex" failonerror="true" dir="${file.dirname}">
-        <arg line="${latex.opts}"/>
-        <arg value="${file.basename}"/>
-      </exec>
-    </sequential>
-  </macrodef>
-
-  <macrodef name="makeindex" description="Run makeindex">
-    <attribute name="file" default=""/>
-    <sequential>
-      <basename property="file.basename" file="@{file}"/>
-      <dirname property="file.dirname" file="@{file}"/>
-      <propertyregex property="file.index" input="${file.basename}" regexp="(.*)\.tex" select="\1.idx"/>
-      <exec executable="makeindex" failonerror="true" dir="${file.dirname}">
-        <arg value="-s"/>
-        <arg value="python.ist"/>
-        <arg value="${file.index}"/>
-      </exec>
-    </sequential>
-  </macrodef>
-
-  <macrodef name="runlatex">
-    <attribute name="file" default=""/>
-    <sequential>
-      <basename property="jar.filename" file="${lib.jarfile}"/>
-      <xelatex file="@{file}"/>
-      <xelatex file="@{file}"/>
-      <makeindex file="@{file}"/>
-      <xelatex file="@{file}"/>
-      <xelatex file="@{file}"/>
-      <xelatex file="@{file}"/>
-    </sequential>
-  </macrodef>
-
-  <target name="latexpdf" depends="init">
-    <sphinx buildtype="latex"
-            srcdir="."
-            destdir="${sphinx.builddir}/latex"
-            opts="${sphinx.opts}"
-            warnopts="${sphinx.warnopts}"/>
-    <copy file="preamble.tex" todir="${sphinx.builddir}/latex"/>
-
-    <for param="file">
-      <path>
-       <fileset dir="${sphinx.builddir}/latex" includes="*.tex"/>
-      </path>
-      <sequential>
-        <runlatex file="@{file}"/>
-      </sequential>
-    </for>
-    <copy file="_build/latex/Bio-Formats.pdf" tofile="${artifact.dir}/Bio-Formats-${sphinx.release}.pdf"/>
-  </target>
-
-  <target name="pdf" depends="latexpdf"/>
 
   <target name="linkcheck" depends="init">
     <sphinx buildtype="linkcheck" srcdir="."
@@ -173,7 +109,6 @@ Type "ant -p" for a list of targets.
 
   <target name="clean">
     <delete dir="${sphinx.builddir}"/>
-    <delete file="conf.py"/>
   </target>
 
 </project>

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -296,24 +296,24 @@ latex_elements = {
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
-target = project + '.tex'
-latex_documents = [
-  (master_doc, target, title, author, 'manual'),
-]
+#target = project + '.tex'
+#latex_documents = [
+#  (master_doc, target, title, author, 'manual'),
+#]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-latex_logo = os.path.join(srcdir, 'images/bio-formats-logo.pdf')
+#latex_logo = os.path.join(srcdir, 'images/bio-formats-logo.pdf')
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-latex_use_parts = True
+#latex_use_parts = True
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-latex_show_urls = 'footnote'
+#latex_show_urls = 'footnote'
 
 # Documents to append as an appendix to all manuals.
 #latex_appendices = []

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -86,7 +86,8 @@ release = 'UNKNOWN'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'CMakeLists.txt']
+relbuildpath=os.path.relpath(builddir, srcdir)
+exclude_patterns = [relbuildpath, 'CMakeLists.txt']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -207,7 +207,7 @@ html_theme = 'sphinxdoc'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ['themes']
+html_theme_path = [os.path.abspath(os.path.join(srcdir, 'themes'))]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/sphinx/developers/commit-testing.txt
+++ b/docs/sphinx/developers/commit-testing.txt
@@ -173,7 +173,7 @@ name of the method:
   cd /path/to/bioformats/components/formats-gpl/test/matlab
   runxunit TestBfsave:testLZW
 
-Finally to output the test results under XML format, you can use the :option:`-xmlfile` option:
+Finally to output the test results under XML format, you can use the ``-xmlfile`` option:
 
 .. code-block:: matlab
 

--- a/docs/sphinx/pom.xml
+++ b/docs/sphinx/pom.xml
@@ -12,10 +12,10 @@
     <relativePath>../..</relativePath>
   </parent>
 
-  <artifactId>formats-docs</artifactId>
+  <artifactId>formats-doc</artifactId>
 
-  <name>Bio-Formats Sphinx documentation</name>
-  <description>Sphinx-generated Bio-Formats documentation.</description>
+  <name>Bio-Formats documentation</name>
+  <description>Documentation for Bio-Formats</description>
   <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
@@ -28,20 +28,42 @@
   </licenses>
 
   <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>formats-gpl</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>formats-bsd</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>formats-gpl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>formats-bsd</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <properties>
-    <project.rootdir>${basedir}/../..</project.rootdir>
+    <!-- User-settable properties -->
+    <sphinx.bioformats.source.branch>develop</sphinx.bioformats.source.branch>
+    <sphinx.openmicroscopy_source.user>openmicroscopy</sphinx.openmicroscopy_source.user>
+    <sphinx.ome_source.user>ome</sphinx.ome_source.user>
+    <sphinx.omerodoc.uri>http://www.openmicroscopy.org/site/support/omero5.2</sphinx.omerodoc.uri>
+
+    <sphinx.builder>html</sphinx.builder>
+    <sphinx.html.theme>sphinxdoc</sphinx.html.theme>
+
+    <sphinx.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</sphinx.version>
+    <sphinx.release>${project.version}</sphinx.release>
+
+    <!-- Properties to pass through to conf.py -->
+    <sphinx_srcdir>${basedir}</sphinx_srcdir>
+    <sphinx_builddir>${project.build.directory}/sphinx</sphinx_builddir>
+
+    <bioformats_source_branch>${sphinx.bioformats.source.branch}</bioformats_source_branch>
+    <openmicroscopy_source_user>${sphinx.openmicroscopy_source.user}</openmicroscopy_source_user>
+    <ome_source_user>${sphinx.ome_source.user}</ome_source_user>
+    <sphinx_omerodoc_uri>${sphinx.omerodoc.uri}</sphinx_omerodoc_uri>
+
+    <ome_common_version>${ome-common.version}</ome_common_version>
+    <ome_model_version>${ome-model.version}</ome_model_version>
   </properties>
 
   <build>
@@ -50,11 +72,11 @@
       <resource>
         <directory>${project.basedir}/developers/examples</directory>
         <includes>
-            <include>**/*.xml</include>
-            <include>**/*.fake*</include>
+          <include>**/*.xml</include>
+          <include>**/*.fake*</include>
         </includes>
-      </resource> 
-    </resources>      
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -75,6 +97,56 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>copy-configuration</id>
+            <!-- here the phase you need -->
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${sphinx_builddir}</outputDirectory>
+              <includeEmptyDirs>true</includeEmptyDirs>
+              <resources>
+                <resource>
+                  <directory>${basedir}</directory>
+                  <filtering>true</filtering>
+                  <includes>
+                    <include>conf.py</include>
+                  </includes>
+                </resource>
+                <resource>
+                  <directory>${basedir}/</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>_static/**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>_static/.*</exclude>
+                  </excludes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.12</version>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -87,4 +159,139 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- Build docs with sphinx -->
+      <id>build-sphinx</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>sphinx.builder</name>
+          <value>!linkcheck</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.5.0</version>
+            <executions>
+              <execution>
+                <id>sphinx-docs</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>sphinx-build</executable>
+                  <arguments>
+                    <argument>-D</argument>
+                    <argument>release=${sphinx.release}</argument>
+                    <argument>-D</argument>
+                    <argument>version=${sphinx.version}</argument>
+                    <argument>-D</argument>
+                    <argument>html_theme=${sphinx.html.theme}</argument>
+                    <argument>-W</argument>
+                    <argument>-b</argument>
+                    <argument>${sphinx.builder}</argument>
+                    <argument>-c</argument>
+                    <argument>${sphinx_builddir}</argument>
+                    <argument>-d</argument>
+                    <argument>${sphinx_builddir}/cache</argument>
+                    <argument>${basedir}</argument>
+                    <argument>${sphinx_builddir}/${sphinx.builder}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- As above, but don't fail on warnings when doing linkchecking -->
+      <id>build-sphinx-warnonerror</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>sphinx.builder</name>
+          <value>linkcheck</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.5.0</version>
+            <executions>
+              <execution>
+                <id>sphinx-docs</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>sphinx-build</executable>
+                  <arguments>
+                    <argument>-D</argument>
+                    <argument>release=${sphinx.release}</argument>
+                    <argument>-D</argument>
+                    <argument>version=${sphinx.version}</argument>
+                    <argument>-D</argument>
+                    <argument>html_theme=${sphinx.html.theme}</argument>
+                    <argument>-b</argument>
+                    <argument>${sphinx.builder}</argument>
+                    <argument>-c</argument>
+                    <argument>${sphinx_builddir}</argument>
+                    <argument>-d</argument>
+                    <argument>${sphinx_builddir}/cache</argument>
+                    <argument>${basedir}</argument>
+                    <argument>${sphinx_builddir}/${sphinx.builder}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Build javadocs by default, but not when running tests -->
+      <id>package-html</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>sphinx.builder</name>
+          <value>html</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.6</version>
+            <configuration>
+              <descriptors>
+                <descriptor>assembly.xml</descriptor>
+              </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+            <executions>
+              <execution>
+                <id>make-zip</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+   </profiles>
 </project>

--- a/docs/sphinx/pom.xml
+++ b/docs/sphinx/pom.xml
@@ -251,6 +251,10 @@
                     <argument>${basedir}</argument>
                     <argument>${sphinx_builddir}/${sphinx.builder}</argument>
                   </arguments>
+                  <successCodes>
+                    <successCode>0</successCode>
+                    <successCode>1</successCode>
+                  </successCodes>
                 </configuration>
               </execution>
             </executions>

--- a/docs/sphinx/users/comlinetools/conversion.txt
+++ b/docs/sphinx/users/comlinetools/conversion.txt
@@ -65,7 +65,7 @@ The output file format is determined by the extension of the output file, e.g.
 
     Also note that the specified tile size will affect performance.  If large
     amounts of data are being processed, it is a good idea to try converting a
-    single tile with a few different tile sizes using the :option:`-crop`
+    single tile with a few different tile sizes using the ``-crop``
     option. This gives an idea of what the most performant size will be.
 
 Images can also be written to multiple files by specifying a pattern string

--- a/docs/sphinx/users/comlinetools/index.txt
+++ b/docs/sphinx/users/comlinetools/index.txt
@@ -114,7 +114,7 @@ something like this:
     1.6.0_24-b24;java.vm.vendor=Sun+Microsystems+Inc.;bioformats.caller=
     Bio-Formats+utilities
 
-To avoid this issue, call the tool with the :option:`-no-upgrade` parameter.
+To avoid this issue, call the tool with the ``-no-upgrade`` option.
 
 Profiling
 ---------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Python requirements
+# ===================
+#
+#     pip install -r requirements.txt
+#
+flake8
+Sphinx


### PR DESCRIPTION
As part of making all of bioformats build with maven, this is now made possible by borrowing the sphinx logic from ome-model:

- Add maven docs build, taken from ome-model with some amendments
- Make `Makefile` invokes `mvn` rather than `ant`
- Ant build updated to generalise some hardcoded behaviour and
  to use a separate build directory as for maven to allow
  correct conf.py generation for maven
- Ant build versioning fix (regex incompatible with maven version in place of git tag)
- Drop Ant manpage generation (there are no manpages)
- Drop remaining Ant PDF generation logic
- Invalid options converted to verbatim strings in the sphinx docs

This PR does not:

- Remove the ant logic, retained for compatibility due to issues invoking maven directly from ant when using the Jenkins Ant build step plugin (it's not guaranteed to be on the `PATH`), but this could be run on a suitable build node.  Can be made to delegate to maven, or drop entirely, as a future followup.

Testing:

```
cd docs/sphinx
make clean html linkcheck
ant clean html linkcheck
mvn clean
mvn
mvn -Dsphinx.builder=linkcheck
```

Or run from the top level with `ant docs-sphinx` or `mvn`.

The `Makefile` behaviour should be completely preserved, including the theming, so the build jobs should not require any changes.  We can switch over the jobs to use maven as a followup step.  Likewise the `_build` directory used by ant could be replaced with `target/sphinx`, but was retained for job compatibility when copying the built docs, but can also be switched over.