### PR TITLE
Metamorph TIFF: wavelength population and dimension calculation fix

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -61,6 +61,7 @@ public class MetamorphHandler extends BaseHandler {
   private Length positionX, positionY;
   private Vector<Double> exposures;
   private String channelName;
+  private Vector<String> channelNames;
   private String stageLabel;
   private Double gain;
   private boolean dualCamera = false;
@@ -78,6 +79,7 @@ public class MetamorphHandler extends BaseHandler {
     wavelengths = new Vector<Integer>();
     zPositions = new Vector<Double>();
     exposures = new Vector<Double>();
+    channelNames = new Vector<String>();
   }
 
   // -- MetamorphHandler API methods --
@@ -85,6 +87,8 @@ public class MetamorphHandler extends BaseHandler {
   public Double getGain() { return gain; }
 
   public String getChannelName() { return channelName; }
+
+  public Vector<String> getChannelNames() { return channelNames; }
 
   public String getStageLabel() { return stageLabel; }
 
@@ -272,7 +276,10 @@ public class MetamorphHandler extends BaseHandler {
       catch (NumberFormatException e) { }
     }
     else if (key.equals("_IllumSetting_")) {
-      channelName = value;
+      if (channelName == null) {
+        channelName = value;
+      }
+      channelNames.add(value);
     }
     else if (key.equals("stage-label")) {
       stageLabel = value;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -332,6 +332,17 @@ public class MetamorphTiffReader extends BaseTiffReader {
 
     int totalPlanes = files.length * ifds.size();
     effectiveC = getSizeC() / samples;
+
+    // if the channel name and Z position are unique
+    // for each plane, then prefer unique channels over unique Zs
+    // the division by uniqueC.size is not a typo - it's meant to
+    // account for the multiple actual Z sections
+    if (effectiveC * getSizeZ() > totalPlanes &&
+      effectiveC * (getSizeZ() / uniqueC.size()) == totalPlanes)
+    {
+      m.sizeZ /= uniqueC.size();
+    }
+
     m.sizeT = totalPlanes /
       (wellCount * fieldRowCount * fieldColumnCount * getSizeZ() * effectiveC);
     if (getSizeT() == 0) m.sizeT = 1;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -338,9 +338,15 @@ public class MetamorphTiffReader extends BaseTiffReader {
     // the division by uniqueC.size is not a typo - it's meant to
     // account for the multiple actual Z sections
     if (effectiveC * getSizeZ() > totalPlanes &&
-      effectiveC * (getSizeZ() / uniqueC.size()) == totalPlanes)
+      (effectiveC * (getSizeZ() / uniqueC.size()) == totalPlanes ||
+      effectiveC == totalPlanes))
     {
-      m.sizeZ /= uniqueC.size();
+      if (getSizeZ() >= uniqueC.size()) {
+        m.sizeZ /= uniqueC.size();
+      }
+      else {
+        m.sizeZ = 1;
+      }
     }
 
     m.sizeT = totalPlanes /

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -185,7 +185,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
 
-    final List<String> uniqueChannels = new ArrayList<String>();
+    List<String> uniqueChannels = new ArrayList<String>();
     final List<Double> uniqueZs = new ArrayList<Double>();
     final List<Length> stageX = new ArrayList<Length>();
     final List<Length> stageY = new ArrayList<Length>();

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -522,6 +522,10 @@ public class MetamorphTiffReader extends BaseTiffReader {
             store.setChannelName(uniqueChannels.get(c), s, c);
           }
           else store.setChannelName(handler.getChannelName(), s, c);
+          if (c < wavelengths.size()) {
+            store.setChannelEmissionWavelength(
+              FormatTools.getEmissionWavelength(Double.valueOf(wavelengths.get(c))), s, c);
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -513,6 +513,10 @@ public class MetamorphTiffReader extends BaseTiffReader {
           store.setPixelsPhysicalSizeZ(sizeZ, s);
         }
 
+        if (uniqueChannels.size() == 0) {
+          uniqueChannels = handler.getChannelNames();
+        }
+
         for (int c=0; c<getEffectiveSizeC(); c++) {
           if (uniqueChannels.size() > c) {
             store.setChannelName(uniqueChannels.get(c), s, c);


### PR DESCRIPTION
Backported from private @glencoesoftware PRs.  This updates ```MetamorphHandler``` to parse all stored channel names, and fixes ```MetamorphTiffReader``` to treat two planes with unique channel names and Z positions as just 2 channels, instead of 2 channels x 2 Z sections.  It also updates ```MetamorphTiffReader``` to set ```Channel.EmissionWavelength``` when appropriate.

I don't have real data that can be copied to data_repo, but an artificial dataset that exhibits the problem is now in ```data_repo/curated/metamorph/thomas/test.tif``` (generated from ```data_repo/curated/metamorph/thomas/t_test2001.tif```).  Without this change, ```showinf test.tif``` should show SizeZ = 2 and SizeC = 2.  ```tiffinfo test.tif | grep -c "TIFF Directory"``` should confirm that there are only two planes in the file.

With this change, ```showinf test.tif``` should show SizeZ = 1 and SizeC = 2.  Both channels are expected to be the same image due to how the file was generated.

The emission wavelength addition can be verified using ```showinf -nopix -omexml``` against the list of files in https://github.com/openmicroscopy/data_repo_config/pull/163.