### PR TITLE
QuickTime: respect openBytes' tile Y coordinate

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
+++ b/components/formats-bsd/src/loci/formats/in/NativeQTReader.java
@@ -260,7 +260,7 @@ public class NativeQTReader extends FormatReader {
         }
       }
       else {
-        System.arraycopy(t, row*srcRowLen + x*bpp*getSizeC(), buf,
+        System.arraycopy(t, (row + y)*srcRowLen + x*bpp*getSizeC(), buf,
           row*destRowLen, destRowLen);
       }
     }


### PR DESCRIPTION
This fixes ```openBytes``` to return the correct tile when ```y``` is greater than 0 and only one channel is present.

To test, use ```data_repo/curated/quicktime/curtis/mri-stack-native.mov```.  Without this change, compare the images shown by ```showinf mri-stack-native.mov``` and ```showinf -crop 0,113,186,113 mri-stack-native.mov```.  The second test specifies coordinates for the bottom half of the original image, but will return the top half instead.

The same test with this change should show the bottom half of the original image as expected.

https://github.com/openmicroscopy/data_repo_config/pull/165 proposes adding the test file to the list covered by https://ci.openmicroscopy.org/view/Bio-Formats/job/BIOFORMATS-DEV-merge-performance, as that would have caught this problem.  Automated tests should otherwise be unaffected.