### PR TITLE
NIFTI: fix up extended metadata parsing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -474,6 +474,7 @@ public class NiftiReader extends FormatReader {
     addGlobalMeta("Dimension 5", dim5);
     addGlobalMeta("Dimension 6", dim6);
     addGlobalMeta("Dimension 7", dim7);
+    addGlobalMeta("Dimension 8", dim8);
     addGlobalMeta("Intent #1", intent1);
     addGlobalMeta("Intent #2", intent2);
     addGlobalMeta("Intent #3", intent3);
@@ -501,6 +502,10 @@ public class NiftiReader extends FormatReader {
     addGlobalMeta("Quaternion x parameter", quaternionX);
     addGlobalMeta("Quaternion y parameter", quaternionY);
     addGlobalMeta("Quaternion z parameter", quaternionZ);
+    addGlobalMeta("Slice code", sliceCode);
+    addGlobalMeta("XYZT units", units);
+    addGlobalMeta("XYZ units", spatialUnits);
+    addGlobalMeta("Time units", timeUnits);
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -433,7 +433,7 @@ public class NiftiReader extends FormatReader {
 
     String intentName = in.readString(16);
 
-    if (in.getFilePointer() + 4 < in.length()) {
+    if (in.getFilePointer() + 8 < in.length()) {
       in.skipBytes(4);
       byte extension = in.readByte();
       in.skipBytes(3);

--- a/components/formats-gpl/src/loci/formats/in/NiftiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NiftiReader.java
@@ -340,12 +340,13 @@ public class NiftiReader extends FormatReader {
   }
 
   private void populateExtendedMetadata() throws IOException {
-    in.seek(40);
-    char sliceOrdering = in.readChar();
+    in.seek(39);
+    byte sliceOrdering = in.readByte();
     in.skipBytes(8);
     short dim5 = in.readShort();
     short dim6 = in.readShort();
     short dim7 = in.readShort();
+    short dim8 = in.readShort();
 
     float intent1 = in.readFloat();
     float intent2 = in.readFloat();
@@ -368,8 +369,8 @@ public class NiftiReader extends FormatReader {
     float scaleSlope = in.readFloat();
     float scaleIntercept = in.readFloat();
     short sliceEnd = in.readShort();
-    char sliceCode = in.readChar();
-    char units = in.readChar();
+    byte sliceCode = in.readByte();
+    byte units = in.readByte();
 
     int spatialUnits = (units & 7);
     int timeUnits = (units & 0x38);


### PR DESCRIPTION
This fixes a few problems with byte alignment when reading non-core metadata from NIFTI headers, most notably switching from ```readChar()``` to ```readByte()```.  This also changes unit handling to use the current API instead of multiplying by a factor of 1000 to get micrometers or seconds.

To test, verify that the changes match the NIFTI specification: https://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields.  Without this change, ```showinf -nopix data_repo/curated/public/NIH/minimal.hdr``` should show ```Intent name: n1``` in the original metadata - this is suspicious because it is the magic string expected in the last four bytes of the file.  With this change, the same test should not show an ```Intent name``` key, as the field is empty.

Some configurations are affected (see https://github.com/openmicroscopy/data_repo_config/pull/166), but only for physical size units (due to using the stored units in 9c1741b) and image descriptions (due to the off-by-two fixed in 2bc9e8c).  Changed values in the affected files can be confirmed with ```nifti_tool -disp_hdr -infiles /path/to/file``` (from https://sourceforge.net/projects/niftilib/) and the source page for the public datasets (https://nifti.nimh.nih.gov/nifti-1/data). 