### PR TITLE
autogen: Update Zeiss TIFF file extensions

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2392,7 +2392,7 @@ which has a similar extension.  As far as we know, the Axio CSM 700 system is \n
 the only one which saves files in the .lms format. \n
 
 [Zeiss AxioVision TIFF]
-extensions = .xml, .tiff
+extensions = .xml, .tif
 owner = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 developer = `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 bsd = no

--- a/docs/sphinx/formats/zeiss-axiovision-tiff.txt
+++ b/docs/sphinx/formats/zeiss-axiovision-tiff.txt
@@ -1,10 +1,10 @@
 .. index:: Zeiss AxioVision TIFF
-.. index:: .xml, .tiff
+.. index:: .xml, .tif
 
 Zeiss AxioVision TIFF
 ===============================================================================
 
-Extensions: .xml, .tiff
+Extensions: .xml, .tif
 
 Developer: `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -1564,7 +1564,7 @@ You can sort this table by clicking on any of the headings.
      - |no|
      - |no|
    * - :doc:`formats/zeiss-axiovision-tiff`
-     - .xml, .tiff
+     - .xml, .tif
      - |Very good|
      - |Very good|
      - |Good|


### PR DESCRIPTION
Use the correct `.tif` file extension to match the reader and all existing samples.