### PR TITLE
ImageJ: resolve thumbnail loading regression

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/SeriesDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/SeriesDialog.java
@@ -155,7 +155,7 @@ public class SeriesDialog extends ImporterDialog implements ActionListener {
   @Override
   protected boolean displayDialog(GenericDialog gd) {
     ThumbLoader loader = null;
-    if (thumbReader != null && !options.isForceThumbnails()) {
+    if (thumbReader != null && !options.isForceThumbnails() && Macro.getOptions() == null) {
       // spawn background thumbnail loader
       loader = new ThumbLoader(thumbReader, p, gd);
     }

--- a/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
@@ -32,7 +32,6 @@ import java.awt.Panel;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Arrays;
-import java.nio.channels.ClosedByInterruptException;
 
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -81,8 +80,13 @@ public class ThumbLoader implements Runnable {
     if (loader == null) return;
     stop = true;
     BF.status(false, "Canceling thumbnail generation");
-    loader.interrupt();
-    loader = null;
+    try {
+      loader.join();
+      loader = null;
+    }
+    catch (InterruptedException exc) {
+      exc.printStackTrace();
+    }
     BF.status(false, "");
   }
 
@@ -134,7 +138,7 @@ public class ThumbLoader implements Runnable {
     }
     catch (FormatException e) { exc = e; }
     catch (IOException e) { exc = e; }
-    if (exc != null && !(exc instanceof ClosedByInterruptException)) {
+    if (exc != null) {
       BF.warn(quiet, "Error loading thumbnail for series #" + (series + 1));
       BF.debug(DebugTools.getStackTrace(exc));
     }

--- a/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
@@ -32,11 +32,13 @@ import java.awt.Panel;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 
 import loci.common.DebugTools;
+import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.IFormatReader;
 import loci.formats.gui.AWTImageTools;
@@ -123,8 +125,19 @@ public class ThumbLoader implements Runnable {
     int series, Panel panel, boolean quiet)
   {
     BF.status(quiet, "Reading thumbnail for series #" + (series + 1));
-    thumbReader.setSeries(series);
-    // open middle image thumbnail
+    // open middle image thumbnail in smallest pyramid resolution
+    List<CoreMetadata> core = thumbReader.getCoreMetadataList();
+    int index = series;
+    for (int i=0; i<=index; i++) {
+      if (core.get(i).resolutionCount > 1 &&
+        i + core.get(i).resolutionCount > index)
+      {
+        index = i + core.get(i).resolutionCount - 1;
+        break;
+      }
+    }
+    thumbReader.setSeries(index);
+
     int z = thumbReader.getSizeZ() / 2;
     int t = thumbReader.getSizeT() / 2;
     int ndx = thumbReader.getIndex(z, 0, t);

--- a/components/formats-bsd/src/loci/formats/DimensionSwapper.java
+++ b/components/formats-bsd/src/loci/formats/DimensionSwapper.java
@@ -299,7 +299,9 @@ public class DimensionSwapper extends ReaderWrapper {
       List<CoreMetadata> oldcore = reader.getCoreMetadataList();
       core = new ArrayList<CoreMetadata>();
       for (int s=0; s<oldcore.size(); s++) {
-        core.add(new SwappableMetadata(reader, s));
+        SwappableMetadata swappable = new SwappableMetadata(reader, s);
+        swappable.resolutionCount = oldcore.get(s).resolutionCount;
+        core.add(swappable);
       }
     }
   }


### PR DESCRIPTION
See https://trello.com/c/ATAFHVLS/12-regression-in-imagej-plugin

622b9cc fully reverts the changes to ```loci.plugins.in.ThumbLoader``` from 5.3.0-m2 noted on the card.  The usage of ```loader.interrupt()``` specifically resulted in a race condition in which a ```java.nio.channels.ClosedChannelException``` could be thrown when reading multiple series from the same dataset.  The exception was intermittently reproduceable when opening multiple series from a macro; opening by clicking ```Plugins > Bio-Formats > Bio-Formats Importer``` may have been affected, but I have so far been unable to reproduce an exception via that path.  I have not tested other scripting languages in ImageJ.

cba8592 disables creation of the ```ThumbLoader``` when macro options are present.  This should resolve the race condition when working with macros independent of 622b9cc, and may offer a very small speed improvement as well since thumbnail loading in macros is entirely unnecessary.  This commit is not essential to the fix, and could be removed or split into a separate PR if desired.

eef320f is a requirement for 0e068d9, and fixes a subtle bug in working with datasets where ```DimensionSwapper``` is in the reader stack, at least one pyramid is present, and ```hasFlattenedResolutions()``` returns true.

0e068d9 updates ```ThumbLoader``` to use the smallest resolution in the corresponding pyramid when generating a thumbnail for each series.  This will not change the behavior of datasets that do not have pyramids, but should improve thumbnail loading time and thumbnail cancellation time for datasets that do have a pyramid.  eef320f and 0e068d9 could be split into a separate PR if desired, but is a compromise for the performance improvement gained in 5543ded and would be nice to have in 5.3.2.

To test, first verify that the exception noted in the card can be reproduced with some consistency without these changes.  I was using the following macro:

```
run("Bio-Formats", "open=[data_repo/curated/leica/michael/2007-01-31_zres_sp2.lei] color_mode=Default view=Hyperstack stack_order=XYCZT series_0");
run("Bio-Formats", "open=[data_repo/curated/leica/michael/2007-01-31_zres_sp2.lei] color_mode=Default view=Hyperstack stack_order=XYCZT series_1");
run("Bio-Formats", "open=[data_repo/curated/leica/michael/2007-01-31_zres_sp2.lei] color_mode=Default view=Hyperstack stack_order=XYCZT series_2");
run("Bio-Formats", "open=[data_repo/curated/leica/michael/2007-01-31_zres_sp2.lei] color_mode=Default view=Hyperstack stack_order=XYCZT series_3");
```
and found that running it 3-4 times in the same ImageJ instance without closing any windows typically resulted in the exception.  Plain ImageJ and any platform should be sufficient.

With this PR, go through the same test, possibly doubling the number of times the macro is run for good measure.  Verify that no exception occurs, and that no logging indicating thumbnail loading is present.

Also with this PR, choose a few datasets with and without pyramids, e.g. whichever dataset was used in the macro test, one or two from ```data_repo/curated/zeiss-czi/zeiss/jpeg-xr```, and one or two others of your choice.  Open each in ImageJ by selecting ```Plugins > Bio-Formats > Bio-Formats Importer```, making sure that ```Open all series``` is not checked.  First verify that all thumbnails in the series chooser window load, then open again but select one of the smaller series and click ```OK``` when only the largest 2-3 pyramid thumbnails have yet to be loaded.  There should not be a significant or annoying delay before the image appears.  The same test can be run with 622b9cc alone to see the effect of 0e0689.