### PR TITLE
Bump ome-model to version 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.1</ome-common.version>
-    <ome-model.version>5.3.1</ome-model.version>
+    <ome-model.version>5.4.0</ome-model.version>
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <jxrlib.version>0.2.1</jxrlib.version>


### PR DESCRIPTION
### Context

See https://trello.com/c/InWdSfGf/8-ome-xml-transform-in-bf

Various aspects of the work included out in Bio-Formats 5.2.0 have been about improvement the ROI branch of the OME data model. Additionally, similar work was carried out at the OMERO level to align the data with the model, especially to handle transforms (see https://github.com/openmicroscopy/design/issues/33 for the underlying design issue and https://github.com/openmicroscopy/openmicroscopy/pull/4672 for the reference work).

Despite all this work, `Shape.Transform` remain non-functional when importing/exporting from OME-TIFF files where ROI shapes are defined with Transform attributes. 

### Proposed changes

The 5.4.0 release of the OME model components includes non-breaking code generation changes allowing to handle Shape Transform attributes (reference PR: https://github.com/ome/ome-model/pull/14).
By bumping the version of the `ome-model`, Bio-Formats uses these new code-generated classes allowing to properly handle Transform Shape attributes either during serialization or deserialization.

### Sample files

To test this PR, use any file that will populates Shape objects with Transform attributes:

- for the OME-XML format, the new version of the [ROI.ome.xml](http://downloads.openmicroscopy.org/images/OME-XML/2016-06/ROI.ome.xml) sample contains both a Mask and a Rectangle object with Tsansform attributes
- a [companion OME-TIFF fileset](https://gist.github.com/sbesson/46972a16b80f77b168671d9d7fae0970) defines a multi-Z multi-T OME-TIFF with one ROI containing one shape of each type per Z-section, untransformed in the first timepoint and transformed in the second timepoint
- for proprietary file formats, both the FV100Reader and the ZeissLSMReader can populate Shape Transforms

###  Bio-Formats testing

- [ ] check all unit and non-regression automated tests remain green. 
- [ ] open a sample file containing Shape transform attributes using `showinf -omexml` and check that all the OME-XML metadata is properly populated with the Transform object. This can be compared to a previous release of Bio-Formats where the Transform is lost on read.
- [ ]  open the sample file in the ImageJ plugin.

### OMERO testing

- [ ] check the OMERO server integration tests are passing notably the Java exporter tests which use and test the upgrade/downgrade of the new XMLMockObjects
- [ ] test the round-tripping of a sample file containing ROIs with Transforms. Importing such an image into an OMERO server with this PR included should add a row the `AffineTransform` table. Exporting the image into an OME-TIFF should also preserve the Shape Transform.
