### PR TITLE
TIFF writing tests: define non-zero default percentages

### DIFF
--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -12,6 +12,8 @@ Type "ant -p" for a list of targets.
   <property name="root.dir" location="../.."/>
   <import file="${root.dir}/ant/java.xml"/>
   <property file="build.properties"/>
+  <property name="testng.runWriterSaveBytesTests" value="50"/>
+  <property name="testng.runWriterTilingTests" value="2"/>
 
   <target name="test" depends="jar,compile-tests,test-long-running,
       test-no-ome-xml,test-no-lurawave,test-no-jai,test-no-exif,
@@ -28,7 +30,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <sysproperty key="testng.runWriterTilingTests" value="${testng.runWriterTilingTests}"/>
-    	<sysproperty key="testng.runWriterSaveBytesTests" value="${testng.runWriterSaveBytesTests}"/>
+      <sysproperty key="testng.runWriterSaveBytesTests" value="${testng.runWriterSaveBytesTests}"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-Dlurawave.license=XXX"/>
     </testng>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -164,6 +164,10 @@
           <additionalClasspathElements>
             <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
           </additionalClasspathElements>
+          <systemPropertyVariables>
+            <testng.runWriterSaveBytesTests>50</testng.runWriterSaveBytesTests>
+            <testng.runWriterTilingTests>2</testng.runWriterTilingTests>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -125,7 +125,7 @@ public class TiffWriterTest {
   
   @DataProvider(name = "nonTiling")
   public Object[][] createNonTiling() {
-    if (percentageOfTilingTests == 0) {
+    if (percentageOfSaveBytesTests == 0) {
       return new Object[][] {{0, false, false, 0, 0, 0, null, 0}};
     }
     int[] tileSizes = {PLANE_WIDTH};


### PR DESCRIPTION
See https://trello.com/c/WZkp5y0e/9-increase-default-percentage-of-writing-tests

- the first commit fixes a bug found when running only non-tiling tests. Without this PR `{ant,mvn} test -Dtestng.runWriterSaveBytesTests=100 -Dtestng.runWriterTilingTests=0` should fail. With 209b3ca, the non-tiling tests should be configured using the correct variable and tests should run as expected.
- the second commit sets non-zero default values for the percentage of tiling and non-tiling tests. With this commit, a subset of the the TIFF writing tests should always be executed when running the default command.

To test this PR:

- check the Travis and Jenkins builds remain green and that  `{mvn,ant} test` includes tiling and non-tiling TIFF writing tests
- check the number of Formats BSD unit tests in [BIOFORMATS-DEV-merge-build](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-build/) is unchanged as the properties are overriden via the job configuration
- check the logic for setting the percentage of tiling/non-tiling tests via  `{mvn,ant} test -Dtestng.runWriterSaveBytesTest=xxx -Dtestng.runWriterTilingTests=yyy` remains functional