### PR TITLE
Improvision TIFF: read channel colors, if present

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -39,6 +39,7 @@ import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.TiffParser;
 
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.PositiveFloat;
 
 import ome.units.quantity.Length;
@@ -57,6 +58,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
 
   // -- Fields --
 
+  private ArrayList<Color> channelColors = new ArrayList<Color>();
   private String[] cNames;
   private int pixelSizeT;
   private double pixelSizeX, pixelSizeY, pixelSizeZ;
@@ -101,6 +103,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
       readers = null;
       files = null;
       lastFile = 0;
+      channelColors.clear();
     }
   }
 
@@ -162,31 +165,57 @@ public class ImprovisionTiffReader extends BaseTiffReader {
 
     put("Improvision", "yes");
 
-    // parse key/value pairs in the comment
-    String comment = ifds.get(0).getComment();
+    // parse key/value pairs in the comments
+    String[] comments = new String[ifds.size()];
     String tz = null, tc = null, tt = null;
-    if (comment != null) {
-      String[] lines = comment.split("\n");
-      for (String line : lines) {
-        int equals = line.indexOf('=');
-        if (equals < 0) continue;
-        String key = line.substring(0, equals);
-        String value = line.substring(equals + 1);
-        addGlobalMeta(key, value);
-        if (key.equals("TotalZPlanes")) tz = value;
-        else if (key.equals("TotalChannels")) tc = value;
-        else if (key.equals("TotalTimepoints")) tt = value;
-        else if (key.equals("XCalibrationMicrons")) {
-          pixelSizeX = DataTools.parseDouble(value);
+    for (int plane=0; plane<ifds.size(); plane++) {
+      String comment = ifds.get(plane).getComment();
+      comments[plane] = comment;
+      if (comment != null) {
+        String[] lines = comment.split("\n");
+        for (String line : lines) {
+          int equals = line.indexOf('=');
+          if (equals < 0) continue;
+          String key = line.substring(0, equals);
+          String value = line.substring(equals + 1);
+          addGlobalMeta(key, value);
+          if (key.equals("TotalZPlanes")) tz = value;
+          else if (key.equals("TotalChannels")) tc = value;
+          else if (key.equals("TotalTimepoints")) tt = value;
+          else if (key.equals("XCalibrationMicrons")) {
+            pixelSizeX = DataTools.parseDouble(value);
+          }
+          else if (key.equals("YCalibrationMicrons")) {
+            pixelSizeY = DataTools.parseDouble(value);
+          }
+          else if (key.equals("ZCalibrationMicrons")) {
+            pixelSizeZ = DataTools.parseDouble(value);
+          }
+          else if (key.equals("WhiteColour")) {
+            String[] rgb = value.split(",");
+            if (rgb.length < 3) {
+              continue;
+            }
+            int red = 255;
+            try {
+              red = Integer.parseInt(rgb[0]);
+            }
+            catch (NumberFormatException e) { }
+            int green = 255;
+            try {
+              green = Integer.parseInt(rgb[1]);
+            }
+            catch (NumberFormatException e) { }
+            int blue = 255;
+            try {
+              blue = Integer.parseInt(rgb[2]);
+            }
+            catch (NumberFormatException e) { }
+            channelColors.add(new Color(red, green, blue, 255));
+          }
         }
-        else if (key.equals("YCalibrationMicrons")) {
-          pixelSizeY = DataTools.parseDouble(value);
-        }
-        else if (key.equals("ZCalibrationMicrons")) {
-          pixelSizeZ = DataTools.parseDouble(value);
-        }
+        metadata.remove("Comment");
       }
-      metadata.remove("Comment");
     }
 
     CoreMetadata m = core.get(0);
@@ -215,7 +244,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
 
     for (int i=0; i<ifds.size(); i++) {
       Arrays.fill(coords[i], -1);
-      comment = ifds.get(i).getComment();
+      String comment = comments[i];
       // TODO : can use loci.common.IniParser to parse the comments
       comment = comment.replaceAll("\r\n", "\n");
       comment = comment.replaceAll("\r", "\n");
@@ -355,6 +384,10 @@ public class ImprovisionTiffReader extends BaseTiffReader {
       for (int i=0; i<getEffectiveSizeC(); i++) {
         if (cNames != null && i < cNames.length) {
           store.setChannelName(cNames[i], 0, i);
+        }
+        int index = getIndex(0, i, 0);
+        if (index < channelColors.size()) {
+          store.setChannelColor(channelColors.get(index), 0, i);
         }
       }
       store.setImageDescription("", 0);

--- a/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImprovisionTiffReader.java
@@ -194,6 +194,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
           else if (key.equals("WhiteColour")) {
             String[] rgb = value.split(",");
             if (rgb.length < 3) {
+              channelColors.add(null);
               continue;
             }
             int red = 255;
@@ -386,7 +387,7 @@ public class ImprovisionTiffReader extends BaseTiffReader {
           store.setChannelName(cNames[i], 0, i);
         }
         int index = getIndex(0, i, 0);
-        if (index < channelColors.size()) {
+        if (index < channelColors.size() && channelColors.get(index) != null) {
           store.setChannelColor(channelColors.get(index), 0, i);
         }
       }


### PR DESCRIPTION
To test, use ```data_repo/curated/improvision/karsten/Spiro.tiff``` and ```data_repo/curated/improvision/Vessels 32-bit Col.tif```.

Without this PR, ```showinf -nopix -omexml``` on each file should show that the ```Color``` attribute on ```Channel``` is not set.  With this PR, the same test should show a valid ```Color``` set for each ```Channel```.  ```Vessels 32-bit Col.tif``` should have a single channel set to ```-1``` (white), as it is an RGB image.  ```Spiro.tiff``` should have colors that match the channel names (```green``` and ```pink```); this can be confirmed by opening in ImageJ with the color mode set to ```Colorized```.

I would expect automated tests to be unaffected by this change.  