### PR TITLE
TiffWriter - Exception when writing bigTiff multi series

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -484,7 +484,8 @@ public class TiffWriter extends FormatWriter {
           tiffParserStream.close();
         }
       }
-    } else {
+    }
+    else {
       saveBytes(no, buf, ifd, x, y, w, h);
     }
   }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -476,6 +476,7 @@ public class TiffWriter extends FormatWriter {
         if (no < ifdOffsets.length) {
           ifd = parser.getIFD(ifdOffsets[no]);
         }
+        saveBytes(no, buf, ifd, x, y, w, h);
       }
       finally {
         RandomAccessInputStream tiffParserStream = parser.getStream();
@@ -484,8 +485,6 @@ public class TiffWriter extends FormatWriter {
         }
       }
     }
-
-    saveBytes(no, buf, ifd, x, y, w, h);
   }
 
   /* @see loci.formats.IFormatWriter#canDoStacks(String) */

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -485,6 +485,9 @@ public class TiffWriter extends FormatWriter {
         }
       }
     }
+    else {
+      saveBytes(no, buf, ifd, x, y, w, h);
+    }
   }
 
   /* @see loci.formats.IFormatWriter#canDoStacks(String) */

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -484,8 +484,7 @@ public class TiffWriter extends FormatWriter {
           tiffParserStream.close();
         }
       }
-    }
-    else {
+    } else {
       saveBytes(no, buf, ifd, x, y, w, h);
     }
   }

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -420,8 +420,8 @@ public class TiffSaver {
     boolean interleaved = ifd.getPlanarConfiguration() == 1;
     boolean isTiled = ifd.isTiled();
 
-    if (!sequentialWrite) {
-      RandomAccessInputStream in = null;
+    RandomAccessInputStream in = null;
+    if (!sequentialWrite) {   
       if (filename != null) {
         in = new RandomAccessInputStream(filename);
       }
@@ -432,19 +432,14 @@ public class TiffSaver {
         throw new IllegalArgumentException(
             "Filename and bytes are null, cannot create new input stream!");
       }
-      try {
-        TiffParser parser = new TiffParser(in);
-        long[] ifdOffsets = parser.getIFDOffsets();
-        LOGGER.debug("IFD offsets: {}", Arrays.toString(ifdOffsets));
-        if (no < ifdOffsets.length) {
-          out.seek(ifdOffsets[no]);
-          LOGGER.debug("Reading IFD from {} in non-sequential write.",
-              ifdOffsets[no]);
-          ifd = parser.getIFD(ifdOffsets[no]);
-        }
-      }
-      finally {
-        in.close();
+      TiffParser parser = new TiffParser(in);
+      long[] ifdOffsets = parser.getIFDOffsets();
+      LOGGER.debug("IFD offsets: {}", Arrays.toString(ifdOffsets));
+      if (no < ifdOffsets.length) {
+        out.seek(ifdOffsets[no]);
+        LOGGER.debug("Reading IFD from {} in non-sequential write.",
+            ifdOffsets[no]);
+        ifd = parser.getIFD(ifdOffsets[no]);
       }
     }
 
@@ -496,6 +491,9 @@ public class TiffSaver {
     else {
       ifd.putIFDValue(IFD.STRIP_BYTE_COUNTS, toPrimitiveArray(byteCounts));
       ifd.putIFDValue(IFD.STRIP_OFFSETS, toPrimitiveArray(offsets));
+    }
+    if (in != null) {
+      in.close();
     }
 
     long fp = out.getFilePointer();

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -112,7 +112,7 @@ public class TiffWriterTest {
   @DataProvider(name = "tiling")
   public Object[][] createTiling() {
     if (percentageOfTilingTests == 0) {
-      return new Object[][] {{0, false, false, 0, 0, 0, null, 0}};
+      return new Object[][] {{0, false, false, 0, 0, 0, null, 0, false}};
     }
 
     int[] tileSizes = {1, 32, 43, 64};
@@ -126,7 +126,7 @@ public class TiffWriterTest {
   @DataProvider(name = "nonTiling")
   public Object[][] createNonTiling() {
     if (percentageOfSaveBytesTests == 0) {
-      return new Object[][] {{0, false, false, 0, 0, 0, null, 0}};
+      return new Object[][] {{0, false, false, 0, 0, 0, null, 0, false}};
     }
     int[] tileSizes = {PLANE_WIDTH};
     int[] channelCounts = {1, 3};
@@ -139,7 +139,7 @@ public class TiffWriterTest {
   private Object[][] getData(int[] tileSizes, int[] channelCounts, int[] seriesCounts, int[] timeCounts, String[] compressions) {
     boolean[] booleanValues = {true, false};
     int compressionPixelTypeSizes = (2 * pixelTypesOther.length) + pixelTypesOther.length - 1 + pixelTypesJ2K.length + 2;
-    int paramSize = tileSizes.length * compressionPixelTypeSizes * 4 * channelCounts.length * seriesCounts.length * timeCounts.length;
+    int paramSize = tileSizes.length * compressionPixelTypeSizes * 8 * channelCounts.length * seriesCounts.length * timeCounts.length;
     Object[][] data = new Object[paramSize][];
     int index = 0;
     for (int tileSize : tileSizes) {
@@ -148,28 +148,30 @@ public class TiffWriterTest {
           for (int channelCount : channelCounts) {
             for (int seriesCount : seriesCounts) {
               for (int timeCount : timeCounts) {
-                for (String compression : compressions) {
-                  int[] pixelTypes = pixelTypesOther;
-                  if (compression.equals(COMPRESSION_J2K)) {
-                    pixelTypes = pixelTypesJ2K;
-                  }
-                  if (compression.equals(COMPRESSION_J2K_LOSSY)) {
-                    // Should also allow for double but JPEG 2K compression codec throws null pointer for 64 bitsPerSample
-                    pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16,
-                        FormatTools.UINT16, FormatTools.INT32, FormatTools.UINT32, FormatTools.FLOAT};
-                  }
-                  else if (compression.equals(COMPRESSION_JPEG)) {
-                    // Should be using pixelTypesJPEG however JPEGCodec throws exception: > 8 bit data cannot be compressed with JPEG
-                    pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8};
-                  }
-                  for (int pixelType : pixelTypes) {
-                    if (FormatTools.getBytesPerPixel(pixelType) > 2 &&
-                        (compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY))) {
-                      data[index] = new Object[] {tileSize, endianness, false, channelCount, seriesCount, timeCount, compression, pixelType};
-                    } else {
-                      data[index] = new Object[] {tileSize, endianness, interleaved, channelCount, seriesCount, timeCount, compression, pixelType};
+                for (Boolean bigTiff : booleanValues) {
+                  for (String compression : compressions) {
+                    int[] pixelTypes = pixelTypesOther;
+                    if (compression.equals(COMPRESSION_J2K)) {
+                      pixelTypes = pixelTypesJ2K;
                     }
-                    index ++;
+                    if (compression.equals(COMPRESSION_J2K_LOSSY)) {
+                      // Should also allow for double but JPEG 2K compression codec throws null pointer for 64 bitsPerSample
+                      pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8, FormatTools.INT16,
+                          FormatTools.UINT16, FormatTools.INT32, FormatTools.UINT32, FormatTools.FLOAT};
+                    }
+                    else if (compression.equals(COMPRESSION_JPEG)) {
+                      // Should be using pixelTypesJPEG however JPEGCodec throws exception: > 8 bit data cannot be compressed with JPEG
+                      pixelTypes = new int[] {FormatTools.INT8, FormatTools.UINT8};
+                    }
+                    for (int pixelType : pixelTypes) {
+                      if (FormatTools.getBytesPerPixel(pixelType) > 2 &&
+                          (compression.equals(COMPRESSION_J2K) || compression.equals(COMPRESSION_J2K_LOSSY))) {
+                        data[index] = new Object[] {tileSize, endianness, false, channelCount, seriesCount, timeCount, compression, pixelType, bigTiff};
+                      } else {
+                        data[index] = new Object[] {tileSize, endianness, interleaved, channelCount, seriesCount, timeCount, compression, pixelType, bigTiff};
+                      }
+                      index ++;
+                    }
                   }
                 }
               }
@@ -496,12 +498,12 @@ public class TiffWriterTest {
 
   @Test(dataProvider = "tiling")
   public void testSaveBytesTiling(int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
-      int seriesCount, int sizeT, String compression, int pixelType) throws Exception {
+      int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfTilingTests == 0) return;
 
     File tmp = File.createTempFile("tiffWriterTest_Tiling", ".tiff");
     tmp.deleteOnExit();
-    Plane originalPlane = writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType);
+    Plane originalPlane = writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
     TiffReader reader = new TiffReader();
     reader.setId(tmp.getAbsolutePath());
@@ -526,12 +528,12 @@ public class TiffWriterTest {
 
   @Test(dataProvider = "nonTiling")
   public void testSaveBytes(int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
-      int seriesCount, int sizeT, String compression, int pixelType) throws Exception {
+      int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     if (percentageOfSaveBytesTests == 0) return;
 
     File tmp = File.createTempFile("tiffWriterTest", ".tiff");
     tmp.deleteOnExit();
-    Plane originalPlane = writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType);
+    Plane originalPlane = writeImage(tmp, tileSize, littleEndian, interleaved, rgbChannels, seriesCount, sizeT, compression, pixelType, bigTiff);
 
     TiffReader reader = new TiffReader();
     reader.setId(tmp.getAbsolutePath());
@@ -543,12 +545,13 @@ public class TiffWriterTest {
   }
 
   private Plane writeImage(File file, int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
-      int seriesCount, int sizeT, String compression, int pixelType) throws Exception {
+      int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     TiffWriter writer = new TiffWriter();
     String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
     writer.setMetadataRetrieve(createMetadata(pixelTypeString, rgbChannels, seriesCount, littleEndian, sizeT));
     writer.setCompression(compression);
     writer.setInterleaved(interleaved);
+    writer.setBigTiff(bigTiff);
     if (tileSize != PLANE_WIDTH) {
       writer.setTileSizeX(tileSize);
       writer.setTileSizeY(tileSize);


### PR DESCRIPTION
An issue was reported during the testing of Bio-Formats 5.3.0 tile writing that errors were encountered when using bigTiff. 

The unit test additions here show that an Exception was indeed being thrown when writing multi series bigTiff images. In fact the same issues can be seen when writing tiles or using the standard TiffWriter. The unit test currently does not write multi series for non tiled scenarios but this can easily be modified to  add that option if required.

**The error:**
The error that was being seen was a NullPointerException when calling saveBytes (without an IFD) and could occur when attempting to read any of the following tags from the IFD when writing the image: STRIP_OFFSETS, IFD.TILE_OFFSETS, IFD.STRIP_BYTE_COUNTS, IFD.TILE_BYTE_COUNTS

**Details of what is happening:**
When calling saveBytes without an IFD provided, TiffParser is used to generate one before calling saveBytes with this IFD. These tags all appear to be correctly present on the IFD and have an associated value. When the value is parsed it is of type OnDemandLongArray. The original type of these tags is primitive long array, but when TiffWriter generates the initial IFD by parsing the file it creates a type OnDemandLongArray. 

The OnDemandLongArray uses an input stream to the current file to read the values. In this case the stream relates to the file being written and was opened during the initial call to saveBytes in order to generate the IFD. As this stream is then closed during this original call, the result is that the IFD contains an OnDemandLongArray which has a RandomAccessInputStream with a null stream which has been closed.

The fix put in place is a rather simple high level solution of keeping the underlying implementation of using OnDemandLongArray as is, but keeping the input stream open and valid during the full saveBytes operation. There are other possible solutions to this at a lower level which could also be open for consideration if this is not seen as suitable (such as populating the IFD with a primitive array, or recognising the closed stream and reopening it).

**To reproduce:**
-  Apply the changes to TiffWriterTest unit test without the TiffWriter change https://github.com/openmicroscopy/bioformats/commit/9bcfae73290f24d9c6803749fd4608f7b9a86cd3
- Set the runWriterTilingTests parameter to run the full suite using -Dtestng.runWriterTilingTests=100
- Run the tests and verify that you can observe 1024 test failures, all should be when bigTiff parameter is set to true.

**Testing:**
- Ensure builds are green and unit tests are all passing
- Set the parameters to run the full suite using -Dtestng.runWriterTilingTests=100 and -Dtestng.runWriterSaveBytesTests=100
- Apply the PR and ensure that the TiffWriterTest unit test now passes fully
