### PR TITLE
Also copy the version history file as NEWS.rst into the MATLAB bundle

### DIFF
--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -59,6 +59,8 @@ Type "ant -p" for a list of targets.
       <zipfileset dir="${root.dir}/components/formats-gpl/matlab"
         includes="**/*" prefix="bfmatlab"/>
       <zipfileset file="${artifact.dir}/${bundle.jar}" prefix="bfmatlab"/>
+      <zipfileset file="${root.dir}/docs/sphinx/about/whats-new.txt"
+        fullpath="bfmatlab/NEWS.rst"/>
     </zip>
   </target>
 </project>


### PR DESCRIPTION
See https://trello.com/c/IFSFT27n/10-add-news-to-all-archives and https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8188

This addition should mirror the packaging of the Octave and command-line tools bundles by adding the Bio-Formats version history file as a NEWS. This should allow to simplify the identification of the toolbox version without using the API until we suffix the package name with a version number.

To test this PR, check all CI jobs remain green especially the ones testing MATLAB and that the bfmatlab.zip bundle now includes a NEWS.rst file with the version history.