### PR TITLE
Add minimal framework for testing the command line tools via TestNG

### DIFF
--- a/components/bio-formats-tools/build.xml
+++ b/components/bio-formats-tools/build.xml
@@ -16,7 +16,6 @@ Type "ant -p" for a list of targets.
     <testng failureProperty="failedTest">
       <classpath refid="test.classpath"/>
       <classpath>
-        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
       </classpath>

--- a/components/bio-formats-tools/build.xml
+++ b/components/bio-formats-tools/build.xml
@@ -12,4 +12,17 @@ Type "ant -p" for a list of targets.
   <import file="${root.dir}/ant/java.xml"/>
   <property file="build.properties"/>
 
+  <target name="test" depends="jar, compile-tests" description="run tests">
+    <testng failureProperty="failedTest">
+      <classpath refid="test.classpath"/>
+      <classpath>
+        <pathelement location="${root.dir}/ant/"/><!-- logback.xml -->
+        <pathelement location="${test-classes.dir}"/>
+        <pathelement location="${classes.dir}"/>
+      </classpath>
+      <xmlfileset file="${tests.dir}/testng.xml"/>
+      <jvmarg value="-mx${testng.memory}"/>
+    </testng>
+    <fail if="failedTest"/>
+  </target>
 </project>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -100,11 +100,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <additionalClasspathElements>
-              <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
-          </additionalClasspathElements>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -84,6 +84,12 @@
       <version>2.7.2</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>
@@ -92,6 +98,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <additionalClasspathElements>
+              <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
+          </additionalClasspathElements>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -196,7 +196,7 @@ public final class ImageConverter {
           catch (NumberFormatException e) { }
         }
         else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
-          LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
+          System.out.println("Found unknown command flag: " + args[i] + "; exiting.");
           return false;
         }
       }

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -196,7 +196,7 @@ public final class ImageConverter {
           catch (NumberFormatException e) { }
         }
         else if (!args[i].equals(CommandLineTools.NO_UPGRADE_CHECK)) {
-          System.out.println("Found unknown command flag: " + args[i] + "; exiting.");
+          LOGGER.error("Found unknown command flag: {}; exiting.", args[i]);
           return false;
         }
       }

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -84,7 +84,7 @@ public class ImageConverterTest {
   }
 
   @BeforeClass
-  public void setUp1() {
+  public void setUp() {
     oldSecurityManager = System.getSecurityManager();
     oldOut = System.out;
     oldErr = System.err;

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -148,7 +148,9 @@ public class ImageConverterTest {
       ImageConverter.main(args);
     } catch (ExitException e) {
       assertEquals(e.status, 1);
-      assertEquals("Found unknown command flag: -foo; exiting.\n", outContent.toString());
+      assertEquals(
+        "Found unknown command flag: -foo; exiting." +
+        System.getProperty("line.separator"), outContent.toString());
     }
   }
 }

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -57,6 +57,9 @@ import static org.testng.Assert.assertTrue;
 public class ImageConverterTest {
 
   private File outFile;
+  private SecurityManager oldSecurityManager;
+  private PrintStream oldOut;
+  private PrintStream oldErr;
   private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
   private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
@@ -83,6 +86,9 @@ public class ImageConverterTest {
 
   @BeforeMethod
   public void setUp() {
+    oldSecurityManager = System.getSecurityManager();
+    oldOut = System.out;
+    oldErr = System.err;
     System.setOut(new PrintStream(outContent));
     System.setErr(new PrintStream(errContent));
     System.setSecurityManager(new NoExitSecurityManager());
@@ -90,9 +96,9 @@ public class ImageConverterTest {
 
   @AfterMethod
   public void tearDown() {
-    System.setOut(null);
-    System.setErr(null);
-    System.setSecurityManager(null);
+    System.setOut(oldOut);
+    System.setErr(oldErr);
+    System.setSecurityManager(oldSecurityManager);
   }
 
   @DataProvider(name = "suffixes")

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -1,0 +1,128 @@
+/*
+ * #%L
+ * Bio-Formats command line tools for reading and converting files
+ * %%
+ * Copyright (C) 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.tools;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.Permission;
+
+import loci.formats.IFormatReader;
+import loci.formats.ImageReader;
+import loci.formats.ImageWriter;
+import loci.formats.FormatException;
+import loci.formats.tools.ImageConverter;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests the functionality of ImageConverter
+ */
+public class ImageConverterTest {
+
+  private File outFile;
+
+  protected static class ExitException extends SecurityException {
+    public final int status;
+    public ExitException(int status) {
+      this.status = status;
+    }
+  }
+
+  private static class NoExitSecurityManager extends SecurityManager {
+    @Override
+    public void checkPermission(Permission perm) {}
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {}
+
+    @Override
+    public void checkExit(int status) {
+      super.checkExit(status);
+      throw new ExitException(status);
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    System.setSecurityManager(new NoExitSecurityManager());
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    System.setSecurityManager(null);
+  }
+
+  @DataProvider(name = "suffixes")
+  public Object[][] createSuffixes() {
+    return new Object[][] {{".ome.tiff"}, {".tif"}, {".ics"}};
+  }
+
+  public void checkImage() throws FormatException, IOException {
+    IFormatReader r = new ImageReader();
+    r.setId(outFile.getAbsolutePath());
+    assertEquals(r.getSizeX(), 512);
+    r.close();
+  }
+
+  @Test(dataProvider = "suffixes")
+  public void testDefault(String suffix) throws FormatException, IOException {
+    outFile = File.createTempFile("test", suffix);
+    outFile.delete();
+    String[] args = {"test.fake", outFile.getAbsolutePath()};
+    try {
+      ImageConverter.main(args);
+    } catch (ExitException e) {
+      outFile.deleteOnExit();
+      assertEquals(e.status, 0);
+      checkImage();
+    }
+  }
+
+  @Test(dataProvider = "suffixes")
+  public void testOverwrite(String suffix) throws FormatException, IOException {
+    outFile = File.createTempFile("test", suffix);
+    String[] args = {"-overwrite", "test.fake", outFile.getAbsolutePath()};
+    try {
+      ImageConverter.main(args);
+    } catch (ExitException e) {
+      outFile.deleteOnExit();
+      assertEquals(e.status, 0);
+      checkImage();
+    }
+  }
+}

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -44,7 +44,8 @@ import loci.formats.ImageWriter;
 import loci.formats.FormatException;
 import loci.formats.tools.ImageConverter;
 
-import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -60,8 +61,6 @@ public class ImageConverterTest {
   private SecurityManager oldSecurityManager;
   private PrintStream oldOut;
   private PrintStream oldErr;
-  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 
   protected static class ExitException extends SecurityException {
     public final int status;
@@ -84,17 +83,15 @@ public class ImageConverterTest {
     }
   }
 
-  @BeforeMethod
-  public void setUp() {
+  @BeforeClass
+  public void setUp1() {
     oldSecurityManager = System.getSecurityManager();
     oldOut = System.out;
     oldErr = System.err;
-    System.setOut(new PrintStream(outContent));
-    System.setErr(new PrintStream(errContent));
     System.setSecurityManager(new NoExitSecurityManager());
   }
 
-  @AfterMethod
+  @AfterClass
   public void tearDown() {
     System.setOut(oldOut);
     System.setErr(oldErr);
@@ -142,6 +139,8 @@ public class ImageConverterTest {
 
   @Test
   public void testBadArgument() throws FormatException, IOException {
+    ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(outContent));
     outFile = File.createTempFile("test", "ome.tif");
     outFile.deleteOnExit();
     String[] args = {"-foo", "test.fake", outFile.getAbsolutePath()};

--- a/components/bio-formats-tools/test/testng.xml
+++ b/components/bio-formats-tools/test/testng.xml
@@ -1,0 +1,39 @@
+<!--
+  #%L
+  Bio-Formats command line tools for reading and converting files
+  %%
+  Copyright (C) 2017 Open Microscopy Environment:
+    - Board of Regents of the University of Wisconsin-Madison
+    - Glencoe Software, Inc.
+    - University of Dundee
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
+<suite name="Bio-Formats Tools Tests">
+  <test name="ImageConverterTest">
+    <classes>
+      <class name="loci.formats.tools.ImageConverterTest"/>
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/10517

## Current status

Although widely used in our daily usage and y the community, we currently lack test coverage of our Bio-Formats command-line tools. This usually implies that some combinations of options are rarely if not never tested and might be subject to regression when proposing fixes or functionalities.

## Proposal

This commit declares `org.testng` as a dependency of the `bio-formats-tools` module like the other components and provides a first test class for `ImageConverter`. As command-line tools classes have private constructors and use `System.exit()`, the security manager is overriden at set up and restored at teardown while individual methods invoke `ImageConverter.main() `directly.

## Impact and limitations

The expected outcome of this proposal is to start adding unit tests for every modification of the command line utility classes. One aspect not covered by this framework are the bash and bat scripts and the set of options used for executing the utility functions. The packaging of the JVM call might require a separate testing step. For now, limiting this testing to to the standard daily/release testing procedure might suffice as the largest number of bugs arise from the Java classes themselves.

## Testing

Primarily, check that the new tests are executed and passing using both build systems and the various continuous integration platforms. As a complete proof of concept, it might be possible to use an existing utility bug (e.g. https://trello.com/c/6e2x7HMe/14-nd2-to-tiff-conversion-error) and write a corresponding failing unit test.

/cc @dgault @melissalinkert 

## References 

http://stackoverflow.com/questions/309396/java-how-to-test-methods-that-call-system-exit