### PR TITLE
Bug fix and update default test percentages for TiffWriterTest

### DIFF
--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -12,7 +12,7 @@ Type "ant -p" for a list of targets.
   <property name="root.dir" location="../.."/>
   <import file="${root.dir}/ant/java.xml"/>
   <property file="build.properties"/>
-  <property name="testng.runWriterSaveBytesTests" value="50"/>
+  <property name="testng.runWriterSaveBytesTests" value="2"/>
   <property name="testng.runWriterTilingTests" value="2"/>
 
   <target name="test" depends="jar,compile-tests,test-long-running,

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -165,7 +165,7 @@
             <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
           </additionalClasspathElements>
           <systemPropertyVariables>
-            <testng.runWriterSaveBytesTests>50</testng.runWriterSaveBytesTests>
+            <testng.runWriterSaveBytesTests>2</testng.runWriterSaveBytesTests>
             <testng.runWriterTilingTests>2</testng.runWriterTilingTests>
           </systemPropertyVariables>
         </configuration>

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -120,7 +120,7 @@ public class TiffWriterTest {
     int[] seriesCounts = {1, 5};
     int[] timeCounts = {1};
     String[] compressions = {COMPRESSION_UNCOMPRESSED, COMPRESSION_LZW, COMPRESSION_J2K, COMPRESSION_J2K_LOSSY, COMPRESSION_JPEG};
-    return getData(tileSizes, channelCounts, seriesCounts, timeCounts, compressions);
+    return getData(tileSizes, channelCounts, seriesCounts, timeCounts, compressions, percentageOfTilingTests);
   }
   
   @DataProvider(name = "nonTiling")
@@ -133,10 +133,10 @@ public class TiffWriterTest {
     int[] seriesCounts = {1};
     int[] timeCounts = {1, 5};
     String[] compressions = {COMPRESSION_UNCOMPRESSED, COMPRESSION_LZW, COMPRESSION_J2K, COMPRESSION_J2K_LOSSY, COMPRESSION_JPEG};
-    return getData(tileSizes, channelCounts, seriesCounts, timeCounts, compressions);
+    return getData(tileSizes, channelCounts, seriesCounts, timeCounts, compressions, percentageOfSaveBytesTests);
   }
 
-  private Object[][] getData(int[] tileSizes, int[] channelCounts, int[] seriesCounts, int[] timeCounts, String[] compressions) {
+  private Object[][] getData(int[] tileSizes, int[] channelCounts, int[] seriesCounts, int[] timeCounts, String[] compressions, int percentage) {
     boolean[] booleanValues = {true, false};
     int compressionPixelTypeSizes = (2 * pixelTypesOther.length) + pixelTypesOther.length - 1 + pixelTypesJ2K.length + 2;
     int paramSize = tileSizes.length * compressionPixelTypeSizes * 4 * channelCounts.length * seriesCounts.length * timeCounts.length;
@@ -180,8 +180,8 @@ public class TiffWriterTest {
     }
 
     // Return a subset of tests if a percentage is selected
-    if (percentageOfTilingTests > 0 && percentageOfTilingTests < 100) {
-      int numTests = (paramSize / 100) * percentageOfTilingTests;
+    if (percentage > 0 && percentage < 100) {
+      int numTests = (paramSize / 100) * percentage;
       Object[][] returnSubset = new Object[numTests][];
       for (int i = 0; i < numTests; i++) {
         Random rand = new Random();


### PR DESCRIPTION
This is a follow up to https://github.com/openmicroscopy/bioformats/pull/2717

There was a bug when attempting to set the 2 test properties (percentageOfTilingTests and percentageOfSaveBytesTests) individually. The value of percentageOfTilingTests was always using the correct setting. For percentageOfSaveBytesTests, if it was set to 0 then it would use the correct setting, otherwise it was using the value from percentageOfTilingTests.

This fix allows percentageOfSaveBytesTests to be set correctly independent of percentageOfTilingTests.

The second commit updates the default number of tests run, this should mean that the Travis unit tests or default ant and maven unit tests will not time out.

To test:
- Run the unit tests with -Dtestng.runWriterTilingTests=100 and -Dtestng.runWriterSaveBytesTests=10
- verify that only 10% of the saveBytes tests are run and the full tiling set is run
- Run the unit tests with -Dtestng.runWriterTilingTests=10 and -Dtestng.runWriterSaveBytesTests=100
- verify that only 10% of the tiling tests are run and the full saveBytes set is run

Note: saveBytes has 512 tests in its full run. saveBytesTiling has 2048 in its full run