### PR TITLE
Correct order of frames for tilescan with timeseries

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -150,6 +150,7 @@ public class LIFReader extends FormatReader {
   private double[] acquiredDate;
 
   private int[] tileCount;
+  private long[] tileBytesInc;
   private long endPointer;
 
   // -- Constructor --
@@ -316,21 +317,13 @@ public class LIFReader extends FormatReader {
       return buf;
     }
 
-    in.seek(offset + planeSize * no);
-
-    int tile = series;
-    for (int i=0; i<index; i++) {
-      tile -= tileCount[i];
-    }
-
-    // seek instead of skipBytes to prevent dangerous int cast
-    in.seek(in.getFilePointer() + tile * planeSize * getImageCount());
-    in.skipBytes(bytesToSkip * getSizeY() * no);
+    seekStartOfPlane(no, offset, planeSize);
 
     if (bytesToSkip == 0) {
       readPlane(in, x, y, w, h, buf);
     }
     else {
+      in.skipBytes(bytesToSkip * getSizeY() * no);
       in.skipBytes(y * (getSizeX() * bpp + bytesToSkip));
       for (int row=0; row<h; row++) {
         in.skipBytes(x * bpp);
@@ -345,6 +338,44 @@ public class LIFReader extends FormatReader {
     }
 
     return buf;
+  }
+  
+  private void seekStartOfPlane(int no, long dataOffset, long planeSize)
+    throws IOException
+  {
+    int index = getTileIndex(series);
+    long posInFile;
+
+    int numberOfTiles = tileCount[index];
+    if (numberOfTiles > 1) {
+      // LAS AF treats tiles just like any other dimension, while we do not.
+      // Hence we need to take the tiles into account for a frame's position.
+      long bytesIncPerTile = tileBytesInc[index];
+      long framesPerTile = bytesIncPerTile / planeSize;
+
+      if (framesPerTile > Integer.MAX_VALUE) {
+        throw new IOException("Could not read frame due to int overflow");
+      }
+
+      int noOutsideTiles = no / (int) framesPerTile;
+      int noInsideTiles = no % (int) framesPerTile;
+
+      int tile = series;
+      for (int i = 0; i < index; i++) {
+        tile -= tileCount[i];
+      }
+
+      posInFile = dataOffset;
+      posInFile += noOutsideTiles * bytesIncPerTile * numberOfTiles;
+      posInFile += tile * bytesIncPerTile;
+      posInFile += noInsideTiles * planeSize;
+    }
+    else {
+      posInFile = dataOffset + no * planeSize;
+    }
+    
+    // seek instead of skipBytes to prevent dangerous int cast
+    in.seek(posInFile);
   }
 
   /* @see loci.formats.IFormatReader#close(boolean) */
@@ -381,6 +412,7 @@ public class LIFReader extends FormatReader {
       acquiredDate = null;
       detectorIndexes = null;
       tileCount = null;
+      tileBytesInc = null;
       fieldPosX.clear();
       fieldPosY.clear();
       endPointer = 0;
@@ -1049,6 +1081,7 @@ public class LIFReader extends FormatReader {
 
     tileCount = new int[imageNodes.size()];
     Arrays.fill(tileCount, 1);
+    tileBytesInc = new long[imageNodes.size()];
     core = new ArrayList<CoreMetadata>(imageNodes.size());
     acquiredDate = new double[imageNodes.size()];
     descriptions = new String[imageNodes.size()];
@@ -1988,6 +2021,7 @@ public class LIFReader extends FormatReader {
           break;
         case 10: // tile axis
           tileCount[i] *= len;
+          tileBytesInc[i] = nBytes;
           break;
         default:
           extras *= len;


### PR DESCRIPTION
We previously assumed tiles are always the outermost dimension. This is
not always the case, resulting in mixed up frames for certain scan
types.