### PR TITLE
Fix support for Metamorph TIFF plates

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -47,6 +47,7 @@ import loci.formats.tiff.TiffParser;
 
 import ome.xml.model.enums.NamingConvention;
 import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
@@ -407,8 +408,13 @@ public class MetamorphTiffReader extends BaseTiffReader {
     // effectively useless).
     if (wellCount > 1) {
       store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
+      store.setPlateRows(new PositiveInteger(1), 0);
+      store.setPlateColumns(new PositiveInteger(wellCount), 0);
       store.setPlateRowNamingConvention(NamingConvention.LETTER, 0);
       store.setPlateColumnNamingConvention(NamingConvention.NUMBER, 0);
+
+      store.setPlateAcquisitionID(
+        MetadataTools.createLSID("PlateAcquisition", 0, 0), 0, 0);
 
       for (int well=0; well<wellCount; well++) {
         store.setWellID(MetadataTools.createLSID("Well", 0, well), 0, well);
@@ -428,6 +434,7 @@ public class MetamorphTiffReader extends BaseTiffReader {
             store.setWellSampleImageRef(imageID, 0, well, field);
             store.setWellSampleIndex(
               new NonNegativeInteger(seriesIndex), 0, well, field);
+            store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, seriesIndex);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -433,6 +433,19 @@ public class MetamorphTiffReader extends BaseTiffReader {
       }
     }
 
+    final List<String> timestamps = handler.getTimestamps();
+    final List<Double> exposures = handler.getExposures();
+    if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
+      for (int i=0; i<timestamps.size(); i++) {
+        long timestamp = DateTools.getTime(timestamps.get(i), DATE_FORMAT, ".");
+        addGlobalMetaList("timestamp", timestamp);
+      }
+      for (int i=0; i<exposures.size(); i++) {
+        addGlobalMetaList("exposure time (ms)",
+          exposures.get(i).floatValue() * 1000);
+      }
+    }
+
     for (int s=0; s<seriesCount; s++) {
       setSeries(s);
       Well well = getWell(s);
@@ -452,18 +465,6 @@ public class MetamorphTiffReader extends BaseTiffReader {
       }
 
       if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-        final List<String> timestamps = handler.getTimestamps();
-        final List<Double> exposures = handler.getExposures();
-
-        for (int i=0; i<timestamps.size(); i++) {
-          long timestamp = DateTools.getTime(timestamps.get(i), DATE_FORMAT, ".");
-          addSeriesMetaList("timestamp", timestamp);
-        }
-        for (int i=0; i<exposures.size(); i++) {
-          addSeriesMetaList("exposure time (ms)",
-            exposures.get(i).floatValue() * 1000);
-        }
-
         long startDate = 0;
         if (timestamps.size() > 0) {
           startDate = DateTools.getTime(timestamps.get(0), DATE_FORMAT, ".");


### PR DESCRIPTION
This follows on from https://github.com/openmicroscopy/openmicroscopy/pull/4992 to address problems reported by @pwalczysko when working with Metamorph TIFF plates, specifically ```curated/metamorph/alessandro/Metamorph-TIFFs/```.

Without this PR, ```showinf -nopix -omexml Metamorph-TIFFs/001.tif``` should result in an ```OutOfMemoryError```.  Importing into OMERO is expected to fail similarly.  With this PR, the same ```showinf``` test should show generated OME-XML without throwing an exception or resulting in validation errors.

With this PR, importing ```Metamorph-TIFFs/001.tif``` into OMERO should result in a Plate with 2 wells.  None of the imported Images should end up under ```Orphaned Images```.  Note that a valid plate name is not present in the dataset, so ```setPlateName``` is not called on the ```MetadataStore```.  https://github.com/openmicroscopy/openmicroscopy/pull/4992 is therefore not required to test this PR, as the plate name in OMERO will be the same with or without it.
