### PR TITLE
CellWorX: fix plate name and dimensions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -440,10 +440,19 @@ public class CellWorxReader extends FormatReader {
 
     String plateID = MetadataTools.createLSID("Plate", 0);
 
-    Location plate = new Location(id).getAbsoluteFile().getParentFile();
+    Location plate = new Location(id).getAbsoluteFile();
 
     store.setPlateID(plateID, 0);
-    store.setPlateName(plate.getName(), 0);
+
+    plateName = plate.getName();
+    if (plateName.indexOf(".") > 0) {
+      plateName = plateName.substring(0, plateName.lastIndexOf("."));
+    }
+    store.setPlateName(plateName, 0);
+
+    store.setPlateRows(new PositiveInteger(wellFiles.length), 0);
+    store.setPlateColumns(new PositiveInteger(wellFiles[0].length), 0);
+
     for (int i=0; i<core.size(); i++) {
       store.setImageID(MetadataTools.createLSID("Image", i), i);
     }

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -445,8 +445,8 @@ public class CellWorxReader extends FormatReader {
     store.setPlateID(plateID, 0);
 
     plateName = plate.getName();
-    if (plateName.indexOf(".") > 0) {
-      plateName = plateName.substring(0, plateName.lastIndexOf("."));
+    if (plateName.indexOf('.') > 0) {
+      plateName = plateName.substring(0, plateName.lastIndexOf('.'));
     }
     store.setPlateName(plateName, 0);
 


### PR DESCRIPTION
This fixes the CellWorX plate naming bug reported by @pwalczysko and @dominikl in https://github.com/openmicroscopy/openmicroscopy/pull/4992#issuecomment-272880607.

The test dataset is ```data_repo/curated/cellworx/pki/SKMEL28_10K_1.HTD```.  Without this PR, ```showinf -nopix -omexml SKMEL28_10K_1.HTD``` should show OME-XML with a ```Plate``` ```Name``` set to ```pki``` (the folder containing the dataset).  No other attributes on ```Plate``` will be present apart from ```ID```.
Moving or copying the .HTD and *.pnl files to a different containing folder and repeating the test should show that the ```Plate``` ```Name``` changes to match the containing folder name.

With this PR, the same ```showinf``` test should indicate that the plate name is always ```SKMEL28_10K_1```, regardless of the containing folder name.  The ```Rows``` and ```Columns``` attributes on ```Plate``` should also be set to 8 and 12 respectively.