### PR TITLE
Leica-LIF: do not store missing timestamps in the OME metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -141,7 +141,7 @@ public class LIFReader extends FormatReader {
   private Length[] posX, posY, posZ;
   private Double[] refractiveIndex;
   private List[] cutIns, cutOuts, filterModels;
-  private double[][] timestamps;
+  private Double[][] timestamps;
   private List[] laserWavelength, laserIntensity, laserActive, laserFrap;
 
   private ROI[][] imageROIs;
@@ -948,14 +948,16 @@ public class LIFReader extends FormatReader {
         }
         store.setPlanePositionZ(posZ[index], i, image);
         if (timestamps[index] != null) {
-          double timestamp = timestamps[index][image];
-          if (timestamps[index][0] == acquiredDate[index]) {
-            timestamp -= acquiredDate[index];
+          if (timestamps[index][image] != null) {
+            double timestamp = timestamps[index][image];
+            if (timestamps[index][0] == acquiredDate[index]) {
+              timestamp -= acquiredDate[index];
+            }
+            else if (timestamp == acquiredDate[index] && image > 0) {
+              timestamp = timestamps[index][0];
+            }
+            store.setPlaneDeltaT(new Time(timestamp, UNITS.SECOND), i, image);
           }
-          else if (timestamp == acquiredDate[index] && image > 0) {
-            timestamp = timestamps[index][0];
-          }
-          store.setPlaneDeltaT(new Time(timestamp, UNITS.SECOND), i, image);
         }
 
         if (expTimes[index] != null) {
@@ -1056,7 +1058,7 @@ public class LIFReader extends FormatReader {
     laserIntensity = new List[imageNodes.size()];
     laserActive = new List[imageNodes.size()];
     laserFrap = new List[imageNodes.size()];
-    timestamps = new double[imageNodes.size()][];
+    timestamps = new Double[imageNodes.size()][];
     activeDetector = new List[imageNodes.size()];
     serialNumber = new String[imageNodes.size()];
     lensNA = new Double[imageNodes.size()];
@@ -1541,7 +1543,7 @@ public class LIFReader extends FormatReader {
     if (timeStampLists == null) return;
 
     Element timeStampList = (Element)timeStampLists.item(0);
-    timestamps[image] = new double[getImageCount()];
+    timestamps[image] = new Double[getImageCount()];
     
     // probe if timestamps are saved in the format of LAS AF 3.1 or newer
     String numberOfTimeStamps = timeStampList.getAttribute("NumberOfTimeStamps");


### PR DESCRIPTION
Follow-up of https://github.com/openmicroscopy/bioformats/pull/2728

In the case of stopped acquisition, the number of timestamps stored in the LIF file can be lower than the number of planes. With this commit, timestamps are parsed as Double rather than double and only non-null timestamps are stored in the OME metadata.

To test this PR, use the sample file from https://trac.openmicroscopy.org/ome/ticket/12793. After opening the image using the command-line tools, the ImageJ plugin or another Bio-Formats client, the planes corresponding to the Z-sections of some images should not contain any `DeltaT` attribute with this PR included (as opposed to extreme negative values without). The corresponding planes should also be blank.