### PR TITLE
Overlapped tiling example and docs

### DIFF
--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -38,7 +38,7 @@ public class ExampleSuite {
 
   public static void execute(String name, String[] args) throws Exception {
     System.out.println("Executing " + name);
-    Class c = Class.forName(name);
+    Class<?> c = Class.forName(name);
     Object passedArgs[] = {args};
     c.getMethod("main", args.getClass()).invoke(null, passedArgs);
     System.out.println("Success");

--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -62,7 +62,9 @@ public class ExampleSuite {
     File exportSPWFile = new File(parentDir, "exportSPW.ome.tiff");
     File simpleTiledFile = new File(parentDir, "simpleTiledFile.ome.tiff");
     File tiledFile = new File(parentDir, "tiledFile.ome.tiff");
+    File tiledFile2 = new File(parentDir, "tiledFile2.ome.tiff");
     File overlappedTiledFile = new File(parentDir, "overlappedTiledFile.ome.tiff");
+    File overlappedTiledFile2 = new File(parentDir, "overlappedTiledFile2.ome.tiff");
 
     // Execute examples
     execute("ReadPhysicalSize", new String[] {inputFile.getAbsolutePath()});
@@ -74,7 +76,11 @@ public class ExampleSuite {
         inputFile.getAbsolutePath(), simpleTiledFile.getAbsolutePath(), "256", "256"});
     execute("TiledReaderWriter", new String[] {
         inputFile.getAbsolutePath(), tiledFile.getAbsolutePath(), "256", "256"});
+    execute("TiledReaderWriter", new String[] {
+        inputFile.getAbsolutePath(), tiledFile2.getAbsolutePath(), "256", "128"});
     execute("OverlappedTiledWriter", new String[] {
         overlappedInputFile.getAbsolutePath(), overlappedTiledFile.getAbsolutePath(), "96", "96"});
+    execute("OverlappedTiledWriter", new String[] {
+        overlappedInputFile.getAbsolutePath(), overlappedTiledFile2.getAbsolutePath(), "192", "96"});
   }
 }

--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -53,13 +53,16 @@ public class ExampleSuite {
 
     // Retrieve local test files
     URL resource =  ExampleSuite.class.getResource("test.fake");
+    URL overlappedResource =  ExampleSuite.class.getResource("test&sizeX=1024&sizeY=1024.fake");
     File inputFile = new File(resource.toURI());
+    File overlappedInputFile = new File(overlappedResource.toURI());
     File parentDir = inputFile.getParentFile();
     File convertedFile = new File(parentDir, "converted.ome.tiff");
     File exportFile = new File(parentDir, "export.ome.tiff");
     File exportSPWFile = new File(parentDir, "exportSPW.ome.tiff");
     File simpleTiledFile = new File(parentDir, "simpleTiledFile.ome.tiff");
     File tiledFile = new File(parentDir, "tiledFile.ome.tiff");
+    File overlappedTiledFile = new File(parentDir, "overlappedTiledFile.ome.tiff");
 
     // Execute examples
     execute("ReadPhysicalSize", new String[] {inputFile.getAbsolutePath()});
@@ -71,5 +74,7 @@ public class ExampleSuite {
         inputFile.getAbsolutePath(), simpleTiledFile.getAbsolutePath(), "256", "256"});
     execute("TiledReaderWriter", new String[] {
         inputFile.getAbsolutePath(), tiledFile.getAbsolutePath(), "256", "256"});
+    execute("OverlappedTiledWriter", new String[] {
+        overlappedInputFile.getAbsolutePath(), overlappedTiledFile.getAbsolutePath(), "96", "96"});
   }
 }

--- a/docs/sphinx/developers/examples/OverlappedTiledWriter.java
+++ b/docs/sphinx/developers/examples/OverlappedTiledWriter.java
@@ -1,0 +1,204 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import java.io.IOException;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.ImageReader;
+import loci.formats.FormatTools;
+import loci.formats.meta.IMetadata;
+import loci.formats.out.OMETiffWriter;
+import loci.formats.services.OMEXMLService;
+
+/**
+ * Example class for reading and writing a file in a tiled OME Tiff format.
+ *
+ * @author David Gault dgault at dundee.ac.uk
+ */
+public class OverlappedTiledWriter {
+
+  /** The file format reader. */
+  private ImageReader reader;
+
+  /** The file format writer. */
+  private OMETiffWriter writer;
+
+  /** The file to be read. */
+  private String inputFile;
+
+  /** The file to be written. */
+  private String outputFile;
+
+  /** The tile width to be used. */
+  private int tileSizeX;
+
+  /** The tile height to be used. */
+  private int tileSizeY;
+
+  /**
+   * Construct a new OverlappedTiledWriter to read the specified input file 
+   * and write the given output file using the tile sizes provided.
+   *
+   * @param inputFile the file to be read
+   * @param outputFile the file to be written
+   * @param tileSizeX the width of tile to attempt to use
+   * @param tileSizeY the height of tile to attempt to use
+   */
+  public OverlappedTiledWriter(String inputFile, String outputFile, int tileSizeX, int tileSizeY) {
+    this.inputFile = inputFile;
+    this.outputFile = outputFile;
+    this.tileSizeX = tileSizeX;
+    this.tileSizeY = tileSizeY;
+  }
+
+  /**
+   * Set up the file reader and writer, ensuring that the input file is
+   * associated with the reader and the output file is associated with the
+   * writer.
+   *
+   * @return true if the reader and writer were successfully set up, or false
+   *   if an error occurred
+   * @throws DependencyException 
+   * @throws IOException 
+   * @throws FormatException 
+   * @throws ServiceException 
+   */
+  private void initialize() throws DependencyException, FormatException, IOException, ServiceException {
+    // construct the object that stores OME-XML metadata
+    ServiceFactory factory = new ServiceFactory();
+    OMEXMLService service = factory.getInstance(OMEXMLService.class);
+    IMetadata omexml = service.createOMEXMLMetadata();
+
+    // set up the reader and associate it with the input file
+    reader = new ImageReader();
+    reader.setMetadataStore(omexml);
+    reader.setId(inputFile);
+
+    // set up the writer and associate it with the output file
+    writer = new OMETiffWriter();
+    writer.setMetadataRetrieve(omexml);
+    writer.setInterleaved(reader.isInterleaved());
+
+    // set the tile size height and width for writing
+    this.tileSizeX = writer.setTileSizeX(tileSizeX);
+    this.tileSizeY = writer.setTileSizeY(tileSizeY);
+
+    writer.setId(outputFile);
+  }
+
+  /** 
+   * Read tiles from input file and write tiles to output OME Tiff. 
+   * In this example we are assuming that the tile size used does not divide evenly
+   * into the image height and width. When this occurs the last row and column
+   * of tiles are instead written as partial tiles rather than a full padded tile.
+   * @throws IOException 
+   * @throws FormatException */
+  public void readWriteTiles() throws FormatException, IOException {
+    int bpp = FormatTools.getBytesPerPixel(reader.getPixelType());
+    int tilePlaneSize = tileSizeX * tileSizeY * reader.getRGBChannelCount() * bpp;
+    byte[] buf = new byte[tilePlaneSize];
+
+    for (int series=0; series<reader.getSeriesCount(); series++) {
+      reader.setSeries(series);
+      writer.setSeries(series);
+
+      // convert each image in the current series
+      for (int image=0; image<reader.getImageCount(); image++) {
+        int width = reader.getSizeX();
+        int height = reader.getSizeY();
+
+        // Determined the number of tiles to read and write
+        int nXTiles = width / tileSizeX;
+        int nYTiles = height / tileSizeY;
+        if (nXTiles * tileSizeX != width) nXTiles++;
+        if (nYTiles * tileSizeY != height) nYTiles++;
+
+        for (int y=0; y<nYTiles; y++) {
+          for (int x=0; x<nXTiles; x++) {
+            // The x and y coordinates for the current tile
+            int tileX = x * tileSizeX;
+            int tileY = y * tileSizeY;
+
+            /* tiling-example-start */
+            // If the last tile row or column overlaps the image size then only a partial tile
+            // is read or written. The tile size used is adjusted to account for any overlap.
+            int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+            int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+
+            // Read tiles from the input file and write them to the output OME Tiff
+            buf = reader.openBytes(image, tileX, tileY, effTileSizeX, effTileSizeY);
+            writer.saveBytes(image, buf, tileX, tileY, effTileSizeX, effTileSizeY);
+            /* overlapped-tiling-example-end */
+          }
+        }
+      }
+    }
+  }
+
+  /** Close the file reader and writer. 
+   * @throws IOException */
+  private void cleanup() {
+    try {
+      reader.close();
+    }
+    catch (IOException e) {
+      System.err.println("Failed to close reader.");
+      e.printStackTrace();
+    }
+    try {
+      writer.close();
+    }
+    catch (IOException e) {
+      System.err.println("Failed to close writer.");
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * To read an image file and write out an OME Tiff tiled image on the command line:
+   *
+   * $ java OverlappedTiledWriter input-file.oib output-file.ome.tiff 256 256
+   * @throws IOException
+   * @throws FormatException
+   * @throws ServiceException 
+   * @throws DependencyException 
+   */
+  public static void main(String[] args) throws FormatException, IOException, DependencyException, ServiceException {
+    int tileSizeX = Integer.parseInt(args[2]);
+    int tileSizeY = Integer.parseInt(args[3]);
+    OverlappedTiledWriter overlappedTiledWriter = new OverlappedTiledWriter(args[0], args[1], tileSizeX, tileSizeY);
+    // initialize the files
+    overlappedTiledWriter.initialize();
+
+    // read and write the image using overlapped tiles
+    overlappedTiledWriter.readWriteTiles();
+
+    // close the files
+    overlappedTiledWriter.cleanup();
+  }
+
+}

--- a/docs/sphinx/developers/examples/OverlappedTiledWriter.java
+++ b/docs/sphinx/developers/examples/OverlappedTiledWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/docs/sphinx/developers/examples/OverlappedTiledWriter.java
+++ b/docs/sphinx/developers/examples/OverlappedTiledWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ * Copyright (C) 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
@@ -35,7 +35,7 @@ import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
 
 /**
- * Example class for reading and writing a file in a tiled OME Tiff format.
+ * Example class for reading and writing a file in a tiled OME-Tiff format.
  *
  * @author David Gault dgault at dundee.ac.uk
  */
@@ -82,10 +82,10 @@ public class OverlappedTiledWriter {
    *
    * @return true if the reader and writer were successfully set up, or false
    *   if an error occurred
-   * @throws DependencyException 
-   * @throws IOException 
-   * @throws FormatException 
-   * @throws ServiceException 
+   * @throws DependencyException thrown if failed to create an OMEXMLService
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown if invalid ID set for reader or writer or invalid tile size set
+   * @throws ServiceException thrown if unable to create OME-XML meta data
    */
   private void initialize() throws DependencyException, FormatException, IOException, ServiceException {
     // construct the object that stores OME-XML metadata
@@ -111,12 +111,13 @@ public class OverlappedTiledWriter {
   }
 
   /** 
-   * Read tiles from input file and write tiles to output OME Tiff. 
+   * Read tiles from input file and write tiles to output OME-Tiff. 
    * In this example we are assuming that the tile size used does not divide evenly
    * into the image height and width. When this occurs the last row and column
    * of tiles are instead written as partial tiles rather than a full padded tile.
-   * @throws IOException 
-   * @throws FormatException */
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown by FormatWriter if attempting to set invalid series
+   */
   public void readWriteTiles() throws FormatException, IOException {
     int bpp = FormatTools.getBytesPerPixel(reader.getPixelType());
     int tilePlaneSize = tileSizeX * tileSizeY * reader.getRGBChannelCount() * bpp;
@@ -149,7 +150,7 @@ public class OverlappedTiledWriter {
             int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
             int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
 
-            // Read tiles from the input file and write them to the output OME Tiff
+            // Read tiles from the input file and write them to the output OME-Tiff
             buf = reader.openBytes(image, tileX, tileY, effTileSizeX, effTileSizeY);
             writer.saveBytes(image, buf, tileX, tileY, effTileSizeX, effTileSizeY);
             /* overlapped-tiling-example-end */
@@ -159,8 +160,7 @@ public class OverlappedTiledWriter {
     }
   }
 
-  /** Close the file reader and writer. 
-   * @throws IOException */
+  /** Close the file reader and writer. */
   private void cleanup() {
     try {
       reader.close();
@@ -179,13 +179,13 @@ public class OverlappedTiledWriter {
   }
 
   /**
-   * To read an image file and write out an OME Tiff tiled image on the command line:
+   * To read an image file and write out an OME-Tiff tiled image on the command line:
    *
    * $ java OverlappedTiledWriter input-file.oib output-file.ome.tiff 256 256
-   * @throws IOException
-   * @throws FormatException
-   * @throws ServiceException 
-   * @throws DependencyException 
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown when setting invalid values in reader or writer
+   * @throws ServiceException thrown if unable to create OME-XML meta data
+   * @throws DependencyException thrown if failed to create an OMEXMLService
    */
   public static void main(String[] args) throws FormatException, IOException, DependencyException, ServiceException {
     int tileSizeX = Integer.parseInt(args[2]);

--- a/docs/sphinx/developers/examples/OverlappedTiledWriter.java
+++ b/docs/sphinx/developers/examples/OverlappedTiledWriter.java
@@ -143,7 +143,7 @@ public class OverlappedTiledWriter {
             int tileX = x * tileSizeX;
             int tileY = y * tileSizeY;
 
-            /* tiling-example-start */
+            /* overlapped-tiling-example-start */
             // If the last tile row or column overlaps the image size then only a partial tile
             // is read or written. The tile size used is adjusted to account for any overlap.
             int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;

--- a/docs/sphinx/developers/examples/OverlappedTiledWriter.java
+++ b/docs/sphinx/developers/examples/OverlappedTiledWriter.java
@@ -194,11 +194,19 @@ public class OverlappedTiledWriter {
     // initialize the files
     overlappedTiledWriter.initialize();
 
-    // read and write the image using overlapped tiles
-    overlappedTiledWriter.readWriteTiles();
-
-    // close the files
-    overlappedTiledWriter.cleanup();
+    try {
+      // read and write the image using overlapped tiles
+      overlappedTiledWriter.readWriteTiles();
+    }
+    catch(Exception e) {
+      System.err.println("Failed to read and write tiles.");
+      e.printStackTrace();
+      throw e;
+    }
+    finally {
+      // close the files
+      overlappedTiledWriter.cleanup();
+    }
   }
 
 }

--- a/docs/sphinx/developers/examples/SimpleTiledWriter.java
+++ b/docs/sphinx/developers/examples/SimpleTiledWriter.java
@@ -83,11 +83,10 @@ public class SimpleTiledWriter {
    * writer. The input reader will read a full plane which will then be passed
    * to the OME Tiff Writer. The writer will then automatically write the
    * image in a tiled format based on the tile size values provided.
-   * @throws FormatException 
-   * @throws DependencyException 
-   * @throws ServiceException 
-   * @throws IOException 
-   *
+   * @throws FormatException thrown when setting invalid values in reader or writer 
+   * @throws DependencyException thrown if failed to create an OMEXMLService
+   * @throws ServiceException thrown if unable to create OME-XML meta data
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
    */
   public void readWriteTiles() throws FormatException, DependencyException, ServiceException, IOException {
     // construct the object that stores OME-XML metadata
@@ -154,10 +153,10 @@ public class SimpleTiledWriter {
    * To read an image file and write out an OME Tiff tiled image on the command line:
    *
    * $ java SimpleTiledWriter input-file.oib output-file.ome.tiff 256 256
-   * @throws IOException
-   * @throws FormatException
-   * @throws ServiceException 
-   * @throws DependencyException 
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown when setting invalid values in reader or writer 
+   * @throws ServiceException thrown if unable to create OME-XML meta data
+   * @throws DependencyException thrown if failed to create an OMEXMLService
    */
   public static void main(String[] args) throws FormatException, IOException, DependencyException, ServiceException {
     int tileSizeX = Integer.parseInt(args[2]);

--- a/docs/sphinx/developers/examples/SimpleTiledWriter.java
+++ b/docs/sphinx/developers/examples/SimpleTiledWriter.java
@@ -80,15 +80,16 @@ public class SimpleTiledWriter {
   /**
    * Set up the file reader and writer, ensuring that the input file is
    * associated with the reader and the output file is associated with the
-   * writer. The input reader will read a full plane which will then be passed
-   * to the OME-Tiff Writer. The writer will then automatically write the
-   * image in a tiled format based on the tile size values provided.
-   * @throws FormatException thrown when setting invalid values in reader or writer 
+   * writer.
+   *
+   * @return true if the reader and writer were successfully set up, or false
+   *   if an error occurred
    * @throws DependencyException thrown if failed to create an OMEXMLService
-   * @throws ServiceException thrown if unable to create OME-XML meta data
    * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown if invalid ID set for reader or writer or invalid tile size set
+   * @throws ServiceException thrown if unable to create OME-XML meta data
    */
-  public void readWriteTiles() throws FormatException, DependencyException, ServiceException, IOException {
+  private void initialize() throws DependencyException, FormatException, IOException, ServiceException {
     // construct the object that stores OME-XML metadata
     ServiceFactory factory = new ServiceFactory();
     OMEXMLService service = factory.getInstance(OMEXMLService.class);
@@ -106,14 +107,26 @@ public class SimpleTiledWriter {
     writer.setInterleaved(reader.isInterleaved());
 
     // set the tile size height and width for writing
-    writer.setTileSizeX(tileSizeX);
-    writer.setTileSizeY(tileSizeY);
+    this.tileSizeX = writer.setTileSizeX(tileSizeX);
+    this.tileSizeY = writer.setTileSizeY(tileSizeY);
 
     writer.setId(outputFile);
-
     /* initialize-tiling-writer-example-end */
-    /* tiling-writer-example-start */
+  }
 
+  /**
+   * Set up the file reader and writer, ensuring that the input file is
+   * associated with the reader and the output file is associated with the
+   * writer. The input reader will read a full plane which will then be passed
+   * to the OME-Tiff Writer. The writer will then automatically write the
+   * image in a tiled format based on the tile size values provided.
+   * @throws FormatException thrown when setting invalid values in reader or writer 
+   * @throws DependencyException thrown if failed to create an OMEXMLService
+   * @throws ServiceException thrown if unable to create OME-XML meta data
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   */
+  public void readWriteTiles() throws FormatException, DependencyException, ServiceException, IOException {
+    /* tiling-writer-example-start */
     byte[] buf = new byte[FormatTools.getPlaneSize(reader)];
 
     for (int series=0; series<reader.getSeriesCount(); series++) {
@@ -162,6 +175,8 @@ public class SimpleTiledWriter {
     int tileSizeX = Integer.parseInt(args[2]);
     int tileSizeY = Integer.parseInt(args[3]);
     SimpleTiledWriter tiledWriter = new SimpleTiledWriter(args[0], args[1], tileSizeX, tileSizeY);
+    // initialize the files
+    tiledWriter.initialize();
 
     try {
       // Read in images from the input and write them out automatically using tiling

--- a/docs/sphinx/developers/examples/SimpleTiledWriter.java
+++ b/docs/sphinx/developers/examples/SimpleTiledWriter.java
@@ -36,7 +36,7 @@ import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
 
 /**
- * Example class for reading a full image and use an OME Tiff writer to 
+ * Example class for reading a full image and use an OME-Tiff writer to 
  * automatically write out the image in a tiled format.
  *
  * @author David Gault dgault at dundee.ac.uk
@@ -81,7 +81,7 @@ public class SimpleTiledWriter {
    * Set up the file reader and writer, ensuring that the input file is
    * associated with the reader and the output file is associated with the
    * writer. The input reader will read a full plane which will then be passed
-   * to the OME Tiff Writer. The writer will then automatically write the
+   * to the OME-Tiff Writer. The writer will then automatically write the
    * image in a tiled format based on the tile size values provided.
    * @throws FormatException thrown when setting invalid values in reader or writer 
    * @throws DependencyException thrown if failed to create an OMEXMLService
@@ -122,8 +122,8 @@ public class SimpleTiledWriter {
 
       // convert each image in the current series
       for (int image=0; image<reader.getImageCount(); image++) {
-        // Read tiles from the input file and write them to the output OME Tiff
-        // The OME Tiff Writer will automatically write the images in a tiled format
+        // Read tiles from the input file and write them to the output OME-Tiff
+        // The OME-Tiff Writer will automatically write the images in a tiled format
         buf = reader.openBytes(image);
         writer.saveBytes(image, buf);
       }
@@ -150,7 +150,7 @@ public class SimpleTiledWriter {
   }
 
   /**
-   * To read an image file and write out an OME Tiff tiled image on the command line:
+   * To read an image file and write out an OME-Tiff tiled image on the command line:
    *
    * $ java SimpleTiledWriter input-file.oib output-file.ome.tiff 256 256
    * @throws IOException thrown if unable to setup input or output stream for reader or writer

--- a/docs/sphinx/developers/examples/SimpleTiledWriter.java
+++ b/docs/sphinx/developers/examples/SimpleTiledWriter.java
@@ -164,11 +164,19 @@ public class SimpleTiledWriter {
     int tileSizeY = Integer.parseInt(args[3]);
     SimpleTiledWriter tiledWriter = new SimpleTiledWriter(args[0], args[1], tileSizeX, tileSizeY);
 
-    // Read in images from the input and write them out automatically using tiling
-    tiledWriter.readWriteTiles();
-
-    // close the files
-    tiledWriter.cleanup();
+    try {
+      // Read in images from the input and write them out automatically using tiling
+      tiledWriter.readWriteTiles();
+    }
+    catch(Exception e) {
+      System.err.println("Failed to read and write tiles.");
+      e.printStackTrace();
+      throw e;
+    }
+    finally {
+      // close the files
+      tiledWriter.cleanup();
+    }
   }
 
 }

--- a/docs/sphinx/developers/examples/SimpleTiledWriter.java
+++ b/docs/sphinx/developers/examples/SimpleTiledWriter.java
@@ -24,6 +24,9 @@
  */
 
 import java.io.IOException;
+
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
 import loci.formats.FormatException;
 import loci.formats.ImageReader;
@@ -80,55 +83,53 @@ public class SimpleTiledWriter {
    * writer. The input reader will read a full plane which will then be passed
    * to the OME Tiff Writer. The writer will then automatically write the
    * image in a tiled format based on the tile size values provided.
+   * @throws FormatException 
+   * @throws DependencyException 
+   * @throws ServiceException 
+   * @throws IOException 
    *
    */
-  public void readWriteTiles() {
-    try {
-      // construct the object that stores OME-XML metadata
-      ServiceFactory factory = new ServiceFactory();
-      OMEXMLService service = factory.getInstance(OMEXMLService.class);
-      IMetadata omexml = service.createOMEXMLMetadata();
+  public void readWriteTiles() throws FormatException, DependencyException, ServiceException, IOException {
+    // construct the object that stores OME-XML metadata
+    ServiceFactory factory = new ServiceFactory();
+    OMEXMLService service = factory.getInstance(OMEXMLService.class);
+    IMetadata omexml = service.createOMEXMLMetadata();
 
-      // set up the reader and associate it with the input file
-      reader = new ImageReader();
-      reader.setMetadataStore(omexml);
-      reader.setId(inputFile);
+    // set up the reader and associate it with the input file
+    reader = new ImageReader();
+    reader.setMetadataStore(omexml);
+    reader.setId(inputFile);
 
-      /* initialize-tiling-writer-example-start */
-      // set up the writer and associate it with the output file
-      writer = new OMETiffWriter();
-      writer.setMetadataRetrieve(omexml);
-      writer.setInterleaved(reader.isInterleaved());
+    /* initialize-tiling-writer-example-start */
+    // set up the writer and associate it with the output file
+    writer = new OMETiffWriter();
+    writer.setMetadataRetrieve(omexml);
+    writer.setInterleaved(reader.isInterleaved());
 
-      // set the tile size height and width for writing
-      writer.setTileSizeX(tileSizeX);
-      writer.setTileSizeY(tileSizeY);
+    // set the tile size height and width for writing
+    writer.setTileSizeX(tileSizeX);
+    writer.setTileSizeY(tileSizeY);
 
-      writer.setId(outputFile);
+    writer.setId(outputFile);
 
-      /* initialize-tiling-writer-example-end */
-      /* tiling-writer-example-start */
+    /* initialize-tiling-writer-example-end */
+    /* tiling-writer-example-start */
 
-      byte[] buf = new byte[FormatTools.getPlaneSize(reader)];
+    byte[] buf = new byte[FormatTools.getPlaneSize(reader)];
 
-      for (int series=0; series<reader.getSeriesCount(); series++) {
-        reader.setSeries(series);
-        writer.setSeries(series);
+    for (int series=0; series<reader.getSeriesCount(); series++) {
+      reader.setSeries(series);
+      writer.setSeries(series);
 
-        // convert each image in the current series
-        for (int image=0; image<reader.getImageCount(); image++) {
-          // Read tiles from the input file and write them to the output OME Tiff
-          // The OME Tiff Writer will automatically write the images in a tiled format
-          buf = reader.openBytes(image);
-          writer.saveBytes(image, buf);
-        }
+      // convert each image in the current series
+      for (int image=0; image<reader.getImageCount(); image++) {
+        // Read tiles from the input file and write them to the output OME Tiff
+        // The OME Tiff Writer will automatically write the images in a tiled format
+        buf = reader.openBytes(image);
+        writer.saveBytes(image, buf);
       }
-      /* tiling-writer-example-end */
     }
-    catch (Exception e) {
-      System.err.println("Failed to read and write tiled files.");
-      e.printStackTrace();
-    }
+    /* tiling-writer-example-end */
   }
 
   /** Close the file reader and writer. */
@@ -155,8 +156,10 @@ public class SimpleTiledWriter {
    * $ java SimpleTiledWriter input-file.oib output-file.ome.tiff 256 256
    * @throws IOException
    * @throws FormatException
+   * @throws ServiceException 
+   * @throws DependencyException 
    */
-  public static void main(String[] args) throws FormatException, IOException {
+  public static void main(String[] args) throws FormatException, IOException, DependencyException, ServiceException {
     int tileSizeX = Integer.parseInt(args[2]);
     int tileSizeY = Integer.parseInt(args[3]);
     SimpleTiledWriter tiledWriter = new SimpleTiledWriter(args[0], args[1], tileSizeX, tileSizeY);

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -198,7 +198,7 @@ public class TiledReaderWriter {
     }
     finally {
       // close the files
-      tiledWriter.cleanup();
+      tiledReadWriter.cleanup();
     }
   }
 

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -35,7 +35,7 @@ import loci.formats.out.OMETiffWriter;
 import loci.formats.services.OMEXMLService;
 
 /**
- * Example class for reading and writing a file in a tiled OME Tiff format.
+ * Example class for reading and writing a file in a tiled OME-Tiff format.
  *
  * @author David Gault dgault at dundee.ac.uk
  */
@@ -110,7 +110,7 @@ public class TiledReaderWriter {
     writer.setId(outputFile);
   }
 
-  /** Read tiles from input file and write tiles to output OME Tiff. 
+  /** Read tiles from input file and write tiles to output OME-Tiff. 
    * @throws IOException thrown if unable to setup input or output stream for reader or writer
    * @throws FormatException thrown by FormatWriter if attempting to set invalid series
    */
@@ -143,7 +143,7 @@ public class TiledReaderWriter {
             int tileX = x * tileSizeX;
             int tileY = y * tileSizeY;
 
-            // Read tiles from the input file and write them to the output OME Tiff
+            // Read tiles from the input file and write them to the output OME-Tiff
             buf = reader.openBytes(image, tileX, tileY, tileSizeX, tileSizeY);
             writer.saveBytes(image, buf, tileX, tileY, tileSizeX, tileSizeY);
           }
@@ -172,7 +172,7 @@ public class TiledReaderWriter {
   }
 
   /**
-   * To read an image file and write out an OME Tiff tiled image on the command line:
+   * To read an image file and write out an OME-Tiff tiled image on the command line:
    *
    * $ java TiledReaderWriter input-file.oib output-file.ome.tiff 256 256
    * @throws IOException thrown if unable to setup input or output stream for reader or writer

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -185,7 +185,7 @@ public class TiledReaderWriter {
     int tileSizeY = Integer.parseInt(args[3]);
     TiledReaderWriter tiledReadWriter = new TiledReaderWriter(args[0], args[1], tileSizeX, tileSizeY);
     // initialize the files
-    boolean initializationSuccess = tiledReadWriter.initialize();
+    tiledReadWriter.initialize();
 
     // read and write the image using tiles
     tiledReadWriter.readWriteTiles();

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -82,10 +82,10 @@ public class TiledReaderWriter {
    *
    * @return true if the reader and writer were successfully set up, or false
    *   if an error occurred
-   * @throws DependencyException 
-   * @throws IOException 
-   * @throws FormatException 
-   * @throws ServiceException 
+   * @throws DependencyException thrown if failed to create an OMEXMLService
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown if invalid ID set for reader or writer or invalid tile size set
+   * @throws ServiceException thrown if unable to create OME-XML meta data
    */
   private void initialize() throws DependencyException, FormatException, IOException, ServiceException {
     // construct the object that stores OME-XML metadata
@@ -111,8 +111,9 @@ public class TiledReaderWriter {
   }
 
   /** Read tiles from input file and write tiles to output OME Tiff. 
-   * @throws IOException 
-   * @throws FormatException */
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown by FormatWriter if attempting to set invalid series
+   */
   public void readWriteTiles() throws FormatException, IOException {
     int bpp = FormatTools.getBytesPerPixel(reader.getPixelType());
     int tilePlaneSize = tileSizeX * tileSizeY * reader.getRGBChannelCount() * bpp;
@@ -152,8 +153,7 @@ public class TiledReaderWriter {
     }
   }
 
-  /** Close the file reader and writer. 
-   * @throws IOException */
+  /** Close the file reader and writer. */
   private void cleanup() {
     try {
       reader.close();
@@ -175,10 +175,10 @@ public class TiledReaderWriter {
    * To read an image file and write out an OME Tiff tiled image on the command line:
    *
    * $ java TiledReaderWriter input-file.oib output-file.ome.tiff 256 256
-   * @throws IOException
-   * @throws FormatException
-   * @throws ServiceException 
-   * @throws DependencyException 
+   * @throws IOException thrown if unable to setup input or output stream for reader or writer
+   * @throws FormatException thrown when setting invalid values in reader or writer
+   * @throws ServiceException thrown if unable to create OME-XML meta data
+   * @throws DependencyException thrown if failed to create an OMEXMLService
    */
   public static void main(String[] args) throws FormatException, IOException, DependencyException, ServiceException {
     int tileSizeX = Integer.parseInt(args[2]);

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -87,9 +87,7 @@ public class TiledReaderWriter {
    * @throws FormatException 
    * @throws ServiceException 
    */
-  private boolean initialize() throws DependencyException, FormatException, IOException, ServiceException {
-    Exception exception = null;
-
+  private void initialize() throws DependencyException, FormatException, IOException, ServiceException {
     // construct the object that stores OME-XML metadata
     ServiceFactory factory = new ServiceFactory();
     OMEXMLService service = factory.getInstance(OMEXMLService.class);
@@ -110,7 +108,6 @@ public class TiledReaderWriter {
     this.tileSizeY = writer.setTileSizeY(tileSizeY);
 
     writer.setId(outputFile);
-    return exception == null;
   }
 
   /** Read tiles from input file and write tiles to output OME Tiff. 
@@ -162,9 +159,21 @@ public class TiledReaderWriter {
 
   /** Close the file reader and writer. 
    * @throws IOException */
-  private void cleanup() throws IOException {
-    reader.close();
-    writer.close();
+  private void cleanup() {
+    try {
+      reader.close();
+    }
+    catch (IOException e) {
+      System.err.println("Failed to close reader.");
+      e.printStackTrace();
+    }
+    try {
+      writer.close();
+    }
+    catch (IOException e) {
+      System.err.println("Failed to close writer.");
+      e.printStackTrace();
+    }
   }
 
   /**
@@ -183,9 +192,8 @@ public class TiledReaderWriter {
     // initialize the files
     boolean initializationSuccess = tiledReadWriter.initialize();
 
-    if (initializationSuccess) {
-      tiledReadWriter.readWriteTiles();
-    }
+    // read and write the image using tiles
+    tiledReadWriter.readWriteTiles();
 
     // close the files
     tiledReadWriter.cleanup();

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -142,11 +142,6 @@ public class TiledReaderWriter {
             int tileX = x * tileSizeX;
             int tileY = y * tileSizeY;
 
-            // If the last tile row or column overlaps the image size then only a partial tile
-            // is read or written. The tile size used is adjusted to account for any overlap.
-            int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
-            int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
-
             // Read tiles from the input file and write them to the output OME Tiff
             buf = reader.openBytes(image, tileX, tileY, tileSizeX, tileSizeY);
             writer.saveBytes(image, buf, tileX, tileY, tileSizeX, tileSizeY);

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -187,11 +187,19 @@ public class TiledReaderWriter {
     // initialize the files
     tiledReadWriter.initialize();
 
-    // read and write the image using tiles
-    tiledReadWriter.readWriteTiles();
-
-    // close the files
-    tiledReadWriter.cleanup();
+    try {
+      // read and write the image using tiles
+      tiledReadWriter.readWriteTiles();
+    }
+    catch(Exception e) {
+      System.err.println("Failed to read and write tiles.");
+      e.printStackTrace();
+      throw e;
+    }
+    finally {
+      // close the files
+      tiledWriter.cleanup();
+    }
   }
 
 }

--- a/docs/sphinx/developers/examples/TiledReaderWriter.java
+++ b/docs/sphinx/developers/examples/TiledReaderWriter.java
@@ -68,7 +68,7 @@ public class TiledReaderWriter {
    * @param tileSizeX the width of tile to attempt to use
    * @param tileSizeY the height of tile to attempt to use
    */
-  public TiledReaderWriter(String inputFile, String outputFile, int tileX, int tileY) {
+  public TiledReaderWriter(String inputFile, String outputFile, int tileSizeX, int tileSizeY) {
     this.inputFile = inputFile;
     this.outputFile = outputFile;
     this.tileSizeX = tileSizeX;

--- a/docs/sphinx/developers/tiling.txt
+++ b/docs/sphinx/developers/tiling.txt
@@ -97,3 +97,25 @@ Full working example code is provided in
    :download:`TiledReaderWriter.java <examples/TiledReaderWriter.java>` - code from that class is
    referenced here in part. You will need to have :file:`bioformats_package.jar` in your 
    Java CLASSPATH in order to compile :file:`TiledReaderWriter.java`.
+
+Tiles which overlap image size
+------------------------------
+
+It may not always be the case that the tile size divides evenly into the image height and width.
+In these scenarios in which the last column or row of tiles overlaps with the image boundary, a smaller tile 
+is instead read or written for the final row or column. If a full sized tile with padding is written then a 
+:javadoc:`loci.formats.FormatException <loci/formats/FormatException.html>` will be thrown for ``Invalid tile size``.
+
+To deal with this we can modify the previous tiled writing example to check if the tile size will overlap
+the image boundaries. If it will not overlap then the full tile size is used, if it does then the tile size 
+for that tile is modified to reflect the partial tile.
+
+.. literalinclude:: examples/OverlappedTiledWriter.java
+   :language: java
+   :start-after: overlapped-tiling-example-start
+   :end-before: overlapped-tiling-example-end
+
+Full working example code is provided in
+   :download:`OverlappedTiledWriter.java <examples/OverlappedTiledWriter.java>` - code from that class is
+   referenced here in part. You will need to have :file:`bioformats_package.jar` in your 
+   Java CLASSPATH in order to compile :file:`OverlappedTiledWriter.java`.


### PR DESCRIPTION
This PR contains a number of updates to the tiling example files and documentation.

- Includes an example file (OverlappedTiledWriter) for tiled reading and writing in scenarios ()
- Fixes a bug in the existing TiledReaderWriter which was not properly initialising the tiling parameters
- Removes the catching of exceptions from the existing examples to allow for the above bug to be caught by CI in case of regression
- Adds an example of using the sizeX and sizeY parameters to the fake files in ExampleSuite
- Updates the tiling sphinx documentation to include further description of overlapped tiling examples

Testing required:
- Ensure that the ExampleSuite runs successfully with the new OverlappedTiledWriter example included
- Ensure all existing examples in that ExampleSuite continue to pass
- Check all the links and formatting in the updated sphinx doc and proof read