### PR TITLE
ImageConverter - Invalid image index bug fix

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -73,6 +73,7 @@ import loci.formats.tiff.IFD;
 
 import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.Image;
+import ome.xml.model.Pixels;
 import ome.xml.model.enums.PixelType;
 import ome.xml.model.primitives.PositiveInteger;
 
@@ -414,7 +415,9 @@ public final class ImageConverter {
         OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) store.getRoot();
         IMetadata meta = service.createOMEXMLMetadata(xml);
         if (series >= 0) {
-          Image exportImage = root.getImage(series);
+          Image exportImage = new Image(root.getImage(series));
+          Pixels exportPixels = new Pixels(root.getImage(series).getPixels());
+          exportImage.setPixels(exportPixels);
           OMEXMLMetadataRoot newRoot = (OMEXMLMetadataRoot) meta.getRoot();
           while (newRoot.sizeOfImageList() > 0) {
             newRoot.removeImage(newRoot.getImage(0));

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -409,21 +409,18 @@ public final class ImageConverter {
     }
 
     if (store instanceof MetadataRetrieve) {
-      if (series >= 0) {
-        try {
-          String xml = service.getOMEXML(service.asRetrieve(store));
-          OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) store.getRoot();
+      try {
+        String xml = service.getOMEXML(service.asRetrieve(store));
+        OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) store.getRoot();
+        IMetadata meta = service.createOMEXMLMetadata(xml);
+        if (series >= 0) {
           Image exportImage = root.getImage(series);
-
-          IMetadata meta = service.createOMEXMLMetadata(xml);
           OMEXMLMetadataRoot newRoot = (OMEXMLMetadataRoot) meta.getRoot();
           while (newRoot.sizeOfImageList() > 0) {
             newRoot.removeImage(newRoot.getImage(0));
           }
-
           newRoot.addImage(exportImage);
           meta.setRoot(newRoot);
-
           meta.setPixelsSizeX(new PositiveInteger(width), 0);
           meta.setPixelsSizeY(new PositiveInteger(height), 0);
 
@@ -443,31 +440,31 @@ public final class ImageConverter {
 
           writer.setMetadataRetrieve((MetadataRetrieve) meta);
         }
-        catch (ServiceException e) {
-          throw new FormatException(e);
+        else {
+          for (int i=0; i<reader.getSeriesCount(); i++) {
+            meta.setPixelsSizeX(new PositiveInteger(width), 0);
+            meta.setPixelsSizeY(new PositiveInteger(height), 0);
+
+            if (autoscale) {
+              store.setPixelsType(PixelType.UINT8, i);
+            }
+
+            if (channel >= 0) {
+              meta.setPixelsSizeC(new PositiveInteger(1), 0);
+            }
+            if (zSection >= 0) {
+              meta.setPixelsSizeZ(new PositiveInteger(1), 0);
+            }
+            if (timepoint >= 0) {
+              meta.setPixelsSizeT(new PositiveInteger(1), 0);
+            }
+          }
+
+          writer.setMetadataRetrieve((MetadataRetrieve) meta);
         }
       }
-      else {
-        for (int i=0; i<reader.getSeriesCount(); i++) {
-          store.setPixelsSizeX(new PositiveInteger(width), 0);
-          store.setPixelsSizeY(new PositiveInteger(height), 0);
-
-          if (autoscale) {
-            store.setPixelsType(PixelType.UINT8, i);
-          }
-
-          if (channel >= 0) {
-            store.setPixelsSizeC(new PositiveInteger(1), 0);
-          }
-          if (zSection >= 0) {
-            store.setPixelsSizeZ(new PositiveInteger(1), 0);
-          }
-          if (timepoint >= 0) {
-            store.setPixelsSizeT(new PositiveInteger(1), 0);
-          }
-        }
-
-        writer.setMetadataRetrieve((MetadataRetrieve) store);
+      catch (ServiceException e) {
+        throw new FormatException(e);
       }
     }
     writer.setWriteSequentially(true);


### PR DESCRIPTION
This is a bug in ImageConverter which saw `IllegalArgumentException` thrown with `Invalid image index` when valid parameters had been entered.

This is caused when the image converter command line tool was used with a parameter such as -z or -channel, but not -series. In the case of a specific channel or z plane being requested the writers metadata is configured to override the number of z planes or channels with the value 1. When -series was being used the behaviour was correct as the writer made a new metadata object from the readers values and overwrote them. Without -series however the readers metadata was being overwritten which then resulted in the Exception.

Trac ticket for issue: https://trac.openmicroscopy.org/ome/ticket/13316#ticket
Related forum thread: https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8182&p=17852#p17852

To reproduce:
- Using sample file QA-17475 run a conversation via the command line tools
- Use a -z, -channel or -timepoint option with a valid value (for this sample file -z works well for testing)
- Verify that an `IllegalArgumentException` is thrown

Testing:
- With the PR applied reproduce the test above and verify that the conversion is successful
