### PR TITLE
Leica LIF: add option to preserve pre-5.3.3 physical sizes

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/config/LIFWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/LIFWidgets.java
@@ -4,7 +4,7 @@
  * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
  * Data Browser and Stack Slicer.
  * %%
- * Copyright (C) 2006 - 2016 Open Microscopy Environment:
+ * Copyright (C) 2006 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee

--- a/components/bio-formats-plugins/src/loci/plugins/config/LIFWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/LIFWidgets.java
@@ -1,0 +1,90 @@
+/*
+ * #%L
+ * Bio-Formats Plugins for ImageJ: a collection of ImageJ plugins including the
+ * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
+ * Data Browser and Stack Slicer.
+ * %%
+ * Copyright (C) 2006 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.plugins.config;
+
+import ij.Prefs;
+
+import java.awt.Component;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.JCheckBox;
+
+import loci.formats.in.LIFReader;
+
+import loci.plugins.util.LociPrefs;
+
+/**
+ * Custom widgets for configuring Bio-Formats Leica LIF support.
+ *
+ */
+public class LIFWidgets implements IFormatWidgets, ItemListener {
+
+  // -- Fields --
+
+  private String[] labels;
+  private Component[] widgets;
+
+  // -- Constructor --
+
+  public LIFWidgets() {
+    boolean physicalSizeBackwardsCompatibility =
+      Prefs.get(LociPrefs.PREF_LEICA_LIF_PHYSICAL_SIZE, LIFReader.OLD_PHYSICAL_SIZE_DEFAULT);
+
+    String physicalSizeLabel = "Physical size";
+    JCheckBox physicalSizeBox = new JCheckBox(
+      "Ensure physical pixel sizes are compatible with versions <= 5.3.2", physicalSizeBackwardsCompatibility);
+    physicalSizeBox.addItemListener(this);
+
+    labels = new String[] {physicalSizeLabel};
+    widgets = new Component[] {physicalSizeBox};
+  }
+
+  // -- IFormatWidgets API methods --
+
+  @Override
+  public String[] getLabels() {
+    return labels;
+  }
+
+  @Override
+  public Component[] getWidgets() {
+    return widgets;
+  }
+
+  // -- ItemListener API methods --
+
+  @Override
+  public void itemStateChanged(ItemEvent e) {
+    JCheckBox box = (JCheckBox) e.getSource();
+    if (box.equals(widgets[0])) {
+      Prefs.set(LociPrefs.PREF_LEICA_LIF_PHYSICAL_SIZE, box.isSelected());
+    }
+  }
+
+}

--- a/components/bio-formats-plugins/src/loci/plugins/util/LociPrefs.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LociPrefs.java
@@ -33,6 +33,7 @@ import loci.formats.ClassList;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.in.DynamicMetadataOptions;
+import loci.formats.in.LIFReader;
 import loci.formats.in.MetadataOptions;
 import loci.formats.in.ND2Reader;
 import loci.formats.in.PictReader;
@@ -61,6 +62,8 @@ public final class LociPrefs {
     "bioformats.zeissczi.allow.autostitch";
   public static final String PREF_CZI_ATTACHMENT =
     "bioformats.zeissczi.include.attachments";
+  public static final String PREF_LEICA_LIF_PHYSICAL_SIZE =
+    "bioformats.leicalif.physicalsize.compatibility";
 
   // -- Constructor --
 
@@ -93,6 +96,8 @@ public final class LociPrefs {
         ZeissCZIReader.ALLOW_AUTOSTITCHING_KEY, allowCZIAutostitch());
       ((DynamicMetadataOptions) options).setBoolean(
         ZeissCZIReader.INCLUDE_ATTACHMENTS_KEY, includeCZIAttachments());
+      ((DynamicMetadataOptions) options).setBoolean(
+        LIFReader.OLD_PHYSICAL_SIZE_KEY, isLeicaLIFPhysicalSizeBackwardsCompatible());
       reader.setMetadataOptions(options);
     }
 
@@ -169,6 +174,11 @@ public final class LociPrefs {
   public static boolean includeCZIAttachments() {
     return Prefs.get(PREF_CZI_ATTACHMENT,
                      ZeissCZIReader.INCLUDE_ATTACHMENTS_DEFAULT);
+  }
+
+  public static boolean isLeicaLIFPhysicalSizeBackwardsCompatible() {
+    return Prefs.get(PREF_LEICA_LIF_PHYSICAL_SIZE,
+      LIFReader.OLD_PHYSICAL_SIZE_DEFAULT);
   }
 
   // -- Helper methods --


### PR DESCRIPTION
Follow up to https://github.com/openmicroscopy/bioformats/pull/2727.

This adds a new ```leicalif.old_physical_size``` boolean option to make physical X and Y size calculation backwards compatible with 5.3.2 and earlier.  By default, the option is set to ```false```.

To test, choose any Leica .lif file from ```data_repo/curated/leica-lif```.  Record the values of ```PhysicalSizeX``` and ```PhysicalSizeY``` shown in the OME-XML produced by ```showinf -nopix -omexml```, both with 5.3.2 and with develop not including this PR.

With this PR, ```showinf -nopix -omexml``` on the same file should result in ```PhysicalSizeX``` and ```PhysicalSizeY``` values that match the recorded output from develop.  With this PR and ```showinf -nopix -omexml -option leicalif.old_physical_size true```, ```PhysicalSizeX``` and ```PhysicalSizeY``` should match the recorded values from 5.3.2.

A corresponding ImageJ checkbox has also been added.  To test, install a ```bioformats_package.jar``` that includes this PR into ImageJ.  Open any series from any Leica .lif file, and note the physical image width and height at the top of the image window. Then click ```Plugins > Bio-Formats > Bio-Formats Plugin Configuration```, select ```Leica Image File Format``` from the list, then tick the ```Ensure physical sizes...``` box.  Close the configuration window and open the same series from the same file as before.  The physical image width and height should be slightly different.  You can also compare the pixel width and height shown in the image properties window (```Ctrl+Alt+p```), but those are typically rounded for display and may not 100% match what ```showinf``` reports.

I am not entirely convinced that the option name is clear, so happy to change it if anyone has a better idea.