### PR TITLE
Add documentation for new Leica LIF metadata option

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1212,7 +1212,20 @@ Commercial applications that support LIF include: \n
 \n
 * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
 * `SVI Huygens <http://svi.nl/>`_ \n
-* `Amira <http://www.amira.com/>`_
+* `Amira <http://www.amira.com/>`_ \n
+\n
+Versions of Bio-Formats prior to 5.3.3 incorrectly calculated the physical \n
+pixel width and height.  The physical image width and height were divided by \n
+the number of pixels, which was inconsistent with the official Leica LIF \n
+specification documents.  Versions 5.3.3 and later correctly calculate \n
+physical pixel sizes by dividing the physical image size by the number of \n
+pixels minus one.  To revert to the old method of physical pixel size \n
+calculation in 5.3.3 and later, set the ``leicalif.old_physical_size`` option \n
+to ``true``.  This can be done on the command line using \n
+:doc:`showinf -option </users/comlinetools/display>`, in ImageJ via the \n
+:doc:`configuration window </users/imagej/features>`, or via the API using the \n
+:javadoc:`DynamicMetadataOptions class <loci/formats/in/DynamicMetadataOptions.html>`.
+
 
 [LaVision Imspector]
 extensions = .msr

--- a/docs/sphinx/formats/leica-lif.txt
+++ b/docs/sphinx/formats/leica-lif.txt
@@ -61,4 +61,16 @@ Commercial applications that support LIF include:
 
 * `Bitplane Imaris <http://www.bitplane.com/>`_ 
 * `SVI Huygens <http://svi.nl/>`_ 
-* `Amira <http://www.amira.com/>`_
+* `Amira <http://www.amira.com/>`_ 
+
+Versions of Bio-Formats prior to 5.3.3 incorrectly calculated the physical 
+pixel width and height.  The physical image width and height were divided by 
+the number of pixels, which was inconsistent with the official Leica LIF 
+specification documents.  Versions 5.3.3 and later correctly calculate 
+physical pixel sizes by dividing the physical image size by the number of 
+pixels minus one.  To revert to the old method of physical pixel size 
+calculation in 5.3.3 and later, set the ``leicalif.old_physical_size`` option 
+to ``true``.  This can be done on the command line using 
+:doc:`showinf -option </users/comlinetools/display>`, in ImageJ via the 
+:doc:`configuration window </users/imagej/features>`, or via the API using the 
+:javadoc:`DynamicMetadataOptions class <loci/formats/in/DynamicMetadataOptions.html>`.


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/pull/2739

If we decide to change the option name, this will need to be updated.

I do wonder if we need a separate page that covers the options in general - I didn't see anything existing apart from Javadocs.  I can start something here if desired, or add a 5.3.x card.