### PR TITLE
ExampleSuite - clean existing output files

### DIFF
--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -31,6 +31,7 @@
  */
 
 import java.net.URL;
+import java.nio.file.Files;
 import java.io.File;
 
 
@@ -65,6 +66,16 @@ public class ExampleSuite {
     File tiledFile2 = new File(parentDir, "tiledFile2.ome.tiff");
     File overlappedTiledFile = new File(parentDir, "overlappedTiledFile.ome.tiff");
     File overlappedTiledFile2 = new File(parentDir, "overlappedTiledFile2.ome.tiff");
+    
+    // Remove any existing output files
+    Files.deleteIfExists(convertedFile.toPath());
+    Files.deleteIfExists(exportFile.toPath());
+    Files.deleteIfExists(exportSPWFile.toPath());
+    Files.deleteIfExists(simpleTiledFile.toPath());
+    Files.deleteIfExists(tiledFile.toPath());
+    Files.deleteIfExists(tiledFile2.toPath());
+    Files.deleteIfExists(overlappedTiledFile.toPath());
+    Files.deleteIfExists(overlappedTiledFile2.toPath());
 
     // Execute examples
     execute("ReadPhysicalSize", new String[] {inputFile.getAbsolutePath()});


### PR DESCRIPTION
In the ExampleSuite it was possible to see NullPointerExceptions when run multiple times without cleaning the directory. An example of this can be seen in https://travis-ci.org/openmicroscopy/bioformats/jobs/196902278

This fix will remove any existing output files if they already exist before beginning writing.
I opted for this approach rather than deleting files on exit as this is part of the ExampleSuite rather than a unit test and as such users may not wish to have output files removed immediately if they are using this as a base.

To reproduce:
- With the PR included run a clean Maven install using `mvn clean install`
- This should complete successfully without error
- Now rerun without cleaning using `mvn install`
- Verify that a NullPointerException is seen in the output

to testy:
- Rerun the above commands and verify that no exceptions are observed in the output