### PR TITLE
Java9 General service loading

### DIFF
--- a/components/forks/jai/src/com/sun/media/imageioimpl/common/ImageUtil.java
+++ b/components/forks/jai/src/com/sun/media/imageioimpl/common/ImageUtil.java
@@ -107,6 +107,8 @@ import java.util.Locale;
 
 //import javax.imageio.ImageTypeSpecifier;
 
+import java.util.ServiceLoader;
+
 import javax.imageio.IIOException;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageReadParam;
@@ -1380,8 +1382,7 @@ public class ImageUtil {
 	    descPart = " image writer";
 	}
 
-	Iterator iter = iioRegistry.getServiceProviders(spiClass, 
-							true); // useOrdering
+	Iterator iter = ServiceLoader.load(spiClass).iterator(); // useOrdering
 
 	String formatNames[];
 	ImageReaderWriterSpi provider;

--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -38,12 +38,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Iterator;
+import java.util.ServiceLoader;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.spi.IIORegistry;
-import javax.imageio.spi.ServiceRegistry;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 
@@ -102,7 +102,7 @@ public class JAIIIOServiceImpl extends AbstractService
 
     IIORegistry registry = IIORegistry.getDefaultInstance();
     Iterator<J2KImageWriterSpi> iter = 
-      ServiceRegistry.lookupProviders(J2KImageWriterSpi.class);
+      ServiceLoader.load(J2KImageWriterSpi.class).iterator();
     registry.registerServiceProviders(iter);
     J2KImageWriterSpi spi =
       registry.getServiceProviderByClass(J2KImageWriterSpi.class);
@@ -196,7 +196,7 @@ public class JAIIIOServiceImpl extends AbstractService
   private static IIORegistry registerServiceProviders() {
     IIORegistry registry = IIORegistry.getDefaultInstance();
     Iterator<J2KImageReaderSpi> iter =
-      ServiceRegistry.lookupProviders(J2KImageReaderSpi.class);
+            ServiceLoader.load(J2KImageReaderSpi.class).iterator();
     registry.registerServiceProviders(iter);
     return registry;
   }


### PR DESCRIPTION
This PR introduces a change required to use Bio-Formats with OMERO
when Java 1.9 is used
This should not change the behaviour with previous versions of Java.

In Java 9, ``javax.imageio.spi.ServiceRegistry`` checks if the requested service is an implementation of the Image I/O service provider interface. This module used the Image I/O service registry for loading external utility services like logging and caching. This is not an intended use and is now prohibited by the Java 9 runtime. javax.imageio.spi.ServiceRegistry uses 'java.util.ServiceLoader' internally.

Detailed of the error
https://trello.com/c/Eh7p5387/18-to-watch-java-1-9

Check that tests are green (especially svs)