### PR TITLE
Pyramid TIFF: support multiple planes and OME-XML comments

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -146,8 +146,8 @@ loci.formats.in.NDPIReader            # ndpi
 loci.formats.in.PCORAWReader          # pcoraw
 
 # TIFF-based readers with slow isThisType
-loci.formats.in.OMETiffReader         # tif
 loci.formats.in.PyramidTiffReader     # tif, tiff
+loci.formats.in.OMETiffReader         # tif
 loci.formats.in.MIASReader            # tif
 loci.formats.in.TCSReader             # xml, tif
 loci.formats.in.LeicaReader           # lei, tif

--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -168,7 +168,7 @@ public class PyramidTiffReader extends BaseTiffReader {
     int seriesCount = ifds.size() / nPlanes;
 
     String comment = ifds.get(0).getComment();
-    if (comment != null && comment.length() > 0) {
+    if (comment != null && comment.length() > 0 && comment.trim().startsWith("<")) {
       try {
         ServiceFactory factory = new ServiceFactory();
         OMEXMLService service = factory.getInstance(OMEXMLService.class);

--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -66,7 +66,7 @@ public class PyramidTiffReader extends BaseTiffReader {
 
   // -- Fields --
 
-  private IMetadata omexml = null;;
+  private IMetadata omexml = null;
 
   // -- Constructor --
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2251,6 +2251,13 @@ public class FormatReaderTest {
               continue;
             }
 
+            // Pyramid TIFF files may include an OME-XML comment
+            if (result && r instanceof PyramidTiffReader &&
+              readers[j] instanceof OMETiffReader)
+            {
+              continue;
+            }
+
             if (result && r instanceof TrestleReader &&
               (readers[j] instanceof JPEGReader ||
               readers[j] instanceof PGMReader ||


### PR DESCRIPTION
Backports recent changes to ```PyramidTiffReader``` to allow multiple planes in each file and an OME-XML comment to determine Z/C/T dimensions and supply additional metadata.

To test, use the new ```data_repo/curated/pyramid-tiff/samples/multi-channel-4D-series.tiff``` file (see also https://github.com/openmicroscopy/data_repo_config/pull/173).  Verify that ```showinf``` detects the reader as ```PyramidTiffReader``` and that the Z, C, and T sizes and ordering matches the text in each plane.