### PR TITLE
Add version 3.2 specification to Leica LIF format page

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1194,8 +1194,9 @@ developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
 bsd = no
 versions = 1.0, 2.0
 software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
-weHave = * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
-* a LIF specification document (version 1, from no later than 206 April 3, in PDF) \n
+weHave = * a LIF/XLLF/XLEF/LOF specification document (version 3.2, from no later than 2016 December 15, in PDF) \n
+* a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
+* a LIF specification document (version 1, from no later than 2006 April 3, in PDF) \n
 * numerous LIF datasets
 pixelsRating = Outstanding
 metadataRating = Very good

--- a/docs/sphinx/formats/leica-lif.txt
+++ b/docs/sphinx/formats/leica-lif.txt
@@ -29,8 +29,9 @@ Freely Available Software:
 
 We currently have:
 
+* a LIF/XLLF/XLEF/LOF specification document (version 3.2, from no later than 2016 December 15, in PDF) 
 * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) 
-* a LIF specification document (version 1, from no later than 206 April 3, in PDF) 
+* a LIF specification document (version 1, from no later than 2006 April 3, in PDF) 
 * numerous LIF datasets
 
 We would like to have:


### PR DESCRIPTION
See also https://trello.com/c/9F2PqPfJ/73-review-latest-leica-lif-specification-documents

Also fixes a typo in the year for the version 1 specification.