### PR TITLE
Documentation: OMERO extlink cleanup

### DIFF
--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -24,10 +24,6 @@ ifdef SOURCE_USER
 ANT_SOURCE_USER := -Dsphinx.source.user="$(SOURCE_USER)"
 endif
 
-ifdef OMERODOC_URI_JOB
-ANT_OMERODOC_URI_JOB := -Dsphinx.omerodoc.uri="$(OMERODOC_URI_JOB)"
-endif
-
 default: html
 
 %:

--- a/docs/sphinx/about/index.txt
+++ b/docs/sphinx/about/index.txt
@@ -55,7 +55,8 @@ Bio-Formats versions
 --------------------
 
 Bio-Formats is now decoupled from OMERO with its own release schedule rather
-than being updated whenever a new version of :omerodoc:`OMERO <>` is released.
+than being updated whenever a new version of :products_plone:`OMERO <omero>`
+is released.
 We expect this to result in more frequent releases to get fixes out to the
 community faster.
 

--- a/docs/sphinx/build.xml
+++ b/docs/sphinx/build.xml
@@ -42,7 +42,6 @@ Type "ant -p" for a list of targets.
     </if>
     <property name="sphinx.openmicroscopy_source.user" value="openmicroscopy"/>
     <property name="sphinx.ome_source.user" value="ome"/>
-    <property name="sphinx.omerodoc.uri" value="http://www.openmicroscopy.org/site/support/omero5.1"/>
 
     <copy file="conf.py.in" tofile="conf.py" overwrite="true"/>
     <replace file="conf.py" token="@sphinx_srcdir@" value="."/>
@@ -51,7 +50,6 @@ Type "ant -p" for a list of targets.
     <replace file="conf.py" token="@common_java_source_branch@" value="${sphinx.common_java.source.branch}"/>
     <replace file="conf.py" token="@openmicroscopy_source_user@" value="${sphinx.openmicroscopy_source.user}"/>
     <replace file="conf.py" token="@ome_source_user@" value="${sphinx.ome_source.user}"/>
-    <replace file="conf.py" token="@sphinx_omerodoc_uri@" value="${sphinx.omerodoc.uri}"/>
     <replace file="conf.py" token="@ome_common_version@" value="${ome-common.version}"/>
     <replace file="conf.py" token="@ome_model_version@" value="${ome-model.version}"/>
   </target>

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -115,11 +115,6 @@ gpl_formats = bf_github_blob + 'components/formats-gpl/src/loci/formats/'
 bsd_formats = bf_github_blob + 'components/formats-bsd/src/loci/formats/'
 bf_cpp = bf_github_blob + 'cpp/'
 
-# Variables used to define Jenkins extlinks
-jenkins_root = 'http://ci.openmicroscopy.org'
-jenkins_job_root = jenkins_root + '/job'
-jenkins_view_root = jenkins_root + '/view'
-
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
 trac_root = 'https://trac.openmicroscopy.org/ome'
@@ -141,10 +136,6 @@ extlinks = {
     'bfwriter' : (gpl_formats + 'out/' + '%s', ''),
     'bsd-writer' : (bsd_formats + 'out/' + '%s', ''),
     'bf-cpp-lib': (bf_cpp + 'lib/' + '%s', ''),
-    # Jenkins links
-    'jenkins' : (jenkins_root + '/%s', ''),
-    'jenkinsjob' : (jenkins_job_root + '/%s', ''),
-    'jenkinsview' : (jenkins_view_root + '/%s', ''),
     # Mailing list/forum links
     'mailinglist' : (lists_root + '/mailman/listinfo/%s', ''),
     'forum' : (oo_root + '/community/%s', ''),

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -17,7 +17,6 @@ builddir = '@sphinx_builddir@'
 bioformats_source_branch = '@bioformats_source_branch@'
 openmicroscopy_source_user = '@openmicroscopy_source_user@'
 ome_source_user = '@ome_source_user@'
-omerodoc_uri = '@sphinx_omerodoc_uri@'
 ome_common_version = '@ome_common_version@'
 ome_model_version = '@ome_model_version@'
 
@@ -157,7 +156,6 @@ extlinks = {
     'legacy_plone' : (oo_site_root + '/support/legacy/%s', ''),
     'about_plone' : (oo_site_root + '/about/%s', ''),
     'team_plone' : (oo_site_root + '/team/%s', ''),
-    'omerodoc' : (omerodoc_uri + '/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/bio-formats5.3/%s', ''),

--- a/docs/sphinx/users/index.txt
+++ b/docs/sphinx/users/index.txt
@@ -47,7 +47,7 @@ OMERO
 =====
 
 OMERO 5 uses Bio-Formats to read original files from over 140 file formats.
-Please refer to the :omerodoc:`OMERO documentation <>` for further
+Please refer to the :products_plone:`OMERO <omero>` documentation for further
 information.
 
 Many other software packages can use Bio-Formats to read and write

--- a/docs/sphinx/users/ome-server/index.txt
+++ b/docs/sphinx/users/ome-server/index.txt
@@ -7,9 +7,9 @@ metadata, image analysis and analysis results. The OME system is capable
 of leveraging Bio-Formats to import files.
 
 **Please note** - the OME server is no longer maintained and has now been
-superseded by the :omerodoc:`OMERO server <>`.  Support for the OME server has
-been entirely removed in the 5.0.0 version of Bio-Formats; the following
-instructions can still be used with the 4.4.x versions.
+superseded by the :products_plone:`OMERO server <omero>`.  Support for the OME
+server has been entirely removed in the 5.0.0 version of Bio-Formats; the
+following instructions can still be used with the 4.4.x versions.
 
 Installation
 ------------
@@ -102,7 +102,7 @@ Upgrading
 
 OME server is not supported by Bio-Formats versions 5.0.0 and above. To take
 advantage of more recent improvements to Bio-Formats, you must switch to
-:omerodoc:`OMERO server <>`.
+:products_plone:`OMERO server <omero>`.
 
 Source Code
 -----------


### PR DESCRIPTION
Initially discussed with @jburel, the `omerodoc` extlink in the Bio-Formats documentation forces us to maintain a mapping with the version of a consumer application like OMERO. Since the decoupling of both components, this reverse mapping does not make sense e.g. a stable Bio-Formats series could be either consumed in either none or multiple stable series of OMERO.

This PR redirects all links to the OMERO documentation to the product page. In addition the unused Jenkins extlinks are also removed.

The documentation builds should remain green and the new links should point to the correct OMERO page.