### PR TITLE
Zeiss ZVI: set valid bits per pixel and channel colors

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -347,7 +347,7 @@ public abstract class BaseZeissReader extends FormatReader {
           store.setChannelEmissionWavelength(emWavelength.get(c), s, i);
           store.setChannelExcitationWavelength(exWavelength.get(c), s, i);
 
-          if (i < channelColors.length) {
+          if (channelColors != null && i < channelColors.length) {
             int color = channelColors[i];
 
             int red = color & 0xff;

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -45,6 +45,7 @@ import loci.formats.MetadataTools;
 import loci.formats.meta.DummyMetadata;
 import loci.formats.meta.MetadataStore;
 
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
@@ -279,6 +280,7 @@ public abstract class BaseZeissReader extends FormatReader {
     else if (bpp == 2 || bpp == 6) m.pixelType = FormatTools.UINT16;
     if (isJPEG) m.pixelType = FormatTools.UINT8;
 
+    m.bitsPerPixel = FormatTools.getBytesPerPixel(m.pixelType) * 8;
     m.indexed = !isRGB() && channelColors != null;
 
     // We shouldn't need to copy the coremetadata here.  This
@@ -344,6 +346,16 @@ public abstract class BaseZeissReader extends FormatReader {
           store.setChannelName(channelName.get(c), s, i);
           store.setChannelEmissionWavelength(emWavelength.get(c), s, i);
           store.setChannelExcitationWavelength(exWavelength.get(c), s, i);
+
+          if (i < channelColors.length) {
+            int color = channelColors[i];
+
+            int red = color & 0xff;
+            int green = (color & 0xff00) >> 8;
+            int blue = (color & 0xff0000) >> 16;
+
+            store.setChannelColor(new Color(red, green, blue, 255), s, i);
+          }
         }
       }
 
@@ -841,7 +853,19 @@ public abstract class BaseZeissReader extends FormatReader {
           {
             System.arraycopy(
               channelColors, 1, channelColors, 0, channelColors.length - 1);
-            channelColors[cIndex - 1] = Integer.parseInt(value);          }
+            channelColors[cIndex - 1] = Integer.parseInt(value);
+          }
+          else if (channelColors != null && channelColors[0] > 0 &&
+            channelColors.length > 1)
+          {
+            int c = 1;
+            while (c < channelColors.length - 1 && channelColors[c] != 0) {
+              c++;
+            }
+            if (channelColors[c] == 0) {
+              channelColors[c] = Integer.parseInt(value);
+            }
+          }
         }
         else if (key.startsWith("Scale Factor for X") && physicalSizeX == null)
         {


### PR DESCRIPTION
Backported from a private PR.  This ensures that the ```bitsPerPixel``` field in ```CoreMetadata``` is always set to match the final pixel type, and populates any channel colors that were parsed in the ```MetadataStore```.

The bits per pixel change should only affect ```uint16``` or ```int16``` files where the acquisition bit depth in the global metadata table is not a multiple of 8, and the RGB channel count is greater than 1.  A suitable test file would be ```data_repo/curated/zeiss-zvi/dan/adultNr1.zvi```, but there may be others.

Without this PR, confirm that ```showinf -nopix -omexml``` on the chosen file shows a pixel type of ```uint16``` and valid bits per pixel of 8.  The ```Color``` attribute on ```Channel``` should not be present in the OME-XML.  With this PR, the same test should show that the valid bits per pixel is 16, and that a ```Color``` is present on each ```Channel```.  The color value should match the color shown in Zen or AxioVision; in the case of ```adultNr1.zvi``` this is white (-1).