### PR TITLE
Add link to public LIF samples

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1197,7 +1197,8 @@ software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/micros
 weHave = * a LIF/XLLF/XLEF/LOF specification document (version 3.2, from no later than 2016 December 15, in PDF) \n
 * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
 * a LIF specification document (version 1, from no later than 2006 April 3, in PDF) \n
-* numerous LIF datasets
+* numerous LIF datasets \n
+* `public sample images <http://downloads.openmicroscopy.org/images/Leica-LIF/>`__
 pixelsRating = Outstanding
 metadataRating = Very good
 opennessRating = Very good

--- a/docs/sphinx/formats/leica-lif.txt
+++ b/docs/sphinx/formats/leica-lif.txt
@@ -32,7 +32,8 @@ We currently have:
 * a LIF/XLLF/XLEF/LOF specification document (version 3.2, from no later than 2016 December 15, in PDF) 
 * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) 
 * a LIF specification document (version 1, from no later than 2006 April 3, in PDF) 
-* numerous LIF datasets
+* numerous LIF datasets 
+* `public sample images <http://downloads.openmicroscopy.org/images/Leica-LIF/>`__
 
 We would like to have:
 


### PR DESCRIPTION
See https://trello.com/c/kbbtkZr7/11-lif-documentation

This adds a link to the new public images to https://www.openmicroscopy.org/site/support/bio-formats5.3-staging/formats/leica-lif.html using the standard template