### PR TITLE
ImageJ: fix NPE when check pixel type

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -439,10 +439,14 @@ public class Exporter {
             // this prevents problems if the user changed the bit depth of the image
             boolean applyCalibrationFunction = false;
             try {
-                int originalType = FormatTools.pixelTypeFromString(
+                int originalType = -1;
+                if (store.getPixelsType(0) != null) {
+                  originalType = FormatTools.pixelTypeFromString(
                   store.getPixelsType(0).toString());
+                }
                 if (ptype != originalType &&
-                  (!FormatTools.isSigned(originalType) ||
+                  (store.getPixelsType(0) == null ||
+                  !FormatTools.isSigned(originalType) ||
                   FormatTools.getBytesPerPixel(originalType) !=
                   FormatTools.getBytesPerPixel(ptype)))
                 {


### PR DESCRIPTION
This prevents exceptions when exporting images that were not opened via the Bio-Formats importer, and thus do not have a complete OMEXMLMetadata store.

See https://github.com/openmicroscopy/bioformats/issues/2752

Without this PR, running the macro listed on gh-2752 (on Windows) or the following on Mac/Linux should result in the ```NullPointerException``` noted on the issue:

```
run("Mitosis (26MB, 5D stack)");
run("Bio-Formats Exporter", "save=[/tmp/test.ics]");
```

With this PR (and after removing the output file), the same test should result in a completed export with no error messages.  This bug was introduced by https://github.com/openmicroscopy/bioformats/pull/2696