### PR TITLE
Allow support for different versions of ECAT7 files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/Ecat7Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/Ecat7Reader.java
@@ -46,6 +46,10 @@ public class Ecat7Reader extends FormatReader {
   // -- Constants --
 
   public static final String ECAT7_MAGIC = "MATRIX72v";
+
+  // there are three ECAT7 versions, see: https://github.com/neurodebian/spm12/blob/master/spm_ecat2nifti.m
+  public static final String ECAT7_MAGIC_REGEX = "MATRIX7[012]v";
+
   private static final long HEADER_SIZE = 1536;
 
   // -- Constructor --
@@ -99,7 +103,7 @@ public class Ecat7Reader extends FormatReader {
     CoreMetadata ms0 = core.get(0);
 
     String check = in.readString(14).trim();
-    if (!check.equals(ECAT7_MAGIC)) {
+    if (!check.matches(ECAT7_MAGIC_REGEX)) {
       throw new FormatException("Invalid ECAT 7 file.");
     }
 


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2017-January/003870.html

Extends the magic string to use a more generic regexp matching various sample filesets (external contribution by Torsten Stoeter).

As per the request of the author, the initial sample data submitted together with the patch will be kept private. Another artificial sample file reproducing the issue was submitted privately and will be made public under the CC-BY 4.0 license.