### PR TITLE
Add link to ECAT7 public samples

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -554,7 +554,8 @@ several attempts to fix the problem blind. \n
 extensions = .v
 developer = `Siemens <http://www.siemens.com>`_
 bsd = no
-weHave = * a few ECAT7 files
+weHave = * a few ECAT7 files \n
+* `public sample images <http://downloads.openmicroscopy.org/images/ECAT7/>`__
 weWant = * an ECAT7 specification document \n
 * more ECAT7 files
 pixelsRating = Good

--- a/docs/sphinx/formats/ecat7.txt
+++ b/docs/sphinx/formats/ecat7.txt
@@ -25,7 +25,8 @@ Reader: Ecat7Reader (:bfreader:`Source Code <Ecat7Reader.java>`, :doc:`Supported
 
 We currently have:
 
-* a few ECAT7 files
+* a few ECAT7 files 
+* `public sample images <http://downloads.openmicroscopy.org/images/ECAT7/>`__
 
 We would like to have:
 


### PR DESCRIPTION
See https://trello.com/c/VdFhKgTO/13-extended-support-for-ecat7-format for context

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.3-staging/formats/ecat7.html