### PR TITLE
ScreenReader: exclude selected readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -78,6 +78,7 @@ public class ScreenReader extends FormatReader {
   // -- Fields --
 
   private String[] plateMetadataFiles;
+  private String[] excludeReaders;
   private String[][] files;
   private String[] ordering;
   private int[][] axisTypes;
@@ -362,6 +363,20 @@ public class ScreenReader extends FormatReader {
     }
 
     core.clear();
+
+    String excludeReadersEntry = plateTable.get("ExcludeReaders");
+    if (null != excludeReadersEntry) {
+      excludeReaders = excludeReadersEntry.split(",", -1);
+    }
+    for (String r : excludeReaders) {
+      try {
+        Class<? extends IFormatReader> c =
+          Class.forName(r).asSubclass(IFormatReader.class);
+        validReaders.removeClass(c);
+      } catch (ClassNotFoundException e) {
+        LOGGER.warn("Reader {} not found", r);
+      }
+    }
 
     ImageReader iReader = new ImageReader(validReaders);
     FileStitcher stitcher = new FileStitcher(iReader, true);

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -379,6 +379,7 @@ public class ScreenReader extends FormatReader {
 
     ImageReader iReader = new ImageReader(validReaders);
     FileStitcher stitcher = new FileStitcher(iReader, true);
+    stitcher.setReaderClassList(validReaders);
     stitcher.setCanChangePattern(false);
     // After setReaderClassList
     reader = new DimensionSwapper(stitcher);

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -78,7 +78,6 @@ public class ScreenReader extends FormatReader {
   // -- Fields --
 
   private String[] plateMetadataFiles;
-  private String[] excludeReaders;
   private String[][] files;
   private String[] ordering;
   private int[][] axisTypes;
@@ -366,15 +365,15 @@ public class ScreenReader extends FormatReader {
 
     String excludeReadersEntry = plateTable.get("ExcludeReaders");
     if (null != excludeReadersEntry) {
-      excludeReaders = excludeReadersEntry.split(",", -1);
-    }
-    for (String r : excludeReaders) {
-      try {
-        Class<? extends IFormatReader> c =
-          Class.forName(r).asSubclass(IFormatReader.class);
-        validReaders.removeClass(c);
-      } catch (ClassNotFoundException e) {
-        LOGGER.warn("Reader {} not found", r);
+      String[] excludeReaders = excludeReadersEntry.split(",", -1);
+      for (String r : excludeReaders) {
+        try {
+          Class<? extends IFormatReader> c =
+            Class.forName(r).asSubclass(IFormatReader.class);
+          validReaders.removeClass(c);
+        } catch (ClassNotFoundException e) {
+          LOGGER.warn("Reader {} not found", r);
+        }
       }
     }
 


### PR DESCRIPTION
Adds support for a new `ExcludeReaders` entry in the `Plate` section that allows to exclude some readers from the list considered by `ImageReader`.

Example:

```
[Plate]
Name = Foo
Rows = 8
Columns = 12
Fields = 1
ExcludeReaders = loci.formats.in.Reader1,loci.formats.in.Reader2
```

This is useful in cases where a multi-file format is detected (e.g., due to the presence of specific TIFF tags) which would override the desired arrangement described in the file patterns.