### PR TITLE
merge RGB intensities using NDPIReaders

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -129,13 +129,13 @@ public class NDPISReader extends FormatReader {
     // each channel is RGB data (with usually only one band used), thus we sum up the intensities
     if (readers[channel].isInterleaved()) {
       for (int i = 0; i < buf.length; i++) {
-        intens = bufRGB[i * 3] + bufRGB[i * 3 + 1] + bufRGB[i * 3 + 2];
+        intens = ((int)bufRGB[i * 3] & 0xff) + ((int)bufRGB[i * 3 + 1] & 0xff) + ((int)bufRGB[i * 3 + 2] & 0xff);
         buf[i] = (byte) (intens <= 255 ? intens : 255);   // clamp to byte
       }
     } else {    // not interleaved
       int offs = w*h;
       for (int i = 0; i < buf.length; i++) {
-        intens = bufRGB[i] + bufRGB[i + offs] + bufRGB[i + offs *2];
+        intens = ((int)bufRGB[i] & 0xff) + ((int)bufRGB[i + offs] & 0xff) + ((int)bufRGB[i + offs *2] & 0xff);
         buf[i] = (byte) (intens <= 255 ? intens : 255);   // clamp to byte
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -222,7 +222,7 @@ public class NDPISReader extends FormatReader {
       store.setChannelEmissionWavelength(new Length(wavelength, UNITS.NANOMETER),getSeries(), c);
 
       bandUsed[c] = 0;
-      if (readers[c].getSizeC()>=3) {
+      if (samplesPerPixel[c]>=3) {
         // define band used based on emission wavelength
         // wavelength = 0  Colour Image
         // 380 =< wavelength <= 490 Blue

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -122,9 +122,7 @@ public class NDPISReader extends FormatReader {
         }
       } else {    // not interleaved
         final int offs = w * h;
-        for (int i = 0; i < buf.length; i++) {
-          buf[i] = bufReader[i + offs * band];
-        }
+        System.arraycopy(bufReader,offs * band,buf,0,buf.length);
       }
       return buf;
     }

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -30,6 +30,9 @@ import loci.common.Location;
 import loci.common.RandomAccessInputStream;
 import loci.formats.*;
 import loci.formats.meta.MetadataStore;
+import loci.formats.tiff.IFD;
+import ome.units.UNITS;
+import ome.units.quantity.Length;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,7 +51,10 @@ public class NDPISReader extends FormatReader {
 
   private String[] ndpiFiles;
   private NDPIReader[] readers;
-  private final static int CHANNELTAG = 65434;
+  private int[] bandUsed;
+  private int[] samplesPerPixel;
+  private final static int TAG_CHANNEL = 65434;
+  private final static int TAG_EMISSION_WAVELENGTH = 65451;
 
   // -- Constructor --
 
@@ -102,24 +108,26 @@ public class NDPISReader extends FormatReader {
     readers[channel].setId(ndpiFiles[channel]);
     readers[channel].setSeries(getSeries());
     readers[channel].setResolution(getResolution());
-    byte[] bufRGB = DataTools.allocate(w, h, 3); // w*h*RGB  - maybe this should be reused...
-    bufRGB = readers[channel].openBytes(0, bufRGB, x, y, w, h);
-    int intens;
-    // each channel is RGB data (with usually only one band used), thus we sum up the intensities
-    if (readers[channel].isInterleaved()) {
-      for (int i = 0; i < buf.length; i++) {
-        intens = ((int)bufRGB[i * 3] & 0xff) + ((int)bufRGB[i * 3 + 1] & 0xff) + ((int)bufRGB[i * 3 + 2] & 0xff);
-        buf[i] = (byte) (intens <= 255 ? intens : 255);   // clamp to byte
-      }
-    } else {    // not interleaved
-      int offs = w*h;
-      for (int i = 0; i < buf.length; i++) {
-        intens = ((int)bufRGB[i] & 0xff) + ((int)bufRGB[i + offs] & 0xff) + ((int)bufRGB[i + offs *2] & 0xff);
-        buf[i] = (byte) (intens <= 255 ? intens : 255);   // clamp to byte
-      }
-    }
+    int spp = samplesPerPixel[channel];
+    if (spp==1) return readers[channel].openBytes(0, buf, x, y, w, h);    // single band reader
 
-    return buf;
+    else {   // read intensity from used band (the other bands are close to zero, only jpeg artifacts and should be ignored)
+      byte[] bufReader = DataTools.allocate(w, h, spp); // w*h*RGB
+      bufReader = readers[channel].openBytes(0, bufReader, x, y, w, h);
+      int band = bandUsed[channel];
+      // each channel is RGB data (with usually only one band used), thus we sum up the intensities
+      if (readers[channel].isInterleaved()) {
+        for (int i = 0; i < buf.length; i++) {
+          buf[i] = bufReader[i * spp + band];
+        }
+      } else {    // not interleaved
+        final int offs = w * h;
+        for (int i = 0; i < buf.length; i++) {
+          buf[i] = bufReader[i + offs * band];
+        }
+      }
+      return buf;
+    }
   }
 
 
@@ -179,6 +187,7 @@ public class NDPISReader extends FormatReader {
       if (key.equals("NoImages")) {
         ndpiFiles = new String[Integer.parseInt(value)];
         readers = new NDPIReader[ndpiFiles.length];
+
       }
       else if (key.startsWith("Image")) {
         int index = Integer.parseInt(key.replaceAll("Image", ""));
@@ -199,12 +208,31 @@ public class NDPISReader extends FormatReader {
       ms.imageCount = ms.sizeC * ms.sizeZ * ms.sizeT;
     }
 
+    samplesPerPixel = new int[ndpiFiles.length];
+    bandUsed = new int[ndpiFiles.length];
     MetadataStore store = makeFilterMetadata();
     for (int c=0; c<readers.length; c++) {     // populate channel names based on IFD entry
       if (c>0) // 0 is already open
         readers[c].setId(ndpiFiles[c]);
-      String channelName = readers[c].getIFDs().get(0).getIFDStringValue(CHANNELTAG);
+      IFD ifd = readers[c].getIFDs().get(0);
+      samplesPerPixel[c] = ifd.getSamplesPerPixel();
+      String channelName = ifd.getIFDStringValue(TAG_CHANNEL);
+      Float wavelength = (Float) ifd.getIFDValue(TAG_EMISSION_WAVELENGTH);
       store.setChannelName(channelName, getSeries(), c);
+      store.setChannelEmissionWavelength(new Length(wavelength, UNITS.NANOMETER),getSeries(), c);
+
+      bandUsed[c] = 0;
+      if (readers[c].getSizeC()>=3) {
+        // define band used based on emission wavelength
+        // wavelength = 0  Colour Image
+        // 380 =< wavelength <= 490 Blue
+        // 490 < wavelength <= 580 Green
+        // 580 < wavelength <= 780 Red
+        bandUsed[c] = 0;
+        if (380 < wavelength && wavelength <= 490) bandUsed[c] = 2;
+        else if (490 < wavelength && wavelength <= 580) bandUsed[c] = 1;
+        else if (580 < wavelength && wavelength <= 780) bandUsed[c] = 0;
+      }
     }
     MetadataTools.populatePixels(store, this);
   }

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -88,27 +88,6 @@ public class NDPISReader extends FormatReader {
   }
 
 
-  /* @see IFormatReader#openBytes(int, int, int, int, int) */
-  @Override
-  public byte[] openBytes(int no, int x, int y, int w, int h)
-          throws FormatException, IOException
-  {
-    int ch = getRGBChannelCount();
-    int bpp = FormatTools.getBytesPerPixel(getPixelType());
-    byte[] newBuffer;
-    try {
-      newBuffer = DataTools.allocate(w, h, ch, bpp);
-    }
-    catch (IllegalArgumentException e) {
-      throw new FormatException("Image plane too large. Only 2GB of data can " +
-              "be extracted at one time. You can workaround the problem by opening " +
-              "the plane in tiles; for further details, see: " +
-              "http://www.openmicroscopy.org/site/support/bio-formats/about/" +
-              "bug-reporting.html#common-issues-to-check", e);
-    }
-    return openBytes(no, newBuffer, x, y, w, h);
-  }
-
   /**
    * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
    */


### PR DESCRIPTION
Here we use NDPIReaders and merge the RGB intensities instead of using ChannelSeparators as before.
Otherwise the images have been black for most  (non red) channels.