### PR TITLE
CellVoyager: metadata fixes and general maintainability improvements

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -149,6 +149,8 @@ public class CellVoyagerReader extends FormatReader
 		final AreaInfo area = well.areas.get( areaIndex );
 		final MinimalTiffReader tiffReader = new MinimalTiffReader();
 
+    imageFolder = new Location(currentId).getAbsoluteFile().getParentFile();
+    imageFolder = new Location(imageFolder, "Image");
 		for ( final FieldInfo field : area.fields )
 		{
 

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -502,7 +502,7 @@ public class CellVoyagerReader extends FormatReader
 		}
 		catch ( final TransformerException e2 )
 		{
-			e2.printStackTrace();
+      LOGGER.debug("", e2);
 		}
 		try
 		{

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -25,11 +25,9 @@
 
 package loci.formats.in;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Hashtable;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -1175,40 +1173,4 @@ public class CellVoyagerReader extends FormatReader
 		return null;
 	}
 
-	public static void main( final String[] args ) throws IOException, FormatException, ServiceException
-	{
-		// final String id =
-		// "/Users/tinevez/Projects/EArena/Data/TestDataset/20131025T092701/MeasurementSetting.xml";
-		// final String id =
-		// "/Users/tinevez/Projects/EArena/Data/30um sections at 40x - last round/1_3_1_2_2/20130731T133622/MeasurementResult.xml";
-		final String id = "/Users/tinevez/Projects/EArena/Data/TestDataset/20131030T142837";
-
-		final CellVoyagerReader importer = new CellVoyagerReader();
-		importer.setId( id );
-
-		final List< CoreMetadata > cms = importer.getCoreMetadataList();
-		for ( final CoreMetadata coreMetadata : cms )
-		{
-			System.out.println( coreMetadata );
-		}
-
-		final Hashtable< String, Object > meta = importer.getGlobalMetadata();
-		final String[] keys = MetadataTools.keys( meta );
-		for ( final String key : keys )
-		{
-			System.out.println( key + " = " + meta.get( key ) );
-		}
-
-		importer.openBytes( 0 );
-
-		importer.setSeries( 1 );
-		final String[] usedFiles = importer.getSeriesUsedFiles();
-		for ( final String file : usedFiles )
-		{
-			System.out.println( "  " + file );
-		}
-
-		importer.close();
-
-	}
 }

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -110,184 +110,184 @@ import org.xml.sax.SAXException;
 public class CellVoyagerReader extends FormatReader
 {
 
-	private static final String SINGLE_TIFF_PATH_BUILDER = "W%dF%03dT%04dZ%02dC%d.tif";
+  private static final String SINGLE_TIFF_PATH_BUILDER = "W%dF%03dT%04dZ%02dC%d.tif";
 
-	private Location measurementFolder;
+  private Location measurementFolder;
   private Location imageFolder;
 
-	private List< ChannelInfo > channelInfos;
+  private List< ChannelInfo > channelInfos;
 
-	private List< WellInfo > wells;
+  private List< WellInfo > wells;
 
-	private List< Integer > timePoints;
+  private List< Integer > timePoints;
 
-	private Location measurementResultFile;
+  private Location measurementResultFile;
 
-	private Location omeMeasurementFile;
+  private Location omeMeasurementFile;
 
-	public CellVoyagerReader()
-	{
-		super( "CellVoyager", new String[] { "tif", "xml" } );
-		this.hasCompanionFiles = true;
-		this.datasetDescription = "Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stitch together several TIF files.";
-		this.domains = new String[] { FormatTools.HISTOLOGY_DOMAIN, FormatTools.LM_DOMAIN, FormatTools.HCS_DOMAIN };
-	}
+  public CellVoyagerReader()
+  {
+    super( "CellVoyager", new String[] { "tif", "xml" } );
+    this.hasCompanionFiles = true;
+    this.datasetDescription = "Directory with 2 master files 'MeasurementResult.xml' and 'MeasurementResult.ome.xml', used to stitch together several TIF files.";
+    this.domains = new String[] { FormatTools.HISTOLOGY_DOMAIN, FormatTools.LM_DOMAIN, FormatTools.HCS_DOMAIN };
+  }
 
-	@Override
-	public byte[] openBytes( final int no, final byte[] buf, final int x, final int y, final int w, final int h ) throws FormatException, IOException
-	{
-		FormatTools.checkPlaneParameters( this, no, buf.length, x, y, w, h );
+  @Override
+  public byte[] openBytes( final int no, final byte[] buf, final int x, final int y, final int w, final int h ) throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters( this, no, buf.length, x, y, w, h );
 
-		final CoreMetadata cm = core.get( getSeries() );
+    final CoreMetadata cm = core.get( getSeries() );
 
     int[] zct = getZCTCoords(no);
 
-		final int[] indices = seriesToWellArea( getSeries() );
-		final int wellIndex = indices[ 0 ];
-		final int areaIndex = indices[ 1 ];
-		final WellInfo well = wells.get( wellIndex );
-		final AreaInfo area = well.areas.get( areaIndex );
-		final MinimalTiffReader tiffReader = new MinimalTiffReader();
+    final int[] indices = seriesToWellArea( getSeries() );
+    final int wellIndex = indices[ 0 ];
+    final int areaIndex = indices[ 1 ];
+    final WellInfo well = wells.get( wellIndex );
+    final AreaInfo area = well.areas.get( areaIndex );
+    final MinimalTiffReader tiffReader = new MinimalTiffReader();
 
     imageFolder = new Location(currentId).getAbsoluteFile().getParentFile();
     imageFolder = new Location(imageFolder, "Image");
-		for ( final FieldInfo field : area.fields )
-		{
+    for ( final FieldInfo field : area.fields )
+    {
 
-			String filename = String.format(SINGLE_TIFF_PATH_BUILDER, wellIndex + 1, field.index, zct[2] + 1, zct[0] + 1, zct[1] + 1);
-			final Location image = new Location( imageFolder, filename );
+      String filename = String.format(SINGLE_TIFF_PATH_BUILDER, wellIndex + 1, field.index, zct[2] + 1, zct[0] + 1, zct[1] + 1);
+      final Location image = new Location( imageFolder, filename );
       if (!image.exists()) {
         LOGGER.warn("Could not find file {}", image);
         continue;
       }
 
-			tiffReader.setId( image.getAbsolutePath() );
+      tiffReader.setId( image.getAbsolutePath() );
 
-			// Tile size
-			final int tw = channelInfos.get( 0 ).tileWidth;
-			final int th = channelInfos.get( 0 ).tileHeight;
+      // Tile size
+      final int tw = channelInfos.get( 0 ).tileWidth;
+      final int th = channelInfos.get( 0 ).tileHeight;
 
-			// Field bounds in full final image, full width, full height
-			// (referential named '0', as if x=0 and y=0).
-			final int xbs0 = ( int ) field.xpixels;
-			final int ybs0 = ( int ) field.ypixels;
+      // Field bounds in full final image, full width, full height
+      // (referential named '0', as if x=0 and y=0).
+      final int xbs0 = ( int ) field.xpixels;
+      final int ybs0 = ( int ) field.ypixels;
 
-			// Subimage bounds in full final image is simply x, y, x+w, y+h
+      // Subimage bounds in full final image is simply x, y, x+w, y+h
 
-			// Do they intersect?
-			if ( x + w < xbs0 || xbs0 + tw < x || y + h < ybs0 || ybs0 + th < y )
-			{
-				continue;
-			}
+      // Do they intersect?
+      if ( x + w < xbs0 || xbs0 + tw < x || y + h < ybs0 || ybs0 + th < y )
+      {
+        continue;
+      }
 
-			// Common rectangle in reconstructed image referential.
-			final int xs0 = Math.max( xbs0 - x, 0 );
-			final int ys0 = Math.max( ybs0 - y, 0 );
+      // Common rectangle in reconstructed image referential.
+      final int xs0 = Math.max( xbs0 - x, 0 );
+      final int ys0 = Math.max( ybs0 - y, 0 );
 
-			// Common rectangle in tile referential (named with '1').
-			final int xs1 = Math.max( x - xbs0, 0 );
-			final int ys1 = Math.max( y - ybs0, 0 );
-			final int xe1 = Math.min( tw, x + w - xbs0 );
-			final int ye1 = Math.min( th, y + h - ybs0 );
-			final int w1 = xe1 - xs1;
-			final int h1 = ye1 - ys1;
+      // Common rectangle in tile referential (named with '1').
+      final int xs1 = Math.max( x - xbs0, 0 );
+      final int ys1 = Math.max( y - ybs0, 0 );
+      final int xe1 = Math.min( tw, x + w - xbs0 );
+      final int ye1 = Math.min( th, y + h - ybs0 );
+      final int w1 = xe1 - xs1;
+      final int h1 = ye1 - ys1;
 
-			if ( w1 <= 0 || h1 <= 0 )
-			{
-				continue;
-			}
+      if ( w1 <= 0 || h1 <= 0 )
+      {
+        continue;
+      }
 
-			// Get corresponding data.
-			final byte[] bytes = tiffReader.openBytes( 0, xs1, ys1, w1, h1 );
-			final int nbpp = cm.bitsPerPixel / 8;
+      // Get corresponding data.
+      final byte[] bytes = tiffReader.openBytes( 0, xs1, ys1, w1, h1 );
+      final int nbpp = cm.bitsPerPixel / 8;
 
-			for ( int row1 = 0; row1 < h1; row1++ )
-			{
-				// Line index in tile coords
-				final int ls1 = nbpp * ( row1 * w1 );
-				final int length = nbpp * w1;
+      for ( int row1 = 0; row1 < h1; row1++ )
+      {
+        // Line index in tile coords
+        final int ls1 = nbpp * ( row1 * w1 );
+        final int length = nbpp * w1;
 
-				// Line index in reconstructed image coords
-				final int ls0 = nbpp * ( ( ys0 + row1 ) * w + xs0 );
+        // Line index in reconstructed image coords
+        final int ls0 = nbpp * ( ( ys0 + row1 ) * w + xs0 );
 
-				// Transfer
-				System.arraycopy( bytes, ls1, buf, ls0, length );
-			}
-			tiffReader.close();
-		}
+        // Transfer
+        System.arraycopy( bytes, ls1, buf, ls0, length );
+      }
+      tiffReader.close();
+    }
 
-		return buf;
-	}
+    return buf;
+  }
 
-	@Override
-	public int fileGroupOption( final String id ) throws FormatException, IOException
-	{
-		return FormatTools.MUST_GROUP;
-	}
+  @Override
+  public int fileGroupOption( final String id ) throws FormatException, IOException
+  {
+    return FormatTools.MUST_GROUP;
+  }
 
-	@Override
-	public int getRequiredDirectories( final String[] files ) throws FormatException, IOException
-	{
-		/*
-		 * We only need the directory where there is the two xml files. The
-		 * parent durectory seems to contain only hardware macros to load and
-		 * eject the plate or slide.
-		 */
-		return 0;
-	}
+  @Override
+  public int getRequiredDirectories( final String[] files ) throws FormatException, IOException
+  {
+    /*
+     * We only need the directory where there is the two xml files. The
+     * parent durectory seems to contain only hardware macros to load and
+     * eject the plate or slide.
+     */
+    return 0;
+  }
 
-	@Override
-	public boolean isSingleFile( final String id ) throws FormatException, IOException
-	{
-		return false;
-	}
+  @Override
+  public boolean isSingleFile( final String id ) throws FormatException, IOException
+  {
+    return false;
+  }
 
-	@Override
-	public boolean isThisType( final String name, final boolean open )
-	{
-		/*
-		 * We want to be pointed to any file in the directory that contains
-		 * 'MeasurementResult.xml'.
-		 */
-		final String localName = new Location( name ).getName();
-		if ( localName.equals( "MeasurementResult.xml" ) ) { return true; }
-		final Location parent = new Location( name ).getAbsoluteFile().getParentFile();
-		Location xml = new Location( parent, "MeasurementResult.xml" );
-		if (!xml.exists()) {
+  @Override
+  public boolean isThisType( final String name, final boolean open )
+  {
+    /*
+     * We want to be pointed to any file in the directory that contains
+     * 'MeasurementResult.xml'.
+     */
+    final String localName = new Location( name ).getName();
+    if ( localName.equals( "MeasurementResult.xml" ) ) { return true; }
+    final Location parent = new Location( name ).getAbsoluteFile().getParentFile();
+    Location xml = new Location( parent, "MeasurementResult.xml" );
+    if (!xml.exists()) {
       xml = new Location(parent.getParentFile(), "MeasurementResult.xml");
       if (!xml.exists()) {
         return false;
       }
     }
 
-		return super.isThisType( name, open );
-	}
+    return super.isThisType( name, open );
+  }
 
-	@Override
-	protected void initFile( final String id ) throws FormatException, IOException
-	{
-		super.initFile( id );
+  @Override
+  protected void initFile( final String id ) throws FormatException, IOException
+  {
+    super.initFile( id );
 
-		measurementFolder = new Location( id ).getAbsoluteFile();
-		if ( !measurementFolder.exists() ) { throw new IOException( "File " + id + " does not exist." ); }
-		if ( !measurementFolder.isDirectory() )
-		{
-			measurementFolder = measurementFolder.getParentFile();
+    measurementFolder = new Location( id ).getAbsoluteFile();
+    if ( !measurementFolder.exists() ) { throw new IOException( "File " + id + " does not exist." ); }
+    if ( !measurementFolder.isDirectory() )
+    {
+      measurementFolder = measurementFolder.getParentFile();
       if (measurementFolder.getName().equals("Image")) {
-			  measurementFolder = measurementFolder.getParentFile();
+        measurementFolder = measurementFolder.getParentFile();
       }
-		}
+    }
     imageFolder = new Location(measurementFolder, "Image");
 
-		measurementResultFile = new Location( measurementFolder, "MeasurementResult.xml" );
-		if ( !measurementResultFile.exists() ) { throw new IOException( "Could not find " + measurementResultFile + " in folder." ); }
+    measurementResultFile = new Location( measurementFolder, "MeasurementResult.xml" );
+    if ( !measurementResultFile.exists() ) { throw new IOException( "Could not find " + measurementResultFile + " in folder." ); }
 
-		omeMeasurementFile = new Location( measurementFolder, "MeasurementResult.ome.xml" );
-		if ( !omeMeasurementFile.exists() ) { throw new IOException( "Could not find " + omeMeasurementFile + " in folder." ); }
+    omeMeasurementFile = new Location( measurementFolder, "MeasurementResult.ome.xml" );
+    if ( !omeMeasurementFile.exists() ) { throw new IOException( "Could not find " + omeMeasurementFile + " in folder." ); }
 
-		/*
-		 * Open MeasurementSettings file
-		 */
+    /*
+     * Open MeasurementSettings file
+     */
 
     RandomAccessInputStream result =
       new RandomAccessInputStream(measurementResultFile.getAbsolutePath());
@@ -305,27 +305,27 @@ public class CellVoyagerReader extends FormatReader
       result.close();
     }
 
-		msDocument.getDocumentElement().normalize();
+    msDocument.getDocumentElement().normalize();
 
-		/*
-		 * Check file version
-		 */
+    /*
+     * Check file version
+     */
 
-		final String fileVersionMajor = getChildText( msDocument.getDocumentElement(), new String[] { "FileVersion", "Major" } );
-		// Note the typo here.
-		final String fileVersionMinor = getChildText( msDocument.getDocumentElement(), new String[] { "FileVersion", "Miner" } );
-		if ( !fileVersionMajor.equals( "1" ) || !fileVersionMinor.equals( "0" ) )
-		{
-			LOGGER.warn( "Detected a file version " + fileVersionMajor + "." + fileVersionMinor + ". This reader was built by reverse-engineering v1.0 files only. Errors might occur." );
-		}
+    final String fileVersionMajor = getChildText( msDocument.getDocumentElement(), new String[] { "FileVersion", "Major" } );
+    // Note the typo here.
+    final String fileVersionMinor = getChildText( msDocument.getDocumentElement(), new String[] { "FileVersion", "Miner" } );
+    if ( !fileVersionMajor.equals( "1" ) || !fileVersionMinor.equals( "0" ) )
+    {
+      LOGGER.warn( "Detected a file version " + fileVersionMajor + "." + fileVersionMinor + ". This reader was built by reverse-engineering v1.0 files only. Errors might occur." );
+    }
 
-		/*
-		 * Open OME metadata file
-		 */
+    /*
+     * Open OME metadata file
+     */
 
     RandomAccessInputStream measurement =
       new RandomAccessInputStream(omeMeasurementFile.getAbsolutePath());
-		Document omeDocument = null;
+    Document omeDocument = null;
     try {
       omeDocument = XMLTools.parseDOM(measurement);
     }
@@ -338,827 +338,827 @@ public class CellVoyagerReader extends FormatReader
     finally {
       measurement.close();
     }
-		omeDocument.getDocumentElement().normalize();
+    omeDocument.getDocumentElement().normalize();
 
-		/*
-		 * Extract metadata from MeasurementSetting.xml & OME xml file. This is
-		 * where the core of parsing and fetching useful info happens
-		 */
+    /*
+     * Extract metadata from MeasurementSetting.xml & OME xml file. This is
+     * where the core of parsing and fetching useful info happens
+     */
 
-		readInfo( msDocument, omeDocument );
-	}
+    readInfo( msDocument, omeDocument );
+  }
 
-	@Override
-	public String[] getSeriesUsedFiles( final boolean noPixels )
-	{
-		FormatTools.assertId( currentId, true, 1 );
+  @Override
+  public String[] getSeriesUsedFiles( final boolean noPixels )
+  {
+    FormatTools.assertId( currentId, true, 1 );
 
-		if ( noPixels )
-		{
-			return new String[] { measurementResultFile.getAbsolutePath(), omeMeasurementFile.getAbsolutePath() };
-		}
-		else
-		{
-			final int[] indices = seriesToWellArea( getSeries() );
-			final int wellIndex = indices[ 0 ];
-			final int areaIndex = indices[ 1 ];
-			final AreaInfo area = wells.get( wellIndex ).areas.get( areaIndex );
-			final int nFields = area.fields.size();
+    if ( noPixels )
+    {
+      return new String[] { measurementResultFile.getAbsolutePath(), omeMeasurementFile.getAbsolutePath() };
+    }
+    else
+    {
+      final int[] indices = seriesToWellArea( getSeries() );
+      final int wellIndex = indices[ 0 ];
+      final int areaIndex = indices[ 1 ];
+      final AreaInfo area = wells.get( wellIndex ).areas.get( areaIndex );
+      final int nFields = area.fields.size();
       ArrayList<String> images = new ArrayList<String>();
       images.add(measurementResultFile.getAbsolutePath());
       images.add(omeMeasurementFile.getAbsolutePath());
 
-			for ( final Integer timepoint : timePoints )
-			{
-				for ( int zslice = 1; zslice <= getSizeZ(); zslice++ )
-				{
-					for ( int channel = 1; channel <= getSizeC(); channel++ )
-					{
-						for ( final FieldInfo field : area.fields )
-						{
-							/*
-							 * Here we compose file names on the fly assuming
-							 * they follow the pattern below. Fragile I guess.
-							 */
+      for ( final Integer timepoint : timePoints )
+      {
+        for ( int zslice = 1; zslice <= getSizeZ(); zslice++ )
+        {
+          for ( int channel = 1; channel <= getSizeC(); channel++ )
+          {
+            for ( final FieldInfo field : area.fields )
+            {
+              /*
+               * Here we compose file names on the fly assuming
+               * they follow the pattern below. Fragile I guess.
+               */
               String relativePath = String.format(SINGLE_TIFF_PATH_BUILDER,
                 wellIndex + 1, field.index, timepoint, zslice, channel);
               Location imageFile = new Location(imageFolder, relativePath);
               if (imageFile.exists()) {
                 images.add(imageFile.getAbsolutePath());
               }
-						}
-					}
-				}
-			}
-			return images.toArray(new String[images.size()]);
-		}
+            }
+          }
+        }
+      }
+      return images.toArray(new String[images.size()]);
+    }
 
-	}
+  }
 
-	/*
-	 * PRIVATE METHODS
-	 */
+  /*
+   * PRIVATE METHODS
+   */
 
-	/**
-	 * Returns the well index (in the field {@link #wells}) and the area index
-	 * (in the field {@link WellInfo#areas} corresponding to the specified
-	 * series.
-	 *
-	 * @param series
-	 *            the desired series.
-	 * @return the corresponding well index and area index, as a 2-element array
-	 *         of <code>int[] { well, area }</code>.
-	 */
-	private int[] seriesToWellArea( final int series )
-	{
-		int nWell = -1;
-		int seriesInc = -1;
-		for ( final WellInfo well : wells )
-		{
-			nWell++;
-			int nAreas = -1;
-			for ( @SuppressWarnings( "unused" )
-			final AreaInfo area : well.areas )
-			{
-				seriesInc++;
-				nAreas++;
-				if ( series == seriesInc ) { return new int[] { nWell, nAreas }; }
-			}
-		}
-		throw new IllegalStateException( "Cannot find a well for series " + series );
-	}
+  /**
+   * Returns the well index (in the field {@link #wells}) and the area index
+   * (in the field {@link WellInfo#areas} corresponding to the specified
+   * series.
+   *
+   * @param series
+   *            the desired series.
+   * @return the corresponding well index and area index, as a 2-element array
+   *         of <code>int[] { well, area }</code>.
+   */
+  private int[] seriesToWellArea( final int series )
+  {
+    int nWell = -1;
+    int seriesInc = -1;
+    for ( final WellInfo well : wells )
+    {
+      nWell++;
+      int nAreas = -1;
+      for ( @SuppressWarnings( "unused" )
+      final AreaInfo area : well.areas )
+      {
+        seriesInc++;
+        nAreas++;
+        if ( series == seriesInc ) { return new int[] { nWell, nAreas }; }
+      }
+    }
+    throw new IllegalStateException( "Cannot find a well for series " + series );
+  }
 
-	private void readInfo( final Document msDocument, final Document omeDocument ) throws FormatException
-	{
-		/*
-		 * Magnification.
-		 *
-		 * We need it early, because the file format reports only un-magnified
-		 * sizes. So if we are to put proper metadata, we need to make the
-		 * conversion to size measured at the sample level ourselves. I feel
-		 * like this is fragile and most likely to change in a future version of
-		 * the file format.
-		 */
+  private void readInfo( final Document msDocument, final Document omeDocument ) throws FormatException
+  {
+    /*
+     * Magnification.
+     *
+     * We need it early, because the file format reports only un-magnified
+     * sizes. So if we are to put proper metadata, we need to make the
+     * conversion to size measured at the sample level ourselves. I feel
+     * like this is fragile and most likely to change in a future version of
+     * the file format.
+     */
 
-		final Element msRoot = msDocument.getDocumentElement();
-		final double objectiveMagnification = Double.parseDouble( getChildText( msRoot, new String[] { "ObjectiveLens", "Magnification" } ) );
-		// final double zoomLensMagnification = Double.parseDouble(
-		// getChildText( msRoot, new String[] { "ZoomLens", "Magnification",
-		// "Value" } ) );
-		final double magnification = objectiveMagnification; // *
-		// zoomLensMagnification;
+    final Element msRoot = msDocument.getDocumentElement();
+    final double objectiveMagnification = Double.parseDouble( getChildText( msRoot, new String[] { "ObjectiveLens", "Magnification" } ) );
+    // final double zoomLensMagnification = Double.parseDouble(
+    // getChildText( msRoot, new String[] { "ZoomLens", "Magnification",
+    // "Value" } ) );
+    final double magnification = objectiveMagnification; // *
+    // zoomLensMagnification;
 
-		/*
-		 * Read the ome.xml file. Since it is malformed, we need to parse all
-		 * nodes, and add an "ID" attribute to those who do not have it.
-		 */
+    /*
+     * Read the ome.xml file. Since it is malformed, we need to parse all
+     * nodes, and add an "ID" attribute to those who do not have it.
+     */
 
-		final NodeList nodeList = omeDocument.getElementsByTagName( "*" );
-		for ( int i = 0; i < nodeList.getLength(); i++ )
-		{
-			final Node node = nodeList.item( i );
-			if ( node.getNodeType() == Node.ELEMENT_NODE )
-			{
-				final NamedNodeMap atts = node.getAttributes();
+    final NodeList nodeList = omeDocument.getElementsByTagName( "*" );
+    for ( int i = 0; i < nodeList.getLength(); i++ )
+    {
+      final Node node = nodeList.item( i );
+      if ( node.getNodeType() == Node.ELEMENT_NODE )
+      {
+        final NamedNodeMap atts = node.getAttributes();
 
-				final Node namedItem = atts.getNamedItem( "ID" );
-				if ( namedItem == null )
-				{
-					final String name = node.getNodeName();
-					final String id = name + ":" + i;
-					if ( !node.getParentNode().getNodeName().equals( "LightSource" ) )
-					{
-						( ( Element ) node ).setAttribute( "ID", id );
-					}
-				}
-			}
-		}
+        final Node namedItem = atts.getNamedItem( "ID" );
+        if ( namedItem == null )
+        {
+          final String name = node.getNodeName();
+          final String id = name + ":" + i;
+          if ( !node.getParentNode().getNodeName().equals( "LightSource" ) )
+          {
+            ( ( Element ) node ).setAttribute( "ID", id );
+          }
+        }
+      }
+    }
 
-		/*
-		 * For single-slice image, the PhysicalSizeZ can be 0, which will make
-		 * the metadata read fail. Correct that.
-		 */
+    /*
+     * For single-slice image, the PhysicalSizeZ can be 0, which will make
+     * the metadata read fail. Correct that.
+     */
 
-		final Element pszEl = getChild( omeDocument.getDocumentElement(), new String[] { "Image", "Pixels" } );
-		final double physicalSizeZ = Double.parseDouble( pszEl.getAttribute( "PhysicalSizeZ" ) );
-		if ( physicalSizeZ <= 0 )
-		{
-			// default to 1 whatever
-			pszEl.setAttribute( "PhysicalSizeZ", "" + 1 );
-		}
+    final Element pszEl = getChild( omeDocument.getDocumentElement(), new String[] { "Image", "Pixels" } );
+    final double physicalSizeZ = Double.parseDouble( pszEl.getAttribute( "PhysicalSizeZ" ) );
+    if ( physicalSizeZ <= 0 )
+    {
+      // default to 1 whatever
+      pszEl.setAttribute( "PhysicalSizeZ", "" + 1 );
+    }
 
-		/*
-		 * Now that the XML document is properly formed, we can build a metadata
-		 * object from it.
-		 */
+    /*
+     * Now that the XML document is properly formed, we can build a metadata
+     * object from it.
+     */
 
-		OMEXMLService service = null;
-		String xml = null;
-		try
-		{
-			xml = XMLTools.getXML( omeDocument );
-		}
-		catch ( final TransformerConfigurationException e2 )
-		{
-			LOGGER.debug( "", e2 );
-		}
-		catch ( final TransformerException e2 )
-		{
+    OMEXMLService service = null;
+    String xml = null;
+    try
+    {
+      xml = XMLTools.getXML( omeDocument );
+    }
+    catch ( final TransformerConfigurationException e2 )
+    {
+      LOGGER.debug( "", e2 );
+    }
+    catch ( final TransformerException e2 )
+    {
       LOGGER.debug("", e2);
-		}
-		try
-		{
-			service = new ServiceFactory().getInstance( OMEXMLService.class );
-		}
-		catch ( final DependencyException e1 )
-		{
-			LOGGER.debug( "", e1 );
-		}
-		OMEXMLMetadata omeMD = null;
-		try
-		{
-			omeMD = service.createOMEXMLMetadata( xml );
-		}
-		catch ( final ServiceException e )
-		{
-			LOGGER.debug( "", e );
-		}
-		catch ( final NullPointerException npe )
-		{
-			LOGGER.debug( "", npe );
-			throw npe;
-		}
+    }
+    try
+    {
+      service = new ServiceFactory().getInstance( OMEXMLService.class );
+    }
+    catch ( final DependencyException e1 )
+    {
+      LOGGER.debug( "", e1 );
+    }
+    OMEXMLMetadata omeMD = null;
+    try
+    {
+      omeMD = service.createOMEXMLMetadata( xml );
+    }
+    catch ( final ServiceException e )
+    {
+      LOGGER.debug( "", e );
+    }
+    catch ( final NullPointerException npe )
+    {
+      LOGGER.debug( "", npe );
+      throw npe;
+    }
 
-		// Correct pixel size for magnification
-		omeMD.setPixelsPhysicalSizeX( FormatTools.createLength( omeMD.getPixelsPhysicalSizeX( 0 ).value().doubleValue() / magnification , omeMD.getPixelsPhysicalSizeX( 0 ).unit()), 0 );
-		omeMD.setPixelsPhysicalSizeY( FormatTools.createLength( omeMD.getPixelsPhysicalSizeY( 0 ).value().doubleValue() / magnification , omeMD.getPixelsPhysicalSizeY( 0 ).unit()), 0 );
+    // Correct pixel size for magnification
+    omeMD.setPixelsPhysicalSizeX( FormatTools.createLength( omeMD.getPixelsPhysicalSizeX( 0 ).value().doubleValue() / magnification , omeMD.getPixelsPhysicalSizeX( 0 ).unit()), 0 );
+    omeMD.setPixelsPhysicalSizeY( FormatTools.createLength( omeMD.getPixelsPhysicalSizeY( 0 ).value().doubleValue() / magnification , omeMD.getPixelsPhysicalSizeY( 0 ).unit()), 0 );
 
-		// Time interval
-		if (Double.valueOf( readFrameInterval( msDocument ) ) != null) {
-			omeMD.setPixelsTimeIncrement(new Time( Double.valueOf( readFrameInterval( msDocument ) ), UNITS.SECOND), 0 );
-		}
+    // Time interval
+    if (Double.valueOf( readFrameInterval( msDocument ) ) != null) {
+      omeMD.setPixelsTimeIncrement(new Time( Double.valueOf( readFrameInterval( msDocument ) ), UNITS.SECOND), 0 );
+    }
 
-		/*
-		 * Channels
-		 */
+    /*
+     * Channels
+     */
 
-		final Element channelsEl = getChild( msRoot, "Channels" );
-		final List< Element > channelEls = getChildren( channelsEl, "Channel" );
-		channelInfos = new ArrayList< ChannelInfo >();
-		for ( final Element channelEl : channelEls )
-		{
-			final boolean isEnabled = Boolean.parseBoolean( getChildText( channelEl, "IsEnabled" ) );
-			if ( !isEnabled )
-			{
-				continue;
-			}
-			final ChannelInfo ci = readChannel( channelEl );
-			channelInfos.add( ci );
-		}
+    final Element channelsEl = getChild( msRoot, "Channels" );
+    final List< Element > channelEls = getChildren( channelsEl, "Channel" );
+    channelInfos = new ArrayList< ChannelInfo >();
+    for ( final Element channelEl : channelEls )
+    {
+      final boolean isEnabled = Boolean.parseBoolean( getChildText( channelEl, "IsEnabled" ) );
+      if ( !isEnabled )
+      {
+        continue;
+      }
+      final ChannelInfo ci = readChannel( channelEl );
+      channelInfos.add( ci );
+    }
 
-		/*
-		 * Fix missing IDs.
-		 *
-		 * Some IDs are missing in the malformed OME.XML file. We must put them
-		 * back manually. Some are fixed here
-		 */
+    /*
+     * Fix missing IDs.
+     *
+     * Some IDs are missing in the malformed OME.XML file. We must put them
+     * back manually. Some are fixed here
+     */
 
-		omeMD.setProjectID( MetadataTools.createLSID( "Project", 0 ), 0 );
-		omeMD.setScreenID( MetadataTools.createLSID( "Screen", 0 ), 0 );
-		omeMD.setPlateID( MetadataTools.createLSID( "Plate", 0 ), 0 );
-		omeMD.setInstrumentID( MetadataTools.createLSID( "Instrument", 0 ), 0 );
+    omeMD.setProjectID( MetadataTools.createLSID( "Project", 0 ), 0 );
+    omeMD.setScreenID( MetadataTools.createLSID( "Screen", 0 ), 0 );
+    omeMD.setPlateID( MetadataTools.createLSID( "Plate", 0 ), 0 );
+    omeMD.setInstrumentID( MetadataTools.createLSID( "Instrument", 0 ), 0 );
 
-		// Read pixel sizes from OME metadata.
-		final double pixelWidth = omeMD.getPixelsPhysicalSizeX( 0 ).value().doubleValue();
-		final double pixelHeight = omeMD.getPixelsPhysicalSizeY( 0 ).value().doubleValue();
+    // Read pixel sizes from OME metadata.
+    final double pixelWidth = omeMD.getPixelsPhysicalSizeX( 0 ).value().doubleValue();
+    final double pixelHeight = omeMD.getPixelsPhysicalSizeY( 0 ).value().doubleValue();
 
-		/*
-		 * Read tile size from channel info. This is weird, but it's like that.
-		 * Since we build a multi-C image, we have to assume that all channels
-		 * have the same dimension, even if the file format allows for changing
-		 * the size, binning, etc. from channel to channel. Failure to load
-		 * datasets that have this exoticity is to be sought here.
-		 */
+    /*
+     * Read tile size from channel info. This is weird, but it's like that.
+     * Since we build a multi-C image, we have to assume that all channels
+     * have the same dimension, even if the file format allows for changing
+     * the size, binning, etc. from channel to channel. Failure to load
+     * datasets that have this exoticity is to be sought here.
+     */
 
-		final int tileWidth = channelInfos.get( 0 ).tileWidth;
-		final int tileHeight = channelInfos.get( 0 ).tileHeight;
+    final int tileWidth = channelInfos.get( 0 ).tileWidth;
+    final int tileHeight = channelInfos.get( 0 ).tileHeight;
 
-		/*
-		 * Handle multiple wells.
-		 *
-		 * The same kind of remark apply: We assume that a channel setting can
-		 * be applied to ALL wells. So this file reader will fail for dataset
-		 * that have one well that has a different dimension that of others.
-		 */
+    /*
+     * Handle multiple wells.
+     *
+     * The same kind of remark apply: We assume that a channel setting can
+     * be applied to ALL wells. So this file reader will fail for dataset
+     * that have one well that has a different dimension that of others.
+     */
 
-		/*
-		 * First remark: there can be two modes to store Areas in the xml file:
-		 * Either we define different areas for each well, and in that case, the
-		 * areas are found as a child element of the well element. Either the
-		 * definition of areas is common to all wells, and in that case they
-		 * area defined in a separate element.
-		 */
+    /*
+     * First remark: there can be two modes to store Areas in the xml file:
+     * Either we define different areas for each well, and in that case, the
+     * areas are found as a child element of the well element. Either the
+     * definition of areas is common to all wells, and in that case they
+     * area defined in a separate element.
+     */
 
-		final boolean sameAreaPerWell = Boolean.parseBoolean( getChildText( msRoot, "UsesSameAreaParWell" ) );
-		List< AreaInfo > areas = null;
-		if ( sameAreaPerWell )
-		{
-			final Element areasEl = getChild( msRoot, new String[] { "SameAreaUsingWell", "Areas" } );
-			final List< Element > areaEls = getChildren( areasEl, "Area" );
-			int areaIndex = 0;
-			areas = new ArrayList< AreaInfo >( areaEls.size() );
-			int fieldIndex = 1;
-			for ( final Element areaEl : areaEls )
-			{
-				final AreaInfo area = readArea( areaEl, fieldIndex, pixelWidth, pixelHeight, tileWidth, tileHeight );
-				area.index = areaIndex++;
-				areas.add( area );
+    final boolean sameAreaPerWell = Boolean.parseBoolean( getChildText( msRoot, "UsesSameAreaParWell" ) );
+    List< AreaInfo > areas = null;
+    if ( sameAreaPerWell )
+    {
+      final Element areasEl = getChild( msRoot, new String[] { "SameAreaUsingWell", "Areas" } );
+      final List< Element > areaEls = getChildren( areasEl, "Area" );
+      int areaIndex = 0;
+      areas = new ArrayList< AreaInfo >( areaEls.size() );
+      int fieldIndex = 1;
+      for ( final Element areaEl : areaEls )
+      {
+        final AreaInfo area = readArea( areaEl, fieldIndex, pixelWidth, pixelHeight, tileWidth, tileHeight );
+        area.index = areaIndex++;
+        areas.add( area );
 
-				// Continue incrementing field index across areas.
-				fieldIndex = area.fields.get( area.fields.size() - 1 ).index + 1;
-			}
-		}
+        // Continue incrementing field index across areas.
+        fieldIndex = area.fields.get( area.fields.size() - 1 ).index + 1;
+      }
+    }
 
-		final Element wellsEl = getChild( msRoot, "Wells" );
-		final List< Element > wellEls = getChildren( wellsEl, "Well" );
-		wells = new ArrayList< WellInfo >();
-		for ( final Element wellEl : wellEls )
-		{
-			final boolean isWellEnabled = Boolean.parseBoolean( getChild( wellEl, "IsEnabled" ).getTextContent() );
-			if ( isWellEnabled )
-			{
-				final WellInfo wi = readWellInfo( wellEl, pixelWidth, pixelHeight, tileWidth, tileHeight );
-				if ( sameAreaPerWell )
-				{
-					wi.areas = areas;
-				}
+    final Element wellsEl = getChild( msRoot, "Wells" );
+    final List< Element > wellEls = getChildren( wellsEl, "Well" );
+    wells = new ArrayList< WellInfo >();
+    for ( final Element wellEl : wellEls )
+    {
+      final boolean isWellEnabled = Boolean.parseBoolean( getChild( wellEl, "IsEnabled" ).getTextContent() );
+      if ( isWellEnabled )
+      {
+        final WellInfo wi = readWellInfo( wellEl, pixelWidth, pixelHeight, tileWidth, tileHeight );
+        if ( sameAreaPerWell )
+        {
+          wi.areas = areas;
+        }
 
-				wells.add( wi );
-			}
-		}
+        wells.add( wi );
+      }
+    }
 
-		/*
-		 * Z range.
-		 *
-		 * In this file format, the Z range appears to be general: it applies to
-		 * all fields of all wells.
-		 */
+    /*
+     * Z range.
+     *
+     * In this file format, the Z range appears to be general: it applies to
+     * all fields of all wells.
+     */
 
-		final int nZSlices = Integer.parseInt( getChildText( msRoot, new String[] { "ZStackConditions", "NumberOfSlices" } ) );
+    final int nZSlices = Integer.parseInt( getChildText( msRoot, new String[] { "ZStackConditions", "NumberOfSlices" } ) );
 
-		/*
-		 * Time points. They are general as well. Which just makes sense.
-		 */
+    /*
+     * Time points. They are general as well. Which just makes sense.
+     */
 
-		timePoints = readTimePoints( msDocument );
+    timePoints = readTimePoints( msDocument );
 
-		/*
-		 * Populate CORE metadata for each area.
-		 *
-		 * This reader takes to convention that state that 1 area = 1 series. So
-		 * if you have 10 wells with 2 areas in each well, and each area is made
-		 * of 20 fields, you will get 20 series, and each series will be
-		 * stitched from 20 fields.
-		 */
+    /*
+     * Populate CORE metadata for each area.
+     *
+     * This reader takes to convention that state that 1 area = 1 series. So
+     * if you have 10 wells with 2 areas in each well, and each area is made
+     * of 20 fields, you will get 20 series, and each series will be
+     * stitched from 20 fields.
+     */
 
     OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) omeMD.getRoot();
     Image firstImage = root.getImage(0);
 
-		core.clear();
-		for ( final WellInfo well : wells )
-		{
-			for ( final AreaInfo area : well.areas )
-			{
-				final CoreMetadata ms = new CoreMetadata();
-				core.add( ms );
+    core.clear();
+    for ( final WellInfo well : wells )
+    {
+      for ( final AreaInfo area : well.areas )
+      {
+        final CoreMetadata ms = new CoreMetadata();
+        core.add( ms );
         if (core.size() > 1) {
           root.addImage(firstImage);
         }
 
-				ms.sizeX = area.width;
-				ms.sizeY = area.height;
-				ms.sizeZ = nZSlices;
-				ms.sizeC = channelInfos.size();
-				ms.sizeT = timePoints.size();
-				ms.dimensionOrder = "XYCZT";
-				ms.rgb = false;
-				ms.imageCount = nZSlices * channelInfos.size() * timePoints.size();
+        ms.sizeX = area.width;
+        ms.sizeY = area.height;
+        ms.sizeZ = nZSlices;
+        ms.sizeC = channelInfos.size();
+        ms.sizeT = timePoints.size();
+        ms.dimensionOrder = "XYCZT";
+        ms.rgb = false;
+        ms.imageCount = nZSlices * channelInfos.size() * timePoints.size();
 
-				// Bit depth.
-				switch ( omeMD.getPixelsType( 0 ) )
-				{
-				case UINT8:
-					ms.pixelType = FormatTools.UINT8;
-					ms.bitsPerPixel = 8;
-					break;
-				case UINT16:
-					ms.pixelType = FormatTools.UINT16;
-					ms.bitsPerPixel = 16;
-					break;
-				case UINT32:
-					ms.pixelType = FormatTools.UINT32;
-					ms.bitsPerPixel = 32;
-					break;
-				default:
-					throw new FormatException( "Cannot read image with pixel type = " + omeMD.getPixelsType( 0 ) );
-				}
+        // Bit depth.
+        switch ( omeMD.getPixelsType( 0 ) )
+        {
+        case UINT8:
+          ms.pixelType = FormatTools.UINT8;
+          ms.bitsPerPixel = 8;
+          break;
+        case UINT16:
+          ms.pixelType = FormatTools.UINT16;
+          ms.bitsPerPixel = 16;
+          break;
+        case UINT32:
+          ms.pixelType = FormatTools.UINT32;
+          ms.bitsPerPixel = 32;
+          break;
+        default:
+          throw new FormatException( "Cannot read image with pixel type = " + omeMD.getPixelsType( 0 ) );
+        }
 
-				// Determined manually on sample data. Check here is the image
-				// you get is weird.
-				ms.littleEndian = true;
-			}
-		}
+        // Determined manually on sample data. Check here is the image
+        // you get is weird.
+        ms.littleEndian = true;
+      }
+    }
     omeMD.setRoot(root);
 
-		/*
-		 * Populate the MetadataStore.
-		 */
+    /*
+     * Populate the MetadataStore.
+     */
 
-		final MetadataStore store = makeFilterMetadata();
-		MetadataConverter.convertMetadata( omeMD, store );
-		MetadataTools.populatePixels( store, this, true );
+    final MetadataStore store = makeFilterMetadata();
+    MetadataConverter.convertMetadata( omeMD, store );
+    MetadataTools.populatePixels( store, this, true );
 
-		/*
-		 * Pinhole disk
-		 */
+    /*
+     * Pinhole disk
+     */
 
-		final double pinholeSize = Double.parseDouble( getChildText( msRoot, new String[] { "PinholeDisk", "PinholeSize_um" } ) );
+    final double pinholeSize = Double.parseDouble( getChildText( msRoot, new String[] { "PinholeDisk", "PinholeSize_um" } ) );
 
-		/*
-		 * MicroPlate specific stuff
-		 */
+    /*
+     * MicroPlate specific stuff
+     */
 
-		final Element containerEl = getChild( msRoot, new String[] { "Attachment", "HolderInfoList", "HolderInfo", "MountedSampleContainer" } );
-		final String type = containerEl.getAttribute( "xsi:type" );
+    final Element containerEl = getChild( msRoot, new String[] { "Attachment", "HolderInfoList", "HolderInfo", "MountedSampleContainer" } );
+    final String type = containerEl.getAttribute( "xsi:type" );
     boolean plateMetadata = false;
-		if ( type.equals( "WellPlate" ) )
-		{
+    if ( type.equals( "WellPlate" ) )
+    {
       plateMetadata = true;
 
-			final int nrows = Integer.parseInt( getChildText( containerEl, "RowCount" ) );
-			final int ncols = Integer.parseInt( getChildText( containerEl, "ColumnCount" ) );
-			store.setPlateRows( new PositiveInteger( nrows ), 0 );
-			store.setPlateColumns( new PositiveInteger( ncols ), 0 );
+      final int nrows = Integer.parseInt( getChildText( containerEl, "RowCount" ) );
+      final int ncols = Integer.parseInt( getChildText( containerEl, "ColumnCount" ) );
+      store.setPlateRows( new PositiveInteger( nrows ), 0 );
+      store.setPlateColumns( new PositiveInteger( ncols ), 0 );
 
-			final String plateAcqID = MetadataTools.createLSID( "PlateAcquisition", 0, 0 );
-			store.setPlateAcquisitionID( plateAcqID, 0, 0 );
+      final String plateAcqID = MetadataTools.createLSID( "PlateAcquisition", 0, 0 );
+      store.setPlateAcquisitionID( plateAcqID, 0, 0 );
 
-			final Element dimInfoEl = getChild( msRoot, "DimensionsInfo" );
-			final int maxNFields = Integer.parseInt( getChild( dimInfoEl, "F" ).getAttribute( "Max" ) );
-			final PositiveInteger fieldCount = FormatTools.getMaxFieldCount( maxNFields );
-			if ( fieldCount != null )
-			{
-				store.setPlateAcquisitionMaximumFieldCount( fieldCount, 0, 0 );
-			}
+      final Element dimInfoEl = getChild( msRoot, "DimensionsInfo" );
+      final int maxNFields = Integer.parseInt( getChild( dimInfoEl, "F" ).getAttribute( "Max" ) );
+      final PositiveInteger fieldCount = FormatTools.getMaxFieldCount( maxNFields );
+      if ( fieldCount != null )
+      {
+        store.setPlateAcquisitionMaximumFieldCount( fieldCount, 0, 0 );
+      }
 
-			// Plate acquisition time
-			final String beginTime = getChildText( msRoot, "BeginTime" );
-			final String endTime = getChildText( msRoot, "EndTime" );
-			store.setPlateAcquisitionStartTime( new Timestamp( beginTime ), 0, 0 );
-			store.setPlateAcquisitionEndTime( new Timestamp( endTime ), 0, 0 );
+      // Plate acquisition time
+      final String beginTime = getChildText( msRoot, "BeginTime" );
+      final String endTime = getChildText( msRoot, "EndTime" );
+      store.setPlateAcquisitionStartTime( new Timestamp( beginTime ), 0, 0 );
+      store.setPlateAcquisitionEndTime( new Timestamp( endTime ), 0, 0 );
 
       store.setPlateName(beginTime, 0);
-		}
+    }
     else if (!type.equals("PreparedSlide")) {
       LOGGER.warn("Unexpected acquisition type: {}", type);
     }
 
-		// Wells position on the plate
-		int seriesIndex = -1;
-		int wellIndex = -1;
-		for ( final WellInfo well : wells )
-		{
-			wellIndex++;
-			final int wellNumber = well.number;
+    // Wells position on the plate
+    int seriesIndex = -1;
+    int wellIndex = -1;
+    for ( final WellInfo well : wells )
+    {
+      wellIndex++;
+      final int wellNumber = well.number;
       if (plateMetadata) {
-			  store.setWellID(MetadataTools.createLSID("Well", 0, wellIndex), 0, wellIndex);
-			  store.setWellRow( new NonNegativeInteger( well.row ), 0, wellIndex );
-			  store.setWellColumn( new NonNegativeInteger( well.col ), 0, wellIndex );
+        store.setWellID(MetadataTools.createLSID("Well", 0, wellIndex), 0, wellIndex);
+        store.setWellRow( new NonNegativeInteger( well.row ), 0, wellIndex );
+        store.setWellColumn( new NonNegativeInteger( well.col ), 0, wellIndex );
       }
-			int areaIndex = -1;
-			for ( final AreaInfo area : well.areas )
-			{
-				seriesIndex++;
-				areaIndex++;
+      int areaIndex = -1;
+      for ( final AreaInfo area : well.areas )
+      {
+        seriesIndex++;
+        areaIndex++;
         String imageID = MetadataTools.createLSID("Image", seriesIndex);
         store.setImageID(imageID, seriesIndex);
-				final String imageName = "Well " + wellNumber + " (UID=" + well.UID + ", r=" + well.row + ", c=" + well.col + ") - Area " + areaIndex;
-				store.setImageName( imageName, seriesIndex );
+        final String imageName = "Well " + wellNumber + " (UID=" + well.UID + ", r=" + well.row + ", c=" + well.col + ") - Area " + areaIndex;
+        store.setImageName( imageName, seriesIndex );
 
         if (plateMetadata) {
-  				Length posX = new Length(Double.valueOf(well.centerX), UNITS.REFERENCEFRAME);
-  				Length posY = new Length(Double.valueOf(well.centerY), UNITS.REFERENCEFRAME);
+          Length posX = new Length(Double.valueOf(well.centerX), UNITS.REFERENCEFRAME);
+          Length posY = new Length(Double.valueOf(well.centerY), UNITS.REFERENCEFRAME);
 
           String wellSample = MetadataTools.createLSID("WellSample", 0, wellIndex, areaIndex);
-	  			store.setWellSampleID(wellSample, 0, wellIndex, areaIndex);
+          store.setWellSampleID(wellSample, 0, wellIndex, areaIndex);
           store.setWellSampleImageRef(imageID, 0, wellIndex, areaIndex);
-		  		store.setWellSampleIndex( new NonNegativeInteger( area.index ), 0, wellIndex, areaIndex );
-		  		store.setWellSamplePositionX(posX, 0, wellIndex, areaIndex);
-		  		store.setWellSamplePositionY(posY, 0, wellIndex, areaIndex);
+          store.setWellSampleIndex( new NonNegativeInteger( area.index ), 0, wellIndex, areaIndex );
+          store.setWellSamplePositionX(posX, 0, wellIndex, areaIndex);
+          store.setWellSamplePositionY(posY, 0, wellIndex, areaIndex);
 
           store.setPlateAcquisitionWellSampleRef(wellSample, 0, 0, seriesIndex);
         }
         store.setImageInstrumentRef(MetadataTools.createLSID("Instrument", 0), seriesIndex);
 
-				for ( int i = 0; i < channelInfos.size(); i++ )
-				{
-					store.setChannelPinholeSize(new Length(pinholeSize, UNITS.MICROMETER), seriesIndex, i);
-					store.setChannelName( channelInfos.get( i ).name, seriesIndex, i );
+        for ( int i = 0; i < channelInfos.size(); i++ )
+        {
+          store.setChannelPinholeSize(new Length(pinholeSize, UNITS.MICROMETER), seriesIndex, i);
+          store.setChannelName( channelInfos.get( i ).name, seriesIndex, i );
           store.setChannelColor(channelInfos.get(i).color, seriesIndex, i);
-				}
-			}
+        }
+      }
 
-		}
+    }
 
-	}
+  }
 
-	private ChannelInfo readChannel( final Element channelEl )
-	{
-		final ChannelInfo ci = new ChannelInfo();
+  private ChannelInfo readChannel( final Element channelEl )
+  {
+    final ChannelInfo ci = new ChannelInfo();
 
-		ci.isEnabled = Boolean.parseBoolean( getChildText( channelEl, "IsEnabled" ) );
+    ci.isEnabled = Boolean.parseBoolean( getChildText( channelEl, "IsEnabled" ) );
 
-		ci.channelNumber = Integer.parseInt( getChildText( channelEl, "Number" ) );
+    ci.channelNumber = Integer.parseInt( getChildText( channelEl, "Number" ) );
 
-		final Element acquisitionSettings = getChild( channelEl, "AcquisitionSetting" );
+    final Element acquisitionSettings = getChild( channelEl, "AcquisitionSetting" );
 
-		final Element cameraEl = getChild( acquisitionSettings, "Camera" );
-		ci.tileWidth = Integer.parseInt( getChildText( cameraEl, "EffectiveHorizontalPixels_pixel" ) );
-		ci.tileHeight = Integer.parseInt( getChildText( cameraEl, "EffectiveVerticalPixels_pixel" ) );
+    final Element cameraEl = getChild( acquisitionSettings, "Camera" );
+    ci.tileWidth = Integer.parseInt( getChildText( cameraEl, "EffectiveHorizontalPixels_pixel" ) );
+    ci.tileHeight = Integer.parseInt( getChildText( cameraEl, "EffectiveVerticalPixels_pixel" ) );
 
-		ci.unmagnifiedPixelWidth = Double.parseDouble( getChildText( cameraEl, "HorizonalCellSize_um" ) );
-		ci.unmagnifiedPixelHeight = Double.parseDouble( getChildText( cameraEl, "VerticalCellSize_um" ) );
+    ci.unmagnifiedPixelWidth = Double.parseDouble( getChildText( cameraEl, "HorizonalCellSize_um" ) );
+    ci.unmagnifiedPixelHeight = Double.parseDouble( getChildText( cameraEl, "VerticalCellSize_um" ) );
 
-		final Element colorElement = getChild( channelEl, new String[] { "ContrastEnhanceParam", "Color" } );
-		final int r = Integer.parseInt( getChildText( colorElement, "R" ) );
-		final int g = Integer.parseInt( getChildText( colorElement, "G" ) );
-		final int b = Integer.parseInt( getChildText( colorElement, "B" ) );
-		final int a = Integer.parseInt( getChildText( colorElement, "A" ) );
-		final Color channelColor = new Color( r, g, b, a );
-		ci.color = channelColor;
+    final Element colorElement = getChild( channelEl, new String[] { "ContrastEnhanceParam", "Color" } );
+    final int r = Integer.parseInt( getChildText( colorElement, "R" ) );
+    final int g = Integer.parseInt( getChildText( colorElement, "G" ) );
+    final int b = Integer.parseInt( getChildText( colorElement, "B" ) );
+    final int a = Integer.parseInt( getChildText( colorElement, "A" ) );
+    final Color channelColor = new Color( r, g, b, a );
+    ci.color = channelColor;
 
-		// Build a channel name from excitation, emission and fluorophore name
-		final String excitationType = getChild( channelEl, "Excitation" ).getAttribute( "xsi:type" );
-		final String excitationName = getChildText( channelEl, new String[] { "Excitation", "Name", "Value" } );
-		final String emissionName = getChildText( channelEl, new String[] { "Emission", "Name", "Value" } );
-		String fluorophoreName = getChildText( channelEl, new String[] { "Emission", "FluorescentProbe", "Value" } );
-		if ( null == fluorophoreName )
-		{
-			fluorophoreName = "ø";
-		}
-		final String channelName = "Ex: " + excitationType + "(" + excitationName + ") / Em: " + emissionName + " / Fl: " + fluorophoreName;
-		ci.name = channelName;
+    // Build a channel name from excitation, emission and fluorophore name
+    final String excitationType = getChild( channelEl, "Excitation" ).getAttribute( "xsi:type" );
+    final String excitationName = getChildText( channelEl, new String[] { "Excitation", "Name", "Value" } );
+    final String emissionName = getChildText( channelEl, new String[] { "Emission", "Name", "Value" } );
+    String fluorophoreName = getChildText( channelEl, new String[] { "Emission", "FluorescentProbe", "Value" } );
+    if ( null == fluorophoreName )
+    {
+      fluorophoreName = "ø";
+    }
+    final String channelName = "Ex: " + excitationType + "(" + excitationName + ") / Em: " + emissionName + " / Fl: " + fluorophoreName;
+    ci.name = channelName;
 
-		return ci;
+    return ci;
 
-	}
+  }
 
-	private WellInfo readWellInfo( final Element wellEl, final double pixelWidth, final double pixelHeight, final int tileWidth, final int tileHeight )
-	{
-		final WellInfo info = new WellInfo();
-		info.UID = Integer.parseInt( getChildText( wellEl, "UniqueID" ) );
-		info.number = Integer.parseInt( getChildText( wellEl, "Number" ) );
-		info.row = Integer.parseInt( getChildText( wellEl, "Row" ) );
-		info.col = Integer.parseInt( getChildText( wellEl, "Column" ) );
-		info.centerX = Double.parseDouble( getChildText( wellEl, new String[] { "CenterCoord_mm", "X" } ) );
-		info.centerY = Double.parseDouble( getChildText( wellEl, new String[] { "CenterCoord_mm", "Y" } ) );
+  private WellInfo readWellInfo( final Element wellEl, final double pixelWidth, final double pixelHeight, final int tileWidth, final int tileHeight )
+  {
+    final WellInfo info = new WellInfo();
+    info.UID = Integer.parseInt( getChildText( wellEl, "UniqueID" ) );
+    info.number = Integer.parseInt( getChildText( wellEl, "Number" ) );
+    info.row = Integer.parseInt( getChildText( wellEl, "Row" ) );
+    info.col = Integer.parseInt( getChildText( wellEl, "Column" ) );
+    info.centerX = Double.parseDouble( getChildText( wellEl, new String[] { "CenterCoord_mm", "X" } ) );
+    info.centerY = Double.parseDouble( getChildText( wellEl, new String[] { "CenterCoord_mm", "Y" } ) );
 
-		final Element areasEl = getChild( wellEl, "Areas" );
-		final List< Element > areaEls = getChildren( areasEl, "Area" );
-		int areaIndex = 0;
-		int fieldIndex = 1;
-		for ( final Element areaEl : areaEls )
-		{
-			final AreaInfo area = readArea( areaEl, fieldIndex, pixelWidth, pixelHeight, tileWidth, tileHeight );
-			area.index = areaIndex++;
-			info.areas.add( area );
+    final Element areasEl = getChild( wellEl, "Areas" );
+    final List< Element > areaEls = getChildren( areasEl, "Area" );
+    int areaIndex = 0;
+    int fieldIndex = 1;
+    for ( final Element areaEl : areaEls )
+    {
+      final AreaInfo area = readArea( areaEl, fieldIndex, pixelWidth, pixelHeight, tileWidth, tileHeight );
+      area.index = areaIndex++;
+      info.areas.add( area );
 
-			// Continue incrementing field index across areas.
-			fieldIndex = area.fields.get( area.fields.size() - 1 ).index + 1;
-		}
+      // Continue incrementing field index across areas.
+      fieldIndex = area.fields.get( area.fields.size() - 1 ).index + 1;
+    }
 
-		return info;
-	}
+    return info;
+  }
 
-	private AreaInfo readArea( final Element areaEl, int startingFieldIndex, final double pixelWidth, final double pixelHeight, final int tileWidth, final int tileHeight )
-	{
-		final AreaInfo info = new AreaInfo();
-		info.UID = Integer.parseInt( getChildText( areaEl, "UniqueID" ) );
+  private AreaInfo readArea( final Element areaEl, int startingFieldIndex, final double pixelWidth, final double pixelHeight, final int tileWidth, final int tileHeight )
+  {
+    final AreaInfo info = new AreaInfo();
+    info.UID = Integer.parseInt( getChildText( areaEl, "UniqueID" ) );
 
-		// Read field position in um
-		double xmin = Double.POSITIVE_INFINITY;
-		double ymin = Double.POSITIVE_INFINITY;
-		double xmax = Double.NEGATIVE_INFINITY;
-		double ymax = Double.NEGATIVE_INFINITY;
+    // Read field position in um
+    double xmin = Double.POSITIVE_INFINITY;
+    double ymin = Double.POSITIVE_INFINITY;
+    double xmax = Double.NEGATIVE_INFINITY;
+    double ymax = Double.NEGATIVE_INFINITY;
 
-		final Element fieldsEl = getChild( areaEl, "Fields" );
-		final List< Element > fieldEls = getChildren( fieldsEl, "Field" );
+    final Element fieldsEl = getChild( areaEl, "Fields" );
+    final List< Element > fieldEls = getChildren( fieldsEl, "Field" );
 
-		// Read basic info and get min & max.
-		for ( final Element fieldEl : fieldEls )
-		{
-			final FieldInfo finfo = readField( fieldEl );
-			info.fields.add( finfo );
+    // Read basic info and get min & max.
+    for ( final Element fieldEl : fieldEls )
+    {
+      final FieldInfo finfo = readField( fieldEl );
+      info.fields.add( finfo );
 
-			final double xum = finfo.x;
-			if ( xum < xmin )
-			{
-				xmin = xum;
-			}
-			if ( xum > xmax )
-			{
-				xmax = xum;
-			}
+      final double xum = finfo.x;
+      if ( xum < xmin )
+      {
+        xmin = xum;
+      }
+      if ( xum > xmax )
+      {
+        xmax = xum;
+      }
 
-			final double yum = -finfo.y;
-			if ( yum < ymin )
-			{
-				ymin = yum;
-			}
-			if ( yum > ymax )
-			{
-				ymax = yum;
-			}
-		}
-		for ( final FieldInfo finfo : info.fields )
-		{
-			final long xpixels = Math.round( ( finfo.x - xmin ) / pixelWidth );
-			/*
-			 * Careful! For the fields to be padded correctly, we need to invert
-			 * their Y position, so that it matches the pixel orientation.
-			 */
-			final long ypixels = Math.round( ( -ymin - finfo.y ) / pixelHeight );
-			finfo.xpixels = xpixels;
-			finfo.ypixels = ypixels;
+      final double yum = -finfo.y;
+      if ( yum < ymin )
+      {
+        ymin = yum;
+      }
+      if ( yum > ymax )
+      {
+        ymax = yum;
+      }
+    }
+    for ( final FieldInfo finfo : info.fields )
+    {
+      final long xpixels = Math.round( ( finfo.x - xmin ) / pixelWidth );
+      /*
+       * Careful! For the fields to be padded correctly, we need to invert
+       * their Y position, so that it matches the pixel orientation.
+       */
+      final long ypixels = Math.round( ( -ymin - finfo.y ) / pixelHeight );
+      finfo.xpixels = xpixels;
+      finfo.ypixels = ypixels;
 
-			/*
-			 * Field index.
-			 *
-			 * Now there is a complexity regarding the way fields (that is:
-			 * tiles in common meaning) are indexed in the 'ImageIndex.xml'
-			 * file. Even if for a well you have two areas made of 5 tiles each,
-			 * there is no indexing of the areas. The field index simply keeps
-			 * increasing when you go from one area to the next one, and this
-			 * index follows the appearance order of the 'Field' xml element in
-			 * the 'MeasurementResult.xml' file.
-			 */
+      /*
+       * Field index.
+       *
+       * Now there is a complexity regarding the way fields (that is:
+       * tiles in common meaning) are indexed in the 'ImageIndex.xml'
+       * file. Even if for a well you have two areas made of 5 tiles each,
+       * there is no indexing of the areas. The field index simply keeps
+       * increasing when you go from one area to the next one, and this
+       * index follows the appearance order of the 'Field' xml element in
+       * the 'MeasurementResult.xml' file.
+       */
 
-			finfo.index = startingFieldIndex++;
-		}
+      finfo.index = startingFieldIndex++;
+    }
 
-		final int width = 1 + ( int ) ( ( xmax - xmin ) / pixelWidth );
-		final int height = 1 + ( int ) ( ( ymax - ymin ) / pixelHeight );
-		info.width = width + tileWidth;
-		info.height = height + tileHeight;
+    final int width = 1 + ( int ) ( ( xmax - xmin ) / pixelWidth );
+    final int height = 1 + ( int ) ( ( ymax - ymin ) / pixelHeight );
+    info.width = width + tileWidth;
+    info.height = height + tileHeight;
 
-		return info;
-	}
+    return info;
+  }
 
-	private FieldInfo readField( final Element fieldEl )
-	{
-		final FieldInfo info = new FieldInfo();
-		info.x = Double.parseDouble( getChildText( fieldEl, "StageX_um" ) );
-		info.y = Double.parseDouble( getChildText( fieldEl, "StageY_um" ) );
-		// I discarded the other info (BottomOffset & co) for I don't what to do
-		// with them.
-		return info;
-	}
+  private FieldInfo readField( final Element fieldEl )
+  {
+    final FieldInfo info = new FieldInfo();
+    info.x = Double.parseDouble( getChildText( fieldEl, "StageX_um" ) );
+    info.y = Double.parseDouble( getChildText( fieldEl, "StageY_um" ) );
+    // I discarded the other info (BottomOffset & co) for I don't what to do
+    // with them.
+    return info;
+  }
 
-	private List< Integer > readTimePoints( final Document document )
-	{
-		final Element root = document.getDocumentElement();
-		final int nTimePoints = Integer.parseInt( getChildText( root, new String[] { "TimelapsCondition", "Iteration" } ) );
-		//
-		final List< Integer > timepoints = new ArrayList< Integer >( nTimePoints );
-		for ( int i = 0; i < nTimePoints; i++ )
-		{
+  private List< Integer > readTimePoints( final Document document )
+  {
+    final Element root = document.getDocumentElement();
+    final int nTimePoints = Integer.parseInt( getChildText( root, new String[] { "TimelapsCondition", "Iteration" } ) );
+    //
+    final List< Integer > timepoints = new ArrayList< Integer >( nTimePoints );
+    for ( int i = 0; i < nTimePoints; i++ )
+    {
       timepoints.add(i + 1);
-		}
-		return timepoints;
-	}
+    }
+    return timepoints;
+  }
 
-	private double readFrameInterval( final Document document )
-	{
-		final Element root = document.getDocumentElement();
-		final double dt = Double.parseDouble( getChildText( root, new String[] { "TimelapsCondition", "Interval" } ) );
-		return dt;
-	}
+  private double readFrameInterval( final Document document )
+  {
+    final Element root = document.getDocumentElement();
+    final double dt = Double.parseDouble( getChildText( root, new String[] { "TimelapsCondition", "Interval" } ) );
+    return dt;
+  }
 
-	/*
-	 * INNER CLASSES
-	 */
+  /*
+   * INNER CLASSES
+   */
 
-	private static final class FieldInfo
-	{
+  private static final class FieldInfo
+  {
 
-		public int index;
+    public int index;
 
-		public long ypixels;
+    public long ypixels;
 
-		public long xpixels;
+    public long xpixels;
 
-		public double y;
+    public double y;
 
-		public double x;
+    public double x;
 
-		@Override
-		public String toString()
-		{
-			return "\t\tField index = " + index + "\n\t\t\tX = " + x + " µm\n\t\t\tY = " + y + " µm\n" + "\t\t\txi = " + xpixels + " pixels\n" + "\t\t\tyi = " + ypixels + " pixels\n";
-		}
+    @Override
+    public String toString()
+    {
+      return "\t\tField index = " + index + "\n\t\t\tX = " + x + " µm\n\t\t\tY = " + y + " µm\n" + "\t\t\txi = " + xpixels + " pixels\n" + "\t\t\tyi = " + ypixels + " pixels\n";
+    }
 
-	}
+  }
 
-	private static final class AreaInfo
-	{
+  private static final class AreaInfo
+  {
 
-		public int index;
+    public int index;
 
-		public int height;
+    public int height;
 
-		public int width;
+    public int width;
 
-		public List< FieldInfo > fields = new ArrayList< FieldInfo >();
+    public List< FieldInfo > fields = new ArrayList< FieldInfo >();
 
-		public int UID;
+    public int UID;
 
-		@Override
-		public String toString()
-		{
-			final StringBuilder str = new StringBuilder();
-			str.append( "\tArea ID = " + UID + '\n' );
-			str.append( "\t\ttotal width = " + width + " pixels\n" );
-			str.append( "\t\ttotal height = " + height + " pixels\n" );
-			for ( final FieldInfo fieldInfo : fields )
-			{
-				str.append( fieldInfo.toString() );
-			}
-			return str.toString();
-		}
+    @Override
+    public String toString()
+    {
+      final StringBuilder str = new StringBuilder();
+      str.append( "\tArea ID = " + UID + '\n' );
+      str.append( "\t\ttotal width = " + width + " pixels\n" );
+      str.append( "\t\ttotal height = " + height + " pixels\n" );
+      for ( final FieldInfo fieldInfo : fields )
+      {
+        str.append( fieldInfo.toString() );
+      }
+      return str.toString();
+    }
 
-	}
+  }
 
-	private static final class WellInfo
-	{
+  private static final class WellInfo
+  {
 
-		public List< AreaInfo > areas = new ArrayList< AreaInfo >();
+    public List< AreaInfo > areas = new ArrayList< AreaInfo >();
 
-		public double centerY;
+    public double centerY;
 
-		public double centerX;
+    public double centerX;
 
-		public int col;
+    public int col;
 
-		public int row;
+    public int row;
 
-		public int number;
+    public int number;
 
-		public int UID;
+    public int UID;
 
-		@Override
-		public String toString()
-		{
-			final StringBuilder str = new StringBuilder();
-			str.append( "Well ID = " + UID + '\n' );
-			str.append( "\tnumber = " + number + '\n' );
-			str.append( "\trow = " + row + '\n' );
-			str.append( "\tcol = " + col + '\n' );
-			str.append( "\tcenter X = " + centerX + " mm\n" );
-			str.append( "\tcenter Y = " + centerY + " mm\n" );
-			for ( final AreaInfo areaInfo : areas )
-			{
-				str.append( areaInfo.toString() );
-			}
-			return str.toString();
-		}
+    @Override
+    public String toString()
+    {
+      final StringBuilder str = new StringBuilder();
+      str.append( "Well ID = " + UID + '\n' );
+      str.append( "\tnumber = " + number + '\n' );
+      str.append( "\trow = " + row + '\n' );
+      str.append( "\tcol = " + col + '\n' );
+      str.append( "\tcenter X = " + centerX + " mm\n" );
+      str.append( "\tcenter Y = " + centerY + " mm\n" );
+      for ( final AreaInfo areaInfo : areas )
+      {
+        str.append( areaInfo.toString() );
+      }
+      return str.toString();
+    }
 
-	}
+  }
 
-	private static final class ChannelInfo
-	{
+  private static final class ChannelInfo
+  {
 
-		public String name;
+    public String name;
 
-		public Color color;
+    public Color color;
 
-		public int height;
+    public int height;
 
-		public int width;
+    public int width;
 
-		public boolean isEnabled;
+    public boolean isEnabled;
 
-		public double unmagnifiedPixelHeight;
+    public double unmagnifiedPixelHeight;
 
-		public double unmagnifiedPixelWidth;
+    public double unmagnifiedPixelWidth;
 
-		public int tileHeight;
+    public int tileHeight;
 
-		public int tileWidth;
+    public int tileWidth;
 
-		public int channelNumber;
+    public int channelNumber;
 
-		@Override
-		public String toString()
-		{
-			final StringBuilder str = new StringBuilder();
-			str.append( "Channel " + channelNumber + ": \n" );
-			str.append( " - name: " + name + "\n" );
-			str.append( " - isEnabled: " + isEnabled + "\n" );
-			str.append( " - width: " + width + "\n" );
-			str.append( " - height: " + height + "\n" );
-			str.append( " - tile width: " + tileWidth + "\n" );
-			str.append( " - tile height: " + tileHeight + "\n" );
-			str.append( " - unmagnifiedPixelWidth: " + unmagnifiedPixelWidth + "\n" );
-			str.append( " - unmagnifiedPixelHeight: " + unmagnifiedPixelHeight + "\n" );
-			return str.toString();
-		}
+    @Override
+    public String toString()
+    {
+      final StringBuilder str = new StringBuilder();
+      str.append( "Channel " + channelNumber + ": \n" );
+      str.append( " - name: " + name + "\n" );
+      str.append( " - isEnabled: " + isEnabled + "\n" );
+      str.append( " - width: " + width + "\n" );
+      str.append( " - height: " + height + "\n" );
+      str.append( " - tile width: " + tileWidth + "\n" );
+      str.append( " - tile height: " + tileHeight + "\n" );
+      str.append( " - unmagnifiedPixelWidth: " + unmagnifiedPixelWidth + "\n" );
+      str.append( " - unmagnifiedPixelHeight: " + unmagnifiedPixelHeight + "\n" );
+      return str.toString();
+    }
 
-	}
+  }
 
-	private static final Element getChild( final Element parent, final String childName )
-	{
+  private static final Element getChild( final Element parent, final String childName )
+  {
     return getChild(parent, new String[] {childName});
-	}
+  }
 
-	private static final Element getChild( final Element parent, final String[] path )
-	{
-		final NodeList childNodes = parent.getChildNodes();
-		for (int i=0; i<childNodes.getLength(); i++) {
-			final Node item = childNodes.item(i);
-			if (item.getNodeName().equals(path[0])) {
+  private static final Element getChild( final Element parent, final String[] path )
+  {
+    final NodeList childNodes = parent.getChildNodes();
+    for (int i=0; i<childNodes.getLength(); i++) {
+      final Node item = childNodes.item(i);
+      if (item.getNodeName().equals(path[0])) {
         if (path.length == 1) {
           return (Element) item;
         }
         return getChild((Element) item, Arrays.copyOfRange(path, 1, path.length));
       }
-		}
-		return null;
-	}
+    }
+    return null;
+  }
 
-	private static final List< Element > getChildren( final Element parent, final String name )
-	{
-		final NodeList nodeList = parent.getElementsByTagName( name );
-		final int nEls = nodeList.getLength();
-		final List< Element > children = new ArrayList< Element >( nEls );
-		for ( int i = 0; i < nEls; i++ )
-		{
-			children.add( ( Element ) nodeList.item( i ) );
-		}
-		return children;
-	}
+  private static final List< Element > getChildren( final Element parent, final String name )
+  {
+    final NodeList nodeList = parent.getElementsByTagName( name );
+    final int nEls = nodeList.getLength();
+    final List< Element > children = new ArrayList< Element >( nEls );
+    for ( int i = 0; i < nEls; i++ )
+    {
+      children.add( ( Element ) nodeList.item( i ) );
+    }
+    return children;
+  }
 
-	private static final String getChildText( final Element parent, final String[] path )
-	{
+  private static final String getChildText( final Element parent, final String[] path )
+  {
     Element child = getChild(parent, path);
     if (child != null) {
       return child.getTextContent();
     }
     return null;
-	}
+  }
 
-	private static final String getChildText( final Element parent, final String childName )
-	{
+  private static final String getChildText( final Element parent, final String childName )
+  {
     return getChildText(parent, new String[] {childName});
-	}
+  }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -748,6 +748,8 @@ public class CellVoyagerReader extends FormatReader
 			final String endTime = getChildText( msRoot, "EndTime" );
 			store.setPlateAcquisitionStartTime( new Timestamp( beginTime ), 0, 0 );
 			store.setPlateAcquisitionEndTime( new Timestamp( endTime ), 0, 0 );
+
+      store.setPlateName(beginTime, 0);
 		}
 
 		// Wells position on the plate

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1711,6 +1711,10 @@ public class FormatReaderTest {
             continue;
           }
 
+          if (reader.getFormat().equals("CellVoyager")) {
+            continue;
+          }
+
           // pattern datasets can only be detected with the pattern file
           if (reader.getFormat().equals("File pattern")) {
             continue;
@@ -2358,6 +2362,13 @@ public class FormatReaderTest {
 
             // QuickTime reader doesn't pick up resource forks
             if (!result && i > 0 && r instanceof QTReader) {
+              continue;
+            }
+
+            if (r instanceof CellVoyagerReader &&
+              (!result || readers[j] instanceof OMEXMLReader) &&
+              used[i].toLowerCase().endsWith(".ome.xml"))
+            {
               continue;
             }
 


### PR DESCRIPTION
See https://trello.com/c/XA5EtcYa/101-fix-plate-naming-for-cellvoyager

CellVoyager datasets were previously untested in OMERO or by regular CI builds.  This adds a plate name as referenced on the card (in 6568998 specifically), but also fixes a number of issues that prevented automated testing and import into OMERO.

It may be easiest to review the diff with ```w=1```, as the final commit (b7de1e1) changes all of the many tabs to spaces for consistency with other readers.  I resisted making more extensive whitespace changes to fully bring the reader into line, but can do so here or elsewhere if desired.

https://github.com/openmicroscopy/data_repo_config/pull/177 adds all 3 known CellVoyager datasets to ```data_repo/curated/cellvoyager```.  As these are previously untested, it would be best to open each in ImageJ or with ```showinf```, checking images and OME-XML for any oddities.  Each should also be imported into OMERO to verify the plate name change, but note that the ```1_3_1_2_1``` dataset is not a plate (the other two datasets are plates).  For all datasets, the target file is ```MeasurementResult.xml```.