### PR TITLE
Fix Ultraview pdf link

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1871,7 +1871,7 @@ Commercial applications that support this format include: \n
 * `Image-Pro Plus <http://www.mediacy.com/>`_ \n
 \n
 .. seealso:: \n
-  `PerkinElmer UltraVIEW system overview (pdf) <http://www.perkinelmer.com/lab-solutions/resources/docs/BRO_UltraVIEW-VoX-Product-Brochure.pdf>`_
+  `PerkinElmer UltraVIEW system overview (pdf) <http://www.perkinelmer.com/lab-solutions/resources/PDFs/LST/Brochures/BRO_UltraVIEW-VoX-Product-Brochure.pdf>`_
 
 [Portable Any Map]
 pagename = pgm

--- a/docs/sphinx/formats/perkinelmer-ultraview.txt
+++ b/docs/sphinx/formats/perkinelmer-ultraview.txt
@@ -55,4 +55,4 @@ Commercial applications that support this format include:
 * `Image-Pro Plus <http://www.mediacy.com/>`_ 
 
 .. seealso:: 
-  `PerkinElmer UltraVIEW system overview (pdf) <http://www.perkinelmer.com/lab-solutions/resources/docs/BRO_UltraVIEW-VoX-Product-Brochure.pdf>`_
+  `PerkinElmer UltraVIEW system overview (pdf) <http://www.perkinelmer.com/lab-solutions/resources/PDFs/LST/Brochures/BRO_UltraVIEW-VoX-Product-Brochure.pdf>`_


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-docs/607/warnings3Result/ this updates the link and should make the build green again.

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.3-staging/formats/perkinelmer-ultraview.html