### PR TITLE
Fix NifTI public specification and data sets links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1517,8 +1517,8 @@ notes = .. seealso:: \n
 extensions = .img, .hdr, .nii, .nii.gz
 developer = `National Institutes of Health <http://www.nih.gov/>`_
 bsd = no
-samples = `Official test data <http://afni.nimh.nih.gov/pub/dist/data/>`_
-weHave = * `NIfTI specification documents <http://afni.nimh.nih.gov/pub/dist/doc/nifti/nifti_revised.html>`_ \n
+samples = `Official test data <https://nifti.nimh.nih.gov/nifti-1/data/>`_
+weHave = * `NIfTI specification documents <https://nifti.nimh.nih.gov/nifti-1/>`_\n
 * several NIfTI datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/NIfTI/>`__
 pixelsRating = Very good

--- a/docs/sphinx/formats/nifti.txt
+++ b/docs/sphinx/formats/nifti.txt
@@ -24,11 +24,11 @@ Reader: NiftiReader (:bfreader:`Source Code <NiftiReader.java>`, :doc:`Supported
 
 Sample Datasets:
 
-- `Official test data <http://afni.nimh.nih.gov/pub/dist/data/>`_
+- `Official test data <https://nifti.nimh.nih.gov/nifti-1/data/>`_
 
 We currently have:
 
-* `NIfTI specification documents <http://afni.nimh.nih.gov/pub/dist/doc/nifti/nifti_revised.html>`_ 
+* `NIfTI specification documents <https://nifti.nimh.nih.gov/nifti-1/>`_
 * several NIfTI datasets 
 * `public sample images <http://downloads.openmicroscopy.org/images/NIfTI/>`__
 


### PR DESCRIPTION
The existing AFNI links seem to have been reorganized or put pages under authentication. This commit redirects the format page links to use https://nifti.nimh.nih.gov/ instead.

To test this PR, check the docs build become green again and the the new NifTI links make sense.