### PR TITLE
Add missing Image-Instrument ref in GatanReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -272,7 +272,9 @@ public class GatanReader extends FormatReader {
         }
       }
 
-      store.setInstrumentID(MetadataTools.createLSID("Instrument", 0), 0);
+      String instrument = MetadataTools.createLSID("Instrument", 0);
+      store.setInstrumentID(instrument, 0);
+      store.setImageInstrumentRef(instrument, 0);
 
       String objective = MetadataTools.createLSID("Objective", 0, 0);
       store.setObjectiveID(objective, 0, 0);


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12939

To test this PR in addition to the automated builds. open the file mentioned in the ticket with the command-line tools `showinf -omexml-only` and check the `Image` element has an `InstrumentRef` with this PR and none without.