### PR TITLE
Formats-API: Initial warnings cleanup 

### DIFF
--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -34,7 +34,6 @@ package loci.formats;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Hashtable;
 import java.util.List;
@@ -48,7 +47,6 @@ import loci.common.RandomAccessInputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
-import loci.common.xml.XMLTools;
 import loci.formats.in.MetadataLevel;
 import loci.formats.meta.DummyMetadata;
 import loci.formats.meta.FilterMetadata;

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -34,7 +34,6 @@ package loci.formats;
 
 import java.awt.image.ColorModel;
 import java.io.IOException;
-import java.util.HashMap;
 
 import ome.xml.model.primitives.PositiveInteger;
 

--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -46,14 +46,10 @@ import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
-import ome.xml.meta.MetadataRoot;
-import ome.xml.meta.OMEXMLMetadataRoot;
-import ome.xml.model.BinData;
 import ome.xml.model.enums.DimensionOrder;
 import ome.xml.model.enums.EnumerationException;
 import ome.xml.model.enums.PixelType;
 import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.NonNegativeLong;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 

--- a/components/formats-api/src/loci/formats/ReaderWrapper.java
+++ b/components/formats-api/src/loci/formats/ReaderWrapper.java
@@ -33,7 +33,6 @@
 package loci.formats;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Hashtable;


### PR DESCRIPTION
This is part of the work to review the resources of various components for potential resource leaks.
As part of this I have completed an initial pass of the formats-api component and reviewed any warnings.

This PR cleans up some simple warnings throughout covering the following:

Remove unused imports
Remove some unused variables

To test:
All builds and tests should remain green