### PR TITLE
Zeiss CZI: make large uncompressed images more performant

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -444,6 +444,9 @@ public class ZeissCZIReader extends FormatReader {
                 s.close();
               }
             }
+            else {
+              emptyTile = false;
+            }
             break;
           }
         }
@@ -3392,9 +3395,14 @@ public class ZeissCZIReader extends FormatReader {
       int bpp = FormatTools.getBytesPerPixel(getPixelType());
       if (directoryEntry.compression == UNCOMPRESSED) {
         if (buf == null) {
-          buf = new byte[tile.width * tile.height * bpp * getRGBChannelCount()];
+          buf = new byte[(int) dataSize];
         }
-        readPlane(s, tile.x, tile.y, tile.width, tile.height, buf);
+        if (tile != null) {
+          readPlane(s, tile.x, tile.y, tile.width, tile.height, buf);
+        }
+        else {
+          s.readFully(buf);
+        }
         return buf;
       }
 
@@ -3439,6 +3447,10 @@ public class ZeissCZIReader extends FormatReader {
         case 504: // camera-specific packed pixels
           data = decode12BitCamera(data, options.maxBytes);
           break;
+      }
+      if (buf != null && buf.length >= data.length) {
+        System.arraycopy(data, 0, buf, 0, data.length);
+        return buf;
       }
       return data;
     }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -434,7 +434,7 @@ public class ZeissCZIReader extends FormatReader {
             else {
               rawData = new SubBlock(plane).readPixelData();
             }
-            if (rawData.length > buf.length) {
+            if (rawData.length > buf.length || pixels.size() > 0) {
               RandomAccessInputStream s = new RandomAccessInputStream(rawData);
               try {
                 readPlane(s, x, y, w, h, realX - getSizeX(), buf);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3376,11 +3376,8 @@ public class ZeissCZIReader extends FormatReader {
     // -- SubBlock API methods --
 
     public byte[] readPixelData() throws FormatException, IOException {
-      RandomAccessInputStream s = new RandomAccessInputStream(filename, (int) dataSize);
-      try {
+      try (RandomAccessInputStream s = new RandomAccessInputStream(filename, (int) dataSize)) {
         return readPixelData(s);
-      } finally {
-        s.close();
       }
     }
 


### PR DESCRIPTION
This speeds up pixel data access when tiles from a large uncompressed image with no internal tiling are requested via openBytes.  Only the specific tile specified in the call to openBytes is read from disk, instead of the entire image being read and then copied.

See https://trello.com/c/YIaXQGvp/105-investigate-zeiss-czi-pyramid-generation-performance and https://github.com/openmicroscopy/data_repo_config/pull/179

Automated tests should pass using the configuration PR both with and without this PR - the actual pixel data should be the same regardless.

Performance testing was done by iterating over all tiles in all planes, using the optimal tile width and height reported by the reader as a guide.  Specifically, something like this:

```
ImageReader reader = new ImageReader();
reader.setId(filename);
int optimalX = reader.getOptimalTileWidth();
int optimalY = reader.getOptimalTileHeight();
int x = reader.getSizeX();
int y = reader.getSizeY();

for (int i=0; i<reader.getImageCount(); i++) {
   for (int yy=0; yy<y; yy+=optimalY) {
      for (int xx=0; xx<x; xx+=optimalX) {
         int w = (int) Math.min(optimalX, x - xx);
         int h = (int) Math.min(optimalY, y - yy);
         reader.openBytes(i, xx, yy, w, h);
      }
    }
}
```

For each change measured, the test code was run three consecutive times against ```data_repo/curated/zeiss-czi/michael-porter/EB01 - Airyscan Fast SR 20x_Airyscan Processing.czi```; the best of the three times was used for comparison and is reported here.

Without this PR, the test code ran in 111m22s.  With this PR, the test code ran in 4m38s.  With this PR and a now-discarded change to set the optimal tile size to 1024x1024, the test code ran in 53m34s.

In addition to verifying that builds pass and observed openBytes performance is consistent with the above, it would be good to spot check a few tiles in ImageJ to make sure that the tiles match up with the corresponding location in the full image (i.e. the file seeking arithmetic is all still correct).