### PR TITLE
Write OME-TIFF as binary + companion

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -61,8 +61,7 @@ import loci.formats.MetadataTools;
 import loci.formats.MinMaxCalculator;
 import loci.formats.MissingLibraryException;
 import loci.formats.gui.Index16ColorModel;
-import loci.formats.in.DefaultMetadataOptions;
-import loci.formats.in.MetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
@@ -115,6 +114,7 @@ public final class ImageConverter {
 
   private HashMap<String, Integer> nextOutputIndex = new HashMap<String, Integer>();
   private boolean firstTile = true;
+  private DynamicMetadataOptions options = new DynamicMetadataOptions();
 
   // -- Constructor --
 
@@ -149,6 +149,9 @@ public final class ImageConverter {
         else if (args[i].equals("-novalid")) validate = false;
         else if (args[i].equals("-validate")) validate = true;
         else if (args[i].equals("-padded")) zeroPadding = true;
+        else if (args[i].equals("-option")) {
+          options.set(args[++i], args[++i]);
+        }
         else if (args[i].equals("-overwrite")) {
           overwrite = true;
         }
@@ -226,7 +229,8 @@ public final class ImageConverter {
       "    [-bigtiff] [-compression codec] [-series series] [-map id]",
       "    [-range start end] [-crop x,y,w,h] [-channel channel] [-z Z]",
       "    [-timepoint timepoint] [-nogroup] [-nolookup] [-autoscale]",
-      "    [-version] [-no-upgrade][-padded] in_file out_file",
+      "    [-version] [-no-upgrade] [-padded] [-option key value]",
+      "    in_file out_file",
       "",
       "    -version: print the library version and exit",
       " -no-upgrade: do not perform the upgrade check",
@@ -253,6 +257,7 @@ public final class ImageConverter {
       "          -z: only convert the specified Z section (indexed from 0)",
       "  -timepoint: only convert the specified timepoint (indexed from 0)",
       "     -padded: filename indexes for series, z, c and t will be zero padded",
+      "     -option: add the specified key/value pair to the options list",
       "",
       "If any of the following patterns are present in out_file, they will",
       "be replaced with the indicated metadata value from the input file.",
@@ -295,7 +300,6 @@ public final class ImageConverter {
     throws FormatException, IOException
   {
     nextOutputIndex.clear();
-    MetadataOptions options= new DefaultMetadataOptions();
     options.setValidate(validate);
     writer.setMetadataOptions(options);
     firstTile = true;

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -45,6 +45,7 @@ import loci.formats.ImageReader;
 import loci.formats.ImageWriter;
 import loci.formats.FormatException;
 import loci.formats.tools.ImageConverter;
+import loci.formats.out.OMETiffWriter;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.testng.annotations.AfterClass;
@@ -179,6 +180,26 @@ public class ImageConverterTest {
       assertEquals(
         "Found unknown command flag: -foo; exiting." +
         System.getProperty("line.separator"), outContent.toString());
+    }
+  }
+
+  @Test
+  public void testCompanion() throws FormatException, IOException {
+    outFile = File.createTempFile("test", ".ome.tif");
+    outFile.delete();
+    File compFile = new File(outFile.getParentFile(), "test.companion.ome");
+    String[] args = {
+      "-option", OMETiffWriter.COMPANION_KEY, compFile.getAbsolutePath(),
+      "test.fake", outFile.getAbsolutePath()
+    };
+    try {
+      ImageConverter.main(args);
+    } catch (ExitException e) {
+      outFile.deleteOnExit();
+      compFile.deleteOnExit();
+      assertEquals(e.status, 0);
+      assertTrue(compFile.exists());
+      checkImage();
     }
   }
 }

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -33,6 +33,7 @@
 package loci.formats.out;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,11 +45,13 @@ import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveInteger;
 
 import loci.common.Location;
+import loci.common.Constants;
 import loci.common.RandomAccessInputStream;
 import loci.common.RandomAccessOutputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.meta.MetadataRetrieve;
@@ -57,6 +60,8 @@ import loci.formats.ome.OMEXMLMetadataImpl;
 import loci.formats.services.OMEXMLService;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.TiffSaver;
+import loci.formats.in.MetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 
 /**
  * OMETiffWriter is the file format writer for OME-TIFF files.
@@ -71,6 +76,8 @@ public class OMETiffWriter extends TiffWriter {
     "Please edit cautiously (if at all), and back up the original data " +
     "before doing so. For more information, see the OME-TIFF web site: " +
     FormatTools.URL_OME_TIFF + ". -->";
+
+  public static final String COMPANION_KEY = "ometiff.companion";
 
   // -- Fields --
 
@@ -106,13 +113,30 @@ public class OMETiffWriter extends TiffWriter {
           populateImage(omeMeta, series);
         }
 
+        String companion = getCompanion();
+        String companionUUID = null;
+        if (null != companion) {
+          String companionXML = getOMEXML(companion);
+          PrintWriter out = new PrintWriter(companion, Constants.ENCODING);
+          out.println(XMLTools.indentXML(companionXML, true));
+          out.close();
+          companionUUID = "urn:uuid:" + getUUID(
+              new Location(companion).getName());
+        }
+
         List<String> files = new ArrayList<String>();
         for (String[] s : imageLocations) {
           for (String f : s) {
             if (!files.contains(f) && f != null) {
               files.add(f);
 
-              String xml = getOMEXML(f);
+              String xml = null;
+              if (null != companion) {
+                xml = getBinaryOnlyOMEXML(f, companion, companionUUID);
+              } else {
+                xml = getOMEXML(f);
+              }
+              xml = insertWarningComment(xml);
               if (getMetadataOptions().isValidate()) {
                 service.validateOMEXML(xml);
               }
@@ -224,6 +248,15 @@ public class OMETiffWriter extends TiffWriter {
     }
   }
 
+  // -- OMETiff-specific methods --
+  public String getCompanion() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).get(COMPANION_KEY);
+    }
+    return null;
+  }
+
   // -- Helper methods --
 
   /** Gets the UUID corresponding to the given filename. */
@@ -251,6 +284,12 @@ public class OMETiffWriter extends TiffWriter {
     omeMeta = service.createOMEXMLMetadata(omexml);
   }
 
+  private String insertWarningComment(String xml) {
+    String prefix = xml.substring(0, xml.indexOf('>') + 1);
+    String suffix = xml.substring(xml.indexOf('>') + 1);
+    return prefix + WARNING_COMMENT + suffix;
+  }
+
   private String getOMEXML(String file) throws FormatException, IOException {
     // generate UUID and add to OME element
     String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
@@ -266,11 +305,22 @@ public class OMETiffWriter extends TiffWriter {
     catch (ServiceException se) {
       throw new FormatException(se);
     }
+    return xml;
+  }
 
-    // insert warning comment
-    String prefix = xml.substring(0, xml.indexOf('>') + 1);
-    String suffix = xml.substring(xml.indexOf('>') + 1);
-    return prefix + WARNING_COMMENT + suffix;
+  private String getBinaryOnlyOMEXML(
+      String file, String companion, String companionUUID) throws
+        FormatException, IOException, DependencyException, ServiceException {
+    ServiceFactory factory = new ServiceFactory();
+    OMEXMLService service = factory.getInstance(OMEXMLService.class);
+    OMEXMLMetadata meta = service.createOMEXMLMetadata();
+    String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
+    meta.setUUID(uuid);
+    meta.setBinaryOnlyMetadataFile(companion);
+    meta.setBinaryOnlyUUID(companionUUID);
+    OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) meta.getRoot();
+    root.setCreator(FormatTools.CREATOR);
+    return service.getOMEXML(meta);
   }
 
   private void saveComment(String file, String xml) throws IOException {

--- a/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/OMETiffWriter.java
@@ -316,7 +316,7 @@ public class OMETiffWriter extends TiffWriter {
     OMEXMLMetadata meta = service.createOMEXMLMetadata();
     String uuid = "urn:uuid:" + getUUID(new Location(file).getName());
     meta.setUUID(uuid);
-    meta.setBinaryOnlyMetadataFile(companion);
+    meta.setBinaryOnlyMetadataFile(new Location(companion).getName());
     meta.setBinaryOnlyUUID(companionUUID);
     OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) meta.getRoot();
     root.setCreator(FormatTools.CREATOR);

--- a/components/formats-bsd/test/loci/formats/utests/out/OMETiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/OMETiffWriterTest.java
@@ -33,10 +33,16 @@
 package loci.formats.utests.out;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import loci.formats.FormatException;
 import loci.formats.in.TiffReader;
+import loci.formats.in.OMETiffReader;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.meta.IMetadata;
 import loci.formats.out.OMETiffWriter;
 import loci.formats.tiff.IFD;
@@ -180,5 +186,42 @@ public class OMETiffWriterTest {
 
     tmp.delete();
     reader.close();
+  }
+
+  @Test
+  public void testCompanion() throws Exception {
+    Path wd = Files.createTempDirectory(this.getClass().getName());
+    File outFile = wd.resolve("test.ome.tif").toFile();
+    File cFile = wd.resolve("test.companion.ome").toFile();
+    String companion = cFile.getAbsolutePath();
+    DynamicMetadataOptions options = new DynamicMetadataOptions();
+    options.set(OMETiffWriter.COMPANION_KEY, companion);
+    int planeCount =
+      WriterUtilities.SIZE_Z * WriterUtilities.SIZE_C * WriterUtilities.SIZE_T;
+    //--
+    OMETiffWriter cwriter = new OMETiffWriter();
+    cwriter.setMetadataOptions(options);
+    cwriter.setMetadataRetrieve(metadata);
+    cwriter.setId(outFile.getAbsolutePath());
+    cwriter.setSeries(0);
+    byte[] img = new byte[WriterUtilities.SIZE_X * WriterUtilities.SIZE_Y];
+    Arrays.fill(img, (byte) 0);
+    for (int i = 0; i < planeCount; i++) {
+      cwriter.saveBytes(i, img);
+    }
+    cwriter.close();
+    //--
+    assertTrue(cFile.exists());
+    OMETiffReader reader = new OMETiffReader();
+    reader.setId(companion);
+    assertEquals(reader.getSizeX(), WriterUtilities.SIZE_X);
+    assertEquals(reader.getSizeY(), WriterUtilities.SIZE_Y);
+    assertEquals(reader.getSizeZ(), WriterUtilities.SIZE_Z);
+    assertEquals(reader.getSizeC(), WriterUtilities.SIZE_C);
+    assertEquals(reader.getSizeT(), WriterUtilities.SIZE_T);
+    reader.close();
+    outFile.deleteOnExit();
+    cFile.deleteOnExit();
+    wd.toFile().deleteOnExit();
   }
 }

--- a/components/formats-bsd/test/loci/formats/utests/out/OMETiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/OMETiffWriterTest.java
@@ -38,7 +38,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import loci.formats.FormatException;
 import loci.formats.in.TiffReader;
 import loci.formats.in.OMETiffReader;
@@ -198,19 +197,18 @@ public class OMETiffWriterTest {
     options.set(OMETiffWriter.COMPANION_KEY, companion);
     int planeCount =
       WriterUtilities.SIZE_Z * WriterUtilities.SIZE_C * WriterUtilities.SIZE_T;
-    //--
+
     OMETiffWriter cwriter = new OMETiffWriter();
     cwriter.setMetadataOptions(options);
     cwriter.setMetadataRetrieve(metadata);
     cwriter.setId(outFile.getAbsolutePath());
     cwriter.setSeries(0);
     byte[] img = new byte[WriterUtilities.SIZE_X * WriterUtilities.SIZE_Y];
-    Arrays.fill(img, (byte) 0);
     for (int i = 0; i < planeCount; i++) {
       cwriter.saveBytes(i, img);
     }
     cwriter.close();
-    //--
+
     assertTrue(cFile.exists());
     OMETiffReader reader = new OMETiffReader();
     reader.setId(companion);


### PR DESCRIPTION
Adds an option to save an OME-TIFF dataset as binary TIFF + companion XML.

To test, convert any image (e.g., [PR2729_frameOrderCombinedScanTypes.lif](http://downloads.openmicroscopy.org/images/Leica-LIF/michael/PR2729_frameOrderCombinedScanTypes.lif)) to OME-TIFF with and without the companion file option, then compare the two `showinf` outputs:

```
./bfconvert PR2729_frameOrderCombinedScanTypes.lif PR2729_frameOrderCombinedScanTypes.ome.tif
./showinf -nopix PR2729_frameOrderCombinedScanTypes.ome.tif >standalone.out
./bfconvert -option ometiff.companion PR2729_frameOrderCombinedScanTypes.companion.ome PR2729_frameOrderCombinedScanTypes.lif PR2729_frameOrderCombinedScanTypes_binonly.ome.tif
./showinf -nopix PR2729_frameOrderCombinedScanTypes.companion.ome >companion.out
```

The `*.out` files should only differ w.r.t file names and possibly initialization time.

**NOTE:**

An important limitation of this PR is that the conversion works only if the binary TIFF and the companion are saved in the same directory, since mutual references between the two files are via basenames. This is due to the fact that it works by simply taking the OME-XML string that would have been embedded in the standalone file as-is and dumping it to the companion file. However, since this feature is currently missing, it might be worth adding it in this limited form and then considering a future generalization.