### PR TITLE
FilePatternReader: KV pairs

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -343,10 +343,10 @@ public class FilePatternReader extends FormatReader {
     String line;
     while ((line = br.readLine()) != null) {
       line = line.trim();
-      if (line.length() == 0) {
+      if (line.isEmpty()) {
         continue;
       }
-      if (line.startsWith("#")) {
+      if (line.charAt(0) == '#') {
         String[] kv = line.substring(1).split("\\s+=\\s+", 2);
         if (kv.length == 2) {
           pairs.put(kv[0].trim(), kv[1].trim());

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -392,6 +392,18 @@ public class FilePatternReader extends FormatReader {
       }
     }
     setSeries(0);
+
+    MetadataStore store = makeFilterMetadata();
+
+    String channelNamesEntry = pairs.get("ChannelNames");
+    if (null != channelNamesEntry) {
+      String[] channelNames = channelNamesEntry.split(",", -1);
+      for (int s = 0; s < getSeriesCount(); s++) {
+        for (int i = 0; i < channelNames.length; i++) {
+          store.setChannelName(channelNames[i], s, i);
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
* Adds support for passing key/value pairs to `FilePatternReader` via comment lines
* Adds selective reader exclusion and channel names setting via the above feature

Example:

```
# ExcludeReaders = loci.formats.in.Reader1,loci.formats.in.Reader2
# ChannelNames = Foo,Bar
/foo/C<a,b>.pattern
```

See also: #2758 (same feature for `ScreenReader`)