### PR TITLE
ImageConverterTest: create temporary directories using java.nio.file

### DIFF
--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -129,7 +129,7 @@ public class ImageConverterTest {
 
   @Test(dataProvider = "suffixes")
   public void testDefault(String suffix) throws FormatException, IOException {
-    outFile = tempDir.resolve("test." + suffix).toFile();
+    outFile = tempDir.resolve("test" + suffix).toFile();
     String[] args = {"test.fake", outFile.getAbsolutePath()};
     try {
       ImageConverter.main(args);


### PR DESCRIPTION
See https://trello.com/c/NBMgI8Xz/113-change-the-file-creation-semantics-in-the-unit-tests

Also move the security manager logic to After and Before Method to allow individual test methods to be run via `mvn test` (see https://trello.com/c/WhRvUkyL/111-image-converter-tests-throw-if-run-individually)

To test this PR, check the Travis and Jenkins builds remain green and that the new logic is easy to understand. Also run individual methods as mentioned in the card above and check the individual tests now pass.