### PR TITLE
Bio-Formats Plugins: Warnings cleanup

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/Calibrator.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Calibrator.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import loci.formats.FormatTools;
 import loci.formats.meta.IMetadata;
 import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 
 import ome.units.quantity.Time;

--- a/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Colorizer.java
@@ -53,8 +53,6 @@ import loci.plugins.BF;
 import loci.plugins.util.ImageProcessorReader;
 import loci.plugins.util.VirtualImagePlus;
 
-import ome.xml.model.primitives.PositiveFloat;
-
 import ome.units.quantity.Length;
 import ome.units.UNITS;
 

--- a/components/bio-formats-plugins/src/loci/plugins/in/Concatenator.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/Concatenator.java
@@ -29,7 +29,6 @@ package loci.plugins.in;
 
 import ij.ImagePlus;
 import ij.ImageStack;
-import ij.gui.GenericDialog;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -34,19 +34,15 @@ import com.jgoodies.forms.layout.FormLayout;
 import java.awt.Checkbox;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.awt.Label;
-import java.awt.Panel;
 import java.awt.event.ItemEvent;
 import java.io.File;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Vector;
 
-import javax.swing.Box;
 import javax.swing.JPanel;
 
 import ij.IJ;

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -45,16 +45,12 @@ import loci.common.Region;
 import loci.common.StatusEvent;
 import loci.common.StatusListener;
 import loci.common.StatusReporter;
-import loci.common.services.DependencyException;
-import loci.common.services.ServiceException;
-import loci.common.services.ServiceFactory;
 import loci.formats.FilePattern;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.Modulo;
 import loci.formats.meta.IMetadata;
-import loci.formats.services.OMEXMLService;
 import loci.plugins.Slicer;
 import loci.plugins.util.BFVirtualStack;
 import loci.plugins.util.ImageProcessorReader;
@@ -575,7 +571,6 @@ public class ImagePlusReader implements StatusReporter {
     r.setSeries(series);
 
     final int[] zct = r.getZCTCoords(ndx);
-    final int sizeC = r.getSizeC();
     final StringBuffer sb = new StringBuffer();
 
     int[] subC;

--- a/components/bio-formats-plugins/src/loci/plugins/in/UpgradeDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/UpgradeDialog.java
@@ -28,13 +28,11 @@
 package loci.plugins.in;
 
 import ij.IJ;
-import ij.Prefs;
 import ij.gui.GenericDialog;
 
 import loci.formats.UpgradeChecker;
 import loci.plugins.BF;
 import loci.plugins.Updater;
-import loci.plugins.prefs.Option;
 
 /**
  * Bio-Formats Importer upgrade checker dialog box.

--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -29,10 +29,8 @@ package loci.plugins.macro;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.process.ImageProcessor;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import loci.common.Region;
 import loci.common.services.DependencyException;
@@ -54,8 +52,6 @@ import loci.plugins.in.ImportProcess;
 import loci.plugins.in.ImporterOptions;
 import loci.plugins.util.ImageProcessorReader;
 import loci.plugins.util.LociPrefs;
-
-import ome.xml.model.primitives.PositiveFloat;
 
 import ome.units.quantity.Length;
 import ome.units.quantity.Time;
@@ -422,8 +418,9 @@ public class LociFunctions extends MacroFunctions {
   public void getFormat(String id, String[] format)
     throws FormatException, IOException
   {
-    ImageReader reader = new ImageReader();
-    format[0] = reader.getFormat(id);
+    try (ImageReader reader = new ImageReader()) {
+      format[0] = reader.getFormat(id);
+    }
   }
 
   public void setId(String id) throws FormatException, IOException {

--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -71,7 +71,6 @@ import loci.formats.gui.ExtensionFileFilter;
 import loci.formats.gui.GUITools;
 import loci.formats.gui.Index16ColorModel;
 import loci.formats.meta.IMetadata;
-import loci.formats.meta.MetadataRetrieve;
 import loci.formats.services.OMEXMLService;
 import loci.plugins.BF;
 import loci.plugins.LociExporter;
@@ -321,7 +320,7 @@ public class Exporter {
             if (multiFile.wasCanceled()) return;
         }
 
-        try {
+        try (IFormatWriter w = new ImageWriter().getWriter(outfile)) {
             int ptype = 0;
             int channels = 1;
             switch (imp.getType()) {
@@ -342,7 +341,6 @@ public class Exporter {
             }
             String title = imp.getTitle();
 
-            IFormatWriter w = new ImageWriter().getWriter(outfile);
             w.setWriteSequentially(true);
             FileInfo fi = imp.getOriginalFileInfo();
             String xml = fi == null ? null : fi.description == null ? null :


### PR DESCRIPTION
This is part of the work to review the resources of various components for potential resource leaks.
As part of this I have completed an initial pass of the bio-formats_plugins component and reviewed any warnings.

This PR cleans up some simple warnings throughout covering the following:

- Remove unused imports
- Close resources which are left open

This is by no means an extensive or complete cleanup of warnings, simply some initial cleanup which would be easy and safe while identifying potential resource leaks.

**To test:**

- All builds and tests should remain green
- Run ImageJ tests from release process