### PR TITLE
DICOM: add support for DICOMDIR files

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -872,8 +872,8 @@ public class DicomReader extends FormatReader {
         rescaleSlope = Double.parseDouble(info);
       }
       else if (key.equals("Pixel Spacing")) {
-        pixelSizeX = info.substring(0, info.indexOf("\\"));
-        pixelSizeY = info.substring(info.lastIndexOf("\\") + 1);
+        pixelSizeY = info.substring(0, info.indexOf("\\"));
+        pixelSizeX = info.substring(info.lastIndexOf("\\") + 1);
       }
       else if (key.equals("Spacing Between Slices")) {
         pixelSizeZ = new Double(info);

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -184,7 +184,7 @@ public class DicomReader extends FormatReader {
   /* @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */
   @Override
   public boolean isThisType(RandomAccessInputStream stream) throws IOException {
-    final int blockLen = 2048;
+    final int blockLen = 1024;
     if (!FormatTools.validStream(stream, blockLen, true)) return false;
 
     stream.seek(128);


### PR DESCRIPTION
This backports existing commits from two private pull requests.  See https://trello.com/c/ciKINMvW/18-dicom-support-for-directory-image

There are three things to test.  First is the physical size configuration change in 184c2f2 and https://github.com/openmicroscopy/data_repo_config/pull/183.  Most existing DICOM files are unaffected; the relevant specification is http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_10.7.html#sect_10.7.1.3

Second is the plane position parsing in eefed6c.  Without this PR, ```showinf -nopix -omexml curated/dicom/charles/img1582.dcm``` should not have any of the OME-XML ```Position*``` attributes set on ```Plane```.  With this PR, all ```Position*``` attributes should be set according to the ```0020,0032 Image Position (Patient) #1``` key in the original metadata.

Finally, a580739 and 6fecdde add remaining logic necessary to support ```DICOMDIR``` files, which allow multiple DICOM files in a single directory to be opened as a single dataset.  The only real example we have of this is QA 11401, which is configured in https://github.com/openmicroscopy/data_repo_config/pull/182.  Without this PR, each of the 3 DICOM files in the ```IMAGES``` directory under ```curated/dicom/qa-11401``` should open with ```showinf``` or ImageJ, but attempting to open the ```DICOMDIR``` file should result in an exception.  With this PR, opening the ```DICOMDIR``` file should result in 3 series (one per DICOM file) with all 4 files on the used files list.  The behavior when opening any of the individual DICOM files should remain unchanged.



