### PR TITLE
ScreenReader: ensure used files contain no duplicates

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -32,6 +32,8 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.LinkedHashSet;
 
 import loci.common.DataTools;
 import loci.common.IniList;
@@ -197,7 +199,7 @@ public class ScreenReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     int spotIndex = seriesMap.get(getCoreIndex());
-    final List<String> allFiles = new ArrayList<String>();
+    final Set<String> allFiles = new LinkedHashSet<String>();
     try {
       for (String file : files[spotIndex]) {
         reader.close();


### PR DESCRIPTION
Changes `getSeriesUsedFiles` to use a set rather than a list, to avoid duplicates. Note that, if calling `getUsedFiles`, to expose this bug it takes a mini-screen with one series (i.e., one well with one field). This is due to the fact that when there are multiple series, `FormatReader.getUsedFiles` merges partial lists into a set anyway.