### PR TITLE
Add image acquisition tests as part of the testDeltaT

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1123,6 +1123,18 @@ public class FormatReaderTest {
     for (int i=0; i<reader.getSeriesCount(); i++) {
       config.setSeries(i);
 
+      // Test image acquisition date
+      String expectedDate = config.getDate();
+      String date = null;
+      if (retrieve.getImageAcquisitionDate(i) != null) {
+        date = retrieve.getImageAcquisitionDate(i).getValue();
+      }
+      if (expectedDate != null && date != null && !expectedDate.equals(date)) {
+        result(testName, false, "series " + i +
+          " (expected " + expectedDate + ", actual " + date + ")");
+        return;
+      }
+
       for (int p=0; p<reader.getImageCount(); p++) {
         Time deltaT = null;
         try {


### PR DESCRIPTION
See https://trello.com/c/Uzb4YXli/116-andor-abd-vs-oiympus-fluoview-date-format

Although the `test-suite` configuration generation logic allows to store acquisition dates in the configuration files, these values are only used in the sanity check of `testSaneOMEXML`. In order to properly address issues like https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8238 together with non-regression tests, it is necessary to have acquisition dates tested as part of the `test-automated` target. Rather than creating another test, this PR proposes to extend the `testDeltaT` non-regression test and also compare read acquisition date with the values stored in the configuration files.

A companion configuration PR should adjust all the incorrect values. In additional to verifying the logic, the main review is to test the full repository job remains green with this PR included.