### PR TITLE
Use latest Bio-Formats 5.4 redirects

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -149,8 +149,8 @@ extlinks = {
     'team_plone' : (oo_site_root + '/team/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/bio-formats5.3/%s', ''),
-    'javadoc' : (downloads_root + '/latest/bio-formats5.3/api/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats5.4/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats5.4/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
     'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_model_version + '/' + '%s', ''),
     'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_model_version + '/' + '%s', ''),

--- a/docs/sphinx/themes/globalbftoc.html
+++ b/docs/sphinx/themes/globalbftoc.html
@@ -1,4 +1,4 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.3/">{{ _('Bio-Formats Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.4/">{{ _('Bio-Formats Downloads') }}</a></br>
 <a href="http://www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
Updates the documentation configuration to point at the latest 5.4 downloads/API.