### PR TITLE
MIAS Reader -  Unhandled Exception

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MIASReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MIASReader.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.ArrayUtils;
+
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.Location;
@@ -613,6 +615,9 @@ public class MIASReader extends FormatReader {
       }
 
       tiffFiles = tmpFiles.toArray(new String[0]);
+      if (ArrayUtils.isEmpty(tiffFiles)){
+        throw new FormatException("Empty dataset - No tiff files were found.");
+      }
 
       Location firstTiff = new Location(tiffFiles[0]);
 


### PR DESCRIPTION
Potential ArrayIndexOutOfBoundsException can occur when no tiff files are found located in channel specific subdirectories.

`MIASReader.initFile` looks for two alternative layouts when browsing well directories:

1. Image files directly under the `Well????` dir
2. Image files under channel-specific subdirectories of the `Well????` dir

In the former case, empty directories are skipped in [line 541](https://github.com/openmicroscopy/bioformats/blob/8e3558fa4efe57a095394310205d67165f5fd08c/components/formats-gpl/src/loci/formats/in/MIASReader.java#L541)

In the latter, if all subdirectories are empty, the `tiffFiles` array will be empty and [line 618](https://github.com/openmicroscopy/bioformats/blob/8e3558fa4efe57a095394310205d67165f5fd08c/components/formats-gpl/src/loci/formats/in/MIASReader.java#L618) leads to an `ArrayIndexOutOfBoundsException`

This will better handle this scenario and instead throw a meaningful FormatException.

To test:
- Ensure all builds and tests remain green
