### PR TITLE
BDReader: Minor fix to check if Experiment.exp is a directory

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -114,8 +114,7 @@ public class BDReader extends FormatReader {
   @Override
   public boolean isThisType(String name, boolean open) {
     String id = new Location(name).getAbsolutePath();
-    File tempf = new File(id);
-    boolean dirCheck = tempf.isDirectory();
+    boolean dirCheck = new Location(name).isDirectory();
     if (dirCheck) return false;
     if (name.endsWith(EXPERIMENT_FILE)) return true;
     if (!open) return false;

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -113,8 +113,10 @@ public class BDReader extends FormatReader {
   /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
   @Override
   public boolean isThisType(String name, boolean open) {
-    String id = new Location(name).getAbsolutePath();
-    boolean dirCheck = new Location(name).isDirectory();
+    
+    Location location = new Location(name);
+    String id = location.getAbsolutePath();
+    boolean dirCheck = location.isDirectory();
     if (dirCheck) return false;
     if (name.endsWith(EXPERIMENT_FILE)) return true;
     if (!open) return false;

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -113,10 +113,14 @@ public class BDReader extends FormatReader {
   /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
   @Override
   public boolean isThisType(String name, boolean open) {
+    String id = new Location(name).getAbsolutePath();
+    File f = new File(id);
+    boolean dirCheck = f.isDirectory();
+    if (dirCheck) return false;
     if (name.endsWith(EXPERIMENT_FILE)) return true;
     if (!open) return false;
 
-    String id = new Location(name).getAbsolutePath();
+    
     try {
       id = locateExperimentFile(id);
     }

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -114,8 +114,8 @@ public class BDReader extends FormatReader {
   @Override
   public boolean isThisType(String name, boolean open) {
     String id = new Location(name).getAbsolutePath();
-    File f = new File(id);
-    boolean dirCheck = f.isDirectory();
+    File tempf = new File(id);
+    boolean dirCheck = tempf.isDirectory();
     if (dirCheck) return false;
     if (name.endsWith(EXPERIMENT_FILE)) return true;
     if (!open) return false;


### PR DESCRIPTION
ref: https://trello.com/c/sQsD1Sy6/124-bd-pathway-reader-misclassifies-directory

Testing instructions : 

1) Create a new directory.
2) Copy a png file, .lsm file and an .ome.tiff file into the directory.
3) Create a subdirectory called "Experiment.exp"
4) Now using Fiji, try opening the files within the folder (.png, .lsm, .ome.tiff) one after the other.

Expectation 

Without this PR
png file should open without any issues, but the other two files should throw errors.
With this PR
All files under the main directory should open without any issues.

The subset jobs have been run here:
https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-repository-subset/399/
Please check if it is green.

@sbesson @pwalczysko 