### PR TITLE
Add Hamamatsu public sample links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -192,6 +192,7 @@ notes = .. seealso:: \n
 extensions = .svs
 owner = `Aperio <http://www.aperio.com/>`_
 bsd = no
+software = `OpenSlide <http://openslide.org>`_
 versions = 8.0, 8.2, 9.0
 weHave = * many SVS datasets\n
 * `public sample images <http://downloads.openmicroscopy.org/images/SVS/>`__\n
@@ -734,7 +735,8 @@ mif = true
 extensions = .ndpi, .ndpis
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
-software = `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_
+software = `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_ \n
+`OpenSlide <http://openslide.org>`_
 weHave = * many example datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/>`__
 weWant = * an official specification document
@@ -751,6 +753,7 @@ pyramid = yes
 extensions = .vms
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
+software = `OpenSlide <http://openslide.org>`_
 weHave = * a few example datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-VMS/>`__ \n
 * `developer documentation from the OpenSlide project <http://openslide.org/Hamamatsu%20format/>`_
@@ -1270,6 +1273,7 @@ Commercial applications that support LEI include: \n
 extensions = .scn
 developer = `Leica Microsystems <http://www.leica-microsystems.com/>`_
 bsd = no
+software = `OpenSlide <http://openslide.org>`_
 versions = 2012-03-10
 weHave = * a few sample datasets
 weWant = * an official specification document \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -735,8 +735,8 @@ extensions = .ndpi, .ndpis
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
 software = `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_
-samples = `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu/>`_
-weHave = * many example datasets
+weHave = * many example datasets \n
+* `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/>`__
 weWant = * an official specification document
 pixelsRating = Fair
 metadataRating = Good
@@ -751,8 +751,8 @@ pyramid = yes
 extensions = .vms
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
-samples = `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu-vms/>`_
 weHave = * a few example datasets \n
+* `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-VMS/>`__ \n
 * `developer documentation from the OpenSlide project <http://openslide.org/Hamamatsu%20format/>`_
 weWant = * an official specification document \n
 * more example datasets

--- a/docs/sphinx/formats/aperio-svs-tiff.rst
+++ b/docs/sphinx/formats/aperio-svs-tiff.rst
@@ -21,6 +21,9 @@ Officially Supported Versions: 8.0, 8.2, 9.0
 Reader: SVSReader (:bfreader:`Source Code <SVSReader.java>`, :doc:`Supported Metadata Fields </metadata/SVSReader>`)
 
 
+Freely Available Software:
+
+- `OpenSlide <http://openslide.org>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/hamamatsu-ndpi.rst
+++ b/docs/sphinx/formats/hamamatsu-ndpi.rst
@@ -28,13 +28,11 @@ Freely Available Software:
 
 - `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_
 
-Sample Datasets:
-
-- `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu/>`_
 
 We currently have:
 
-* many example datasets
+* many example datasets 
+* `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/>`__
 
 We would like to have:
 

--- a/docs/sphinx/formats/hamamatsu-ndpi.rst
+++ b/docs/sphinx/formats/hamamatsu-ndpi.rst
@@ -26,7 +26,8 @@ Readers:
 
 Freely Available Software:
 
-- `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_
+- `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_ 
+- `OpenSlide <http://openslide.org>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/hamamatsu-vms.rst
+++ b/docs/sphinx/formats/hamamatsu-vms.rst
@@ -22,13 +22,11 @@ Reader: HamamatsuVMSReader (:bfreader:`Source Code <HamamatsuVMSReader.java>`, :
 
 
 
-Sample Datasets:
-
-- `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu-vms/>`_
 
 We currently have:
 
 * a few example datasets 
+* `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-VMS/>`__ 
 * `developer documentation from the OpenSlide project <http://openslide.org/Hamamatsu%20format/>`_
 
 We would like to have:

--- a/docs/sphinx/formats/hamamatsu-vms.rst
+++ b/docs/sphinx/formats/hamamatsu-vms.rst
@@ -21,6 +21,9 @@ Officially Supported Versions:
 Reader: HamamatsuVMSReader (:bfreader:`Source Code <HamamatsuVMSReader.java>`, :doc:`Supported Metadata Fields </metadata/HamamatsuVMSReader>`)
 
 
+Freely Available Software:
+
+- `OpenSlide <http://openslide.org>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/leica-scn.rst
+++ b/docs/sphinx/formats/leica-scn.rst
@@ -21,6 +21,9 @@ Officially Supported Versions: 2012-03-10
 Reader: LeicaSCNReader (:bfreader:`Source Code <LeicaSCNReader.java>`, :doc:`Supported Metadata Fields </metadata/LeicaSCNReader>`)
 
 
+Freely Available Software:
+
+- `OpenSlide <http://openslide.org>`_
 
 
 We currently have:


### PR DESCRIPTION
See https://trello.com/c/NlcprkHA/12-make-openslide-test-data-public

I've removed the Openslide links because the provenance for the files is listed in the readme anyway and we don't have it for any of the other samples on the format pages.

Staged at https://www.openmicroscopy.org/site/support/bio-formats5.4-staging/formats/hamamatsu-ndpi.html and https://www.openmicroscopy.org/site/support/bio-formats5.4-staging/formats/hamamatsu-vms.html