### PR TITLE
Add sphinx doc for in-memory read and write

### DIFF
--- a/components/formats-gpl/utils/ReadWriteInMemory.java
+++ b/components/formats-gpl/utils/ReadWriteInMemory.java
@@ -47,6 +47,7 @@ public class ReadWriteInMemory {
     }
     String path = args[0];
 
+    /* file-read-start */
     // read in entire file
     System.out.println("Reading file into memory from disk...");
     File inputFile = new File(path);
@@ -55,7 +56,9 @@ public class ReadWriteInMemory {
     byte[] inBytes = new byte[fileSize];
     in.readFully(inBytes);
     System.out.println(fileSize + " bytes read.");
+    /* file-read-end */
 
+    /* mapping-start */
     // determine input file suffix
     String fileName = inputFile.getName();
     int dot = fileName.lastIndexOf(".");
@@ -64,11 +67,13 @@ public class ReadWriteInMemory {
     // map input id string to input byte array
     String inId = "inBytes" + suffix;
     Location.mapFile(inId, new ByteArrayHandle(inBytes));
+    /* mapping-end */
 
     // read data from byte array using ImageReader
     System.out.println();
     System.out.println("Reading image data from memory...");
 
+    /* read-start */
     ServiceFactory factory = new ServiceFactory();
     OMEXMLService service = factory.getInstance(OMEXMLService.class);
     IMetadata omeMeta = service.createOMEXMLMetadata();
@@ -76,6 +81,8 @@ public class ReadWriteInMemory {
     ImageReader reader = new ImageReader();
     reader.setMetadataStore(omeMeta);
     reader.setId(inId);
+    /* read-end */
+
     int seriesCount = reader.getSeriesCount();
     int imageCount = reader.getImageCount();
     int sizeX = reader.getSizeX();
@@ -94,18 +101,23 @@ public class ReadWriteInMemory {
     System.out.println("\tSizeC = " + sizeC);
     System.out.println("\tSizeT = " + sizeT);
 
+    /* out—mapping-start */
     // map output id string to output byte array
     String outId = fileName + ".ome.tif";
     ByteArrayHandle outputFile = new ByteArrayHandle();
     Location.mapFile(outId, outputFile);
+    /* out—mapping-end */
 
+    /* write—init-start */
     // write data to byte array using ImageWriter
     System.out.println();
     System.out.print("Writing planes to destination in memory: ");
     ImageWriter writer = new ImageWriter();
     writer.setMetadataRetrieve(omeMeta);
     writer.setId(outId);
+    /* write—init-end */
 
+    /* write-start */
     byte[] plane = null;
     for (int i=0; i<imageCount; i++) {
       if (plane == null) {
@@ -125,7 +137,9 @@ public class ReadWriteInMemory {
 
     byte[] outBytes = outputFile.getBytes();
     outputFile.close();
+    /* write-end */
 
+    /* flush-start */
     // flush output byte array to disk
     System.out.println();
     System.out.println("Flushing image data to disk...");
@@ -133,6 +147,7 @@ public class ReadWriteInMemory {
     DataOutputStream out = new DataOutputStream(new FileOutputStream(outFile));
     out.write(outBytes);
     out.close();
+    /* flush-end */
   }
 
 }

--- a/components/formats-gpl/utils/ReadWriteInMemory.java
+++ b/components/formats-gpl/utils/ReadWriteInMemory.java
@@ -35,6 +35,8 @@ import loci.formats.services.OMEXMLService;
 
 /**
  * Tests the Bio-Formats I/O logic to and from byte arrays in memory.
+ * @deprecated Class has been moved to documentation examples and is available for download 
+ * from http://www.openmicroscopy.org/site/support/bio-formats/developers/in-memory.html
  */
 public class ReadWriteInMemory {
 

--- a/components/formats-gpl/utils/ReadWriteInMemory.java
+++ b/components/formats-gpl/utils/ReadWriteInMemory.java
@@ -38,6 +38,7 @@ import loci.formats.services.OMEXMLService;
  * @deprecated Class has been moved to documentation examples and is available for download 
  * from http://www.openmicroscopy.org/site/support/bio-formats/developers/in-memory.html
  */
+@Deprecated
 public class ReadWriteInMemory {
 
   public static void main(String[] args)

--- a/docs/sphinx/developers/examples/ExampleSuite.java
+++ b/docs/sphinx/developers/examples/ExampleSuite.java
@@ -66,6 +66,7 @@ public class ExampleSuite {
     File tiledFile2 = new File(parentDir, "tiledFile2.ome.tiff");
     File overlappedTiledFile = new File(parentDir, "overlappedTiledFile.ome.tiff");
     File overlappedTiledFile2 = new File(parentDir, "overlappedTiledFile2.ome.tiff");
+    File inMemoryFile = new File(parentDir, inputFile.getName() +".ome.tif");
     
     // Remove any existing output files
     Files.deleteIfExists(convertedFile.toPath());
@@ -76,6 +77,7 @@ public class ExampleSuite {
     Files.deleteIfExists(tiledFile2.toPath());
     Files.deleteIfExists(overlappedTiledFile.toPath());
     Files.deleteIfExists(overlappedTiledFile2.toPath());
+    Files.deleteIfExists(inMemoryFile.toPath());
 
     // Execute examples
     execute("ReadPhysicalSize", new String[] {inputFile.getAbsolutePath()});
@@ -93,5 +95,6 @@ public class ExampleSuite {
         overlappedInputFile.getAbsolutePath(), overlappedTiledFile.getAbsolutePath(), "96", "96"});
     execute("OverlappedTiledWriter", new String[] {
         overlappedInputFile.getAbsolutePath(), overlappedTiledFile2.getAbsolutePath(), "192", "96"});
+    execute("ReadWriteInMemory", new String[] {inputFile.getAbsolutePath()});
   }
 }

--- a/docs/sphinx/developers/examples/ReadWriteInMemory.java
+++ b/docs/sphinx/developers/examples/ReadWriteInMemory.java
@@ -1,0 +1,153 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import java.io.*;
+import loci.common.ByteArrayHandle;
+import loci.common.Location;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.*;
+import loci.formats.meta.IMetadata;
+import loci.formats.services.OMEXMLService;
+
+/**
+ * Tests the Bio-Formats I/O logic to and from byte arrays in memory.
+ */
+public class ReadWriteInMemory {
+
+  public static void main(String[] args)
+    throws DependencyException, FormatException, IOException, ServiceException
+  {
+    if (args.length < 1) {
+      System.out.println("Please specify a (small) image file.");
+      System.exit(1);
+    }
+    String path = args[0];
+
+    /* file-read-start */
+    // read in entire file
+    System.out.println("Reading file into memory from disk...");
+    File inputFile = new File(path);
+    int fileSize = (int) inputFile.length();
+    DataInputStream in = new DataInputStream(new FileInputStream(inputFile));
+    byte[] inBytes = new byte[fileSize];
+    in.readFully(inBytes);
+    System.out.println(fileSize + " bytes read.");
+    /* file-read-end */
+
+    /* mapping-start */
+    // determine input file suffix
+    String fileName = inputFile.getName();
+    int dot = fileName.lastIndexOf(".");
+    String suffix = dot < 0 ? "" : fileName.substring(dot);
+
+    // map input id string to input byte array
+    String inId = "inBytes" + suffix;
+    Location.mapFile(inId, new ByteArrayHandle(inBytes));
+    /* mapping-end */
+
+    // read data from byte array using ImageReader
+    System.out.println();
+    System.out.println("Reading image data from memory...");
+
+    /* read-start */
+    ServiceFactory factory = new ServiceFactory();
+    OMEXMLService service = factory.getInstance(OMEXMLService.class);
+    IMetadata omeMeta = service.createOMEXMLMetadata();
+
+    ImageReader reader = new ImageReader();
+    reader.setMetadataStore(omeMeta);
+    reader.setId(inId);
+    /* read-end */
+
+    int seriesCount = reader.getSeriesCount();
+    int imageCount = reader.getImageCount();
+    int sizeX = reader.getSizeX();
+    int sizeY = reader.getSizeY();
+    int sizeZ = reader.getSizeZ();
+    int sizeC = reader.getSizeC();
+    int sizeT = reader.getSizeT();
+
+    // output some details
+    System.out.println("Series count: " + seriesCount);
+    System.out.println("First series:");
+    System.out.println("\tImage count = " + imageCount);
+    System.out.println("\tSizeX = " + sizeX);
+    System.out.println("\tSizeY = " + sizeY);
+    System.out.println("\tSizeZ = " + sizeZ);
+    System.out.println("\tSizeC = " + sizeC);
+    System.out.println("\tSizeT = " + sizeT);
+
+    /* out—mapping-start */
+    // map output id string to output byte array
+    String outId = fileName + ".ome.tif";
+    ByteArrayHandle outputFile = new ByteArrayHandle();
+    Location.mapFile(outId, outputFile);
+    /* out—mapping-end */
+
+    /* write—init-start */
+    // write data to byte array using ImageWriter
+    System.out.println();
+    System.out.print("Writing planes to destination in memory: ");
+    ImageWriter writer = new ImageWriter();
+    writer.setMetadataRetrieve(omeMeta);
+    writer.setId(outId);
+    /* write—init-end */
+
+    /* write-start */
+    byte[] plane = null;
+    for (int i=0; i<imageCount; i++) {
+      if (plane == null) {
+        // allow reader to allocate a new byte array
+        plane = reader.openBytes(i);
+      }
+      else {
+        // reuse previously allocated byte array
+        reader.openBytes(i, plane);
+      }
+      writer.saveBytes(i, plane);
+      System.out.print(".");
+    }
+    reader.close();
+    writer.close();
+    System.out.println();
+
+    byte[] outBytes = outputFile.getBytes();
+    outputFile.close();
+    /* write-end */
+
+    /* flush-start */
+    // flush output byte array to disk
+    System.out.println();
+    System.out.println("Flushing image data to disk...");
+    File outFile = new File(fileName + ".ome.tif");
+    DataOutputStream out = new DataOutputStream(new FileOutputStream(outFile));
+    out.write(outBytes);
+    out.close();
+    /* flush-end */
+  }
+
+}

--- a/docs/sphinx/developers/in-memory.rst
+++ b/docs/sphinx/developers/in-memory.rst
@@ -19,7 +19,7 @@ Reading file from memory
 In order for Bio-Formats to read a file from memory it must be available in a 
 byte array. For this example an input file is read from disk into a byte array.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: file-read-start
    :end-before: file-read-end
@@ -28,7 +28,7 @@ This data can now be handled by a Bio-Formats reader. This is achieved by provid
 a mapping from the in-memory data to a suitable filename which will be used by the 
 reader. The filename used must have the same suffix as the original data type.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: mapping-start
    :end-before: mapping-end
@@ -36,7 +36,7 @@ reader. The filename used must have the same suffix as the original data type.
 Once the in-memory data has been mapped to a suitable filename the data can be 
 handled by the reader as normal.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: read-start
    :end-before: read-end
@@ -48,14 +48,14 @@ To use a writer to output to memory rather than an output file a similar process
 is required. First a mapping is created between a suitable output filename and 
 the in-memory data.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: out—mapping-start
    :end-before: out—mapping-end
 
 The mapped filename can now be passed to initialize the writer as standard.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: write—init-start
    :end-before: write—init-end
@@ -63,7 +63,7 @@ The mapped filename can now be passed to initialize the writer as standard.
 The data can then be written to memory using the same read and write loop which would 
 normally be used to write a file to disk.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: write-start
    :end-before: write-end
@@ -71,12 +71,12 @@ normally be used to write a file to disk.
 If it desired the data written to memory can then be flushed to disk and written to 
 an output file location.
 
-.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+.. literalinclude:: examples/ReadWriteInMemory.java
    :language: java
    :start-after: flush-start
    :end-before: flush-end
 
 .. seealso:: 
-   :source:`ReadWriteInMemory.java <components/formats-gpl/utils/ReadWriteInMemory.java>` - Full source code which is
+   :download:`ReadWriteInMemory.java <examples/ReadWriteInMemory.java>` - Full source code which is
    referenced here in part. You will need to have :file:`bioformats_package.jar` in your 
    Java :envvar:`CLASSPATH` in order to compile :file:`ReadWriteInMemory.java`.

--- a/docs/sphinx/developers/in-memory.rst
+++ b/docs/sphinx/developers/in-memory.rst
@@ -1,0 +1,82 @@
+In memory reading and writing in Bio-Formats
+============================================
+
+Bio-Formats readers and writers are traditionally used to handle image files 
+from disk. However it is also possible to achieve reading and writing of files from 
+in-memory sources. This is handled by mapping the in-memory data to a file location using :common_javadoc:`Location.mapFile() 
+<loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess->`.
+
+::
+
+    Location.mapFile(fileName, byteArrayHandle);
+
+This file location is not created on disk but rather maps internally to the 
+in-memory data provided.
+
+Reading file from memory
+------------------------
+
+In order for Bio-Formats to read a file from memory it must be available in a 
+byte array. For this example an input file is read from disk into a byte array.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: file-read-start
+   :end-before: file-read-end
+
+This data can now be handled by a Bio-Formats reader. This is achieved by providing 
+a mapping from the in-memory data to a suitable filename which will be used by the 
+reader. The filename used must have the same suffix as the original data type.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: mapping-start
+   :end-before: mapping-end
+
+Once the in-memory data has been mapped to a suitable filename the data can be 
+handled by the reader as normal.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: read-start
+   :end-before: read-end
+
+Writing to memory
+-----------------
+
+To use a writer to output to memory rather than an output file a similar process 
+is required. First a mapping is created between a suitable output filename and 
+the in-memory data.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: out—mapping-start
+   :end-before: out—mapping-end
+
+The mapped filename can now be passed to initialise the writer as standard.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: write—init-start
+   :end-before: write—init-end
+
+The data can then be written to memory using the same read and write loop which would 
+normally be used to write a file disk.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: write-start
+   :end-before: write-end
+
+If it desired the data written to memory can then be flushed to disk and written to 
+an output file location.
+
+.. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
+   :language: java
+   :start-after: flush-start
+   :end-before: flush-end
+
+.. seealso:: 
+   :source:`ReadWriteInMemory.java <components/formats-gpl/utils/ReadWriteInMemory.java>` - Full source code which is
+   referenced here in part. You will need to have :file:`bioformats_package.jar` in your 
+   Java CLASSPATH in order to compile :file:`ReadWriteInMemory.java`.

--- a/docs/sphinx/developers/in-memory.rst
+++ b/docs/sphinx/developers/in-memory.rst
@@ -68,7 +68,7 @@ normally be used to write a file to disk.
    :start-after: write-start
    :end-before: write-end
 
-If it desired the data written to memory can then be flushed to disk and written to 
+If desired the data written to memory can then be flushed to disk and written to 
 an output file location.
 
 .. literalinclude:: examples/ReadWriteInMemory.java

--- a/docs/sphinx/developers/in-memory.rst
+++ b/docs/sphinx/developers/in-memory.rst
@@ -1,4 +1,4 @@
-In memory reading and writing in Bio-Formats
+In-memory reading and writing in Bio-Formats
 ============================================
 
 Bio-Formats readers and writers are traditionally used to handle image files 
@@ -53,7 +53,7 @@ the in-memory data.
    :start-after: out—mapping-start
    :end-before: out—mapping-end
 
-The mapped filename can now be passed to initialise the writer as standard.
+The mapped filename can now be passed to initialize the writer as standard.
 
 .. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
    :language: java
@@ -61,7 +61,7 @@ The mapped filename can now be passed to initialise the writer as standard.
    :end-before: write—init-end
 
 The data can then be written to memory using the same read and write loop which would 
-normally be used to write a file disk.
+normally be used to write a file to disk.
 
 .. literalinclude:: ../../../components/formats-gpl/utils/ReadWriteInMemory.java
    :language: java
@@ -79,4 +79,4 @@ an output file location.
 .. seealso:: 
    :source:`ReadWriteInMemory.java <components/formats-gpl/utils/ReadWriteInMemory.java>` - Full source code which is
    referenced here in part. You will need to have :file:`bioformats_package.jar` in your 
-   Java CLASSPATH in order to compile :file:`ReadWriteInMemory.java`.
+   Java :envvar:`CLASSPATH` in order to compile :file:`ReadWriteInMemory.java`.

--- a/docs/sphinx/developers/index.rst
+++ b/docs/sphinx/developers/index.rst
@@ -39,6 +39,7 @@ Using Bio-Formats as a Java library
     export
     export2
     tiling
+    in-memory
     logging
     conversion
     matlab-dev

--- a/docs/sphinx/developers/java-library.rst
+++ b/docs/sphinx/developers/java-library.rst
@@ -179,7 +179,7 @@ Simple example of how to open multiple files simultaneously.
 :source:`ParallelRead <components/formats-gpl/utils/ParallelRead.java>` -
 Reads all files in given directory in parallel, using a separate thread for each.
 
-:source:`ReadWriteInMemory <components/formats-gpl/utils/ReadWriteInMemory.java>` -
+:doc:`ReadWriteInMemory <in-memory>` -
 Tests the Bio-Formats I/O logic to and from byte arrays in memory.
 
 File writing:


### PR DESCRIPTION
This PR follows on from the request in https://github.com/openmicroscopy/bioformats/issues/2775
Adding new documentation for an existing file available in utils. I have kept the file in its original location rather than moving it too the docs examples folders, this however is easily changed if its believed the examples folder is a better home for it.

To test:
- Ensure builds are green
- Test all links and markup is displaying correctly
- Ensure text is suitable for describing the use case for both reading and writing in-memory