### PR TITLE
Add version history for 5.4.1

### DIFF
--- a/docs/sphinx/about/whats-new.rst
+++ b/docs/sphinx/about/whats-new.rst
@@ -18,9 +18,9 @@ File format improvements:
 Documentation improvements:
 
 * updated external homepage link for FocalPoint
-* removed imago from list of visualization and analysis applications as it is no
+* removed Imago from list of visualization and analysis applications as it is no
   longer available from the Mayachitra website
-* added links to public sample files for Hamamatsu ndpi and Hamamatsu VMS
+* added links to public sample files for Hamamatsu NDPI and Hamamatsu VMS
 * listed OpenSlide as available software for supported formats
 * added a new developer page detailing in-memory reading and writing
 * updated the Bio-Formats API versioning policy, which now follows strict 

--- a/docs/sphinx/about/whats-new.rst
+++ b/docs/sphinx/about/whats-new.rst
@@ -12,7 +12,7 @@ File format improvements:
 * BD Pathway
    - added fix to check if ``Experiment.exp`` is a directory or an experiment file
 * Imspector OBF
-   - enabled forward compatibility for future versions as the OBF format is backwards 
+   - enabled forward compatibility for future versions, as the OBF format is backwards 
      compatible (thanks to Bjoern Thiel)
 
 Documentation improvements:
@@ -23,9 +23,9 @@ Documentation improvements:
 * added links to public sample files for Hamamatsu ndpi and Hamamatsu VMS
 * listed OpenSlide as available software for supported formats
 * added a new developer page detailing in-memory reading and writing
-* updated the Bio-Formats API versioning policy which now follows strict 
+* updated the Bio-Formats API versioning policy, which now follows strict 
   semantic versioning
-* a new options page has been added detailing the usage of configurable format-specific 
+* a new options page has been added, detailing the usage of configurable format-specific 
   options for readers and writers. Links to the available options are also included under 
   the relevant supported formats
 

--- a/docs/sphinx/about/whats-new.rst
+++ b/docs/sphinx/about/whats-new.rst
@@ -25,7 +25,7 @@ Documentation improvements:
 * added a new developer page detailing in-memory reading and writing
 * updated the Bio-Formats API versioning policy which now follows strict 
   semantic versioning
-* a new options page has been added detailing the usage of configurable format specific 
+* a new options page has been added detailing the usage of configurable format-specific 
   options for readers and writers. Links to the available options are also included under 
   the relevant supported formats
 

--- a/docs/sphinx/about/whats-new.rst
+++ b/docs/sphinx/about/whats-new.rst
@@ -1,6 +1,34 @@
 Version history
 ===============
 
+5.4.1 (2017 April 13)
+---------------------
+
+File format improvements:
+
+* MIAS (Maia Scientific)
+   - added a fix for a possible exception when image files are not found under 
+     channel-specific subdirectories
+* BD Pathway
+   - added fix to check if ``Experiment.exp`` is a directory or an experiment file
+* Imspector OBF
+   - enabled forward compatibility for future versions as the OBF format is backwards 
+     compatible (thanks to Bjoern Thiel)
+
+Documentation improvements:
+
+* updated external homepage link for FocalPoint
+* removed imago from list of visualization and analysis applications as it is no
+  longer available from the Mayachitra website
+* added links to public sample files for Hamamatsu ndpi and Hamamatsu VMS
+* listed OpenSlide as available software for supported formats
+* added a new developer page detailing in-memory reading and writing
+* updated the Bio-Formats API versioning policy which now follows strict 
+  semantic versioning
+* a new options page has been added detailing the usage of configurable format specific 
+  options for readers and writers. Links to the available options are also included under 
+  the relevant supported formats
+
 5.4.0 (2017 March 21)
 ---------------------
 


### PR DESCRIPTION
For a list of included PR's:
Versioning clarifications - https://github.com/openmicroscopy/bioformats/pull/2813
Add sphinx doc for in-memory read and write - https://github.com/openmicroscopy/bioformats/pull/2812
Add Hamamatsu public sample links - https://github.com/openmicroscopy/bioformats/pull/2809
Options doc - https://github.com/openmicroscopy/bioformats/pull/2804
BDReader: Minor fix to check if Experiment.exp is a directory -
 https://github.com/openmicroscopy/bioformats/pull/2802
Imago doesn't exist anymore - https://github.com/openmicroscopy/bioformats/pull/2801
Update focalpoint link - https://github.com/openmicroscopy/bioformats/pull/2800
MIAS Reader - Unhandled Exception - https://github.com/openmicroscopy/bioformats/pull/2799
Enable forward compatibility OBF - https://github.com/openmicroscopy/bioformats/pull/2810