### PR TITLE
Fix Ant build.version property for non-SNAPSHOT versions

### DIFF
--- a/ant/global.xml
+++ b/ant/global.xml
@@ -109,10 +109,9 @@ Type "ant -p" for a list of targets.
       </exec>
       <property name="build.version" value="${build.revision}"/>
     </try>
-    <catch>
-      <property name="build.version" value="${release.version}"/>
-    </catch>
+    <catch/>
   </trycatch>
+  <property name="build.version" value="${release.version}"/>
 
   <!-- Internal build targets -->
 

--- a/ant/global.xml
+++ b/ant/global.xml
@@ -97,22 +97,22 @@ Type "ant -p" for a list of targets.
     <isset property="isSnapshot"/>
     <then>
       <echo>isSnapshot = ${isSnapshot}</echo>
-      <trycatch>
-        <try>
-          <exec executable="git" outputproperty="build.revision"
-                failifexecutionfails="true" failonerror="true">
-            <arg value="rev-parse"/>
-            <arg value="--verify"/>
-            <arg value="HEAD"/>
-          </exec>
-          <property name="build.version" value="${build.revision}"/>
-        </try>
-        <catch>
-        </catch>
-      </trycatch>
     </then>
   </if>
-  <property name="build.version" value="${release.version}"/>
+  <trycatch>
+    <try>
+      <exec executable="git" outputproperty="build.revision"
+            failifexecutionfails="true" failonerror="true">
+        <arg value="rev-parse"/>
+        <arg value="--verify"/>
+        <arg value="HEAD"/>
+      </exec>
+      <property name="build.version" value="${build.revision}"/>
+    </try>
+    <catch>
+      <property name="build.version" value="${release.version}"/>
+    </catch>
+  </trycatch>
 
   <!-- Internal build targets -->
 

--- a/ant/global.xml
+++ b/ant/global.xml
@@ -111,7 +111,7 @@ Type "ant -p" for a list of targets.
     </try>
     <catch/>
   </trycatch>
-  <property name="build.version" value="${release.version}"/>
+  <property name="build.version" value="v${release.version}"/>
 
   <!-- Internal build targets -->
 


### PR DESCRIPTION
## Context

In https://github.com/openmicroscopy/bioformats/pull/2644, the hardcoding of the Git revision number into a properties file was replaced by the introspection of the `Implementation-Build` property in the JAR manifest.

While the [Build Number Plugin](http://www.mojohaus.org/buildnumber-maven-plugin/) is directly used for the Maven build, additional logic was added to the Ant build in `ant/global.xml` to parse the SCM revision.  Whilst testing the Ant-generated command-line tools, it was noticed that for non SNAPSHOT builds, the VCS revision is set to be equal to the release version:

```
$ ~/bftools-5.4.0/showinf -version
Version: 5.4.0
Build date: 20 March 2017
VCS revision: 5.4.0
```

## Changes

This commit fixes the behavior of the Ant calculation of the `build.version` property to use `git rev-parse --verify HEAD`  independently of whether a SNAPSHOT or a release version is built. This implementation is in agreement with the behavior of the Maven build number plugin and should fix the current discrepancy for the value of Implementation-Build stored in the JAR manifest.

## Testing

To test these changes, review the content of the `MANIFEST.MF` of JARs generated by either Ant or Maven for:
- a SNAPSHOT build e.g. the daily Jenkins CI builds 
- a release build, i.e. by running `./tools/bump_maven_version.py X.Y.Z` on top of this branch and generating the JARs

In all cases, the `Implementation-Build` should contain the full Git revision number e.g.

```
$ unzip -qc artifacts/bioformats_package.jar META-INF/MANIFEST.MF | grep Implementation-Build
Implementation-Build: 598e0a31688b92d5e54b9b6d880b73fe9be7face
```