### PR TITLE
fix broken doc links to websites

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1063,7 +1063,7 @@ notes = Commercial applications that support IPLab include: \n
 
 [JEOL]
 extensions = .dat, .img, .par
-owner = `JEOL <http://www.jeol.com>`_
+owner = `JEOL <https://www.jeol.co.jp/en/>`_
 bsd = no
 weHave = * Pascal code that reads JEOL files (from ImageSXM) \n
 * a few JEOL files

--- a/docs/sphinx/formats/jeol.rst
+++ b/docs/sphinx/formats/jeol.rst
@@ -7,7 +7,7 @@ JEOL
 Extensions: .dat, .img, .par
 
 
-Owner: `JEOL <http://www.jeol.com>`_
+Owner: `JEOL <https://www.jeol.co.jp/en/>`_
 
 **Support**
 

--- a/docs/sphinx/users/idl/index.rst
+++ b/docs/sphinx/users/idl/index.rst
@@ -1,10 +1,11 @@
 IDL
 ===
 
-`IDL <http://www.harrisgeospatial.com/ProductsandTechnology/Software/IDL.aspx>`_ (Interactive
-Data Language) is a popular data visualization and analysis platform
-used for interactive processing of large amounts of data including
-images.
+`IDL
+<http://www.harrisgeospatial.com/ProductsandTechnology/Software/IDL.aspx>`_
+(Interactive Data Language) is a popular data visualization and analysis
+platform used for interactive processing of large amounts of data
+including images.
 
 IDL possesses the ability to interact with Java applications via its
 IDL-Java bridge. Karsten Rodenacker has written a script that uses

--- a/docs/sphinx/users/idl/index.rst
+++ b/docs/sphinx/users/idl/index.rst
@@ -1,7 +1,7 @@
 IDL
 ===
 
-`IDL <http://www.exelisvis.com/ProductsServices/IDL.aspx>`_ (Interactive
+`IDL <http://www.harrisgeospatial.com/ProductsandTechnology/Software/IDL.aspx>`_ (Interactive
 Data Language) is a popular data visualization and analysis platform
 used for interactive processing of large amounts of data including
 images.


### PR DESCRIPTION
Fixes broken links reported in https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-docs/672/. Staged at http://www.openmicroscopy.org/site/support/bio-formats5.4-staging/users/idl/index.html and http://www.openmicroscopy.org/site/support/bio-formats5.4-staging/formats/jeol.html.