### PR TITLE
ND2Handler - Only use uiBpcInMemory and uiBpcSignificant

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -493,7 +493,7 @@ public class ND2Handler extends BaseHandler {
           LOGGER.warn("Could not set the pixel type", e);
         }
       }
-      else if (qName.equals("uiWidthBytes") || qName.startsWith("uiBpc")) {
+      else if (qName.equals("uiWidthBytes") || qName.startsWith("uiBpcInMemory") || qName.startsWith("uiBpcSignificant")) {
         int div = qName.equals("uiWidthBytes") ? ms0.sizeX : 8;
         if (div > 0) {
           int bits = Integer.parseInt(value);


### PR DESCRIPTION
This PR is a followup to https://github.com/openmicroscopy/bioformats/issues/2820 for testing

In the sample file related to the above Github issue we are setting bitsPerPixel as 14 but the PixelType is set to INT8. The original PixelType of the image would have been UINT16 but is overwritten by parsing "uiBpc" with a value of 8.

The possible tags which can be found in the ND2 file appear to be "uiBpc", "uiBpcInMemory" and "uiBpcSignificant". Originally we were parsing "uiBpcInMemory" but this was updated in https://github.com/openmicroscopy/bioformats/commit/63572fbc557f4e01514135e252d2464f2ac8193f 