### PR TITLE
Fix acquisition dates format for Andor ABD TIFF format

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FluoviewReader.java
@@ -93,7 +93,7 @@ public class FluoviewReader extends BaseTiffReader {
   private static final int BASELINE_OFFSET = 4944;
 
   /** Date format */
-  private static final String DATE_FORMAT = "MM/dd/yyyy HH:mm:ss.SSS";
+  private static final String DATE_FORMAT = "dd/MM/yyyy HH:mm:ss.SSS";
 
   // -- Fields --
 
@@ -837,7 +837,7 @@ public class FluoviewReader extends BaseTiffReader {
       }
       if (date != null) {
         date = DateTools.formatDate(date.trim(),
-          new String[] {"MM/dd/yyyy hh:mm:ss a", "MM-dd-yyyy hh:mm:ss","MM/dd/yyyy H:mm:ss"}, true);
+          new String[] {"dd/MM/yyyy hh:mm:ss a", "MM-dd-yyyy hh:mm:ss","dd/MM/yyyy H:mm:ss"}, true);
         Timestamp timestamp = Timestamp.valueOf(date);
         if (timeIndex >= 0 && timestamp != null) {
           long ms = timestamp.asInstant().getMillis();


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8238 for more context

The FluoviewReader is used for both Olympus FluoView and Andor ABD TIFF formats given their similarity. As reported in the OME forums, the date format for Andor files is wrongly parsed. This commit uses the proper convention and should fix the issue for Andor files.

Parallely to the open-source thread, we contacted Andor and received confirmation this is the expected behavior. A companion PR will be opened to update the configuration for existing Andor ABD TIFF files in our data repository.