### PR TITLE
Operetta: make sure TIFF files exist before reading

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -294,8 +294,6 @@ public class OperettaReader extends FormatReader {
     for (int i=0; i<seriesCount; i++) {
       CoreMetadata ms = new CoreMetadata();
       core.add(ms);
-      ms.sizeX = planes[i][0].x;
-      ms.sizeY = planes[i][0].y;
       ms.sizeZ = uniqueZs.size();
       ms.sizeC = uniqueCs.size();
       ms.sizeT = uniqueTs.size();
@@ -304,6 +302,11 @@ public class OperettaReader extends FormatReader {
       ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
 
       int planeIndex = 0;
+      while (planes[i][planeIndex] == null) {
+        planeIndex++;
+      }
+      ms.sizeX = planes[i][planeIndex].x;
+      ms.sizeY = planes[i][planeIndex].y;
       String filename = planes[i][planeIndex].filename;
       while ((filename == null || !new Location(filename).exists()) &&
         planeIndex < planes[i].length - 1)

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -138,7 +138,9 @@ public class OperettaReader extends FormatReader {
     ArrayList<String> files = new ArrayList<String>();
     files.add(currentId);
     for (Plane p : planes[getSeries()]) {
-      if (p.filename != null && new Location(p.filename).exists()) {
+      if (p != null && p.filename != null &&
+        new Location(p.filename).exists())
+      {
         files.add(p.filename);
       }
     }
@@ -172,7 +174,7 @@ public class OperettaReader extends FormatReader {
     if (getSeries() < planes.length && no < planes[getSeries()].length) {
       Plane p = planes[getSeries()][no];
 
-      if (p.filename != null && new Location(p.filename).exists()) {
+      if (p != null && p.filename != null && new Location(p.filename).exists()) {
         if (reader == null) {
           reader = new MinimalTiffReader();
         }
@@ -302,38 +304,52 @@ public class OperettaReader extends FormatReader {
       ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
 
       int planeIndex = 0;
-      while (planes[i][planeIndex] == null) {
+      while (planeIndex < planes[i].length && planes[i][planeIndex] == null) {
+        LOGGER.debug("skipping null plane series = {}, plane = {}", i, planeIndex);
         planeIndex++;
       }
-      ms.sizeX = planes[i][planeIndex].x;
-      ms.sizeY = planes[i][planeIndex].y;
-      String filename = planes[i][planeIndex].filename;
-      while ((filename == null || !new Location(filename).exists()) &&
-        planeIndex < planes[i].length - 1)
-      {
-        LOGGER.debug("Missing TIFF file: {}", filename);
-        planeIndex++;
-        filename = planes[i][planeIndex].filename;
-      }
-
-      if (filename != null && new Location(filename).exists()) {
-        RandomAccessInputStream s =
-          new RandomAccessInputStream(filename, 16);
-        TiffParser parser = new TiffParser(s);
-        parser.setDoCaching(false);
-
-        IFD firstIFD = parser.getFirstIFD();
-        ms.littleEndian = firstIFD.isLittleEndian();
-        ms.pixelType = firstIFD.getPixelType();
-        s.close();
-      }
-      else if (i > 0) {
-        LOGGER.warn("Could not find valid TIFF file for series {}", i);
-        ms.littleEndian = core.get(0).littleEndian;
-        ms.pixelType = core.get(0).pixelType;
+      if (planeIndex >= planes[i].length) {
+        if (i > 0) {
+          ms.sizeX = core.get(i - 1).sizeX;
+          ms.sizeY = core.get(i - 1).sizeY;
+          ms.pixelType = core.get(i - 1).pixelType;
+          ms.littleEndian = core.get(i - 1).littleEndian;
+        }
+        else {
+          LOGGER.warn("Could not find valid plane for series 0");
+        }
       }
       else {
-        LOGGER.warn("Could not find valid TIFF file for series 0; pixel type may be wrong");
+        ms.sizeX = planes[i][planeIndex].x;
+        ms.sizeY = planes[i][planeIndex].y;
+        String filename = planes[i][planeIndex].filename;
+        while ((filename == null || !new Location(filename).exists()) &&
+          planeIndex < planes[i].length - 1)
+        {
+          LOGGER.debug("Missing TIFF file: {}", filename);
+          planeIndex++;
+          filename = planes[i][planeIndex].filename;
+        }
+
+        if (filename != null && new Location(filename).exists()) {
+          RandomAccessInputStream s =
+            new RandomAccessInputStream(filename, 16);
+          TiffParser parser = new TiffParser(s);
+          parser.setDoCaching(false);
+
+          IFD firstIFD = parser.getFirstIFD();
+          ms.littleEndian = firstIFD.isLittleEndian();
+          ms.pixelType = firstIFD.getPixelType();
+          s.close();
+        }
+        else if (i > 0) {
+          LOGGER.warn("Could not find valid TIFF file for series {}", i);
+          ms.littleEndian = core.get(0).littleEndian;
+          ms.pixelType = core.get(0).pixelType;
+        }
+        else {
+          LOGGER.warn("Could not find valid TIFF file for series 0; pixel type may be wrong");
+        }
       }
     }
 
@@ -398,18 +414,24 @@ public class OperettaReader extends FormatReader {
         store.setImageExperimenterRef(experimenterID, i);
 
         for (int c=0; c<getSizeC(); c++) {
-          store.setChannelName(planes[i][c].channelName, i, c);
+          if (planes[i][c] != null && planes[i][c].channelName != null) {
+            store.setChannelName(planes[i][c].channelName, i, c);
+          }
         }
 
-        store.setPixelsPhysicalSizeX(
-          FormatTools.getPhysicalSizeX(planes[i][0].resolutionX), i);
-        store.setPixelsPhysicalSizeY(
-          FormatTools.getPhysicalSizeY(planes[i][0].resolutionY), i);
+        if (planes[i][0] != null) {
+          store.setPixelsPhysicalSizeX(
+            FormatTools.getPhysicalSizeX(planes[i][0].resolutionX), i);
+          store.setPixelsPhysicalSizeY(
+            FormatTools.getPhysicalSizeY(planes[i][0].resolutionY), i);
+        }
 
         for (int p=0; p<getImageCount(); p++) {
-          store.setPlanePositionX(planes[i][p].positionX, i, p);
-          store.setPlanePositionY(planes[i][p].positionY, i, p);
-          store.setPlanePositionZ(planes[i][p].positionZ, i, p);
+          if (planes[i][p] != null) {
+            store.setPlanePositionX(planes[i][p].positionX, i, p);
+            store.setPlanePositionY(planes[i][p].positionY, i, p);
+            store.setPlanePositionZ(planes[i][p].positionZ, i, p);
+          }
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -334,6 +334,11 @@ public class OperettaReader extends FormatReader {
       }
     }
 
+    addGlobalMeta("Plate name", handler.getPlateName());
+    addGlobalMeta("Plate description", handler.getPlateDescription());
+    addGlobalMeta("Plate ID", handler.getPlateIdentifier());
+    addGlobalMeta("Measurement ID", handler.getMeasurementID());
+
     // populate the MetadataStore
 
     MetadataStore store = makeFilterMetadata();
@@ -418,6 +423,7 @@ public class OperettaReader extends FormatReader {
 
     private String displayName;
     private String plateID;
+    private String measurementID;
     private String measurementTime;
     private String plateName;
     private String plateDescription;
@@ -438,6 +444,10 @@ public class OperettaReader extends FormatReader {
 
     public String getPlateIdentifier() {
       return plateID;
+    }
+
+    public String getMeasurementID() {
+      return measurementID;
     }
 
     public String getMeasurementTime() {
@@ -488,6 +498,9 @@ public class OperettaReader extends FormatReader {
       }
       else if ("PlateID".equals(currentName)) {
         plateID = value;
+      }
+      else if ("MeasurementID".equals(currentName)) {
+        measurementID = value;
       }
       else if ("MeasurementStartTime".equals(currentName)) {
         measurementTime = value;


### PR DESCRIPTION
See https://trello.com/c/iXCflqLT/588-hipsci-davide-danovi-idr0034-kilpinen-hipsci and dataset in ```data_repo/from_IDR/operetta```.

I haven't tested importing into OMERO, but ```setId``` should work and planes can be read.  As with other readers, blank planes are returned when an expected file is missing.