### PR TITLE
OBFReader - Empty Description

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OBFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OBFReader.java
@@ -367,7 +367,7 @@ public class OBFReader extends FormatReader
       obf.seriesMetadata.put("Name", name);
       String description = in.readString(lengthOfDescription);
 
-      if (description != null) {
+      if (description != null && lengthOfDescription > 0) {
         description = XMLTools.sanitizeXML(description);
 
         // some XML node names may contain white space, which prevents parsing


### PR DESCRIPTION
This issue was discovered in QA-17698

In this case the image description is empty and a parser exception is thrown. Although the images can still be opened and displayed as the exception is caught and a warning message is output rather than an uncaught exception. The reader currently checks for a Null description, but in this scenario the length is 0 and the value is an empty string instead.

Without this PR a SAXParseException is encountered
`[WARN] Could not parse description as XML
org.xml.sax.SAXParseException: Premature end of file.
	at org.apache.xerces.parsers.DOMParser.parse(Unknown Source)
	at org.apache.xerces.jaxp.DocumentBuilderImpl.parse(Unknown Source)
	at javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:121)
	at loci.common.xml.XMLTools.parseDOM(XMLTools.java:215)
	at loci.common.xml.XMLTools.parseDOM(XMLTools.java:196)
	at loci.formats.in.OBFReader.initStack(OBFReader.java:379)
	at loci.formats.in.OBFReader.initFile(OBFReader.java:184)
	at loci.formats.FormatReader.setId(FormatReader.java:1397)
	at loci.plugins.in.ImportProcess.initializeFile(ImportProcess.java:498)
	at loci.plugins.in.ImportProcess.execute(ImportProcess.java:141)
	at loci.plugins.in.Importer.showDialogs(Importer.java:140)
	at loci.plugins.in.Importer.run(Importer.java:76)
	at loci.plugins.LociImporter.run(LociImporter.java:78)
	at ij.IJ.runUserPlugIn(IJ.java:217)
	at ij.IJ.runPlugIn(IJ.java:181)
	at ij.Executer.runCommand(Executer.java:137)
	at ij.Executer.run(Executer.java:66)
	at java.lang.Thread.run(Thread.java:745)`

To test:
- Import QA-17698 without the PR and verify the warning message is output
- With the PR applied retry the import and the warning should no longer be present
- Ensure that jobs and tests are all green