### PR TITLE
ImageInfo: fix image dimensions when the '-autoscale' option is used

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -855,9 +855,16 @@ public class ImageInfo {
             pix = DataTools.normalizeDoubles((double[]) pix);
           }
         }
-        images[i - start] = AWTImageTools.makeImage(ImageTools.make24Bits(pix,
-          sizeX, sizeY, reader.isInterleaved(), false, min, max),
-          sizeX, sizeY, FormatTools.isSigned(pixelType));
+        if (thumbs) {
+          images[i - start] = AWTImageTools.makeImage(ImageTools.make24Bits(pix,
+            sizeX, sizeY, reader.isInterleaved(), false, min, max),
+            sizeX, sizeY, FormatTools.isSigned(pixelType));
+        }
+        else {
+          images[i - start] = AWTImageTools.makeImage(ImageTools.make24Bits(pix,
+            width, height, reader.isInterleaved(), false, min, max),
+            width, height, FormatTools.isSigned(pixelType));
+        }
       }
       if (images[i - start] == null) {
         LOGGER.warn("\t************ Failed to read plane #{} ************", i);


### PR DESCRIPTION
See https://trello.com/c/kbzOM2NF/298-incorrect-dimensions-used-for-autoscaling-in-imageinfo

As noted on the card, the original exception can be reproduced without this PR using ```showinf -series 0 -autoscale -crop 0,0,512,512 data_repo/curated/hamamatsu/public/openslide/CMU-3.ndpi```, or any other use of ```-autoscale``` combined with ```-crop```.  With the PR, the same command should result in an image of the size specified by ```-crop```.  Note that ```-crop``` does not apply if ```-thumbs``` is also used, which is why there is a special case.