### PR TITLE
Autogen: gen-meta-support fix

### DIFF
--- a/components/autogen/build.xml
+++ b/components/autogen/build.xml
@@ -46,6 +46,7 @@ Type "ant -p" for a list of targets.
     description="generate docs for Bio-Formats metadata support">
     <exec executable="python">
       <arg value="${src.dir}/gen-meta-support.py"/>
+      <arg value="${ome-model.version}"/>
     </exec>
     <if>
       <isset property="omexml.version"/>

--- a/components/autogen/build.xml
+++ b/components/autogen/build.xml
@@ -16,6 +16,7 @@ Type "ant -p" for a list of targets.
     description="generate Sphinx pages for each supported format">
     <java classname="FormatPageAutogen"
       classpath="${classes.dir}" fork="true" failonerror="true">
+      <classpath location="${root.dir}/ant/"/><!-- logback.xml -->
       <classpath refid="runtime.classpath"/>
       <arg value="${filelist}"/>
     </java>
@@ -25,6 +26,7 @@ Type "ant -p" for a list of targets.
     description="generate dataset structure table">
     <java classname="MakeDatasetStructureTable"
       classpath="${classes.dir}" fork="true" failonerror="true">
+      <classpath location="${root.dir}/ant/"/><!-- logback.xml -->
       <classpath refid="runtime.classpath"/>
        <arg value="../../docs/sphinx/formats/dataset-table.rst"/>
     </java>
@@ -34,6 +36,7 @@ Type "ant -p" for a list of targets.
     description="generate docs for Bio-Formats original metadata support">
     <java classname="OriginalMetadataAutogen"
       classpath="${classes.dir}" fork="true" failonerror="true">
+      <classpath location="${root.dir}/ant/"/><!-- logback.xml -->
       <classpath refid="runtime.classpath"/>
       <arg value="${filelist}"/>
     </java>
@@ -50,6 +53,7 @@ Type "ant -p" for a list of targets.
         <java classname="${component.main-class}"
           classpath="${classes.dir}"
           fork="true" dir="${component.meta-support-dir}" failonerror="true">
+            <classpath location="${root.dir}/ant/"/><!-- logback.xml -->
             <classpath refid="runtime.classpath"/>
             <arg value="${omexml.version}"/>
         </java>

--- a/components/autogen/src/gen-meta-support.py
+++ b/components/autogen/src/gen-meta-support.py
@@ -69,14 +69,34 @@ def is_file(f, ftype=".java"):
 
 def get_xml_elements():
     """List all XML elements from the model"""
-    elements = []
-    modelDir = join(
-        componentsDir, 'ome-xml', 'build', 'src', 'ome', 'xml', 'model')
-    for f in sorted(listdir(modelDir)):
-        if not is_file(join(modelDir, f)):
-            continue
-        elements.append(basename(f).rstrip('.java'))
-    return elements
+
+    # Since Bio-Formats 5.3.0, the ome-xml component is decoupled from
+    # Bio-Formats. This function returns a hard-coded list of the OME-XML
+    # elements which should be updated for each model change
+    return [
+        'AffineTransform', 'Annotation', 'AnnotationRef', 'Arc',
+        'BasicAnnotation', 'BinDat', 'BinaryFile', 'BinaryOnly',
+        'BooleanAnnotation', 'Channel', 'ChannelRef', 'CommentAnnotation',
+        'Dataset', 'DatasetRef', 'Detector', 'DetectorSettings', 'Dichroic',
+        'DichroicRef', 'DoubleAnnotation', 'Ellipse', 'EmissionFilterRef',
+        'ExcitationFilterRef', 'Experiment', 'ExperimentRef', 'Experimenter',
+        'ExperimenterGroup', 'ExperimenterGroupRef', 'ExperimenterRef',
+        'External', 'Filament', 'FileAnnotation', 'Filter', 'FilterRef',
+        'FilterSet', 'FilterSetRef', 'Folder', 'FolderRef',
+        'GenericExcitationSource', 'Image', 'ImageRef', 'ImagingEnvironment',
+        'Instrument', 'InstrumentRef', 'Label', 'Laser', 'Leader',
+        'LightEmittingDiode', 'LightPath', 'LightSource',
+        'LightSourceSettings', 'Line', 'ListAnnotation', 'LongAnnotation',
+        'ManufacturerSpec', 'MapAnnotation', 'Mask', 'MetadataOnly',
+        'MicrobeamManipulation', 'MicrobeamManipulationRef', 'Microscope',
+        'NumericAnnotation', 'OME', 'Objective', 'ObjectiveSettings',
+        'Pixels', 'Plane', 'Plate', 'PlateAcquisition', 'PlateRef', 'Point',
+        'Polygon', 'Polyline', 'Project', 'ProjectRef', 'Pump', 'ROI',
+        'ROIRef', 'Reagent', 'ReagentRef', 'Rectangle', 'Reference', 'Rights',
+        'Screen', 'Settings', 'Shape', 'StageLabel', 'StructuredAnnotations',
+        'TagAnnotation', 'TermAnnotation', 'TextAnnotation', 'TiffData',
+        'TimestampAnnotation', 'TransmittanceRange', 'TypeAnnotation', 'UUID',
+        'Union', 'Well', 'WellSample', 'WellSampleRef', 'XMLAnnotation']
 
 
 def get_readers():

--- a/components/autogen/src/gen-meta-support.py
+++ b/components/autogen/src/gen-meta-support.py
@@ -79,8 +79,8 @@ def get_xml_elements():
     """List all XML elements from the model"""
 
     # Since Bio-Formats 5.3.0, the ome-xml component is decoupled from
-    # Bio-Formats. This function returns introspect the OME-XML JAR under
-    # the local Maven repository to return the list of elements
+    # Bio-Formats. This logic introspects the OME-XML JAR from the local
+    # Maven repository to create the list of elements
     elements = []
     with zipfile.ZipFile(OMEXML_PATH, 'r') as zf:
         for zi in zf.infolist():


### PR DESCRIPTION
See https://trello.com/c/GTMfjd5R/34-fix-bio-formats-autogen-jobs

Following the decoupling of the model components in Bio-Formats 5.3.0, the assumption that the generated ome-xml sources are available in the source tree is no longer correct. A long term solution might be some API to introspect the model elements.

As Bio-Formats is now following semantic versioning and the list of elements should only change for major version bumps, this PR tackles the issue by hardcoding the list of elements. This list will need to be reviewed during model development. 

Additionally this PR uses the logback.xml in the `ant` folder similarly to the other components to reduce the amount of logging generated by the `autogen` targets by default.