### PR TITLE
Clear initialized List variables in CellH5Reader.close() (rebased onto metadata54)

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -272,7 +272,9 @@ public class CellH5Reader extends FormatReader {
     super.close(fileOnly);
     if (!fileOnly) {
       seriesCount = 0;
-
+      CellH5PositionList.clear();
+      CellH5PathsToImageData.clear();
+      cellObjectNames.clear();
       if (jhdf != null) {
         jhdf.close();
       }


### PR DESCRIPTION

This is the same as gh-2845 but rebased onto metadata54.

----

This should fix the exception thrown when recycling an IFormatReader to reopen another CellH5 file.

See https://trello.com/c/hTxcpCtl/37-full-repository-skipped-filesets for more background, without this PR trying to open 2 CellH5 files reusing the same reader (see this [gist](https://gist.github.com/sbesson/775de3588d5bee00c018d67ea94a01c7) for an example) should fail when initializing the second file with an exception of type

```
Exception in thread "main" ncsa.hdf.hdf5lib.exceptions.HDF5SymbolTableException: Symbol table:Object not found ["H5Gtraverse.c line 755 in H5G_traverse_real(): component not found"]
    at ch.systemsx.cisd.hdf5.hdf5lib.H5.H5Dopen(Native Method)
    at ch.systemsx.cisd.hdf5.hdf5lib.H5D.H5Dopen(H5D.java:78)
    at ch.systemsx.cisd.hdf5.HDF5.openDataSet(HDF5.java:753)
    at ch.systemsx.cisd.hdf5.HDF5CompoundInformationRetriever.getFullCompoundDataSetInformation(HDF5CompoundInformationRetriever.java:153)
    at ch.systemsx.cisd.hdf5.HDF5CompoundInformationRetriever.getDataSetType(HDF5CompoundInformationRetriever.java:528)
    at ch.systemsx.cisd.hdf5.HDF5CompoundInformationRetriever.getDataSetType(HDF5CompoundInformationRetriever.java:539)
    at ch.systemsx.cisd.hdf5.HDF5CompoundReader.readArray(HDF5CompoundReader.java:302)
    at ch.systemsx.cisd.hdf5.HDF5Reader.readCompoundArray(HDF5Reader.java:1459)
    at loci.formats.services.JHDFServiceImpl.readCompoundArrayDataMap(JHDFServiceImpl.java:189)
    at loci.formats.in.CellH5Reader.parseROIs(CellH5Reader.java:619)
    at loci.formats.in.CellH5Reader.initFile(CellH5Reader.java:304)
    at loci.formats.FormatReader.setId(FormatReader.java:1426)
    at CellH5Test.openCellH5(CellH5Test.java:13)
    at CellH5Test.main(CellH5Test.java:22)
```

With this PR included, the initialization should complete as expected. All CellH5 samples in our data repository should also be reenabled for daily testing.

                