### PR TITLE
FormatTools - Chanel IndexOutOfBoundsException

### DIFF
--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1118,7 +1118,7 @@ public final class FormatTools {
     filename = filename.replaceAll(SERIES_NAME, imageName);
 
     DimensionOrder order = retrieve.getPixelsDimensionOrder(series);
-    int sizeC = retrieve.getPixelsSizeC(series).getValue();
+    int sizeC = retrieve.getChannelCount(series);
     int sizeT = retrieve.getPixelsSizeT(series).getValue();
     int sizeZ = retrieve.getPixelsSizeZ(series).getValue();
     int[] coordinates = FormatTools.getZCTCoords(order.getValue(), sizeZ, sizeC, sizeT, sizeZ*sizeC*sizeT, image);


### PR DESCRIPTION
This PR is in relation to https://github.com/openmicroscopy/bioformats/issues/2847
An associated sample file can be found in QA-17718

The IndexOutOfBoundsException is thrown as the file has 4 samples per pixel but 1 effective channel. All of the other utility methods take a reader as an input parameter and use the following for dimensions:
`    int zSize = reader.getSizeZ();
    int cSize = reader.getEffectiveSizeC();
    int tSize = reader.getSizeT();`

In this case MetadataRetrieve is available but not the reader, as such getEffectiveSizeC or getImageCount are not able to be used. The `int sizeC = retrieve.getPixelsSizeC(series).getValue();` will return 4 which will then result in the out of bounds exception.

I have updated this to use `int sizeC = retrieve.getChannelCount(series);` which should be equivalent of `getEffectiveSizeC()`

To reproduce:
- Use bfconvert with the sample file provided and verify that an IndexOutOfBoundsException is thrown (a standard `bfconvert input output` is suitable)

To test:
- Ensure all existing tests remain green
- With the the PR applied retest the sample file and verify no errors are thrown
- Sanity test other samples to verify that the behaviour remains unchanged