### PR TITLE
Fix CellH5Reader.openBytes() for non-zero y values

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -337,7 +337,7 @@ public class CellH5Reader extends FormatReader {
 
     int elementSize = jhdf.getElementSize(CellH5PathsToImageData.get(series));
 
-    int[] arrayOrigin = new int[] {channel, time, zslice, 0, 0};
+    int[] arrayOrigin = new int[] {channel, time, zslice, y, 0};
     int[] arrayDimension = new int[] {1, 1, 1, height, width};
 
     MDIntArray test = jhdf.readIntBlockArray(CellH5PathsToImageData.get(series),


### PR DESCRIPTION
See https://trello.com/c/Rlg1SdFD/12-cellh5-broken-tile-loading

While testing the new iviewer app on a CellH5 file, a bug was discovered related to opening of subsets of CellH5 files, namely `openBytes(r, no, x, y, w, h)` for `y>0`. 

This commit fixes this behavior by adjusting the origin of the block array to account for the vertical origin in the private `getImageData` method.

In addition to the automated testing (which should not be affected as we are not testing any non (0,0) based tiles, it might be useful to check that plane loading either using the full planes or tiles now works as expected. https://gist.github.com/sbesson/2d3ea28313dfdb2988df8b3b368a5432 shows the testing script used in MATLAB against a sample `.h5` data but can be converted in Java or other language.