### PR TITLE
FileHandleTest: exclude JHDF5 native libraries

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FileHandleTest.java
+++ b/components/test-suite/src/loci/tests/testng/FileHandleTest.java
@@ -90,7 +90,8 @@ public class FileHandleTest {
       if (s.endsWith("libnio.so") || s.endsWith("resources.jar") ||
         s.startsWith("/usr/lib") || s.startsWith("/opt/") ||
         s.startsWith("/usr/share/locale") || s.startsWith("/lib") ||
-        s.indexOf("turbojpeg") > 0 || s.indexOf("/jre/") > 0)
+        s.indexOf("turbojpeg") > 0 || s.indexOf("/jre/") > 0 ||
+        s.indexOf("nativedata") > 0 || s.indexOf("jhdf") > 0)
       {
         finalHandles.remove(s);
         i--;


### PR DESCRIPTION
See https://github.com/openmicroscopy/data_repo_config/pull/201#issuecomment-301613406

With this PR, https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-breaking-performance/ should become green again.