### PR TITLE
Zeiss CZI and LSM channel fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2247,44 +2247,46 @@ public class ZeissCZIReader extends FormatReader {
       return;
     }
 
-    Element displaySetting = (Element) displaySettings.item(0);
-    NodeList channelNodes = getGrandchildren(displaySetting, "Channel");
+    for (int display=0; display<displaySettings.getLength(); display++) {
+      Element displaySetting = (Element) displaySettings.item(display);
+      NodeList channelNodes = getGrandchildren(displaySetting, "Channel");
 
-    if (channelNodes != null) {
-      for (int i=0; i<channelNodes.getLength(); i++) {
-        Element channel = (Element) channelNodes.item(i);
-        String color = getFirstNodeValue(channel, "Color");
-        if (color == null) {
-          color = getFirstNodeValue(channel, "OriginalColor");
-        }
+      if (channelNodes != null) {
+        for (int i=0; i<channelNodes.getLength(); i++) {
+          Element channel = (Element) channelNodes.item(i);
+          String color = getFirstNodeValue(channel, "Color");
+          if (color == null) {
+            color = getFirstNodeValue(channel, "OriginalColor");
+          }
 
-        while (channels.size() <= i) {
-          channels.add(new Channel());
-        }
-        channels.get(i).color = color;
+          while (channels.size() <= i) {
+            channels.add(new Channel());
+          }
+          channels.get(i).color = color;
 
-        String fluor = getFirstNodeValue(channel, "DyeName");
-        if (fluor != null) {
-          channels.get(i).fluor = fluor;
-        }
-        String name = channel.getAttribute("Name");
-        if (name != null) {
-          channels.get(i).name = name;
-        }
+          String fluor = getFirstNodeValue(channel, "DyeName");
+          if (fluor != null) {
+            channels.get(i).fluor = fluor;
+          }
+          String name = channel.getAttribute("Name");
+          if (name != null) {
+            channels.get(i).name = name;
+          }
 
-        String emission = getFirstNodeValue(channel, "DyeMaxEmission");
-        if (emission != null) {
-          channels.get(i).emission = emission;
-        }
-        String excitation = getFirstNodeValue(channel, "DyeMaxExcitation");
-        if (excitation != null) {
-          channels.get(i).excitation = excitation;
-        }
+          String emission = getFirstNodeValue(channel, "DyeMaxEmission");
+          if (emission != null) {
+            channels.get(i).emission = emission;
+          }
+          String excitation = getFirstNodeValue(channel, "DyeMaxExcitation");
+          if (excitation != null) {
+            channels.get(i).excitation = excitation;
+          }
 
-        String illumination = getFirstNodeValue(channel, "IlluminationType");
+          String illumination = getFirstNodeValue(channel, "IlluminationType");
 
-        if (illumination != null) {
-          channels.get(i).illumination = getIlluminationType(illumination);
+          if (illumination != null) {
+            channels.get(i).illumination = getIlluminationType(illumination);
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -1103,6 +1103,23 @@ public class ZeissLSMReader extends FormatReader {
             int green = (color & 0xff00) >> 8;
             int blue = (color & 0xff0000) >> 16;
 
+            // specially handle the case when the stored color is black
+            // if this is not the first channel, copy the color from the
+            // previous channel (necessary for SIM data)
+            // otherwise set the color to white, as this will display better
+            if (red == 0 && green == 0 & blue == 0) {
+              if (i > 0) {
+                red = channelColor[i - 1].getRed();
+                green = channelColor[i - 1].getGreen();
+                blue = channelColor[i - 1].getBlue();
+              }
+              else {
+                red = 255;
+                green = 255;
+                blue = 255;
+              }
+            }
+
             channelColor[i] = new Color(red, green, blue, 255);
 
             for (int j=0; j<256; j++) {


### PR DESCRIPTION
This should resolve http://trac.openmicroscopy.org.uk/ome/ticket/13325 and points 6 and 9 of http://trac.openmicroscopy.org/ome/ticket/12935#comment:8.  See also https://trello.com/c/y6KpD3sU/7-czi-tickets

To test, use the following files (all referenced on cards/tickets above):

* ```curated/zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/LambdaCh10T3ConvertedForZENblack.czi```
* ```curated/zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/LambdaCh10T1ConvertedForZENblack.czi```
* ```curated/zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/ConfocalCh3T1Z54BigFrameSize.czi```
* ```curated/zeiss-czi/nottingham/incorrect-colors/Image 6_Structured Illumination.czi```
* ```curated/zeiss-czi/nottingham/incorrect-colors/SIM SpinalChord2ch SeqFrame modeLongerExpo_OutResaved.lsm```
* ```curated/zeiss-czi/nottingham/incorrect-colors/SpinalChord63x_1 SIMcrop_Structured Illumination.czi```

With this PR, channel names and colors for all should match the names and colors reported by ZEN.  Without the PR, the names and/or colors will be incorrect for each.

This also changes the emission and excitation wavelengths for ```curated/zeiss-czi/sebastian/OME-TIFF_ROI_Wrong_from_CZI/Original_CZI_File.czi```.  I believe the previous values were incorrect, as the new values match what I see in ZEN, but this should be double-checked as well.

See also corresponding configuration PR: https://github.com/openmicroscopy/data_repo_config/pull/202