### PR TITLE
Zeiss CZI: better handling of truncated/invalid files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -638,6 +638,11 @@ public class ZeissCZIReader extends FormatReader {
 
     calculateDimensions();
 
+    if (planes.size() == 0) {
+      throw new FormatException(
+        "Pixel data could not be found; this file may be corrupted");
+    }
+
     int firstX = planes.get(0).x;
     int firstY = planes.get(0).y;
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -177,7 +177,7 @@ public class ZeissCZIReader extends FormatReader {
   public ZeissCZIReader() {
     super("Zeiss CZI", "czi");
     domains = new String[] {FormatTools.LM_DOMAIN, FormatTools.HISTOLOGY_DOMAIN};
-    suffixSufficient = true;
+    suffixSufficient = false;
     suffixNecessary = false;
   }
 


### PR DESCRIPTION
See https://trello.com/c/6aobhHCH/43-zeiss-czi-truncated-file-handling, https://trac.openmicroscopy.org/ome/ticket/13217, and https://trello.com/c/y6KpD3sU/4-czi-tickets

To test, use the file from QA 17168 and the files in ```curated/zeiss-czi/nottingham/truncated-files```.

Without this PR, ```showinf``` on QA 17168 should throw the exception listed in https://trac.openmicroscopy.org/ome/ticket/13217.  With this PR, ```showinf``` should result in a ```FormatException``` indicating that pixel data was not found.  Opening the file in ZEN should confirm that there are no valid pixels.

Without this PR, ```showinf``` on each of the files in ```curated/zeiss-czi/nottingham/truncated-files``` should throw an exception as listed in https://trello.com/c/6aobhHCH/43-zeiss-czi-truncated-file-handling.  With this PR, ```showinf``` should read each file and identify it as a TIFF (not CZI).  ```file *.czi``` should confirm the TIFF identification, and opening in ZEN (or changing the file name extension and opening in some other software) should confirm that the images are correct.

The relevant configuration PR is: https://github.com/openmicroscopy/data_repo_config/pull/206