### PR TITLE
FV1000Reader: fix "---" filter models

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -540,14 +540,26 @@ public class FV1000Reader extends FormatReader {
         if (gain != null) channel.gain = new Double(gain);
         String voltage = guiChannel.get("AnalogPMTVoltage");
         if (voltage != null) channel.voltage = new Double(voltage);
-        channel.barrierFilter = guiChannel.get("BF Name");
+        String barrierFilter = guiChannel.get("BF Name");
+        if (barrierFilter != null && barrierFilter.equals("---")) {
+          channel.barrierFilter = "";
+        }
+        else channel.barrierFilter = barrierFilter;
         channel.active = Integer.parseInt(guiChannel.get("CH Activate")) != 0;
         channel.name = guiChannel.get("CH Name");
         channel.dyeName = guiChannel.get("DyeName");
-        channel.emissionFilter = guiChannel.get("EmissionDM Name");
+        String emissionFilter = guiChannel.get("EmissionDM Name");
+        if (emissionFilter != null && emissionFilter.equals("---")) {
+          channel.emissionFilter = "";
+        }
+        else channel.emissionFilter = emissionFilter;
         String emWave = guiChannel.get("EmissionWavelength");
         if (emWave != null) channel.emWave = new Double(emWave);
-        channel.excitationFilter = guiChannel.get("ExcitationDM Name");
+        String excitationFilter = guiChannel.get("ExcitationDM Name");
+        if (excitationFilter != null && excitationFilter.equals("---")) {
+          channel.excitationFilter = "";
+        }
+        else channel.excitationFilter = excitationFilter;
         String exWave = guiChannel.get("ExcitationWavelength");
         if (emWave != null) channel.exWave = new Double(exWave);
         channels.add(channel);


### PR DESCRIPTION
Under some circumstances, filter names in OIBs/OIFs are `"---"` instead of `""`. This triggers parsing of the transmittance range cut-in and cut-out values from the name which raises an ArrayIndexOutOfBoundsException in [FV1000Reader.java#L1103](https://github.com/openmicroscopy/bioformats/blob/9088cd5a056d742066d2befdf19a83c71ec76e5d/components/formats-gpl/src/loci/formats/in/FV1000Reader.java#L1103).