### PR TITLE
Fix VeecoReader openBytes for tiles where y is larger than 0

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/VeecoReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VeecoReader.java
@@ -74,7 +74,7 @@ public class VeecoReader extends FormatReader {
 
     if (image instanceof byte[][]) {
       byte[][] byteImage = (byte[][]) image;
-      for (int row=h+y-1; row>=y; row--) {
+      for (int row=getSizeY()-1-y; row>=getSizeY()-y-h; row--) {
         System.arraycopy(byteImage[row], x, buf, (row - y) * w, w);
       }
     }
@@ -82,7 +82,7 @@ public class VeecoReader extends FormatReader {
       short[][] shortImage = (short[][]) image;
       int output = 0;
 
-      for (int row=h+y-1; row>=y; row--) {
+      for (int row=getSizeY()-1-y; row>=getSizeY()-y-h; row--) {
         for (int col=x; col<x+w; col++) {
           DataTools.unpackBytes(
             shortImage[row][col], buf, output, 2, unpackEndian);


### PR DESCRIPTION
VeecoReader.openBytes needs to flip the image retrieved using the HDF service vertically to match the expected origin in Bio-Formats. This commit should fix the implementation to work for any version of (y,w) when retrieving a tile and fix the openbytes tests.