### PR TITLE
MetaMorph ND file matching

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1361,6 +1361,8 @@ public class MetamorphReader extends BaseTiffReader {
     String parent = l.getParent();
 
     if (name.indexOf('_') > 0) {
+      String pattern = "_[swt]\\d+";
+      System.out.println(name.replaceAll(pattern, ""));
       String prefix = name.substring(0, name.indexOf('_'));
       String suffix = name.substring(name.indexOf('_'));
 


### PR DESCRIPTION
This PR is being used as a test for an issue raised in https://github.com/openmicroscopy/bioformats/issues/2613

Previously the reader matched associated files based on the first underscore, from the ND documentation we have it only mentions associated files as having the possibility of `_w#wavename, _s#, _t#`. Testing this on breaking against all existing sample data to see if we can change the current behaviour.