### PR TITLE
Fix NPE in OMEXMLServiceImpl

### DIFF
--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -198,7 +198,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   public String transformToLatestVersion(String xml) throws ServiceException {
     String version = getOMEXMLVersion(xml);
     if (null == version) {
-      throw new ServiceException("Could not get OME XML version");
+      throw new ServiceException("Could not get OME-XML version");
     }
     if (version.equals(getLatestVersion())) return xml;
     LOGGER.debug("Attempting to update XML with version: {}", version);

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -197,6 +197,9 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
   @Override
   public String transformToLatestVersion(String xml) throws ServiceException {
     String version = getOMEXMLVersion(xml);
+    if (null == version) {
+      throw new ServiceException("Could not get OME XML version");
+    }
     if (version.equals(getLatestVersion())) return xml;
     LOGGER.debug("Attempting to update XML with version: {}", version);
     LOGGER.trace("Initial dump: {}", xml);

--- a/components/formats-gpl/test/loci/formats/utests/xml/OMEXMLServiceTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/xml/OMEXMLServiceTest.java
@@ -91,6 +91,7 @@ public class OMEXMLServiceTest {
 
   @Test
   public void getOMEXMLVersion() throws ServiceException {
+    assertEquals("2008-09", service.getOMEXMLVersion(xml));
     assertEquals("2016-06",
       service.getOMEXMLVersion(service.createOMEXMLMetadata(xml)));
   }
@@ -98,6 +99,17 @@ public class OMEXMLServiceTest {
   @Test
   public void getOMEXML() throws ServiceException {
     assertNotNull(service.getOMEXML(service.createOMEXMLMetadata(xml)));
+  }
+
+  @Test
+  public void transformToLatestVersion() throws ServiceException {
+    String updated = service.transformToLatestVersion(xml);
+    assertEquals("2016-06", service.getOMEXMLVersion(updated));
+  }
+
+  @Test(expectedExceptions={ServiceException.class})
+  public void transformToLatestVersionBad() throws ServiceException {
+    service.transformToLatestVersion("");
   }
 
 }


### PR DESCRIPTION
`OMEXMLServiceImpl.transformToLatestVersion` is currently not handling `null` results from `getOMEXMLVersion`. This leads to an unhandled `NullPointerException` propagating to upper layers. For instance, in `OMETiffReader` the NPE is thrown [here](https://github.com/openmicroscopy/bioformats/blob/0e53c11bea06021d941007fe14531104e9881b3c/components/formats-bsd/src/loci/formats/in/OMETiffReader.java#L487) but the block expects to catch a `ServiceException`.

With this PR, the `null` value is handled and a `ServiceException` is thrown. New unit tests have been added to test both this specific scenario and `transformToLatestVersion`'s "normal" functionality.