### PR TITLE
CZI: fix detection of Z line scans

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1499,7 +1499,7 @@ public class ZeissCZIReader extends FormatReader {
             }
             break;
           case 'Z':
-            if (dimension.start >= getSizeZ()) {
+            if (dimension.start > 0 && dimension.start >= getSizeZ()) {
               ms0.sizeZ = dimension.start + 1;
             }
             else if (dimension.size > getSizeZ()) {


### PR DESCRIPTION
See http://trac.openmicroscopy.org/ome/ticket/13186 and https://trello.com/c/y6KpD3sU/10-czi-tickets

To test, use the two files in ```curated/zeiss-czi/aaron/ticket-13186```.  Verify that ```showinf -nopix``` without this PR matches the behavior described in the mailing list thread linked from the ticket.  With this PR, the dimensions reported by ```showinf``` for each file should match the description in the mailing list thread and ZEN.