### PR TITLE
Fv1000: channel metadata population refactoring

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -536,10 +536,9 @@ public class FV1000Reader extends FormatReader {
       IniTable guiChannel = f.getTable("GUI Channel " + index + " Parameters");
       while (guiChannel != null) {
         ChannelData channel = new ChannelData();
-        String gain = guiChannel.get("AnalogPMTGain");
-        if (gain != null) channel.gain = new Double(gain);
-        String voltage = guiChannel.get("AnalogPMTVoltage");
-        if (voltage != null) channel.voltage = new Double(voltage);
+        channel.gain = DataTools.parseDouble(guiChannel.get("AnalogPMTGain"));
+        channel.voltage = DataTools.parseDouble(
+          guiChannel.get("AnalogPMTVoltage"));
         String barrierFilter = guiChannel.get("BF Name");
         if (barrierFilter != null && barrierFilter.equals("---")) {
           channel.barrierFilter = "";
@@ -553,15 +552,15 @@ public class FV1000Reader extends FormatReader {
           channel.emissionFilter = "";
         }
         else channel.emissionFilter = emissionFilter;
-        String emWave = guiChannel.get("EmissionWavelength");
-        if (emWave != null) channel.emWave = new Double(emWave);
+        channel.emWave = DataTools.parseDouble(
+          guiChannel.get("EmissionWavelength"));
         String excitationFilter = guiChannel.get("ExcitationDM Name");
         if (excitationFilter != null && excitationFilter.equals("---")) {
           channel.excitationFilter = "";
         }
         else channel.excitationFilter = excitationFilter;
-        String exWave = guiChannel.get("ExcitationWavelength");
-        if (emWave != null) channel.exWave = new Double(exWave);
+        channel.exWave = DataTools.parseDouble(
+          guiChannel.get("ExcitationWavelength"));
         channels.add(channel);
         index++;
         guiChannel = f.getTable("GUI Channel " + index + " Parameters");

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -539,14 +539,16 @@ public class FV1000Reader extends FormatReader {
         channel.gain = DataTools.parseDouble(guiChannel.get("AnalogPMTGain"));
         channel.voltage = DataTools.parseDouble(
           guiChannel.get("AnalogPMTVoltage"));
-        channel.setBarrierFilter(guiChannel.get("BF Name"));
+        channel.barrierFilter = channel.getFilter(guiChannel.get("BF Name"));
         channel.active = Integer.parseInt(guiChannel.get("CH Activate")) != 0;
         channel.name = guiChannel.get("CH Name");
         channel.dyeName = guiChannel.get("DyeName");
-        channel.setEmissionFilter(guiChannel.get("EmissionDM Name"));
+        channel.emissionFilter = channel.getFilter(
+          guiChannel.get("EmissionDM Name"));
         channel.emWave = DataTools.parseDouble(
           guiChannel.get("EmissionWavelength"));
-        channel.setExcitationFilter(guiChannel.get("ExcitationDM Name"));
+        channel.excitationFilter = channel.getFilter(
+          guiChannel.get("ExcitationDM Name"));
         channel.exWave = DataTools.parseDouble(
           guiChannel.get("ExcitationWavelength"));
         channels.add(channel);
@@ -1790,20 +1792,8 @@ public class FV1000Reader extends FormatReader {
     public String barrierFilter;
 
     /* Return a valid filter string */
-    private String getFilter(String value) {
+    public String getFilter(String value) {
       if ("---".equals(value)) return null; else return value;
-    }
-
-    public void setBarrierFilter(String value) {
-      this.barrierFilter = getFilter(value);
-    }
-
-    public void setEmissionFilter(String value) {
-      this.emissionFilter = getFilter(value);
-    }
-
-    public void setExcitationFilter(String value) {
-      this.excitationFilter = getFilter(value);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -539,26 +539,14 @@ public class FV1000Reader extends FormatReader {
         channel.gain = DataTools.parseDouble(guiChannel.get("AnalogPMTGain"));
         channel.voltage = DataTools.parseDouble(
           guiChannel.get("AnalogPMTVoltage"));
-        String barrierFilter = guiChannel.get("BF Name");
-        if (barrierFilter != null && barrierFilter.equals("---")) {
-          channel.barrierFilter = "";
-        }
-        else channel.barrierFilter = barrierFilter;
+        channel.setBarrierFilter(guiChannel.get("BF Name"));
         channel.active = Integer.parseInt(guiChannel.get("CH Activate")) != 0;
         channel.name = guiChannel.get("CH Name");
         channel.dyeName = guiChannel.get("DyeName");
-        String emissionFilter = guiChannel.get("EmissionDM Name");
-        if (emissionFilter != null && emissionFilter.equals("---")) {
-          channel.emissionFilter = "";
-        }
-        else channel.emissionFilter = emissionFilter;
+        channel.setEmissionFilter(guiChannel.get("EmissionDM Name"));
         channel.emWave = DataTools.parseDouble(
           guiChannel.get("EmissionWavelength"));
-        String excitationFilter = guiChannel.get("ExcitationDM Name");
-        if (excitationFilter != null && excitationFilter.equals("---")) {
-          channel.excitationFilter = "";
-        }
-        else channel.excitationFilter = excitationFilter;
+        channel.setExcitationFilter(guiChannel.get("ExcitationDM Name"));
         channel.exWave = DataTools.parseDouble(
           guiChannel.get("ExcitationWavelength"));
         channels.add(channel);
@@ -1800,6 +1788,23 @@ public class FV1000Reader extends FormatReader {
     public Double exWave;
     public String dyeName;
     public String barrierFilter;
+
+    /* Return a valid filter string */
+    private String getFilter(String value) {
+      if ("---".equals(value)) return null; else return value;
+    }
+
+    public void setBarrierFilter(String value) {
+      this.barrierFilter = getFilter(value);
+    }
+
+    public void setEmissionFilter(String value) {
+      this.emissionFilter = getFilter(value);
+    }
+
+    public void setExcitationFilter(String value) {
+      this.excitationFilter = getFilter(value);
+    }
   }
 
   class PlaneData {


### PR DESCRIPTION
Following https://github.com/openmicroscopy/bioformats/pull/2858, this PR reviews the channel metadata population section of the `FV1000Reader` to use `DataTools.parseDouble`when appropriate and move the filter checking  logic to the `ChannelData` setters.

With this PR included, the automated tests should keep passing for all `oib/oif` samples.