### PR TITLE
Bump ome-model to 5.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.1</ome-common.version>
-    <ome-model.version>5.4.0</ome-model.version>
+    <ome-model.version>5.5.4</ome-model.version>
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <jxrlib.version>0.2.1</jxrlib.version>


### PR DESCRIPTION
The version bump should only include C++ and documentation changes - see [5.5.0](https://github.com/ome/ome-model/milestone/5?closed=1), [5.5.1](https://github.com/ome/ome-model/milestone/6?closed=1), [5.5.2](https://github.com/ome/ome-model/milestone/7?closed=1), [5.5.3](https://github.com/ome/ome-model/milestone/8?closed=1) and [5.5.4](https://github.com/ome/ome-model/milestone/9?closed=1) milestones.

To test this PR, check all unit and integration tests remain green.