### PR TITLE
Allow companion file to wrap plain TIFFs

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -470,15 +470,8 @@ public class OMETiffReader extends FormatReader {
       companion = true;
     }
     else {
-      RandomAccessInputStream ras = new RandomAccessInputStream(fileName, 16);
-      try {
-        TiffParser tp = new TiffParser(ras);
-        firstIFD = tp.getFirstIFD();
-        xml = firstIFD.getComment();
-      }
-      finally {
-        ras.close();
-      }
+      firstIFD = getFirstIFD(fileName);
+      xml = firstIFD.getComment();
     }
 
     if (service == null) setupService();
@@ -489,8 +482,8 @@ public class OMETiffReader extends FormatReader {
       }
       if (companion) {
         String firstTIFF = meta.getUUIDFileName(0, 0);
-        initFile(new Location(dir, firstTIFF).getAbsolutePath());
-        return;
+        firstIFD = getFirstIFD(new Location(dir, firstTIFF).getAbsolutePath());
+        metadataFile = fileName;
       }
     }
     catch (ServiceException se) {
@@ -498,10 +491,12 @@ public class OMETiffReader extends FormatReader {
     }
 
     String metadataPath = null;
-    try {
-      metadataPath = meta.getBinaryOnlyMetadataFile();
-    }
-    catch (NullPointerException e) {
+    if (metadataFile == null) {
+      try {
+        metadataPath = meta.getBinaryOnlyMetadataFile();
+      }
+      catch (NullPointerException e) {
+      }
     }
 
     if (metadataPath != null) {
@@ -1120,6 +1115,19 @@ public class OMETiffReader extends FormatReader {
     }
     // assume metadata file is an XML file
     return DataTools.readFile(metadataFile);
+  }
+
+  private static IFD getFirstIFD(String fname) throws IOException {
+    IFD firstIFD = null;
+    RandomAccessInputStream ras = new RandomAccessInputStream(fname, 16);
+    try {
+      TiffParser tp = new TiffParser(ras);
+      firstIFD = tp.getFirstIFD();
+    }
+    finally {
+      ras.close();
+    }
+    return firstIFD;
   }
 
   // -- Helper classes --

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -77,6 +77,9 @@ import ome.xml.model.primitives.Timestamp;
  */
 public class OMETiffReader extends FormatReader {
 
+  public static final String[] OME_TIFF_SUFFIXES =
+    {"ome.tiff", "ome.tif", "ome.tf2", "ome.tf8", "ome.btf", "companion.ome"};
+
   // -- Fields --
 
   /** Mapping from series and plane numbers to files and IFD entries. */
@@ -101,8 +104,7 @@ public class OMETiffReader extends FormatReader {
 
   /** Constructs a new OME-TIFF reader. */
   public OMETiffReader() {
-    super("OME-TIFF", new String[] {"ome.tiff", "ome.tif", "ome.tf2",
-                                    "ome.tf8", "ome.btf", "companion.ome"});
+    super("OME-TIFF", OME_TIFF_SUFFIXES);
     suffixNecessary = false;
     suffixSufficient = false;
     domains = FormatTools.NON_GRAPHICS_DOMAINS;

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1732,6 +1732,17 @@ public class FormatReaderTest {
             continue;
           }
 
+          // Companion file grouping non-ome-tiff files:
+          // setId must be called on the companion file
+          if (reader.getFormat().equals("OME-TIFF")) {
+            if (file.toLowerCase().endsWith(".companion.ome") &&
+                !OMETiffReader.checkSuffix(base[i],
+                                           OMETiffReader.OME_TIFF_SUFFIXES))
+            {
+              continue;
+            }
+          }
+
           r.setId(base[i]);
 
           String[] comp = r.getUsedFiles();
@@ -2195,6 +2206,16 @@ public class FormatReaderTest {
           // and only one reader, identifies the dataset as its own
           for (int j=0; j<readers.length; j++) {
             boolean result = readers[j].isThisType(used[i]);
+
+            // Companion file grouping non-ome-tiff files:
+            // setId must be called on the companion file
+            if (!result && readers[j] instanceof OMETiffReader &&
+                r.getCurrentFile().toLowerCase().endsWith(".companion.ome") &&
+                !OMETiffReader.checkSuffix(used[i],
+                                           OMETiffReader.OME_TIFF_SUFFIXES))
+            {
+              continue;
+            }
 
             // TIFF reader is allowed to redundantly green-light files
             if (result && readers[j] instanceof TiffDelegateReader) continue;


### PR DESCRIPTION
See https://trello.com/c/wBeP0xmA/4-companion-fileset-relaxation-investigation and the "External Companion File" design proposal. With this PR, when `initFile` is called on a companion file, it sets the metadata file as the companion itself and moves forward, instead of recursively calling `initFile` on the first TIFF referenced by the companion.

See data_repo_config PR no. 211 for a test case.