### PR TITLE
ND2 scanline pad fix

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2326,15 +2326,9 @@ public class NativeND2Reader extends FormatReader {
   }
 
   private int getScanlinePad() {
-    int scanlinePad = isJPEG ? 0 : getSizeX() % 2;
-    if (scanlinePad == 1) {
-      if (split && !isLossless && ((nXFields % 2) != 0 ||
-        (nXFields == 0 && (getSizeC() >= 4 || getSizeC() == 2))))
-      {
-        scanlinePad = 0;
-      }
-    }
-    return scanlinePad;
+    if (getSizeX() % 2 == 0) return 0;
+    if (getSizeC() % 2 == 0) return 0;
+    return 1;
   }
 
   private void parseText(String textString, int offsetCount, boolean useDimensions) {


### PR DESCRIPTION
See https://trello.com/c/TaqXNGco/152-nd2-pixel-offset.

From the Nikon ND2 samples in our repository, it seems like having an odd size both alongside the X dimension and the C dimension is necessary and sufficient to have the scanline padded.

This PR simplifies the `NativeND2Reader.getScanlinePad()` method to use this simpler calculation. To test this PR, check the automated tests keep passing against all ND2 samples. Additionally, test the sample file provided in the [Fiji forum thread](http://forum.imagej.net/t/importing-nd2-files-results-in-horizontal-lines-for-channels/5607) and check that without this PR, the image display with some horizontal lines while with this PR, it matches the expectation from NIS Elements.