### PR TITLE
Update POM version numbers to 5.5.2

### DIFF
--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/bundles/loci_tools/pom.xml
+++ b/components/bundles/loci_tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/forks/jai/pom.xml
+++ b/components/forks/jai/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../../..</relativePath>
   </parent>
 

--- a/components/forks/turbojpeg/pom.xml
+++ b/components/forks/turbojpeg/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-bsd/src/loci/formats/UpgradeChecker.java
+++ b/components/formats-bsd/src/loci/formats/UpgradeChecker.java
@@ -64,7 +64,7 @@ public class UpgradeChecker {
   // -- Constants --
 
   /** Version number of the latest stable release. */
-  public static final String STABLE_VERSION = "5.5.1";
+  public static final String STABLE_VERSION = "5.5.2";
 
   /** Location of the OME continuous integration server. */
   public static final String CI_SERVER = "http://ci.openmicroscopy.org";

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/docs/sphinx/pom.xml
+++ b/docs/sphinx/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>5.5.2-SNAPSHOT</version>
+    <version>5.5.2</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>pom-bio-formats</artifactId>
-  <version>5.5.2-SNAPSHOT</version>
+  <version>5.5.2</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>
@@ -38,7 +38,7 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
-    <release.version>5.5.2-SNAPSHOT</release.version>
+    <release.version>5.5.2</release.version>
     <date>${maven.build.timestamp}</date>
     <year>2017</year>
     <project.rootdir>${basedir}</project.rootdir>


### PR DESCRIPTION
Repository: openmicroscopy/bioformats
Already up-to-date.



Generated by build [BIOFORMATS-DEV-latest-version-bump#46](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-latest-version-bump/46/).

----
--no-rebase