### PR TITLE
CZI: store bezier ROIs as Polygons

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2444,6 +2444,12 @@ public class ZeissCZIReader extends FormatReader {
           shape = populatePolylines(closedPolylines, i, shape, true);
         }
 
+        NodeList beziers =
+          getGrandchildren(layer, "Elements", "Bezier");
+        if (beziers != null) {
+          shape = populatePolylines(beziers, i, shape, true);
+        }
+
         NodeList rectRoi = getGrandchildren(layer, "Elements", "RectRoi");
         if (rectRoi != null) {
           shape = populateRectangles(rectRoi, i, shape);


### PR DESCRIPTION
Resolves point 7 of http://trac.openmicroscopy.org/ome/ticket/12935.  See also https://trello.com/c/y6KpD3sU/4-czi-tickets

To test, use ```data_repo/curated/zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/ConfocalCh1T15Z1Bleaching2ROIS/ConfocalCh1T15Z1Bleaching2ROIS.czi```.  Opening in ZEN should show two ROI shapes in red: one rectangle and one closed contour.  Without this PR, ```showinf -nopix -omexml``` should only show the rectangle shape being parsed; opening in ImageJ with ```Display ROIs``` checked can also confirm this.

With this PR, the same test should show an additional polygon shape which approximates the shape shown in ZEN.  As far as I can see, the points defined in the .czi file are the control points for a set of Bezier curves, which is why the shapes will not exactly match.  I'm not sure if logging a warning would be useful in this case, but it would be easy enough to add instead of or in addition to ffbfbb1.