### PR TITLE
Kodak .bip: enforce stricter file type checking

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/KodakReader.java
+++ b/components/formats-gpl/src/loci/formats/in/KodakReader.java
@@ -69,6 +69,7 @@ public class KodakReader extends FormatReader {
   public KodakReader() {
     super("Kodak Molecular Imaging", "bip");
     domains = new String[] {FormatTools.GEL_DOMAIN};
+    suffixSufficient = false;
   }
 
   // -- IFormatReader API methods --


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13321.  See also https://trello.com/c/tcGhzBQl/96-bug-kodakreader

To test, use the .bip file from QA 17540.  Without this change, ```showinf``` should throw an ```IllegalArgumentException``` as noted in the ticket.  The file is not a Kodak .bip file, however, as it only contains unrelated text data (this can be confirmed by opening in a text editor).  With this change, ```showinf``` should correctly throw ```UnknownFormatException```.