### PR TITLE
MINC metadata parsing improvements

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MINCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MINCReader.java
@@ -226,9 +226,9 @@ public class MINCReader extends FormatReader {
       throw new FormatException(e);
     }
 
-    Double physicalX = null;
-    Double physicalY = null;
-    Double physicalZ = null;
+    Length physicalX = null;
+    Length physicalY = null;
+    Length physicalZ = null;
 
     if (isMINC2) {
       Hashtable<String, Object> attrs =
@@ -282,28 +282,22 @@ public class MINCReader extends FormatReader {
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       store.setImageDescription(history, 0);
 
-      Length sizeX = FormatTools.getPhysicalSizeX(physicalX);
-      Length sizeY = FormatTools.getPhysicalSizeY(physicalY);
-      Length sizeZ = FormatTools.getPhysicalSizeZ(physicalZ);
-      if (sizeX != null) {
-        store.setPixelsPhysicalSizeX(sizeX, 0);
+      if (physicalX != null) {
+        store.setPixelsPhysicalSizeX(physicalX, 0);
       }
-      if (sizeY != null) {
-        store.setPixelsPhysicalSizeY(sizeY, 0);
+      if (physicalY != null) {
+        store.setPixelsPhysicalSizeY(physicalY, 0);
       }
-      if (sizeZ != null) {
-        store.setPixelsPhysicalSizeZ(sizeZ, 0);
+      if (physicalZ != null) {
+        store.setPixelsPhysicalSizeZ(physicalZ, 0);
       }
     }
   }
 
-  private Double getStepSize(Hashtable<String, Object> attrs) {
+  private Length getStepSize(Hashtable<String, Object> attrs) {
     Double stepSize = Double.parseDouble(attrs.get("step").toString());
     String units = attrs.get("units").toString();
-    if (units.equals("mm")) {
-      stepSize *= 1000.0;
-    }
-    return stepSize;
+    return FormatTools.getPhysicalSize(stepSize, units);
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/MINCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MINCReader.java
@@ -153,14 +153,30 @@ public class MINCReader extends FormatReader {
         isMINC2 = true;
       }
       m.littleEndian = isMINC2;
-      
+
+      boolean signed = false;
+      if (isMINC2) {
+        Hashtable<String, Object> attrs = netcdf.getVariableAttributes("/minc-2.0/image/0/image");
+        String unsigned = attrs.get("_Unsigned").toString();
+        if (!unsigned.startsWith("true")) {
+          signed = true;
+        }
+      }
+      else {
+        Hashtable<String, Object> attrs = netcdf.getVariableAttributes("/image");
+        String signtype = attrs.get("signtype").toString();
+        if (signtype.startsWith("signed")) {
+          signed = true;
+        }
+      }
+
       if (pixels instanceof byte[][][]) {
-        m.pixelType = FormatTools.UINT8;
+        m.pixelType = signed ? FormatTools.INT8 : FormatTools.UINT8;
         pixelData = (byte[][][]) pixels;
       }
       else if (pixels instanceof byte[][][][]) {
         byte[][][][] actualPixels = (byte[][][][]) pixels;
-        m.pixelType = FormatTools.UINT8;
+        m.pixelType = signed ? FormatTools.INT8 : FormatTools.UINT8;
 
         pixelData = new byte[actualPixels.length * actualPixels[0].length][][];
         int nextPlane = 0;
@@ -171,7 +187,7 @@ public class MINCReader extends FormatReader {
         }
       }
       else if (pixels instanceof short[][][]) {
-        m.pixelType = FormatTools.UINT16;
+        m.pixelType = signed ? FormatTools.INT16 : FormatTools.UINT16;
 
         short[][][] s = (short[][][]) pixels;
         pixelData = new byte[s.length][][];
@@ -184,7 +200,7 @@ public class MINCReader extends FormatReader {
         }
       }
       else if (pixels instanceof int[][][]) {
-        m.pixelType = FormatTools.UINT32;
+        m.pixelType = signed ? FormatTools.INT32 : FormatTools.UINT32;
 
         int[][][] s = (int[][][]) pixels;
         pixelData = new byte[s.length][][];


### PR DESCRIPTION
See https://trello.com/c/9iQdOahX/52-qa-17215-minc-metadata

d3b69ef addresses point 1 on the card; 52050fc addresses point 3, and fa6bab1 addresses point 2.  Only d3b69ef affects the configurations of existing MINC files.

To test, use the file from QA 17215 as indicated on the card.  Without this change, ```showinf -omexml``` should show a uint16 image with ```PhysicalSizeX```, ```PhysicalSizeY```, and ```PhysicalSizeZ``` reported in micrometers and no ```Plane``` elements.  With this change, the pixel type should be int16, all physical sizes should be reported in millimeters, and there should be one ```Plane``` and associated ```Position{X,Y,Z}``` for each image.  The original metadata and output of ```mincheader``` and ```mincinfo``` referenced on the card should confirm that the new metadata is correct.

The pixel type change in fa6bab1 is arguably breaking, though it doesn't affect any previously-configured files (all are unsigned).  If anyone is uncomfortable with having that change in a patch release, I can revert and open a separate PR for the next minor release.