### PR TITLE
CZI: populate Pixels.TimeIncrement

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -142,6 +142,7 @@ public class ZeissCZIReader extends FormatReader {
   private String userInstitution;
   private String temperature, airPressure, humidity, co2Percent;
   private String correctionCollar, medium, refractiveIndex;
+  private transient Time timeIncrement;
 
   private String zoom;
   private String gain;
@@ -504,6 +505,7 @@ public class ZeissCZIReader extends FormatReader {
       positionsZ = null;
       zoom = null;
       gain = null;
+      timeIncrement = null;
 
       channels.clear();
       binnings.clear();
@@ -1117,6 +1119,9 @@ public class ZeissCZIReader extends FormatReader {
       }
       if (experimenterID != null) {
         store.setImageExperimenterRef(experimenterID, i);
+      }
+      if (timeIncrement != null) {
+        store.setPixelsTimeIncrement(timeIncrement, i);
       }
 
       String imageIndex = String.valueOf(i + 1);
@@ -1805,6 +1810,21 @@ public class ZeissCZIReader extends FormatReader {
       }
 
       Element dimensions = getFirstNode(image, "Dimensions");
+
+      Element tNode = getFirstNode(dimensions, "T");
+      if (tNode != null) {
+        Element positions = getFirstNode(tNode, "Positions");
+        if (positions != null) {
+          Element interval = getFirstNode(positions, "Interval");
+          if (interval != null) {
+            Element incrementNode = getFirstNode(interval, "Increment");
+            if (incrementNode != null) {
+              String increment = incrementNode.getTextContent();
+              timeIncrement = new Time(DataTools.parseDouble(increment), UNITS.SECOND);
+            }
+          }
+        }
+      }
 
       NodeList channelNodes = getGrandchildren(dimensions, "Channel");
       if (channelNodes == null) {


### PR DESCRIPTION
ZEN often shows timestamps calculated from the T increment, instead of the actual timestamps that are stored with each plane.  We now store the increment in Pixels.TimeIncrement, so that it is easy to work with either timestamp interpretation.

Resolves point 8 of http://trac.openmicroscopy.org/ome/ticket/12935

The new ```timeIncrement``` variable is not needed after ```setId```, so it is ```transient``` to be non-breaking.

To test, use ```data_repo/curated/zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/ConfocalCh1T15Z1Bleaching2ROIs/ConfocalCh1T15Z1Bleaching2ROIs.czi```.  Open in ZEN, then mouse over the ```Time``` slider and observe the ```dt``` value in the mouse-over label at various timepoints:

![clipboard](https://user-images.githubusercontent.com/109998/27487387-3b7a5b0a-57f9-11e7-8322-25bd687f4498.png)

Compare with the value of ```TimeIncrement``` on ```Pixels``` as reported by ```showinf -nopix -omexml``` with this change.  ```dt``` at the second timepoint should match ```TimeIncrement```, and subsequent values of ```dt``` should be a multiple of ```TimeIncrement```.  Without this change, ```TimeIncrement``` is not populated.  With or without this change, ```showinf -nopix -omexml``` should report the same values for ```DeltaT``` on ```Plane```.

