### PR TITLE
CZI: remaining fixes for ticket 12935

### DIFF
--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -592,16 +592,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
       omexml.setRoot(root);
       xml = getOMEXML(omexml);
     }
-    catch (ServiceException e) {
-      LOGGER.warn("Could not remove Modulo annotations", e);
-    }
-    catch (ParserConfigurationException e) {
-      LOGGER.warn("Could not remove Modulo annotations", e);
-    }
-    catch (SAXException e) {
-      LOGGER.warn("Could not remove Modulo annotations", e);
-    }
-    catch (IOException e) {
+    catch (ServiceException|ParserConfigurationException|SAXException|IOException e) {
       LOGGER.warn("Could not remove Modulo annotations", e);
     }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import javax.xml.parsers.DocumentBuilder;
 
@@ -1988,6 +1989,7 @@ public class ZeissCZIReader extends FormatReader {
 
       NodeList detectors = getGrandchildren(instrument, "Detector");
       if (detectors != null) {
+        HashSet<String> uniqueDetectors = new HashSet<String>();
         for (int i=0; i<detectors.getLength(); i++) {
           Element detector = (Element) detectors.item(i);
 
@@ -2006,40 +2008,45 @@ public class ZeissCZIReader extends FormatReader {
           if (!detectorID.startsWith("Detector:")) {
             detectorID = "Detector:" + detectorID;
           }
+          if (uniqueDetectors.contains(detectorID)) {
+            continue;
+          }
+          uniqueDetectors.add(detectorID);
+          int detectorIndex = uniqueDetectors.size() - 1;
 
-          store.setDetectorID(detectorID, 0, i);
-          store.setDetectorManufacturer(manufacturer, 0, i);
-          store.setDetectorModel(model, 0, i);
-          store.setDetectorSerialNumber(serialNumber, 0, i);
-          store.setDetectorLotNumber(lotNumber, 0, i);
+          store.setDetectorID(detectorID, 0, detectorIndex);
+          store.setDetectorManufacturer(manufacturer, 0, detectorIndex);
+          store.setDetectorModel(model, 0, detectorIndex);
+          store.setDetectorSerialNumber(serialNumber, 0, detectorIndex);
+          store.setDetectorLotNumber(lotNumber, 0, detectorIndex);
 
           if (gain == null) {
             gain = getFirstNodeValue(detector, "Gain");
           }
           if (gain != null && !gain.equals("")) {
-            store.setDetectorGain(new Double(gain), 0, i);
+            store.setDetectorGain(new Double(gain), 0, detectorIndex);
           }
 
           String offset = getFirstNodeValue(detector, "Offset");
           if (offset != null && !offset.equals("")) {
-            store.setDetectorOffset(new Double(offset), 0, i);
+            store.setDetectorOffset(new Double(offset), 0, detectorIndex);
           }
 
           if (zoom == null) {
             zoom = getFirstNodeValue(detector, "Zoom");
           }
           if (zoom != null && !zoom.equals("")) {
-            store.setDetectorZoom(new Double(zoom), 0, i);
+            store.setDetectorZoom(new Double(zoom), 0, detectorIndex);
           }
 
           String ampGain = getFirstNodeValue(detector, "AmplificationGain");
           if (ampGain != null && !ampGain.equals("")) {
-            store.setDetectorAmplificationGain(new Double(ampGain), 0, i);
+            store.setDetectorAmplificationGain(new Double(ampGain), 0, detectorIndex);
           }
 
           String detectorType = getFirstNodeValue(detector, "Type");
           if (detectorType != null && !detectorType.equals("")) {
-            store.setDetectorType(getDetectorType(detectorType), 0, i);
+            store.setDetectorType(getDetectorType(detectorType), 0, detectorIndex);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1829,6 +1829,28 @@ public class ZeissCZIReader extends FormatReader {
         }
       }
 
+      Element sNode = getFirstNode(dimensions, "S");
+      if (sNode != null) {
+        NodeList scenes = sNode.getElementsByTagName("Scene");
+        int nextPosition = 0;
+        for (int i=0; i<scenes.getLength(); i++) {
+          Element scene = (Element) scenes.item(i);
+          NodeList positions = scene.getElementsByTagName("Position");
+          for (int p=0; p<positions.getLength(); p++) {
+            Element position = (Element) positions.item(p);
+            String x = position.getAttribute("X");
+            String y = position.getAttribute("Y");
+            String z = position.getAttribute("Z");
+            if (nextPosition < positionsX.length && positionsX[nextPosition] == null) {
+              positionsX[nextPosition] = new Length(DataTools.parseDouble(x), UNITS.MICROM);
+              positionsY[nextPosition] = new Length(DataTools.parseDouble(y), UNITS.MICROM);
+              positionsZ[nextPosition] = new Length(DataTools.parseDouble(z), UNITS.MICROM);
+              nextPosition++;
+            }
+          }
+        }
+      }
+
       NodeList channelNodes = getGrandchildren(dimensions, "Channel");
       if (channelNodes == null) {
         channelNodes = image.getElementsByTagName("Channel");


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/12935#comment:8 and https://trello.com/c/y6KpD3sU/6-czi-tickets

325a4c9 addresses point 2 on the ticket comment, d026924 addresses point 3, 8a596d1 addresses point 4, and 0242c1d addresses point 5.

To test points 2 and 3, compare ```showinf -nopix -omexml``` against the ```Info``` tab in ZEN for each of the following files.  The ```Stage Position``` in ZEN should match ```PositionX``` and ```PositionY``` in the OME-XML, and the ```Detector Gain``` for each channel in ZEN should match the ```Gain``` for each channel's linked ```Detector``` in the OME-XML.  File list:

```
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Fluo#1_ZEN2-1-Airyscan.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Lambda1.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/LambdaImage.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/LambdaImage_Linear unmixing.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/LambdaImage_Spectral channel extraction2CHannel.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/LAmbda+Rand+Tpmt.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/MT-Tilescan2-3stitched.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/MT-Tilescan2-3unstitched.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/MT-ZStack5_Position4_Time3.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/OnlineFingerprinting_2Channel.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/SIM_nicht verrechnet.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/SIM_verrechnet.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Tile4-4Zstack5_Gestitchen.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/TileZstack5_Nicht Gestitchen.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Time_Bleaching_Marker_BleachROI.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Timeserie_GraphikElemente.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/WF.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/5Positionen.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/channel_3.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/HDR_Illu.czi
zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/HDRsampling.czi
```

To test point 4, verify that the ```test-automated``` repository test on ```curated/zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015``` fails on ```testValidXML``` for ```SIM_nicht verrechnet.czi``` without this change, and passes with it.  It may be worth a deeper discussion of how to handle/document modulo annotation ```Label``` vs ROI ```Label``` at some point, but this solves the immediate issue of not being able to test files that have a modulo annotation ```Label```.

To test point 5, check the output of ```showinf -nopix -omexml``` for each of the following files.  Without this change, there should be XML validation errors indicating that there are ```Detector```s with duplicate ```ID```s.  With this change, there should be no errors and no duplicate ```ID```s.  File list:

```
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/LambdaCh10T3/LambdaCh10T3.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/LambdaCh10T3ConvertedForZENblack/LambdaCh10T3ConvertedForZENblack.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/LambdaCh10T1/LambdaCh10T1.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/LambdaCh10T1ConvertedForZENblack/LambdaCh10T1ConvertedForZENblack.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanCh3T1Z1/AiryscanCh3T1Z1.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanCh3T1Z5/AiryscanCh3T1Z5.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanCh3T3Z1/AiryscanCh3T3Z1.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanCh3T3Z5/AiryscanCh3T3Z5.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanProcessedCh3T1Z1/AiryscanProcessedCh3T1Z1.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanProcessedCh3T1Z5/AiryscanProcessedCh3T1Z5.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanProcessedCh3T3Z1/AiryscanProcessedCh3T3Z1.czi
zeiss-czi/zeiss/ZEN 2.1 blue LSM 800 -May2015/AiryscanProcessedCh3T3Z5/AiryscanProcessedCh3T3Z5.czi