### PR TITLE
Docs: update CellSens VSI page to include spec list

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -479,8 +479,8 @@ weHave = * a few example datasets \n
 * a VSI specification document (v1.6, 2012 November 27, in PDF) \n
 * a VSI specification document (v1.3, 2010 February 5, in PDF)
 pixelsRating = Fair
-metadataRating = Fair
-opennessRating = Fair
+metadataRating = Very good
+opennessRating = Good
 presenceRating = Fair
 utilityRating = Fair
 pyramid = yes

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -475,8 +475,9 @@ mif = true
 extensions = .vsi
 developer = `Olympus <http://www.olympus.com/>`_
 bsd = no
-weHave = * a few example datasets
-weWant = * an official specification document
+weHave = * a few example datasets \n
+* a VSI specification document (v1.6, 2012 November 27, in PDF) \n
+* a VSI specification document (v1.3, 2010 February 5, in PDF)
 pixelsRating = Fair
 metadataRating = Fair
 opennessRating = Fair
@@ -485,6 +486,7 @@ utilityRating = Fair
 pyramid = yes
 reader = CellSensReader
 mif = true
+privateSpecification = true
 
 [CellVoyager]
 extensions = .xml, .tif

--- a/docs/sphinx/formats/cellsens-vsi.rst
+++ b/docs/sphinx/formats/cellsens-vsi.rst
@@ -25,11 +25,12 @@ Reader: CellSensReader (:bfreader:`Source Code <CellSensReader.java>`, :doc:`Sup
 
 We currently have:
 
-* a few example datasets
+* a few example datasets 
+* a VSI specification document (v1.6, 2012 November 27, in PDF) 
+* a VSI specification document (v1.3, 2010 February 5, in PDF)
 
 We would like to have:
 
-* an official specification document
 
 **Ratings**
 
@@ -44,5 +45,8 @@ Presence: |Fair|
 
 Utility: |Fair|
 
+**Additional Information**
 
+**Please note that while we have specification documents for this
+format, we are not able to distribute them to third parties.**
 

--- a/docs/sphinx/formats/cellsens-vsi.rst
+++ b/docs/sphinx/formats/cellsens-vsi.rst
@@ -37,9 +37,9 @@ We would like to have:
 
 Pixels: |Fair|
 
-Metadata: |Fair|
+Metadata: |Very good|
 
-Openness: |Fair|
+Openness: |Good|
 
 Presence: |Fair|
 

--- a/docs/sphinx/supported-formats.rst
+++ b/docs/sphinx/supported-formats.rst
@@ -312,8 +312,8 @@ You can sort this table by clicking on any of the headings.
    * - :doc:`formats/cellsens-vsi`
      - .vsi
      - |Fair|
-     - |Fair|
-     - |Fair|
+     - |Very good|
+     - |Good|
      - |Fair|
      - |Fair|
      - |no|


### PR DESCRIPTION
We have two specification documents for Olympus' CellSens .vsi format, both of which were missing from the format page.  See ```data_repo/curated/specs/VSI File Format v1.6.pdf``` and ```data_repo/curated/specs/XV VSI File Format v1.3_confidential.pdf``` (both private).

Discussed with @sbesson in connection with https://list.nih.gov/cgi-bin/wa.exe?A2=IMAGEJ;2b3255.1706