### PR TITLE
CZI: Deal with multiple empty planes in a row

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -986,6 +986,7 @@ public class ZeissCZIReader extends FormatReader {
                 plane.coreIndex--;
               }
             }
+            r--;
           }
           else {
             int div = (int) Math.pow(scaleFactor, r);


### PR DESCRIPTION
This code fix was suggested by Nick Trahearn on a mailing list thread: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-June/006532.html

Description from the mailing list thread:
On line 972 there's a loop where each series is checked to see if it is blank (meaning that no planes correspond to this series). If one is found then it is removed from the list of series. However, the index variable, r, is not updated after the removal. So when the loop starts its next iteration, and r is incremented, the following series gets skipped. If there are multiple blank series in a row then the ones that are skipped don't get removed.

This is simple to readjust the index after removal of an empty plane to deal with instances of multiple empty planes in a row.

To test:
Ensure all builds, tests and repo tests remain green