### PR TITLE
JPEG: support images with more than Integer.MAX_VALUE pixels

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/JPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/JPEGReader.java
@@ -185,7 +185,12 @@ public class JPEGReader extends DelegateReader {
 
     /* @see loci.formats.FormatReader#initFile(String) */
     protected void initFile(String id) throws FormatException, IOException {
-      super.initFile(id);
+      try {
+        super.initFile(id);
+      }
+      catch (IllegalArgumentException e) {
+        throw new FormatException(e);
+      }
 
       MetadataStore store = makeFilterMetadata();
       LOGGER.info("Parsing JPEG EXIF data");

--- a/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
@@ -106,20 +106,20 @@ public class TileJPEGReader extends FormatReader {
 
     in = new RandomAccessInputStream(id);
     JPEGTileDecoder decoder = new JPEGTileDecoder();
-    decoder.initialize(in, 0, 1, 0);
+    int[] dimensions = decoder.preprocess(in);
+    decoder.close();
+    decoder = null;
 
     CoreMetadata m = core.get(0);
 
     m.interleaved = true;
     m.littleEndian = false;
 
-    m.sizeX = decoder.getWidth();
-    m.sizeY = decoder.getHeight();
+    m.sizeX = dimensions[0];
+    m.sizeY = dimensions[1];
     m.sizeZ = 1;
     m.sizeT = 1;
 
-    decoder.close();
-    decoder = null;
     reopenFile();
 
     m.sizeC = 3;

--- a/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
@@ -47,7 +47,7 @@ import loci.formats.services.JPEGTurboService;
 import loci.formats.services.JPEGTurboServiceImpl;
 
 /**
- * Reader for decoding JPEG images using java.awt.Toolkit.
+ * Reader for decoding JPEG images using java.awt.Toolkit and TurboJPEG.
  * This reader is useful for reading very large JPEG images, as it supports
  * tile-based access.
  *
@@ -58,8 +58,7 @@ public class TileJPEGReader extends FormatReader {
 
   // -- Fields --
 
-  private JPEGTileDecoder decoder;
-  private JPEGTurboService service;
+  private transient JPEGTurboService service;
 
   // -- Constructor --
 
@@ -82,18 +81,6 @@ public class TileJPEGReader extends FormatReader {
     if (service != null) {
       service.getTile(buf, x, y, w, h);
     }
-    else {
-      int c = getRGBChannelCount();
-
-      for (int ty=y; ty<y+h; ty++) {
-        byte[] scanline = decoder.getScanline(ty);
-        if (scanline == null) {
-          decoder.initialize(currentId, 0);
-          scanline = decoder.getScanline(ty);
-        }
-        System.arraycopy(scanline, c * x, buf, (ty - y) * c * w, c * w);
-      }
-    }
 
     return buf;
   }
@@ -103,10 +90,6 @@ public class TileJPEGReader extends FormatReader {
   public void close(boolean fileOnly) throws IOException {
     super.close(fileOnly);
     if (!fileOnly) {
-      if (decoder != null) {
-        decoder.close();
-      }
-      decoder = null;
       if (service != null) {
         service.close();
       }
@@ -122,7 +105,7 @@ public class TileJPEGReader extends FormatReader {
     super.initFile(id);
 
     in = new RandomAccessInputStream(id);
-    decoder = new JPEGTileDecoder();
+    JPEGTileDecoder decoder = new JPEGTileDecoder();
     decoder.initialize(in, 0, 1, 0);
 
     CoreMetadata m = core.get(0);
@@ -134,22 +117,12 @@ public class TileJPEGReader extends FormatReader {
     m.sizeY = decoder.getHeight();
     m.sizeZ = 1;
     m.sizeT = 1;
-    try {
-      m.sizeC = decoder.getScanline(0).length / getSizeX();
-    }
-    catch (Exception e) {
-      decoder.close();
-      in = new RandomAccessInputStream(id);
-      in.seek(0);
-      service = new JPEGTurboServiceImpl();
-      try {
-        service.initialize(in, m.sizeX, m.sizeY);
-      }
-      catch (ServiceException se) {
-        throw new FormatException("Could not initialize JPEG service", se);
-      }
-      m.sizeC = 3;
-    }
+
+    decoder.close();
+    decoder = null;
+    reopenFile();
+
+    m.sizeC = 3;
     m.rgb = getSizeC() > 1;
     m.imageCount = 1;
     m.pixelType = FormatTools.UINT8;
@@ -159,6 +132,22 @@ public class TileJPEGReader extends FormatReader {
 
     MetadataStore store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this);
+  }
+
+  @Override
+  public void reopenFile() throws IOException {
+    if (in != null) {
+      in.close();
+    }
+    in = new RandomAccessInputStream(currentId);
+    in.seek(0);
+    service = new JPEGTurboServiceImpl();
+    try {
+      service.initialize(in, getSizeX(), getSizeY());
+    }
+    catch (ServiceException se) {
+      throw new IOException("Could not initialize JPEG service", se);
+    }
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
@@ -78,9 +78,7 @@ public class TileJPEGReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    if (service != null) {
-      service.getTile(buf, x, y, w, h);
-    }
+    service.getTile(buf, x, y, w, h);
 
     return buf;
   }
@@ -146,6 +144,7 @@ public class TileJPEGReader extends FormatReader {
       service.initialize(in, getSizeX(), getSizeY());
     }
     catch (ServiceException se) {
+      service = null;
       throw new IOException("Could not initialize JPEG service", se);
     }
   }


### PR DESCRIPTION
See https://trello.com/c/M8PidMnv/16-use-jpegturboservice-to-read-large-jpeg-images

There are two new files in ```data_repo/curated/jpeg/big-images```, both of which were created by copying the raw bytes from the first strip in the first IFD of an existing .ndpi file.

With and without this change, attempting to open ```smithd_20111115_2.ndpi.jpg``` (from ```data_repo/curated/hamamatsu/david-smith/smithd_20111115_2.ndpi```) should throw a ```javax.imageio.IIOException``` as noted on the card.  This is because the image dimensions exceed 65500 x 65500 (the maximum allowed by JPEG), and so are set to 0.

Without this change, ```showinf -nopix``` on ```PB_9217_Retina_04 - 2010-07-16 19.04.48.ndpi.jpg``` (from ```data_repo/curated/hamamatsu/harvey/PB_9217_Retina_04 - 2010-07-16 19.04.48.ndpi```) should throw an ```IllegalArgumentException``` as noted in https://github.com/openmicroscopy/bioformats/issues/2132.  With this change, ```showinf -crop 0,0,512,512``` or similar should log an ```IllegalArgumentException``` but then proceed to open the requested tile.  The detected size X and Y should confirm that there more than ```Integer.MAX_VALUE``` pixels.