### PR TITLE
Plugins: Concatenated images memory fix

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImagePlusReader.java
@@ -294,8 +294,11 @@ public class ImagePlusReader implements StatusReporter {
     // configure image
 
     // place metadata key/value pairs in ImageJ's info field
-    final String metadata = process.getOriginalMetadata().toString();
-    imp.setProperty("Info", metadata);
+    // if concatenating images only store metadata on first series
+    if (!options.isConcatenate() || s == 0) {
+      final String metadata = process.getOriginalMetadata().toString();
+      imp.setProperty("Info", metadata);
+    }
     imp.setProperty(PROP_SERIES, s);
 
     // retrieve the spatial calibration information, if available


### PR DESCRIPTION
This issue was raised by mailing list thread http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-June/006527.html

The problem occurring is an out of memory exception occurring while opening all series in the QA file with the options "open all series" and "concatenate series when compatible".

From debugging and taking memory dumps the issue is due to the full metadata being stored on every ImagePlus object before concatenation. Each ImagePlus object is around 60MB, however 59MB of each of those is a String which is the metadata key value pairs stored in an Info String.

As these objects are being concatenated together there is no need to store the entire metadata string on each one.

A sample file is available for testing: QA-17769

See https://trello.com/c/evfYjQ4y/15-imagej-concatenate-memory-usage for more details

To test:
- Ensure all builds and tests are green
- Without the PR open the sample file QA-17769 with FIJI. In the Importer Options window select "open all series" and "concatenate series when compatible". Verify that an out of memory exception occurs.
- With the PR applied redo the above test and verify that the sample file opens correctly displaying the concatenated image.