### PR TITLE
Rebase operetta fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -333,6 +333,11 @@ public class OperettaReader extends FormatReader {
       }
     }
 
+    addGlobalMeta("Plate name", handler.getPlateName());
+    addGlobalMeta("Plate description", handler.getPlateDescription());
+    addGlobalMeta("Plate ID", handler.getPlateIdentifier());
+    addGlobalMeta("Measurement ID", handler.getMeasurementID());
+
     // populate the MetadataStore
 
     MetadataStore store = makeFilterMetadata();
@@ -417,6 +422,7 @@ public class OperettaReader extends FormatReader {
 
     private String displayName;
     private String plateID;
+    private String measurementID;
     private String measurementTime;
     private String plateName;
     private String plateDescription;
@@ -437,6 +443,10 @@ public class OperettaReader extends FormatReader {
 
     public String getPlateIdentifier() {
       return plateID;
+    }
+
+    public String getMeasurementID() {
+      return measurementID;
     }
 
     public String getMeasurementTime() {
@@ -487,6 +497,9 @@ public class OperettaReader extends FormatReader {
       }
       else if ("PlateID".equals(currentName)) {
         plateID = value;
+      }
+      else if ("MeasurementID".equals(currentName)) {
+        measurementID = value;
       }
       else if ("MeasurementStartTime".equals(currentName)) {
         measurementTime = value;

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -293,8 +293,6 @@ public class OperettaReader extends FormatReader {
     for (int i=0; i<seriesCount; i++) {
       CoreMetadata ms = new CoreMetadata();
       core.add(ms);
-      ms.sizeX = planes[i][0].x;
-      ms.sizeY = planes[i][0].y;
       ms.sizeZ = uniqueZs.size();
       ms.sizeC = uniqueCs.size();
       ms.sizeT = uniqueTs.size();
@@ -303,6 +301,11 @@ public class OperettaReader extends FormatReader {
       ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
 
       int planeIndex = 0;
+      while (planes[i][planeIndex] == null) {
+        planeIndex++;
+      }
+      ms.sizeX = planes[i][planeIndex].x;
+      ms.sizeY = planes[i][planeIndex].y;
       String filename = planes[i][planeIndex].filename;
       while ((filename == null || !new Location(filename).exists()) &&
         planeIndex < planes[i].length - 1)

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -137,7 +137,9 @@ public class OperettaReader extends FormatReader {
     ArrayList<String> files = new ArrayList<String>();
     files.add(currentId);
     for (Plane p : planes[getSeries()]) {
-      files.add(p.filename);
+      if (p.filename != null && new Location(p.filename).exists()) {
+        files.add(p.filename);
+      }
     }
 
     return files.toArray(new String[files.size()]);
@@ -165,10 +167,11 @@ public class OperettaReader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
+    Arrays.fill(buf, (byte) 0);
     if (getSeries() < planes.length && no < planes[getSeries()].length) {
       Plane p = planes[getSeries()][no];
 
-      if (new Location(p.filename).exists()) {
+      if (p.filename != null && new Location(p.filename).exists()) {
         if (reader == null) {
           reader = new MinimalTiffReader();
         }
@@ -299,15 +302,35 @@ public class OperettaReader extends FormatReader {
       ms.rgb = false;
       ms.imageCount = getSizeZ() * getSizeC() * getSizeT();
 
-      RandomAccessInputStream s =
-        new RandomAccessInputStream(planes[i][0].filename, 16);
-      TiffParser parser = new TiffParser(s);
-      parser.setDoCaching(false);
+      int planeIndex = 0;
+      String filename = planes[i][planeIndex].filename;
+      while ((filename == null || !new Location(filename).exists()) &&
+        planeIndex < planes[i].length - 1)
+      {
+        LOGGER.debug("Missing TIFF file: {}", filename);
+        planeIndex++;
+        filename = planes[i][planeIndex].filename;
+      }
 
-      IFD firstIFD = parser.getFirstIFD();
-      ms.littleEndian = firstIFD.isLittleEndian();
-      ms.pixelType = firstIFD.getPixelType();
-      s.close();
+      if (filename != null && new Location(filename).exists()) {
+        RandomAccessInputStream s =
+          new RandomAccessInputStream(filename, 16);
+        TiffParser parser = new TiffParser(s);
+        parser.setDoCaching(false);
+
+        IFD firstIFD = parser.getFirstIFD();
+        ms.littleEndian = firstIFD.isLittleEndian();
+        ms.pixelType = firstIFD.getPixelType();
+        s.close();
+      }
+      else if (i > 0) {
+        LOGGER.warn("Could not find valid TIFF file for series {}", i);
+        ms.littleEndian = core.get(0).littleEndian;
+        ms.pixelType = core.get(0).pixelType;
+      }
+      else {
+        LOGGER.warn("Could not find valid TIFF file for series 0; pixel type may be wrong");
+      }
     }
 
     // populate the MetadataStore
@@ -482,9 +505,11 @@ public class OperettaReader extends FormatReader {
       }
       else if (activePlane != null) {
         if ("URL".equals(currentName)) {
-          Location parent =
-            new Location(currentId).getAbsoluteFile().getParentFile();
-          activePlane.filename = new Location(parent, value).getAbsolutePath();
+          if (value.length() > 0) {
+            Location parent =
+              new Location(currentId).getAbsoluteFile().getParentFile();
+            activePlane.filename = new Location(parent, value).getAbsolutePath();
+          }
         }
         else if ("Row".equals(currentName)) {
           activePlane.row = Integer.parseInt(value) - 1;


### PR DESCRIPTION
Rebases https://github.com/openmicroscopy/bioformats/pull/2827 on top of `metadata54`. This makes `OperettaReader.java` identical to the version on `metadata` except for the following:

```diff
diff --git a/components/formats-gpl/src/loci/formats/in/OperettaReader.java b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
index 07540af130..470c846632 100644
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -2,7 +2,7 @@
  * #%L
  * OME Bio-Formats package for reading and converting biological file formats.
  * %%
- * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
@@ -46,7 +46,6 @@ import loci.formats.tiff.TiffParser;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
 import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 
 import org.xml.sax.Attributes;
@@ -455,7 +454,7 @@ public class OperettaReader extends FormatReader {
     private int plateRows, plateCols;
     private ArrayList<Plane> planes = new ArrayList<Plane>();
 
-    private StringBuffer currentValue = new StringBuffer();
+    private final StringBuilder currentValue = new StringBuilder();
 
     // -- OperettaHandler API methods --
```