### PR TITLE
Metamorph: resurrect changes from gh-2411

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -92,6 +92,8 @@ public class MinimalTiffReader extends FormatReader {
 
   protected boolean noSubresolutions = false;
 
+  protected boolean seriesToIFD = false;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -279,7 +281,13 @@ public class MinimalTiffReader extends FormatReader {
 
     IFD firstIFD = ifds.get(0);
     lastPlane = no;
-    IFD ifd = ifds.get(no);
+    IFD ifd;
+    if (seriesToIFD) {
+      ifd = ifds.get(getSeries());
+    } else {
+      ifd = ifds.get(no);
+    }
+
     if ((firstIFD.getCompression() == TiffCompression.JPEG_2000
         || firstIFD.getCompression() == TiffCompression.JPEG_2000_LOSSY)
         && resolutionLevels != null) {
@@ -376,6 +384,7 @@ public class MinimalTiffReader extends FormatReader {
       tiffParser = null;
       resolutionLevels = null;
       j2kCodecOptions = null;
+      seriesToIFD = false;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -767,8 +767,7 @@ public class MetamorphReader extends BaseTiffReader {
         }
         core.add(toAdd);
       }
-      // METADATA-ONLY
-      // seriesToIFD = true;
+      seriesToIFD = true;
     }
 
     List<String> timestamps = null;


### PR DESCRIPTION
The merge commit lost these changes from `metadata` leading to idr0010 showing only A1.

See https://trello.com/c/aRc1bvJJ/73-idr0010-wrong-image-shown