### PR TITLE
Docs: Fix broken links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -956,10 +956,10 @@ reader = ImprovisionTiffReader
 [Imspector OBF]
 extensions = .obf, .msr
 owner = `MPI-BPC <http://www.mpibpc.mpg.de/>`_
-developer = `Department of NanoBiophotonics, MPI-BPC <https://imspector.mpibpc.mpg.de/index.html>`_
+developer = `Department of NanoBiophotonics, MPI-BPC <https://imspector.mpibpc.mpg.de>`_
 bsd = yes
 weHave = * a few .msr datasets \n
-* `a specification document <https://imspector.mpibpc.mpg.de/documentation/fileformat.html>`_
+* `a specification document <https://imspectordocs.readthedocs.io/en/latest/fileformat.html#>`_
 pixelsRating = Very good
 metadataRating = Very good
 opennessRating = Very good
@@ -2026,7 +2026,7 @@ extensions = .mov
 owner = `Apple Computer <http://www.apple.com/>`_
 bsd = yes
 software = `QuickTime Player <https://support.apple.com/downloads/quicktime>`_
-weHave = * a `QuickTime specification document <http://developer.apple.com/documentation/Quicktime/QTFF/>`_ (from 2001 March 1, in HTML) \n
+weHave = * a `QuickTime specification document <https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFPreface/qtffPreface.html>`_ \n
 * several QuickTime datasets \n
 * the ability to produce more datasets
 weWant = * more QuickTime datasets, including: \n
@@ -2200,7 +2200,7 @@ developer = Aldus and Microsoft
 bsd = yes
 samples = `LZW TIFF data gallery <http://marlin.life.utsa.edu/Data_Gallery.html>`_ \n
 `Big TIFF <http://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
-weHave = * a `TIFF specification document <http://partners.adobe.com/asn/developer/PDFS/TN/TIFF6.pdf>`_ (v6.0, from 1992 June 3, in PDF) \n
+weHave = * a `TIFF specification document <http://www.awaresystems.be/imaging/tiff.html>`_ \n
 * many TIFF datasets \n
 * a few BigTIFF datasets
 pixelsRating = Very good

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -959,7 +959,7 @@ owner = `MPI-BPC <http://www.mpibpc.mpg.de/>`_
 developer = `Department of NanoBiophotonics, MPI-BPC <https://imspector.mpibpc.mpg.de>`_
 bsd = yes
 weHave = * a few .msr datasets \n
-* `a specification document <https://imspectordocs.readthedocs.io/en/latest/fileformat.html#>`_
+* `a specification document <https://imspectordocs.readthedocs.io/en/latest/fileformat.html>`_
 pixelsRating = Very good
 metadataRating = Very good
 opennessRating = Very good

--- a/docs/sphinx/formats/imspector-obf.rst
+++ b/docs/sphinx/formats/imspector-obf.rst
@@ -6,7 +6,7 @@ Imspector OBF
 
 Extensions: .obf, .msr
 
-Developer: `Department of NanoBiophotonics, MPI-BPC <https://imspector.mpibpc.mpg.de/index.html>`_
+Developer: `Department of NanoBiophotonics, MPI-BPC <https://imspector.mpibpc.mpg.de/>`_
 
 Owner: `MPI-BPC <http://www.mpibpc.mpg.de/>`_
 
@@ -27,7 +27,7 @@ Reader: OBFReader (:bsd-reader:`Source Code <OBFReader.java>`, :doc:`Supported M
 We currently have:
 
 * a few .msr datasets 
-* `a specification document <https://imspector.mpibpc.mpg.de/documentation/fileformat.html>`_
+* `a specification document <https://imspectordocs.readthedocs.io/en/latest/fileformat.html#>`_
 
 We would like to have:
 

--- a/docs/sphinx/formats/imspector-obf.rst
+++ b/docs/sphinx/formats/imspector-obf.rst
@@ -27,7 +27,7 @@ Reader: OBFReader (:bsd-reader:`Source Code <OBFReader.java>`, :doc:`Supported M
 We currently have:
 
 * a few .msr datasets 
-* `a specification document <https://imspectordocs.readthedocs.io/en/latest/fileformat.html#>`_
+* `a specification document <https://imspectordocs.readthedocs.io/en/latest/fileformat.html>`_
 
 We would like to have:
 

--- a/docs/sphinx/formats/quicktime-movie.rst
+++ b/docs/sphinx/formats/quicktime-movie.rst
@@ -32,7 +32,7 @@ Freely Available Software:
 
 We currently have:
 
-* a `QuickTime specification document <http://developer.apple.com/documentation/Quicktime/QTFF/>`_ (from 2001 March 1, in HTML) 
+* a `QuickTime specification document <https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFPreface/qtffPreface.html>` 
 * several QuickTime datasets 
 * the ability to produce more datasets
 

--- a/docs/sphinx/formats/tiff.rst
+++ b/docs/sphinx/formats/tiff.rst
@@ -31,7 +31,7 @@ Sample Datasets:
 
 We currently have:
 
-* a `TIFF specification document <http://partners.adobe.com/asn/developer/PDFS/TN/TIFF6.pdf>`_ (v6.0, from 1992 June 3, in PDF) 
+* a `TIFF specification <http://www.awaresystems.be/imaging/tiff.html>`_
 * many TIFF datasets 
 * a few BigTIFF datasets
 


### PR DESCRIPTION
Fixing 4 broken documentation links: 
https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-docs/766/warnings3Result/new/

To test:
- Ensure builds are green and links are valid