### PR TITLE
CZI: add basic support for PALM data

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -174,6 +174,8 @@ public class ZeissCZIReader extends FormatReader {
   private int[] tileHeight;
   private int scaleFactor;
 
+  private transient boolean isPALM = false;
+
   // -- Constructor --
 
   /** Constructs a new Zeiss .czi reader. */
@@ -535,6 +537,7 @@ public class ZeissCZIReader extends FormatReader {
       tileWidth = null;
       tileHeight = null;
       scaleFactor = 0;
+      isPALM = false;
     }
   }
 
@@ -1003,6 +1006,77 @@ public class ZeissCZIReader extends FormatReader {
       }
     }
 
+    // check for PALM data; requires planes to split into separate series
+
+    String firstXML = null;
+    boolean canSkipXML = true;
+    String currentPath = new Location(currentId).getAbsolutePath();
+    if (planes.size() <= 2 && getImageCount() <= 2) {
+      for (Segment segment : segments) {
+        String path = new Location(segment.filename).getAbsolutePath();
+        if (currentPath.equals(path) && segment instanceof Metadata) {
+          segment.fillInData();
+          String xml = ((Metadata) segment).xml;
+          xml = XMLTools.sanitizeXML(xml);
+          if (firstXML == null && canSkipXML) {
+            firstXML = xml;
+          }
+          if (canSkipXML && firstXML.equals(xml)) {
+            isPALM = checkPALM(xml);
+          }
+          else if (!firstXML.equals(xml)) {
+            canSkipXML = false;
+          }
+          ((Metadata) segment).clearXML();
+        }
+      }
+    }
+
+    if (isPALM) {
+      LOGGER.debug("Detected PALM data");
+      core.get(0).sizeC = 1;
+      core.get(0).imageCount = core.get(0).sizeZ * core.get(0).sizeT;
+
+      for (int i=0; i<planes.size(); i++) {
+        SubBlock p = planes.get(i);
+        int storedX = p.directoryEntry.dimensionEntries[0].storedSize;
+        int storedY = p.directoryEntry.dimensionEntries[1].storedSize;
+        if (p.planeIndex >= getImageCount()) {
+          if (core.size() == 1) {
+            CoreMetadata second = new CoreMetadata(core.get(0));
+            core.add(second);
+          }
+          p.coreIndex = 1;
+          p.planeIndex -= (planes.size() / 2);
+          core.get(1).sizeX = storedX;
+          core.get(1).sizeY = storedY;
+        }
+        else {
+          core.get(0).sizeX = storedX;
+          core.get(0).sizeY = storedY;
+        }
+      }
+      if (core.size() == 2) {
+        // prevent misidentification of PALM data; each plane should be a different size
+        if (core.get(0).sizeX == core.get(1).sizeX &&
+          core.get(0).sizeY == core.get(1).sizeY)
+        {
+          isPALM = false;
+          core.remove(1);
+          core.get(0).sizeC = 2;
+          core.get(0).imageCount *= getSizeC();
+
+          for (int i=0; i<planes.size(); i++) {
+            SubBlock p = planes.get(i);
+            if (p.coreIndex == 1) {
+              p.coreIndex = 0;
+              p.planeIndex += (planes.size() / 2);
+            }
+          }
+        }
+      }
+    }
+
     // find and add attached label/overview images
 
     readAttachments();
@@ -1012,9 +1086,8 @@ public class ZeissCZIReader extends FormatReader {
     store = makeFilterMetadata();
     MetadataTools.populatePixels(store, this, true);
 
-    String firstXML = null;
-    boolean canSkipXML = true;
-    String currentPath = new Location(currentId).getAbsolutePath();
+    firstXML = null;
+    canSkipXML = true;
     for (Segment segment : segments) {
       String path = new Location(segment.filename).getAbsolutePath();
       if (currentPath.equals(path) && segment instanceof Metadata) {
@@ -1288,7 +1361,12 @@ public class ZeissCZIReader extends FormatReader {
 
       for (int c=0; c<getEffectiveSizeC(); c++) {
         if (c < channels.size()) {
-          store.setChannelName(channels.get(c).name, i, c);
+          if (isPALM && i < channels.size()) {
+            store.setChannelName(channels.get(i).name, i, c);
+          }
+          else {
+            store.setChannelName(channels.get(c).name, i, c);
+          }
           store.setChannelFluor(channels.get(c).fluor, i, c);
           if (channels.get(c).filterSetRef != null) {
             store.setChannelFilterSetRef(channels.get(c).filterSetRef, i, c);
@@ -1404,6 +1482,7 @@ public class ZeissCZIReader extends FormatReader {
 
       if (segment instanceof SubBlock) {
         planes.add((SubBlock) segment);
+        LOGGER.trace("plane #{} = {}", planes.size() - 1, segment);
       }
       segment.close();
     }
@@ -1788,6 +1867,66 @@ public class ZeissCZIReader extends FormatReader {
 
     final Deque<String> nameStack = new ArrayDeque<String>();
     populateOriginalMetadata(realRoot, nameStack);
+  }
+
+  private boolean checkPALM(String xml) throws FormatException, IOException {
+    Element root = null;
+    try {
+      ByteArrayInputStream s =
+        new ByteArrayInputStream(xml.getBytes(Constants.ENCODING));
+      root = parser.parse(s).getDocumentElement();
+      s.close();
+    }
+    catch (SAXException e) {
+      throw new FormatException(e);
+    }
+
+    if (root == null) {
+      throw new FormatException("Could not parse the XML metadata.");
+    }
+
+    NodeList customAttributes = root.getElementsByTagName("CustomAttributes");
+    if (customAttributes != null && customAttributes.getLength() > 0) {
+      Element attributes = (Element) customAttributes.item(0);
+      if (attributes != null) {
+        NodeList lsmTags = attributes.getElementsByTagName("LsmTag");
+        if (lsmTags != null) {
+          for (int i=0; i<lsmTags.getLength(); i++) {
+            Element tag = (Element) lsmTags.item(i);
+            String name = tag.getAttribute("Name");
+            if (name.toLowerCase().startsWith("palm")) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+
+    NodeList experiments = root.getElementsByTagName("Experiment");
+    if (experiments == null || experiments.getLength() == 0) {
+      return false;
+    }
+
+    Element experimentBlock =
+      getFirstNode((Element) experiments.item(0), "ExperimentBlocks");
+    Element acquisition = getFirstNode(experimentBlock, "AcquisitionBlock");
+    if (acquisition == null) {
+      return false;
+    }
+
+    Element multiTrack = getFirstNode(acquisition, "MultiTrackSetup");
+    if (multiTrack == null) {
+      return false;
+    }
+    Element trackSetup = getFirstNode(multiTrack, "TrackSetup");
+    if (trackSetup == null) {
+      return false;
+    }
+    Element palmSlider = getFirstNode(trackSetup, "PalmSlider");
+    if (palmSlider == null) {
+      return false;
+    }
+    return Boolean.parseBoolean(palmSlider.getTextContent());
   }
 
   private void translateInformation(Element root) throws FormatException {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -174,8 +174,6 @@ public class ZeissCZIReader extends FormatReader {
   private int[] tileHeight;
   private int scaleFactor;
 
-  private transient boolean isPALM = false;
-
   // -- Constructor --
 
   /** Constructs a new Zeiss .czi reader. */
@@ -537,7 +535,6 @@ public class ZeissCZIReader extends FormatReader {
       tileWidth = null;
       tileHeight = null;
       scaleFactor = 0;
-      isPALM = false;
     }
   }
 
@@ -1011,6 +1008,7 @@ public class ZeissCZIReader extends FormatReader {
     String firstXML = null;
     boolean canSkipXML = true;
     String currentPath = new Location(currentId).getAbsolutePath();
+    boolean isPALM = false;
     if (planes.size() <= 2 && getImageCount() <= 2) {
       for (Segment segment : segments) {
         String path = new Location(segment.filename).getAbsolutePath();


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/12469, see also https://trello.com/c/y6KpD3sU/18-czi-tickets

I would expect tests to remain green and memo files to be unaffected.  The following are new or previously untested files:

```
data_repo/curated/zeiss-czi/qa-11007/SCC47 EGF647 LAMP1488 - LAMP1 only 3D with 405 2_PALM - KAthrin.czi
data_repo/curated/zeiss-czi/qa-11007/SCC47 EGF647 LAMP1488 - EGF only 3D with 405_PALM.czi
data_repo/curated/zeiss-czi/qa-17616/abeta647-dilution1milliontimesnanomolar.czi
data_repo/curated/zeiss-czi/qa-9410/cav_PALM_drift_correct_Convert to Image.czi
data_repo/curated/zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Image 5_PALM_verrechnet.czi
data_repo/curated/zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/PALM_OnlineVerrechnet.czi
data_repo/curated/zeiss-czi/zeiss/ZEN 2.1 black LSM 880 -May 2015/Palm_Source.czi
```
and existing files with updated configuration:

```
data_repo/curated/zeiss-czi/zeiss/dvds/lsm-disk1/CZI-Example Data LSM/PALM/Palm_mitDrift.czi
```

For each, compare in ZEN vs. ```showinf``` or ImageJ with this PR.  With the exception of ```Palm_Source.czi```, I'd expect ZEN to show either one or two channels with the same XY size.  The first channel is stored at a higher resolution, but downsampled for display; if you mouse over the image, you can see that pixel values are not displayed.  The ```Histo``` tab can be used to confirm pixel min/max values, otherwise it's a matter of checking whether the image looks roughly the same in ```showinf```/ImageJ.  The second channel, if present, is stored and displayed at the same (lower) resolution; the pixel values will be shown if you mouse over the image in ZEN.

```showinf```/ImageJ should show the two channels as being split into separate series due to the difference in XY size.  The images and pixel min/max values should look the same as in ZEN, and basic metadata (physical pixel size, channel names, etc.) should match.

```Palm_Source.czi``` is a special case in that Bio-Formats detects a single channel with 100 timepoints, where ZEN shows 2 channels as described above.  All 100 timepoints should show data, and that image count is consistent with the size of the file.  The thumbnail in the right-hand panel of ZEN should be consistent with the images returned by Bio-Formats.  My understanding is that ZEN Lite does not have true PALM support (only ZEN black does), so in my opinion ZEN is not definitive in this case and what Bio-Formats does is reasonable.  If there is a usable installation of ZEN black, that be more definitive, else happy to hear other thoughts on how this file should be handled.