### PR TITLE
CellSens .vsi: add option to fail on missing .ets file

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/config/CellSensWidgets.java
+++ b/components/bio-formats-plugins/src/loci/plugins/config/CellSensWidgets.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * Bio-Formats Plugins for ImageJ: a collection of ImageJ plugins including the
+ * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
+ * Data Browser and Stack Slicer.
+ * %%
+ * Copyright (C) 2006 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.plugins.config;
+
+import ij.Prefs;
+
+import java.awt.Component;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.JCheckBox;
+
+import loci.formats.in.CellSensReader;
+import loci.plugins.util.LociPrefs;
+
+/**
+ * Custom widgets for configuring Bio-Formats CellSens .vsi support.
+ *
+ */
+public class CellSensWidgets implements IFormatWidgets, ItemListener {
+
+  // -- Fields --
+
+  private String[] labels;
+  private Component[] widgets;
+
+  // -- Constructor --
+
+  public CellSensWidgets() {
+    boolean failOnMissing = Prefs.get(LociPrefs.PREF_CELLSENS_FAIL,
+      CellSensReader.FAIL_ON_MISSING_DEFAULT);
+
+    String failOnMissingLabel = "Fail";
+    JCheckBox failOnMissingBox = new JCheckBox(
+      "Throw an exception if an expected .ets file is missing", failOnMissing);
+    failOnMissingBox.addItemListener(this);
+
+    labels = new String[] {failOnMissingLabel};
+    widgets = new Component[] {failOnMissingBox};
+  }
+
+  // -- IFormatWidgets API methods --
+
+  @Override
+  public String[] getLabels() {
+    return labels;
+  }
+
+  @Override
+  public Component[] getWidgets() {
+    return widgets;
+  }
+
+  // -- ItemListener API methods --
+
+  @Override
+  public void itemStateChanged(ItemEvent e) {
+    JCheckBox box = (JCheckBox) e.getSource();
+    if (box.equals(getWidgets()[0])) {
+      Prefs.set(LociPrefs.PREF_CELLSENS_FAIL, box.isSelected());
+    }
+  }
+
+}

--- a/components/bio-formats-plugins/src/loci/plugins/util/LociPrefs.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LociPrefs.java
@@ -32,6 +32,7 @@ import ij.Prefs;
 import loci.formats.ClassList;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.in.CellSensReader;
 import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.LIFReader;
 import loci.formats.in.MetadataOptions;
@@ -67,6 +68,8 @@ public final class LociPrefs {
     "bioformats.nativend2.chunkmap";
   public static final String PREF_LEICA_LIF_PHYSICAL_SIZE =
     "bioformats.leicalif.physicalsize.compatibility";
+  public static final String PREF_CELLSENS_FAIL =
+    "bioformats.cellsens.fail_on_missing_ets";
 
   // -- Constructor --
 
@@ -103,6 +106,8 @@ public final class LociPrefs {
         NativeND2Reader.USE_CHUNKMAP_KEY, useND2Chunkmap());
       ((DynamicMetadataOptions) options).setBoolean(
         LIFReader.OLD_PHYSICAL_SIZE_KEY, isLeicaLIFPhysicalSizeBackwardsCompatible());
+      ((DynamicMetadataOptions) options).setBoolean(
+        CellSensReader.FAIL_ON_MISSING_KEY, isCellsensFailOnMissing());
       reader.setMetadataOptions(options);
     }
 
@@ -188,6 +193,10 @@ public final class LociPrefs {
   public static boolean isLeicaLIFPhysicalSizeBackwardsCompatible() {
     return Prefs.get(PREF_LEICA_LIF_PHYSICAL_SIZE,
       LIFReader.OLD_PHYSICAL_SIZE_DEFAULT);
+  }
+
+  public static boolean isCellsensFailOnMissing() {
+    return Prefs.get(PREF_CELLSENS_FAIL, CellSensReader.FAIL_ON_MISSING_DEFAULT);
   }
 
   // -- Helper methods --

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1430,10 +1430,6 @@ public class CellSensReader extends FormatReader {
           return;
         }
 
-        if (tag == EXTERNAL_FILE_PROPERTIES) {
-          expectETS = true;
-        }
-
         if (tag == EXTERNAL_FILE_PROPERTIES && previousTag == IMAGE_FRAME_VOLUME) {
           metadataIndex++;
         }
@@ -1725,6 +1721,10 @@ public class CellSensReader extends FormatReader {
           if (tag == DOCUMENT_TIME || tag == CREATION_TIME) {
             value = DateTools.convertDate(
               Long.parseLong(value) * 1000, DateTools.UNIX);
+          }
+
+          if (tag == HAS_EXTERNAL_FILE) {
+            expectETS = Integer.parseInt(value) == 1;
           }
 
           if (tagName != null && populateMetadata) {

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -63,6 +63,9 @@ public class CellSensReader extends FormatReader {
 
   // -- Constants --
 
+  public static final String FAIL_ON_MISSING_KEY = "cellsens.fail_on_missing_ets";
+  public static final boolean FAIL_ON_MISSING_DEFAULT = false;
+
   // Compression types
   private static final int RAW = 0;
   private static final int JPEG = 2;
@@ -399,6 +402,8 @@ public class CellSensReader extends FormatReader {
 
   private ArrayList<Pyramid> pyramids = new ArrayList<Pyramid>();
 
+  private transient boolean expectETS = false;
+
   // -- Constructor --
 
   /** Constructs a new cellSens reader. */
@@ -408,6 +413,18 @@ public class CellSensReader extends FormatReader {
     suffixSufficient = true;
     datasetDescription = "One .vsi file and an optional directory with a " +
       "similar name that contains at least one subdirectory with .ets files";
+  }
+
+  // -- CellSensReader API methods --
+
+
+  public boolean failOnMissingETS() {
+    MetadataOptions options = getMetadataOptions();
+    if (options instanceof DynamicMetadataOptions) {
+      return ((DynamicMetadataOptions) options).getBoolean(
+       FAIL_ON_MISSING_KEY, FAIL_ON_MISSING_DEFAULT);
+    }
+    return FAIL_ON_MISSING_DEFAULT;
   }
 
   // -- IFormatReader API methods --
@@ -589,6 +606,7 @@ public class CellSensReader extends FormatReader {
       backgroundColor.clear();
       metadataIndex = -1;
       previousTag = 0;
+      expectETS = false;
     }
   }
 
@@ -652,6 +670,19 @@ public class CellSensReader extends FormatReader {
     }
     files.add(file.getAbsolutePath());
     usedFiles = files.toArray(new String[files.size()]);
+
+    if (expectETS && files.size() == 1) {
+      String message = "Missing expected .ets files in " + pixelsDir.getAbsolutePath();
+      if (failOnMissingETS()) {
+        throw new FormatException(message);
+      }
+      else {
+        LOGGER.warn(message);
+      }
+    }
+    else if (!expectETS && files.size() > 1) {
+      LOGGER.warn(".ets files present but not expected");
+    }
 
     int seriesCount = files.size();
     core.clear();
@@ -1397,6 +1428,10 @@ public class CellSensReader extends FormatReader {
             vsi.skipBytes(dataSize);
           }
           return;
+        }
+
+        if (tag == EXTERNAL_FILE_PROPERTIES) {
+          expectETS = true;
         }
 
         if (tag == EXTERNAL_FILE_PROPERTIES && previousTag == IMAGE_FRAME_VOLUME) {

--- a/docs/sphinx/formats/options.rst
+++ b/docs/sphinx/formats/options.rst
@@ -14,7 +14,7 @@ Reader options
      - Option
      - Default
      - Description
-   * - :doc:`cellsens`
+   * - :doc:`cellsens-vsi`
      - ``cellsens.fail_on_missing_ets``
      - false
      - Throw an exception if an expected associated .ets file is missing

--- a/docs/sphinx/formats/options.rst
+++ b/docs/sphinx/formats/options.rst
@@ -14,6 +14,10 @@ Reader options
      - Option
      - Default
      - Description
+   * - :doc:`cellsens`
+     - ``cellsens.fail_on_missing_ets``
+     - false
+     - Throw an exception if an expected associated .ets file is missing
    * - :doc:`leica-lif`
      - ``leicalif.old_physical_size``
      - false


### PR DESCRIPTION
See https://trello.com/c/fkWsjC4R/157-vsi-detect-warn-about-missing-ets-folder

This updates ```CellSensReader``` to detect whether one or more .ets files are expected.  By default, if an .ets file is expected but not present, then a message will be logged at ```WARN```.  If the new ```cellsens.fail_on_missing_ets``` option is set to true, then a ```FormatException``` will be thrown instead.  If an .ets file is present but not expected, a message will be logged at ```WARN``` no matter what.

We have the following datasets with no .ets file:

```
/ome/data_repo/curated/cellsens/samples/Channels/Composite.vsi
/ome/data_repo/curated/cellsens/samples/Count & Measure/Cell Multichannel-z-stack corr..vsi
/ome/data_repo/curated/cellsens/samples/Count & Measure/Cell Multichannel-z-stack.vsi
/ome/data_repo/curated/cellsens/samples/Fluorescence/Dako_CISH.vsi
/ome/data_repo/curated/cellsens/robert/Lung_Mite.vsi
```

With this change, ```showinf -nopix``` on each of the ```samples``` datasets should not log anything - as these are official example datasets, it's expected that there are no missing files.  ```showinf -nopix``` on ```Lung_Mite.vsi``` should log a warning regarding missing .ets files; ```showinf -nopix -option cellsens.fail_on_missing_ets true``` should throw an exception instead.  This is a community submitted example, and it's reasonable to assume that part of the dataset was omitted during upload.  For confirmation, removing the .ets files from any of the complete datasets should show the same behavior.

The new option is also propagated to the ImageJ plugin, so setting/unsetting it as described in the docs should result in an exception or warning as with ```showinf``` on ```Lung_Mite.vsi```.