### PR TITLE
Gatan dm3/dm4: add stack and ROI support

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -598,8 +598,7 @@ public class GatanReader extends FormatReader {
         }
 
         boolean validPhysicalSize = parent != null && (parent.equals("Dimension") ||
-          ((pixelSizes.size() == 4 || units.size() == 4) &&
-          (parent.equals("Transform List") || parent.equals("2"))));
+          ((pixelSizes.size() == 4 || units.size() == 4) && parent.equals("2")));
         if (labelString.equals("Scale") && validPhysicalSize) {
           if (value.indexOf(',') == -1) {
             pixelSizes.add(f.parse(value).doubleValue());


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/5871 and https://trac.openmicroscopy.org/ome/ticket/13057

This adds support for Z stacks and ROIs to ```GatanReader```, and cleans up several bugs in tag parsing accordingly.

To test ROI support, use ```data_repo/curated/gatan/melissa/annotation-test.dm3``` and ```data_repo/curated/gatan/melissa/annotation-test.tif```.  Without this PR, ```showinf -omexml -nopix annotation-test.dm3``` should not show any populated ROIs.  With this PR, the same test should show 8 ROIs linked to the ```Image```, and no OME-XML validation errors.  Opening ```annotation-test.dm3``` in ImageJ with this PR and ```Display ROIs``` checked should show 8 ROIs, all matching what is in ```annotation-test.tif``` (which has the ROIs burned in).

To test Z stack support, use ```data_repo/curated/gatan/emdb/BGal_000438_frames.dm4```.  Without this PR,  ```showinf -nopix``` should throw a ```FormatException``` as indicated in http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2015-October/003480.html.  The same test with this PR should show 38 Z sections; the dimensions should all match what is listed in the ```Sample set of multi-frame micrographs``` section of http://www.ebi.ac.uk/pdbe/emdb/empiar/entry/10013/ (the source of this file).