### PR TITLE
JPEGTileDecoder: Implement and use AutoCloseable

### DIFF
--- a/components/formats-bsd/src/loci/formats/codec/JPEGTileDecoder.java
+++ b/components/formats-bsd/src/loci/formats/codec/JPEGTileDecoder.java
@@ -36,7 +36,7 @@ import loci.common.RandomAccessInputStream;
 
 /**
  */
-public class JPEGTileDecoder {
+public class JPEGTileDecoder implements AutoCloseable {
   private ome.codecs.JPEGTileDecoder decoder;
 
   public JPEGTileDecoder() {

--- a/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TileJPEGReader.java
@@ -103,10 +103,10 @@ public class TileJPEGReader extends FormatReader {
     super.initFile(id);
 
     in = new RandomAccessInputStream(id);
-    JPEGTileDecoder decoder = new JPEGTileDecoder();
-    int[] dimensions = decoder.preprocess(in);
-    decoder.close();
-    decoder = null;
+    int[] dimensions;
+    try (JPEGTileDecoder decoder = new JPEGTileDecoder()) {
+      dimensions = decoder.preprocess(in);
+    }
 
     CoreMetadata m = core.get(0);
 

--- a/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
@@ -321,10 +321,11 @@ public class HamamatsuVMSReader extends FormatReader {
           break;
       }
 
-      JPEGTileDecoder decoder = new JPEGTileDecoder();
-      RandomAccessInputStream s = new RandomAccessInputStream(file);
-      int[] dims = decoder.preprocess(s);
-      s.close();
+      int[] dims;
+      try (RandomAccessInputStream s = new RandomAccessInputStream(file);
+           JPEGTileDecoder decoder = new JPEGTileDecoder()) {
+        dims = decoder.preprocess(s);
+      }
 
       CoreMetadata m = new CoreMetadata();
       if (i == 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <ome-jai.version>0.1.0</ome-jai.version>
-    <ome-codecs.version>0.1.0</ome-codecs.version>
+    <ome-codecs.version>0.2.0</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->


### PR DESCRIPTION
Clean up automatically to prevent resource leaks.  Followup for the corresponding change in ome-codecs.

Testing: check all jobs are green.