### PR TITLE
Rebase FlexReader changes from metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1053,6 +1053,9 @@ public class FlexReader extends FormatReader {
     if (fieldCount == 1) {
       fieldCount *= (nFiles / runCount);
     }
+    if (fieldCount == 0) {
+      fieldCount = 1;
+    }
 
     int seriesCount = runCount * plateCount * wellCount * fieldCount;
     if (seriesCount > 1) {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -204,13 +204,20 @@ public class FlexReader extends FormatReader {
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
 
-    FlexFile file = lookupFile(0);
-    IFD ifd = file.ifds.get(0);
-    try {
-      return (int) ifd.getTileWidth();
+    int index = 0;
+    FlexFile file = lookupFile(index);
+    while ((file == null || file.ifds == null) && index < getSeriesCount()) {
+      index++;
+      file = lookupFile(index);
     }
-    catch (FormatException e) {
-      LOGGER.debug("Could not retrieve tile width", e);
+    if (file != null && file.ifds != null && file.ifds.size() > 0) {
+      IFD ifd = file.ifds.get(0);
+      try {
+        return (int) ifd.getTileWidth();
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Could not retrieve tile width", e);
+      }
     }
     return super.getOptimalTileWidth();
   }
@@ -220,13 +227,20 @@ public class FlexReader extends FormatReader {
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
 
-    FlexFile file = lookupFile(0);
-    IFD ifd = file.ifds.get(0);
-    try {
-      return (int) ifd.getTileLength();
+    int index = 0;
+    FlexFile file = lookupFile(index);
+    while ((file == null || file.ifds == null) && index < getSeriesCount()) {
+      index++;
+      file = lookupFile(index);
     }
-    catch (FormatException e) {
-      LOGGER.debug("Could not retrieve tile height", e);
+    if (file != null && file.ifds != null && file.ifds.size() > 0) {
+      IFD ifd = file.ifds.get(0);
+      try {
+        return (int) ifd.getTileLength();
+      }
+      catch (FormatException e) {
+        LOGGER.debug("Could not retrieve tile height", e);
+      }
     }
     return super.getOptimalTileHeight();
   }

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1369,7 +1369,7 @@ public class FlexReader extends FormatReader {
           FlexFile file = new FlexFile();
           file.row = row;
           file.column = col;
-          file.field = field % runCount;
+          file.field = field % (nFiles / (wellCount * runCount));
           file.file = files.get(field);
           file.acquisition = runDirs.size() == 0 ? 0:
             runDirs.indexOf(new Location(file.file).getParentFile());

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -242,6 +242,9 @@ public class FlexReader extends FormatReader {
 
     FlexFile firstFile = lookupFile(0);
     FlexFile file = lookupFile(getSeries());
+    if (file == null) {
+      return buf; // EARLY EXIT
+    }
 
     int[] lengths =
       new int[] {fieldCount / effectiveFieldCount, wellCount, plateCount, runCount};

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -565,7 +565,18 @@ public class FlexReader extends FormatReader {
     for (int run=0; run<runCount; run++) {
       String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, run);
       store.setPlateAcquisitionID(plateAcqID, 0, run);
-      store.setPlateAcquisitionName(runDirs.get(run).getName(), 0, run);
+
+      String acqName = runDirs.get(run).getName();
+      store.setPlateAcquisitionName(acqName, 0, run);
+
+      int timeStart = acqName.indexOf("(");
+      if (timeStart > 0) {
+        String time = acqName.substring(timeStart);
+        time = DateTools.formatDate(time, "(yyyy-MM-dd_HH-mm-ss)");
+
+        store.setPlateAcquisitionStartTime(new Timestamp(time), 0, run);
+        plateAcqStartTime = null;
+      }
 
       PositiveInteger maxFieldCount = FormatTools.getMaxFieldCount(fieldCount);
       if (maxFieldCount != null) {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -829,7 +829,7 @@ public class FlexReader extends FormatReader {
    * If the 'firstFile' flag is set, then the core metadata is also
    * populated.
    */
-  private void parseFlexFile(int currentWell, int wellRow, int wellCol,
+  private boolean parseFlexFile(int currentWell, int wellRow, int wellCol,
     int field, boolean firstFile, MetadataStore store)
     throws FormatException, IOException
   {
@@ -838,7 +838,7 @@ public class FlexReader extends FormatReader {
     int fieldIndex = field < 0 || fieldCount == 0 ? 0 : field % fieldCount;
     int runIndex = field < 0 || fieldCount == 0 ? 0 : field / fieldCount;
     FlexFile file = lookupFile(wellRow, wellCol, fieldIndex, runIndex);
-    if (file == null) return;
+    if (file == null) return false;
 
     int originalFieldCount = fieldCount;
 
@@ -966,6 +966,7 @@ public class FlexReader extends FormatReader {
     if (oneFactors) {
       file.factors = null;
     }
+    return true;
   }
 
   /** Populate core metadata using the given list of image names. */
@@ -1406,9 +1407,9 @@ public class FlexReader extends FormatReader {
 
           // setting a negative field index indicates that the field count
           // should be taken from the XML
-          parseFlexFile(currentWell, row, col, nFiles == 1 ? -1 : field, firstFile, store);
+          boolean parsedXML = parseFlexFile(currentWell, row, col, nFiles == 1 ? -1 : field, firstFile, store);
           s.close();
-          if (firstFile) firstFile = false;
+	  if (firstFile && parsedXML) firstFile = false;
         }
         currentWell++;
       }
@@ -1555,9 +1556,8 @@ public class FlexReader extends FormatReader {
         plateBarcodes.add(value);
         if (plateBarcodes.size() > size) {
           nextPlate++;
-          plateCount++;
         }
-        if (populateCore) {
+        if (populateCore && value != null && nextPlate == 1) {
           store.setPlateExternalIdentifier(value, nextPlate - 1);
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1356,6 +1356,9 @@ public class FlexReader extends FormatReader {
           continue;
         }
 
+        // 'files' represents all of the files for a specific well
+        // this can be a combination of runs and fields
+
         nFiles = files.size();
 
         String[] sortedFiles = files.toArray(new String[files.size()]);
@@ -1369,7 +1372,7 @@ public class FlexReader extends FormatReader {
           FlexFile file = new FlexFile();
           file.row = row;
           file.column = col;
-          file.field = field % (nFiles / (wellCount * runCount));
+          file.field = field % (nFiles / runCount);
           file.file = files.get(field);
           file.acquisition = runDirs.size() == 0 ? 0:
             runDirs.indexOf(new Location(file.file).getParentFile());

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -275,7 +275,7 @@ public class FlexReader extends FormatReader {
       ifd = file.ifds.get(imageNumber);
       factor = 1d;
     }
-    else {
+    else if (firstFile != null && firstFile.ifds != null) {
       // Only the first IFD was read. Hack the IFD to adjust the offset.
       final IFD firstIFD = firstFile.ifds.get(0);
       ifd = new IFD(firstIFD);
@@ -297,6 +297,9 @@ public class FlexReader extends FormatReader {
         offsets[i] += offset;
       }
       ifd.putIFDValue(tag, offsets);
+    }
+    else {
+      return buf;
     }
     int nBytes = ifd.getBitsPerSample()[0] / 8;
     int bpp = FormatTools.getBytesPerPixel(getPixelType());

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -565,6 +565,7 @@ public class FlexReader extends FormatReader {
     for (int run=0; run<runCount; run++) {
       String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, run);
       store.setPlateAcquisitionID(plateAcqID, 0, run);
+      store.setPlateAcquisitionName(runDirs.get(run).getName(), 0, run);
 
       PositiveInteger maxFieldCount = FormatTools.getMaxFieldCount(fieldCount);
       if (maxFieldCount != null) {
@@ -624,8 +625,15 @@ public class FlexReader extends FormatReader {
       String instrumentID = MetadataTools.createLSID("Instrument", 0);
       store.setInstrumentID(instrumentID, 0);
 
-      if (plateName == null) plateName = currentFile.getParentFile().getName();
-      if (plateBarcodes.size() > 0) plateName = plateBarcodes.iterator().next() + " " + plateName;
+      if (plateName == null) {
+        if (runCount <= 1) {
+          plateName = " " + currentFile.getParentFile().getName();
+        }
+        else {
+          plateName = "";
+        }
+      }
+      if (plateBarcodes.size() > 0) plateName = plateBarcodes.iterator().next() + plateName;
       store.setPlateName(plateName, 0);
       store.setPlateRowNamingConvention(getNamingConvention("Letter"), 0);
       store.setPlateColumnNamingConvention(getNamingConvention("Number"), 0);


### PR DESCRIPTION
Rebases `FlexReader` changes **only** from #1845, #1976, #2112, #2175. Does **not** rebase 0567d4379fdd0d9c0d3f268f7846948d7592491e and 0097d895c5e85c4dcfb0e4f3bc0af93ebe879e41 because they contain changes to `MetadataConverter`, which has been essentially "moved" to ome-model after #2677. In addition, there are previous changes to `MetadataConverter` in the `metadata` branch since it was forked, so even porting the changes to ome-model has prerequisites.

--breaking