### PR TITLE
Add missing SIF format to docs

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -160,6 +160,7 @@ owner = `Andor Technology <http://www.andor.com/>`_
 developer = Andor Bioimaging Department
 bsd = no
 weHave = * a small number of Andor SIF datasets
+weWant = * an Andor SIF specification document
 pixelsRating = Good
 metadataRating = Fair
 opennessRating = Fair

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -154,6 +154,19 @@ mif = true
 notes = With a few minor exceptions, the ABD-TIFF format is identical to the \n
 Fluoview TIFF format.
 
+[Andor SIF]
+extensions = .sif
+owner = `Andor Technology <http://www.andor.com/>`_
+developer = Andor Bioimaging Department
+bsd = no
+weHave = * a small number of Andor SIF datasets
+pixelsRating = Good
+metadataRating = Fair
+opennessRating = Fair
+presenceRating = Fair
+utilityRating = Fair
+reader = SIFReader
+
 [Animated PNG]
 extensions = .png
 developer = `The Animated PNG Project <http://www.animatedpng.com/>`_

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2039,7 +2039,7 @@ extensions = .mov
 owner = `Apple Computer <http://www.apple.com/>`_
 bsd = yes
 software = `QuickTime Player <https://support.apple.com/downloads/quicktime>`_
-weHave = * a `QuickTime specification document <https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFPreface/qtffPreface.html>`_ \n
+weHave = * a `QuickTime specification document <https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFPreface/qtffPreface.html#//apple_ref/doc/uid/TP40000939>`_ \n
 * several QuickTime datasets \n
 * the ability to produce more datasets
 weWant = * more QuickTime datasets, including: \n

--- a/docs/sphinx/formats/andor-sif.rst
+++ b/docs/sphinx/formats/andor-sif.rst
@@ -1,0 +1,49 @@
+.. index:: Andor SIF
+.. index:: .sif
+
+Andor SIF
+===============================================================================
+
+Extensions: .sif
+
+Developer: `Andor Technology <http://www.andor.com/>`_
+
+
+**Support**
+
+
+BSD-licensed: |no|
+
+Export: |no|
+
+Officially Supported Versions: 
+
+Reader: SIFReader (:bfreader:`Source Code <SIFReader.java>`, :doc:`Supported Metadata Fields </metadata/SIFReader>`)
+
+
+
+
+We currently have:
+
+* a small number of Andor SIF datasets
+
+We would like to have:
+
+* a specification document
+
+
+**Ratings**
+
+
+Pixels: |Good|
+
+Metadata: |Fair|
+
+Openness: |Fair|
+
+Presence: |Fair|
+
+Utility: |Fair|
+
+
+

--- a/docs/sphinx/supported-formats.rst
+++ b/docs/sphinx/supported-formats.rst
@@ -111,6 +111,17 @@ You can sort this table by clicking on any of the headings.
      - |no|
      - |no|
      - |no|
+   * - :doc:`formats/andor-sif`
+     - .sif
+     - |Good|
+     - |Fair|
+     - |Fair|
+     - |Fair|
+     - |Fair|
+     - |no|
+     - |no|
+     - |no|
+     - |no|
    * - :doc:`formats/animated-png`
      - .png
      - |Very good|
@@ -1708,6 +1719,7 @@ Bio-Formats currently supports **146** formats
     formats/amira-mesh
     formats/amnis-flowsight
     formats/analyze-75
+    formats/andor-sif
     formats/animated-png
     formats/aperio-afi
     formats/aperio-svs-tiff


### PR DESCRIPTION
While testing a PR in Bio-Formats 5.5.3 (https://github.com/openmicroscopy/bioformats/pull/2876) I noticed that we were missing SIF on the formats docs pages.

I have tried to base the ratings on the comments from https://trello.com/c/WmLyfC5N/7-rfe-update-format-metadata-support-ratings

The reader itself is very basic and doesn't support many metadata fields.