### PR TITLE
Imspector metadata fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -416,6 +416,8 @@ public class ImspectorReader extends FormatReader {
         else if (key.equals("xyz-Table Z Resolution")) {
           int z = DataTools.parseDouble(value).intValue();
           if (z == 1 && getSizeZ() > 1) {
+            originalT = getSizeT();
+            originalZ = getSizeZ();
             m.sizeT *= getSizeZ();
             m.sizeZ = 1;
           }
@@ -439,6 +441,9 @@ public class ImspectorReader extends FormatReader {
       if (getSizeZ() == 1 || getSizeT() == 1) {
         m.sizeZ = 1;
         m.sizeT = m.imageCount;
+        if (m.imageCount % uniquePMTs.size() == 0) {
+          m.sizeT /= uniquePMTs.size();
+        }
       }
       LOGGER.debug("m.imageCount = {}", m.imageCount);
       m.moduloT.parentType = FormatTools.SPECTRA;
@@ -602,7 +607,7 @@ public class ImspectorReader extends FormatReader {
     // as far as we know, valid PMT names only start with "PMT" or "TCSPC",
     // depending upon the acquisition mode
     if (!uniquePMTs.contains(pmt) && (pmt.startsWith("PMT") ||
-      pmt.startsWith("TCSPC")))
+      pmt.indexOf("TCSPC") >= 0))
     {
       uniquePMTs.add(pmt);
     }
@@ -619,6 +624,7 @@ public class ImspectorReader extends FormatReader {
       newCount * planeSize < in.length() - in.getFilePointer() &&
       newCount > 0 && newCount * planeSize > 0)
     {
+      uniquePMTs.remove(0);
       planesPerBlock.remove(planesPerBlock.size() - 1);
       pixelsOffsets.remove(pixelsOffsets.size() - 1);
       m.sizeZ = newZ;

--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -171,6 +171,7 @@ public class ImspectorReader extends FormatReader {
 
     int check = in.readShort();
     while (check != 3 && check != 2) {
+      in.seek(in.getFilePointer() - 1);
       check = in.readShort();
     }
 
@@ -418,7 +419,9 @@ public class ImspectorReader extends FormatReader {
       m.moduloT.type = FormatTools.LIFETIME;
 
       m.sizeC = m.imageCount / (m.sizeZ * m.sizeT);
-      if (getSizeZ() > 1 && getSizeT() > 1) {
+      if (getSizeZ() > 1 && getSizeT() > 1 &&
+        getSizeZ() < getSizeT())
+      {
         m.dimensionOrder = "XYTZC";
       }
       else {

--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -320,9 +321,11 @@ public class ImspectorReader extends FormatReader {
             value = String.valueOf(in.readInt() == 1);
             break;
           case 2:
+          case 3:
           case 9:
           case 13:
           case 14:
+          case 17:
             key = value;
             value = String.valueOf(in.readFloat());
             break;
@@ -400,6 +403,7 @@ public class ImspectorReader extends FormatReader {
         addGlobalMeta(key, value);
 
         if (key.equals("TCSPC  Z Length") ||
+          key.equals("TDC  Z Length") ||
           key.equals("DC-TCSPC T Length"))
         {
           try {
@@ -410,7 +414,7 @@ public class ImspectorReader extends FormatReader {
           catch (NumberFormatException e) { }
         }
         else if (key.equals("xyz-Table Z Resolution")) {
-          int z = Integer.parseInt(value);
+          int z = DataTools.parseDouble(value).intValue();
           if (z == 1 && getSizeZ() > 1) {
             m.sizeT *= getSizeZ();
             m.sizeZ = 1;


### PR DESCRIPTION
This fixes several metadata parsing bugs in ```ImspectorReader``` that affect the dimensions and ```ModuloAlongT```.  The following tickets should be fixed with these changes:

https://trac.openmicroscopy.org/ome/ticket/13002
https://trac.openmicroscopy.org/ome/ticket/13180
https://trac.openmicroscopy.org/ome/ticket/13181
https://trac.openmicroscopy.org/ome/ticket/13182

Existing Imspector .msr files should be unaffected, but new files for QA 17102 and QA 11369 need to be tested.  Ticket 13180 references a file in QA 17101, but the same file is also present in QA 17102.

For each file, check ```showinf -nopix -omexml``` and verify that the ```step``` in ```ModuloAlongT``` matches the time per FLIM channel referenced in each ticket (usually 220.875 ps).  If an expected value is not in the tickets, check that ```end``` in ```ModuloAlongT``` is greater than 1.

Also verify that ```SizeZ```, ```SizeC```, and ```SizeT``` match the expected values in the tickets.  The images will be easier to check in ImageJ; in particular check that the second channel looks plausible (for files with ```SizeC == 2```) and that the plane ordering seems sensible (i.e. the dimension order is not mixed up).

This should not affect memo files, so could be deferred until 5.6.1 if necessary.  If @imunro gets a chance, a quick review from the original reporter/triager of the above tickets might be useful.
