### PR TITLE
Fix file extension missing bug

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -578,6 +578,10 @@ public class ZeissCZIReader extends FormatReader {
     super.initFile(id);
 
     parser = XMLTools.createBuilder();
+    // manage the case when extension is missing
+    if (id.lastIndexOf(".") == -1) {
+  	  id = id + ".czi";
+    }
 
     // switch to the master file if this is part of a multi-file dataset
     String base = id.substring(0, id.lastIndexOf("."));

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -578,13 +578,12 @@ public class ZeissCZIReader extends FormatReader {
     super.initFile(id);
 
     parser = XMLTools.createBuilder();
-    // manage the case when extension is missing
-    if (id.lastIndexOf(".") == -1) {
-  	  id = id + ".czi";
-    }
 
     // switch to the master file if this is part of a multi-file dataset
-    String base = id.substring(0, id.lastIndexOf("."));
+    String base = id;
+    if (~id.lastIndexOf(".") == -1) {
+    		base = id.substring(0, id.lastIndexOf("."));
+    }
     if (base.endsWith(")") && isGroupFiles()) {
       LOGGER.info("Checking for master file");
       int lastFileSeparator = base.lastIndexOf(File.separator);
@@ -626,8 +625,10 @@ public class ZeissCZIReader extends FormatReader {
 
     Location file = new Location(id).getAbsoluteFile();
     base = file.getName();
-    base = base.substring(0, base.lastIndexOf("."));
-
+    if (~base.lastIndexOf(".") == -1) {
+    		base = base.substring(0, base.lastIndexOf("."));
+    }
+    
     Location parent = file.getParentFile();
     String[] list = parent.list(true);
     for (String f : list) {
@@ -1397,10 +1398,7 @@ public class ZeissCZIReader extends FormatReader {
     if (in != null) {
       in.close();
     }
-    File f = new File(id);
-    if (!f.exists()){
-    		id = id.substring(0, id.lastIndexOf('.'));
-    }
+
     in = new RandomAccessInputStream(id, BUFFER_SIZE);
     in.order(isLittleEndian());
     while (in.getFilePointer() < in.length()) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1397,6 +1397,10 @@ public class ZeissCZIReader extends FormatReader {
     if (in != null) {
       in.close();
     }
+    File f = new File(id);
+    if (!f.exists()){
+    		id = id.substring(0, id.lastIndexOf('.'));
+    }
     in = new RandomAccessInputStream(id, BUFFER_SIZE);
     in.order(isLittleEndian());
     while (in.getFilePointer() < in.length()) {


### PR DESCRIPTION
ref: https://trello.com/c/m7LqcpdM/167-czi-reader-fails-when-the-extension-is-missing

Testing instructions:
1) Using bftools please open an CZI file from /data_repo/curated/zeiss-czi/ (Should open without any issues)
2) please copy the file locally and remove the ".czi" extension and try opening the file again using bftools (Should open without any issues)

Without this PR, you should get the following error for the file without the ".czi" extension in bftools (5.5.3),
`Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1967)
	at loci.formats.in.ZeissCZIReader.initFile(ZeissCZIReader.java:583)
	at loci.formats.FormatReader.setId(FormatReader.java:1397)
	at loci.formats.ImageReader.setId(ImageReader.java:839)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1031)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1117)`

As always code review please : 
@melissalinkert @sbesson 