### PR TITLE
ant: remove bundles build files during 'clean'

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -55,7 +55,8 @@ Type "ant -p" for a list of targets.
       clean-bio-formats-tools,
       clean-tests,
       clean-turbojpeg,
-      clean-docs-sphinx"
+      clean-docs-sphinx,
+      clean-bundles"
     description="remove build files for all components">
     <delete dir="${artifact.dir}"/>
     <delete dir="build"/>
@@ -383,6 +384,12 @@ Type "ant -p" for a list of targets.
   </target>
 
   <!-- Tool collections -->
+
+  <target name="clean-bundles"
+    description="remove build files in bundles component">
+    <ant dir="components/bundles/bioformats_package" target="bioformats_package.clean"/>
+    <ant dir="components/bundles/loci_tools" target="loci_tools.clean"/>
+  </target>
 
   <target name="tools" depends="jars"
     description="generate JAR file bundles of Bio-Formats and dependencies">


### PR DESCRIPTION
This prevents the Maven *-dependencies.xml files from being retained in ```components/bundles/*/build```, as that can cause the bundle jars to include a confusing mix of dependencies.

To reproduce the original problem:

 ```
$ git checkout v5.4.0 # no Olympus .oir support
$ find . -name *-dependencies.xml -exec rm {} \; # clean cached dependencies so that build is really 5.4.0
$ ant clean jars tools
$ showinf -nopix olympus-oir/olympus/40X_4CH_XY.oir # should throw UnknownFormatException as expected
$ git checkout develop # has Olympus .oir support since v5.5.0
$ ant clean jars tools # don't explicitly clean cached dependencies
$ showinf -nopix olympus-oir/olympus/40X_4CH_XY.oir # incorrectly throws UnknownFormatException
```

Repeating the above test, replacing ```develop``` with this PR's branch or the merge branch should result in the .oir file being initialized in the last step, indicating that the 5.4.0 dependency files were automatically removed.