### PR TITLE
Metamorph: Correct DeltaT across channels

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -946,7 +946,7 @@ public class MetamorphReader extends BaseTiffReader {
         Double expTime = exposureTime;
         Double xmlZPosition = null;
 
-        int fileIndex = getIndex(0, 0, coords[2]) / getSizeZ();
+        int fileIndex = getIndex(0, coords[1], coords[2]) / getSizeZ();
         if (fileIndex >= 0) {
           String file = stks == null ? currentId : stks[i][fileIndex];
           if (file != null) {


### PR DESCRIPTION
Issue was originally raised in forum thread https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8325
A sample set of files was also provided in QA-17824

In short each plane should have a unique delta T value, however each channel has the same timepoints as the that of the first channel. This is due to the fact that for the given sample file set, the channels are split across files but when determining which file to read in order to populate metadata the channel index is not taken into account.

Opening this PR to test against other filesets in the data repo