### PR TITLE
TiffSaver: Don't write new IFD for each tile

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -943,7 +943,9 @@ public class TiffSaver {
     else if (isTiled) {
       fp = sequentialTileFilePointer;
     }
-    writeIFD(ifd, 0);
+    if (fp == out.getFilePointer()) { // Create IFD only if at the end of file
+      writeIFD(ifd, 0);
+    }
 
     // strips.length is the total number of strips being written during
     // this method call, which is no more than the total number of


### PR DESCRIPTION
This removes the addition of an unused (and unreferenced) IFD for each call to `TiffSaver.writeImage()` in `TiffSaver.writeIFDStrips()`.  This fixes the problem noted [here](https://trello.com/c/YBsFrE0Q/171-performance-problem-writing-tiles).

Testing: With and without this PR, try bfconverting a large file to a TIFF or OME-TIFF with different tiling parameters.  Without the PR, small tile sizes e.g. 64×64 will cause the file size to bloat dramatically.  This will not occur with the PR merged.