### PR TITLE
Imaris - incorrect dimensions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImarisHDFReader.java
@@ -486,6 +486,14 @@ public class ImarisHDFReader extends FormatReader {
       if (value == null) continue;
       value = value.trim();
 
+      if (attr.startsWith("DataSet/ResolutionLevel_")) {
+        int slash = attr.indexOf("/", 24);
+        int n = Integer.parseInt(attr.substring(24, slash == -1 ?
+          attr.length() : slash));
+        if (n == seriesCount) seriesCount++;
+        if (n > 0) continue;
+      }
+
       if (name.equals("X") || name.equals("ImageSizeX")) {
         try {
           ms0.sizeX = Integer.parseInt(value);
@@ -531,13 +539,6 @@ public class ImarisHDFReader extends FormatReader {
       else if (name.equals("ExtMin0")) minX = Double.parseDouble(value);
       else if (name.equals("ExtMin1")) minY = Double.parseDouble(value);
       else if (name.equals("ExtMin2")) minZ = Double.parseDouble(value);
-
-      if (attr.startsWith("DataSet/ResolutionLevel_")) {
-        int slash = attr.indexOf("/", 24);
-        int n = Integer.parseInt(attr.substring(24, slash == -1 ?
-          attr.length() : slash));
-        if (n == seriesCount) seriesCount++;
-      }
 
       if (attr.startsWith("DataSetInfo/Channel_")) {
         String originalValue = value;


### PR DESCRIPTION
This issue was first raised on twitter https://twitter.com/alexcarisey/status/894714414909104128
A set of QA files has been submitted QA-17835

The issue is caused when the core metadata for the first series is setup during the parseAttributes function. This will identify any additional resolutions to increase the series count. The metadata for these additional series are then setup after the call to parseAttributes. 

What is occuring is that after identifying an additional resolution in parseAttributes it is then continuing to parse those attributes and overwriting the metadata for the first series.

This change means that once a resolution is identified its metadata does not overwrite that of the first series.

To test:
- Ensure all builds and tests are green
- Import the ims files in QA-17835 and verify that the dimensions of the image are correct and match those in the associated tiff