### PR TITLE
Update website & other docs URLs

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1720,7 +1720,7 @@ reader = SISReader
 
 [OME-TIFF]
 indexExtensions = .ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf
-extensions = `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+extensions = :model_doc:`.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <ome-tiff/index.html>`
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01, 2016-06
@@ -1749,7 +1749,7 @@ Commercial applications that support OME-TIFF include: \n
 
 [OME-XML]
 indexExtensions = .ome, .ome.xml
-extensions = `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
+extensions = :model_doc:`.ome, .ome.xml <ome-xml/index.html>`
 developer = `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 bsd = yes
 versions = 2003FC, 2007-06, 2008-02, 2008-09, 2009-09, 2010-04, 2010-06, 2011-06, 2012-06, 2013-06, 2015-01, 2016-06

--- a/docs/sphinx/_templates/globalbftoc.html
+++ b/docs/sphinx/_templates/globalbftoc.html
@@ -1,4 +1,4 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.5/">{{ _('Bio-Formats Downloads') }}</a></br>
-<a href="http://www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>
+<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.6/">{{ _('Bio-Formats Downloads') }}</a></br>
+<a href="https://www.openmicroscopy.org/licensing/">{{ _('Licensing') }}</a>

--- a/docs/sphinx/about/index.rst
+++ b/docs/sphinx/about/index.rst
@@ -28,10 +28,8 @@ command line tools, refer to the :doc:`users documentation </users/index>`.
 You can also find tips on common issues with specific formats on the
 pages linked from the :doc:`supported formats table </supported-formats>`.
 
-Please `contact us 
-<http://www.openmicroscopy.org/site/community/mailing-lists>`__ if
-you have any questions or problems with Bio-Formats not addressed by referring
-to the documentation.
+Please :community:`contact us <>` if you have any questions or problems with
+Bio-Formats not addressed by referring to the documentation.
 
 Other places where questions are commonly asked and/or bugs are reported
 include:

--- a/docs/sphinx/about/index.rst
+++ b/docs/sphinx/about/index.rst
@@ -55,7 +55,7 @@ Bio-Formats versions
 
 Since Bio-Formats 5.1.3, Bio-Formats is decoupled from OMERO with its own
 release schedule rather than being updated whenever a new version of
-:products_plone:`OMERO <omero>` is released.
+:omero:`OMERO <>` is released.
 This change allows for more frequent releases to get fixes out to the
 community faster. See the :doc:`version history <whats-new>` for a list of
 changes in each release.

--- a/docs/sphinx/about/whats-new.rst
+++ b/docs/sphinx/about/whats-new.rst
@@ -1044,7 +1044,7 @@ Java bug fixes:
 
 * Improvements to performance with network file systems
 * Improvements to developer documentation
-* Initial version of `native C++ implementation <http://www.openmicroscopy.org/site/support/bio-formats5.1/developers/cpp/overview.html>`__
+* Initial version of native C++ implementation
 * Improved support for opening and saving ROI data with ImageJ
 * Added support for :doc:`CellH5 </formats/cellh5>` data (thanks to Christoph Sommer)
 * Added support for :doc:`Perkin Elmer Nuance </formats/perkinelmer-nuance>` data (thanks to Lee Kamentsky)

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -119,9 +119,9 @@ bf_cpp = bf_github_blob + 'cpp/'
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
 trac_root = 'https://trac.openmicroscopy.org/ome'
 oo_root = 'http://www.openmicroscopy.org'
-oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
+docs_root = 'http://docs.openmicroscopy.org'
 
 extlinks = {
     # Trac links
@@ -139,18 +139,16 @@ extlinks = {
     # Mailing list/forum links
     'mailinglist' : (lists_root + '/mailman/listinfo/%s', ''),
     'forum' : (oo_root + '/community/%s', ''),
-    # Plone links. Separating them out so that we can add prefixes and
+    # Website links. Separating them out so that we can add prefixes and
     # suffixes during testing.
-    'community_plone' : (oo_site_root + '/community/%s', ''),
-    'products_plone' : (oo_site_root + '/products/%s', ''),
-    'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
-    'legacy_plone' : (oo_site_root + '/support/legacy/%s', ''),
-    'about_plone' : (oo_site_root + '/about/%s', ''),
-    'team_plone' : (oo_site_root + '/team/%s', ''),
-    'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
+    'community' : (oo_root + '/support/%s', ''),
+    'omero' : (oo_root + '/omero/%s', ''),
+    # Documentation
+	 'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', ''),
+    'devs_doc' : (docs_root + '/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/bio-formats5.5/%s', ''),
-    'javadoc' : (downloads_root + '/latest/bio-formats5.5/api/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats5.6/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats5.6/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
     'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_model_version + '/' + '%s', ''),
     'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_model_version + '/' + '%s', ''),

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -144,7 +144,7 @@ extlinks = {
     'community' : (oo_root + '/support/%s', ''),
     'omero' : (oo_root + '/omero/%s', ''),
     # Documentation
-	 'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', ''),
+    'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/bio-formats5.6/%s', ''),

--- a/docs/sphinx/developers/reader-guide.rst
+++ b/docs/sphinx/developers/reader-guide.rst
@@ -307,4 +307,4 @@ Other useful things
   most straightforward one). :bfreader:`loci.formats.in.LIFReader <LIFReader.java>` and :bfreader:`InCellReader <InCellReader.java>` are also
   good references that show off some of the nicer features of Bio-Formats.
 
-If you have questions about Bio-Formats, please contact `the OME team <http://www.openmicroscopy.org/site/community>`_.
+If you have questions about Bio-Formats, please contact :community:`the OME team <>`.

--- a/docs/sphinx/formats/index.rst
+++ b/docs/sphinx/formats/index.rst
@@ -16,7 +16,7 @@ the entries in the supported formats table).
 support for different formats.** If you would like to help, you can upload
 files using our `QA system uploader <http://qa.openmicroscopy.org.uk/qa/upload/>`_.
 If you have any questions, or would prefer not to use QA, please email the
-`ome-users mailing list <http://www.openmicroscopy.org/site/community/mailing-lists>`_.
+:mailinglist:`ome-users mailing list <ome-users>`.
 If your format is already supported, please refer to the 'we would like to
 have' section on the individual page for that format, to see if your dataset
 would be useful to us.

--- a/docs/sphinx/formats/ome-tiff.rst
+++ b/docs/sphinx/formats/ome-tiff.rst
@@ -4,7 +4,7 @@
 OME-TIFF
 ===============================================================================
 
-Extensions: `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+Extensions: :model_doc:`.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <ome-tiff/index.html>`
 
 Developer: `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 

--- a/docs/sphinx/formats/ome-xml.rst
+++ b/docs/sphinx/formats/ome-xml.rst
@@ -4,7 +4,7 @@
 OME-XML
 ===============================================================================
 
-Extensions: `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
+Extensions: :model_doc:`.ome, .ome.xml <ome-xml/index.html>`
 
 Developer: `Open Microscopy Environment <http://www.openmicroscopy.org/>`_
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -24,7 +24,7 @@ Bio-Formats |release| uses the *June 2016* release of the
 **Bio-Formats is a community project and we welcome your input.** You can
 find guidance on :doc:`about/bug-reporting`, upload files to our
 `QA system <http://qa.openmicroscopy.org.uk/qa/upload/>`_ for testing, and
-:community_plone:`contact us <>` via our mailing lists or forums. Further
+:community:`contact us <>` via our mailing lists or forums. Further
 information about how the OME team works and how you can contribute to our
 projects is in the :devs_doc:`Contributing Developer Documentation <>`.
 

--- a/docs/sphinx/pom.xml
+++ b/docs/sphinx/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats Sphinx documentation</name>
   <description>Sphinx-generated Bio-Formats documentation.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <licenses>

--- a/docs/sphinx/supported-formats.rst
+++ b/docs/sphinx/supported-formats.rst
@@ -1091,7 +1091,7 @@ You can sort this table by clicking on any of the headings.
      - |no|
      - |no|
    * - :doc:`formats/ome-tiff`
-     - `.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/index.html>`_
+     - :model_doc:`.ome.tiff, .ome.tif, .ome.tf2, .ome.tf8, .ome.btf <ome-tiff/index.html>`
      - |Outstanding|
      - |Outstanding|
      - |Outstanding|
@@ -1102,7 +1102,7 @@ You can sort this table by clicking on any of the headings.
      - |yes|
      - |no|
    * - :doc:`formats/ome-xml`
-     - `.ome, .ome.xml <http://www.openmicroscopy.org/site/support/ome-model/ome-xml/index.html>`_
+     - :model_doc:`.ome, .ome.xml <ome-xml/index.html>`
      - |Outstanding|
      - |Outstanding|
      - |Outstanding|

--- a/docs/sphinx/users/index.rst
+++ b/docs/sphinx/users/index.rst
@@ -47,7 +47,7 @@ OMERO
 =====
 
 OMERO 5 uses Bio-Formats to read original files from over 140 file formats.
-Please refer to the :products_plone:`OMERO <omero>` documentation for further
+Please refer to the :omero:`OMERO <>` documentation for further
 information.
 
 Many other software packages can use Bio-Formats to read and write

--- a/docs/sphinx/users/ome-server/index.rst
+++ b/docs/sphinx/users/ome-server/index.rst
@@ -1,13 +1,13 @@
 OME Server
 ==========
 
-`OME <http://openmicroscopy.org/site/support/legacy/ome-server>`_ is a
+The OME server is a
 set of software that interacts with a database to manage images, image
 metadata, image analysis and analysis results. The OME system is capable
 of leveraging Bio-Formats to import files.
 
 **Please note** - the OME server is no longer maintained and has now been
-superseded by the :products_plone:`OMERO server <omero>`.  Support for the OME
+superseded by the :omero:`OMERO server <>`.  Support for the OME
 server has been entirely removed in the 5.0.0 version of Bio-Formats; the
 following instructions can still be used with the 4.4.x versions.
 
@@ -102,7 +102,7 @@ Upgrading
 
 OME server is not supported by Bio-Formats versions 5.0.0 and above. To take
 advantage of more recent improvements to Bio-Formats, you must switch to
-:products_plone:`OMERO server <omero>`.
+:omero:`OMERO server <>`.
 
 Source Code
 -----------


### PR DESCRIPTION
See https://trello.com/c/UeQVAofv/170-docs-check-internal-urls-in-bf

This updates the old plone links to use the new website URLs and removes unused extlinks and updates the downloads and javadoc links to 5.6.x

No decision has been made yet re: the future status of downloads.oo.org