### PR TITLE
TIFF: add support for FillOrder == 2

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -882,7 +882,7 @@ public class TiffParser {
       photoInterp != PhotoInterp.WHITE_IS_ZERO &&
       photoInterp != PhotoInterp.CMYK && photoInterp != PhotoInterp.Y_CB_CR &&
       compression == TiffCompression.UNCOMPRESSED &&
-      ifd.getIFDIntValue(IFD.FILL_ORDER) == 1 &&
+      ifd.getIFDIntValue(IFD.FILL_ORDER) != 2 &&
       numTileRows * numTileCols == 1 && stripOffsets != null && stripByteCounts != null &&
       in.length() >= stripOffsets[0] + stripByteCounts[0])
     {

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -725,6 +725,14 @@ public class TiffParser {
     in.seek(stripOffset);
     in.read(tile);
 
+    // reverse bits in each byte if FillOrder == 2
+
+    if (ifd.getIFDIntValue(IFD.FILL_ORDER) == 2) {
+      for (int i=0; i<tile.length; i++) {
+        tile[i] = (byte) (Integer.reverse(tile[i]) >> 24);
+      }
+    }
+
     codecOptions.maxBytes = (int) Math.max(size, tile.length);
     codecOptions.ycbcr =
       ifd.getPhotometricInterpretation() == PhotoInterp.Y_CB_CR &&
@@ -874,6 +882,7 @@ public class TiffParser {
       photoInterp != PhotoInterp.WHITE_IS_ZERO &&
       photoInterp != PhotoInterp.CMYK && photoInterp != PhotoInterp.Y_CB_CR &&
       compression == TiffCompression.UNCOMPRESSED &&
+      ifd.getIFDIntValue(IFD.FILL_ORDER) == 1 &&
       numTileRows * numTileCols == 1 && stripOffsets != null && stripByteCounts != null &&
       in.length() >= stripOffsets[0] + stripByteCounts[0])
     {


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/4166

This updates ```TiffParser``` to use ```Integer.reverse(int)``` to reverse the bits in each byte of a tile when the ```FillOrder``` tag is set to 2.  The reversal is performed immediately after the tile buffer is read from the file, before any decompression or unpacking takes place.  An extra check is added to the tile reading logic, so that the special case of returning a single raw tile is never used for ```FillOrder == 2```.

This is a much simpler approach than either of the fixes proposed on the ticket, as it does not require any additional API or changes to other components.  It should be safe for a patch release, but is not urgent and can be deferred if needed.

To test, use the ```data_repo/curated/tiff/john/C100915-MA_AXIS_LEH_IMAGE_KIND_FLAT_ICE_3.tif``` file.  Without this change, ```showinf``` should result in an image with vertical black and white pinstripes.  With this change, ```showinf``` should show a smooth gradient, matching the results of ImageMagick's ```display``` command.