### PR TITLE
Improve string handling for large metadata

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -431,7 +431,7 @@ public class TiffReader extends BaseTiffReader {
         }
         else if (!line.startsWith("[")) {
           buf.append(line);
-          buf.append("\n");
+          buf.append('\n');
         }
       }
       description = buf.toString();

--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -421,7 +421,7 @@ public class TiffReader extends BaseTiffReader {
     if (comment == null) return;
     String[] lines = comment.split("\n");
     if (lines.length > 1) {
-      comment = "";
+      StringBuilder buf = new StringBuilder(comment.length());
       for (String line : lines) {
         int eq = line.indexOf('=');
         if (eq != -1) {
@@ -430,11 +430,12 @@ public class TiffReader extends BaseTiffReader {
           addGlobalMeta(key, value);
         }
         else if (!line.startsWith("[")) {
-          comment += line + "\n";
+          buf.append(line);
+          buf.append("\n");
         }
       }
-      addGlobalMeta("Comment", comment);
-      description = comment;
+      description = buf.toString();
+      addGlobalMeta("Comment", description);
     }
   }
 


### PR DESCRIPTION
When working with OME-TIFF files with large metadata (e.g. 38 megabytes on one of our z-stacks), the TiffReader bogs down with some inefficient string handling.  This patch seeks to at least do the concatenation in a single preallocated buffer, instead of flipping back and forth between String and StringBuilder continually.

Why this particular parsing routine (which tries to extract property-esque key-value pairs) is being called on OME-XML at all is a mystery to me, but since it is, we may as well not spend 10s of minutes on string buffer mismanagement.

I can provide a sample OME-TIFF image with such large metadata if necessary.