### PR TITLE
Review URLs in the source code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to Bio-Formats
 
 Guidance for contributing to OME projects in general can be found at
-http://www.openmicroscopy.org/site/support/contributing/
+https://docs.openmicroscopy.org/contributing/
 
 Developer documentation specifically for Bio-Formats is at
-http://www.openmicroscopy.org/site/support/bio-formats/developers/
+https://docs.openmicroscopy.org/bio-formats/
 
 The README file gives instructions for testing your code before opening a PR,
 please ensure you read these.
@@ -22,7 +22,7 @@ please ensure you read these.
 * We may need you to submit some test data
   [via our QA system](http://qa.openmicroscopy.org.uk/qa/upload/). If the
   files are particularly large (> ~2 GB), contact the
-  [mailing list](http://www.openmicroscopy.org/site/community/mailing-lists)
+  [mailing list](https://www.openmicroscopy.org/support)
   and we will get back to you with secure upload details.
 
 ## External Contributors
@@ -50,13 +50,13 @@ please ensure you read these.
 ## Contributing to Bio-Formats Documentation
 
 The documentation hosted at
-http://www.openmicroscopy.org/site/support/bio-formats/ is built from the
+https://docs.openmicroscopy.org/bio-formats/ is built from the
 `/docs/sphinx/` directory. Contributions are welcome but please follow the
 style guidance from the
 [OME Documentation Repository README](https://github.com/openmicroscopy/ome-documentation/blob/develop/README.rst#conventions-used).
 
 Documentation for new supported formats is auto-generated so it is best to
-contact the [mailing list](http://www.openmicroscopy.org/site/community/mailing-lists)
+contact the [mailing list](https://www.openmicroscopy.org/support)
 before embarking on such a change, or submit your new reader code and let one
 of the main OME team deal with the documentation for you.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Purpose
 
 Bio-Formats' primary purpose is to convert proprietary microscopy data into 
 an open standard called the OME data model, particularly into the OME-TIFF 
-file format. See the [statement of purpose](http://www.openmicroscopy.org/site/support/bio-formats/about/index.html) 
+file format. See the [statement of purpose](docs/sphinx/about/index.rst)
 for a thorough explanation and rationale.
 
 
@@ -20,29 +20,27 @@ Supported formats
 -----------------
 
 Bio-Formats supports [more than a hundred file
-formats](http://www.openmicroscopy.org/site/support/bio-formats/supported-formats.html).
+formats](docs/sphinx/supported-formats.rst).
 
 
 For users
 ---------
 
-[Many software
-packages](http://www.openmicroscopy.org/site/support/bio-formats/users/index.html)
+[Many software packages](docs/sphinx/users/index.rst)
 use Bio-Formats to read and write microscopy formats.
 
 
 For developers
 --------------
 
-You can use Bio-Formats to easily [support these formats in your
-software](http://www.openmicroscopy.org/site/support/bio-formats/developers/java-library.html).
+You can use Bio-Formats to easily [support these formats in your software](docs/sphinx/developers/java-library.rst).
 
 
 More information
 ----------------
 
 For more information, see the [Bio-Formats web
-site](http://www.openmicroscopy.org/site/products/bio-formats).
+site](https://www.openmicroscopy.org/bio-formats).
 
 
 Pull request testing
@@ -59,7 +57,7 @@ following before submitting a pull request:
  * test at least one file in each affected format, using the ```showinf```
    command
  * internal developers only: [run the data
-   tests](http://www.openmicroscopy.org/site/support/bio-formats/developers/commit-testing.html)
+   tests](docs/sphinx/developers/commit-testing.rst)
    against directories corresponding to the affected format(s)
  * make sure that your commits contain the correct authorship information and,
    if necessary, a signed-off-by line

--- a/README.md
+++ b/README.md
@@ -12,28 +12,28 @@ Purpose
 
 Bio-Formats' primary purpose is to convert proprietary microscopy data into 
 an open standard called the OME data model, particularly into the OME-TIFF 
-file format. See the [statement of purpose](docs/sphinx/about/index.rst)
-for a thorough explanation and rationale.
+file format. See [About Bio-Formats](https://docs.openmicroscopy.org/latest/bio-formats/about/index.html)
+for further information.
 
 
 Supported formats
 -----------------
 
 Bio-Formats supports [more than a hundred file
-formats](docs/sphinx/supported-formats.rst).
+formats](https://docs.openmicroscopy.org/latest/bio-formats/supported-formats.html).
 
 
 For users
 ---------
 
-[Many software packages](docs/sphinx/users/index.rst)
+[Many software packages](https://docs.openmicroscopy.org/latest/bio-formats/users/index.html)
 use Bio-Formats to read and write microscopy formats.
 
 
 For developers
 --------------
 
-You can use Bio-Formats to easily [support these formats in your software](docs/sphinx/developers/java-library.rst).
+You can use Bio-Formats to easily [support these formats in your software](https://docs.openmicroscopy.org/latest/bio-formats/developers/java-library.html).
 
 
 More information

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -190,7 +190,7 @@ your FindBugs installation's lib directory. E.g.:
         <attribute name="Implementation-Date" value="${DATE}"/>
         <attribute name="Implementation-Vendor" value="Open Microscopy Environment"/>
         <attribute name="Implementation-Build" value="${build.version}"/>
-        <attribute name="Implementation-URL" value="http://www.openmicroscopy.org/site/products/bio-formats/"/>
+        <attribute name="Implementation-URL" value="https://www.openmicroscopy.org/bio-formats/"/>
       </manifest>
     </jar>
     <artifact:install file="${artifact.dir}/${component.jar}">
@@ -212,7 +212,7 @@ your FindBugs installation's lib directory. E.g.:
         <attribute name="Implementation-Date" value="${DATE}"/>
         <attribute name="Implementation-Vendor" value="Open Microscopy Environment"/>
         <attribute name="Implementation-Build" value="${build.version}"/>
-        <attribute name="Implementation-URL" value="http://www.openmicroscopy.org/site/products/bio-formats/"/>
+        <attribute name="Implementation-URL" value="https://www.openmicroscopy.org/bio-formats/"/>
       </manifest>
     </jar>
     <artifact:install file="${artifact.dir}/${bundle.jar}">

--- a/components/autogen/pom.xml
+++ b/components/autogen/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats code generator</name>
   <description>Package for generating other code, particularly the Bio-Formats metadata documentation.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2007</inceptionYear>
 
   <licenses>
@@ -121,16 +121,13 @@
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
   </developers>
 </project>

--- a/components/autogen/src/MakeDatasetStructureTable.java
+++ b/components/autogen/src/MakeDatasetStructureTable.java
@@ -37,7 +37,7 @@ import loci.formats.ImageReader;
  * Utility class for generating a table containing the dataset structure for
  * every supported format.
  * This class is used to generate this wiki page:
- * http://www.openmicroscopy.org/site/support/bio-formats5.1/formats/dataset-table.html
+ * http://docs.openmicroscopy.org/latest/bio-formats/formats/dataset-table.html
  *
  * @author Melissa Linkert melissa at glencoesoftware.com
  */

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats Plugins for ImageJ</name>
   <description>A collection of plugins for ImageJ, including the Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions, Data Browser and Stack Slicer.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>
@@ -151,7 +151,7 @@ Data Browser and Stack Slicer.</projectName>
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
@@ -159,9 +159,6 @@ Data Browser and Stack Slicer.</projectName>
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
   </developers>
 </project>

--- a/components/bio-formats-plugins/src/loci/plugins/About.java
+++ b/components/bio-formats-plugins/src/loci/plugins/About.java
@@ -48,7 +48,8 @@ public final class About implements PlugIn {
 
   /** URL of Bio-Formats ImageJ web page. */
   public static final String URL_BIO_FORMATS_IMAGEJ =
-    "http://www.openmicroscopy.org/site/support/bio-formats/users/imagej/features.html";
+    "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
+    "/users/imagej/features.html";
 
   /** URL of Data Browser web page. */
   public static final String URL_DATA_BROWSER =

--- a/components/bio-formats-plugins/src/loci/plugins/About.java
+++ b/components/bio-formats-plugins/src/loci/plugins/About.java
@@ -44,7 +44,7 @@ public final class About implements PlugIn {
 
   /** URL of the Bio-Formats web page. */
   public static final String URL_SOFTWARE =
-    "http://www.openmicroscopy.org/site/products/bio-formats";
+    "https://www.openmicroscopy.org/bio-formats";
 
   /** URL of Bio-Formats ImageJ web page. */
   public static final String URL_BIO_FORMATS_IMAGEJ =

--- a/components/bio-formats-plugins/src/loci/plugins/config/libraries.txt
+++ b/components/bio-formats-plugins/src/loci/plugins/config/libraries.txt
@@ -104,7 +104,7 @@ notes = Bio-Formats Plugins for ImageJ: a collection of ImageJ plugins including
 type = ImageJ plugin
 class = loci.plugins.ome.About
 version = omeVersion
-url = http://www.openmicroscopy.org/site/products/bio-formats/downloads
+url = https://www.openmicroscopy.org/bio-formats/downloads
 license = GPL
 notes = OME Plugins for ImageJ: a collection of ImageJ plugins including
         the Download from OME and Upload to OME plugins.
@@ -131,7 +131,7 @@ notes = Optional plugin. If you have View5D installed, the Bio-Formats
 type = Java library
 class = loci.formats.IFormatReader
 version = bfVersion
-url = https://www.openmicroscopy.org/site/products/bio-formats/downloads
+url = https://www.openmicroscopy.org/bio-formats/downloads
 license = GPL
 notes = OME Bio-Formats package for reading and converting
         biological file formats.

--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -75,7 +75,7 @@ public class LociFunctions extends MacroFunctions {
 
   /** URL for Javadocs. */
   public static final String URL_JAVADOCS =
-    "http://ci.openmicroscopy.org/job/BIOFORMATS-5.1-latest/javadoc/";
+    "https://downloads.openmicroscopy.org/bio-formats/" + FormatTools.VERSION + "/api/";
 
   // -- Fields --
 

--- a/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
@@ -56,7 +56,7 @@ public final class LibraryChecker {
 
   /** URL for Bio-Formats web page. */
   public static final String URL_BF_SOFTWARE =
-    "http://www.openmicroscopy.org/site/products/bio-formats";
+    "https://www.openmicroscopy.org/bio-formats";
 
   // -- Constructor --
 

--- a/components/bio-formats-plugins/src/plugins.config
+++ b/components/bio-formats-plugins/src/plugins.config
@@ -50,7 +50,7 @@ Plugins>Bio-Formats, "-"
 Plugins>Bio-Formats, "Update Bio-Formats Plugins", loci.plugins.Updater("")
 
 Plugins>Bio-Formats, "-"
-Plugins>Bio-Formats, "Help", ij.plugin.BrowserLauncher("http://www.openmicroscopy.org/site/support/bio-formats/users/index.html")
+Plugins>Bio-Formats, "Help", ij.plugin.BrowserLauncher("https://docs.openmicroscopy.org/latest/bio-formats/users/index.html")
 Help>About Plugins, "Bio-Formats Plugins...", loci.plugins.About("")
 
 File>Save As, "OME-TIFF...", loci.plugins.LociExporter("")

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats command line tools</name>
   <description>Bio-Formats command line tools for reading and converting files</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <licenses>
@@ -137,7 +137,7 @@
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
@@ -145,9 +145,6 @@
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
     <developer>
       <id>curtis</id>

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -17,7 +17,7 @@
 
   <name>bioformats_package bundle</name>
   <description>A bundle of Bio-Formats and dependencies, without slf4j bindings.</description>
-  <url>https://openmicroscopy.org/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -17,7 +17,7 @@
 
   <name>bioformats_package bundle</name>
   <description>A bundle of Bio-Formats and dependencies, without slf4j bindings.</description>
-  <url>http://openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://openmicroscopy.org/bio-formats</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>

--- a/components/bundles/loci_tools/pom.xml
+++ b/components/bundles/loci_tools/pom.xml
@@ -17,7 +17,7 @@
 
   <name>LOCI Tools bundle</name>
   <description>An all-in-one bundle of LOCI libraries.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats API</name>
   <description>Top-level reader and writer APIs.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <licenses>
@@ -194,7 +194,7 @@
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
@@ -202,9 +202,6 @@
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
     <developer>
       <id>curtis</id>

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -880,8 +880,8 @@ public abstract class FormatReader extends FormatHandler
       throw new FormatException("Image plane too large. Only 2GB of data can " +
         "be extracted at one time. You can workaround the problem by opening " +
         "the plane in tiles; for further details, see: " +
-        "http://www.openmicroscopy.org/site/support/bio-formats/about/" +
-        "bug-reporting.html#common-issues-to-check", e);
+        "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
+        "/about/bug-reporting.html#common-issues-to-check", e);
     }
     return openBytes(no, newBuffer, x, y, w, h);
   }

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -382,7 +382,7 @@ public final class FormatTools {
 
   /** URL of OME-TIFF web page. */
   public static final String URL_OME_TIFF =
-    "http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/";
+    "https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/";
 
   // -- Constructor --
 

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -378,7 +378,7 @@ public final class FormatTools {
 
   /** URL of 'Bio-Formats as a Java Library' web page. */
   public static final String URL_BIO_FORMATS_LIBRARIES =
-    "http://www.openmicroscopy.org/site/support/bio-formats/developers/java-library.html";
+    "https://docs.openmicroscopy.org/bio-formats/" + VERSION + "/developers/java-library.html";
 
   /** URL of OME-TIFF web page. */
   public static final String URL_OME_TIFF =

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -374,7 +374,7 @@ public final class FormatTools {
 
   /** URL of Bio-Formats web page. */
   public static final String URL_BIO_FORMATS =
-    "http://www.openmicroscopy.org/site/products/bio-formats";
+    "https://www.openmicroscopy.org/bio-formats";
 
   /** URL of 'Bio-Formats as a Java Library' web page. */
   public static final String URL_BIO_FORMATS_LIBRARIES =

--- a/components/formats-api/src/loci/formats/Modulo.java
+++ b/components/formats-api/src/loci/formats/Modulo.java
@@ -34,7 +34,7 @@ package loci.formats;
 
 /**
  * Represents a subdimension of Z, C, or T as needed for supporting Modulo
- * annotations.  See http://www.openmicroscopy.org/site/support/ome-model/developers/6d-7d-and-8d-storage.html
+ * annotations.  See https://docs.openmicroscopy.org/latest/ome-model/developers/6d-7d-and-8d-storage.html
  */
 public class Modulo {
 

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -16,7 +16,7 @@
 
   <name>BSD Bio-Formats readers and writers</name>
   <description>Reader and writer implementations that are BSD-licensed.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <licenses>
@@ -252,7 +252,7 @@
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
@@ -260,9 +260,6 @@
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
     <developer>
       <id>curtis</id>

--- a/components/formats-bsd/src/loci/formats/gui/ImageViewer.java
+++ b/components/formats-bsd/src/loci/formats/gui/ImageViewer.java
@@ -605,8 +605,10 @@ public class ImageViewer extends JFrame implements ActionListener,
         "<br>Version " + FormatTools.VERSION + " (VCS revision " +
         FormatTools.VCS_REVISION + "), built on " +
         FormatTools.DATE + "<br><br>See <a href=\"" +
-        "http://www.openmicroscopy.org/site/support/bio-formats/users/index.html\">" +
-        "http://www.openmicroscopy.org/site/support/bio-formats/users/index.html</a>" +
+        "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
+        "/users/index.html\">" +
+        "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
+        "/users/index.html</a>" +
         "<br>for help with using Bio-Formats.";
       ImageIcon bioFormatsLogo = new ImageIcon(
           IFormatHandler.class.getResource("bio-formats-logo.png"));

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -72,7 +72,7 @@ import ome.xml.model.primitives.Timestamp;
 
 /**
  * OMETiffReader is the file format reader for
- * <a href="http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/">OME-TIFF</a>
+ * <a href="https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/">OME-TIFF</a>
  * files.
  */
 public class OMETiffReader extends FormatReader {

--- a/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
+++ b/components/formats-bsd/src/loci/formats/services/JAIIIOServiceImpl.java
@@ -50,6 +50,7 @@ import javax.imageio.stream.MemoryCacheImageInputStream;
 import loci.common.services.AbstractService;
 import loci.common.services.ServiceException;
 import loci.formats.codec.JPEG2000CodecOptions;
+import loci.formats.FormatTools;
 
 import com.sun.media.imageio.plugins.jpeg2000.J2KImageReadParam;
 import com.sun.media.imageio.plugins.jpeg2000.J2KImageWriteParam;
@@ -70,7 +71,8 @@ public class JAIIIOServiceImpl extends AbstractService
   public static final String NO_J2K_MSG =
     "The JAI Image I/O Tools are required to read JPEG-2000 files. " +
     "Please obtain jai_imageio.jar from " +
-    "http://www.openmicroscopy.org/site/support/bio-formats/developers/java-library.html";
+    "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
+    "/developers/java-library.html";
 
   // -- Fields --
 

--- a/components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java
+++ b/components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java
@@ -262,7 +262,7 @@ public class MakeTestOmeTiff {
     if (isModulo) {
       meta.setXMLAnnotationID("Annotation:Modulo:0", 0);
       meta.setXMLAnnotationNamespace("openmicroscopy.org/omero/dimension/modulo", 0);
-      meta.setXMLAnnotationDescription("For a description of how 6D, 7D, and 8D data is stored using the Modulo extension see http://www.openmicroscopy.org/site/support/ome-model/developers/6d-7d-and-8d-storage.html", 0);
+      meta.setXMLAnnotationDescription("For a description of how 6D, 7D, and 8D data is stored using the Modulo extension see https://docs.openmicroscopy.org/latest/ome-model/developers/6d-7d-and-8d-storage.html", 0);
       StringBuilder moduloBlock = new StringBuilder();
       
       moduloBlock.append("<Modulo namespace=\"http://www.openmicroscopy.org/Schemas/Additions/2011-09\">");

--- a/components/formats-bsd/utils/mipav/readme.txt
+++ b/components/formats-bsd/utils/mipav/readme.txt
@@ -4,7 +4,7 @@ MIPAV plugin for opening life sciences images using Bio-Formats.
 Steps to try out the plugin:
 
 1) Download the bioformats_package.jar trunk build from:
-     http://www.openmicroscopy.org/site/products/bio-formats/downloads
+     https://www.openmicroscopy.org/bio-formats/downloads
    and save it in your MIPAV directory.
 
 2) Compile the plugin with:

--- a/components/formats-gpl/matlab/bfopen.m
+++ b/components/formats-gpl/matlab/bfopen.m
@@ -46,7 +46,7 @@ function [result] = bfopen(id, varargin)
 %     bioformats_package.jar.
 %
 % For many examples of how to use the bfopen function, please see:
-%     http://www.openmicroscopy.org/site/support/bio-formats5.1/developers/matlab-dev.html
+%     https://docs.openmicroscopy.org/latest/bio-formats/developers/matlab-dev.html
 
 % OME Bio-Formats package for reading and converting biological file formats.
 %

--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -17,7 +17,7 @@ function bfsave(varargin)
 %    OME-XML metadata object when saving the file instead of creating a
 %    minimal OME-XML metadata object from the input 5D matrix.
 %
-%    For more information, see https://docs.openmicroscopy.org/latest/bio-formats5/developers/matlab-dev.html
+%    For more information, see https://docs.openmicroscopy.org/latest/bio-formats/developers/matlab-dev.html
 %
 %    Examples:
 %

--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -17,7 +17,7 @@ function bfsave(varargin)
 %    OME-XML metadata object when saving the file instead of creating a
 %    minimal OME-XML metadata object from the input 5D matrix.
 %
-%    For more information, see https://www.openmicroscopy.org/site/support/bio-formats5/developers/matlab-dev.html
+%    For more information, see https://docs.openmicroscopy.org/latest/bio-formats5/developers/matlab-dev.html
 %
 %    Examples:
 %

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -304,9 +304,9 @@
     <developer>
       <id>callan</id>
       <name>Chris Allan</name>
-      <email>callan@lifesci.dundee.ac.uk</email>
+      <email>callan@glencoesoftware.com</email>
       <url>https://glencoesoftware.com/chris-allan.html</url>
-      <organization>Swedlow Lab, University of Dundee</organization>
+      <organization>Glencoe Software</organization>
       <organizationUrl>https://glencoesoftware.com</organizationUrl>
       <roles>
         <role>architect</role>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats library</name>
   <description>A library for reading and writing popular microscopy file formats.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <licenses>
@@ -276,7 +276,7 @@
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
@@ -284,9 +284,6 @@
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
     <developer>
       <id>curtis</id>
@@ -308,43 +305,20 @@
       <id>callan</id>
       <name>Chris Allan</name>
       <email>callan@lifesci.dundee.ac.uk</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/jason</url>
+      <url>https://glencoesoftware.com/chris-allan.html</url>
       <organization>Swedlow Lab, University of Dundee</organization>
-      <organizationUrl>http://www.lifesci.dundee.ac.uk/groups/jason_swedlow/</organizationUrl>
+      <organizationUrl>https://glencoesoftware.com</organizationUrl>
       <roles>
         <role>architect</role>
         <role>developer</role>
       </roles>
       <timezone>0</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/jason/chrisallan.jpg</picUrl>
-      </properties>
     </developer>
   </developers>
 
   <contributors>
-    <contributor>
-      <name>Eric Kjellman</name>
-      <organization>UW-Madison LOCI</organization>
-      <organizationUrl>http://loci.wisc.edu/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>-6</timezone>
-    </contributor>
-    <contributor>
-      <name>Brian Loranger</name>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/jason</url>
-      <organization>Swedlow Lab, University of Dundee</organization>
-      <organizationUrl>http://www.lifesci.dundee.ac.uk/groups/jason_swedlow/</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>0</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/jason/brian.jpg</picUrl>
-      </properties>
-    </contributor>
+    <contributor><name>Eric Kjellman</name></contributor>
+    <contributor><name>Brian Loranger</name></contributor>
     <contributor><name>Eric Albert</name></contributor>
     <contributor><name>Jonathan Armond</name></contributor>
     <contributor><name>Simon Blanchoud</name></contributor>

--- a/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
@@ -52,7 +52,8 @@ public class LegacyND2Reader extends FormatReader {
   private static final int MULTI_PHOTON = 5;
 
   private static final String URL_NIKON_ND2 =
-    "http://www.openmicroscopy.org/site/support/bio-formats/formats/nikon-nis-elements-nd2.html";
+   "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION" +
+   "/formats/nikon-nis-elements-nd2.html";
   private static final String NO_NIKON_MSG = "Nikon ND2 library not found. " +
     "Please see " + URL_NIKON_ND2 + " for details.";
 

--- a/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/LegacyND2Reader.java
@@ -52,7 +52,7 @@ public class LegacyND2Reader extends FormatReader {
   private static final int MULTI_PHOTON = 5;
 
   private static final String URL_NIKON_ND2 =
-   "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION" +
+   "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
    "/formats/nikon-nis-elements-nd2.html";
   private static final String NO_NIKON_MSG = "Nikon ND2 library not found. " +
     "Please see " + URL_NIKON_ND2 + " for details.";

--- a/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
@@ -49,7 +49,8 @@ public class JHDFServiceImpl extends AbstractService
     public static final String NO_JHDF_MSG
             = "JHDF is required to read HDF5 files. "
             + "Please obtain the necessary JAR files from "
-            + "http://www.openmicroscopy.org/site/support/bio-formats/developers/java-library.html.\n"
+            + "https://docs.openmicroscopy.org/bio-formats/"
+            + FormatTools.VERSION + "/developers/java-library.html.\n"
             + "Required JAR files is cisd-jhdf5-batteries_included_lin_win_mac.jar.";
 
     // -- Fields --

--- a/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JHDFServiceImpl.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.List;
 
 import loci.common.services.AbstractService;
+import loci.formats.FormatTools;
 
 import ch.systemsx.cisd.base.mdarray.MDByteArray;
 import ch.systemsx.cisd.base.mdarray.MDIntArray;

--- a/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
@@ -62,7 +62,8 @@ public class NetCDFServiceImpl extends AbstractService
   public static final String NO_NETCDF_MSG =
     "NetCDF is required to read NetCDF/HDF variants. " +
     "Please obtain the necessary JAR files from " +
-    "http://www.openmicroscopy.org/site/support/bio-formats/developers/java-library.html.\n" +
+    "https://docs.openmicroscopy.org/bio-formats/" + FormatTools.VERSION +
+    "/developers/java-library.html.\n" +
     "Required JAR files are netcdf-4.3.22.jar and slf4j-jdk14.jar.";
 
   // -- Fields --

--- a/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/NetCDFServiceImpl.java
@@ -38,6 +38,8 @@ import loci.common.Constants;
 import loci.common.Location;
 import loci.common.services.AbstractService;
 import loci.common.services.ServiceException;
+import loci.formats.FormatTools;
+
 import ucar.ma2.Array;
 import ucar.ma2.InvalidRangeException;
 import ucar.nc2.Attribute;

--- a/components/formats-gpl/utils/ReadWriteInMemory.java
+++ b/components/formats-gpl/utils/ReadWriteInMemory.java
@@ -36,7 +36,7 @@ import loci.formats.services.OMEXMLService;
 /**
  * Tests the Bio-Formats I/O logic to and from byte arrays in memory.
  * @deprecated Class has been moved to documentation examples and is available for download 
- * from http://www.openmicroscopy.org/site/support/bio-formats/developers/in-memory.html
+ * from https://docs.openmicroscopy.org/latest/bio-formats/developers/in-memory.html
  */
 @Deprecated
 public class ReadWriteInMemory {

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Bio-Formats testing framework</name>
   <description>A framework for manual and automated testing, in particular data-driven Bio-Formats testing.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>
@@ -138,7 +138,7 @@
       <id>melissa</id>
       <name>Melissa Linkert</name>
       <email>melissa@glencoesoftware.com</email>
-      <url>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software</url>
+      <url>https://www.glencoesoftware.com/melissa-linkert.html</url>
       <organization>Glencoe Software</organization>
       <organizationUrl>http://glencoesoftware.com/</organizationUrl>
       <roles>
@@ -146,9 +146,6 @@
         <role>developer</role>
       </roles>
       <timezone>-6</timezone>
-      <properties>
-        <picUrl>http://www.openmicroscopy.org/site/about/development-teams/glencoe-software/melissalinkert.png</picUrl>
-      </properties>
     </developer>
   </developers>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <name>Bio-Formats projects</name>
   <description>Umbrella project for the Bio-Formats software project.</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/bio-formats</url>
   <inceptionYear>2005</inceptionYear>
 
   <modules>

--- a/tools/ijview
+++ b/tools/ijview
@@ -38,7 +38,7 @@ then
     echo "Required JAR libraries not found. Please download:"
     echo "  bioformats_package.jar"
     echo "from:"
-    echo "  http://www.openmicroscopy.org/site/products/bio-formats/downloads"
+    echo "  https://www.openmicroscopy.org/bio-formats/downloads"
     echo "and place in the same directory as the command line tools."
     echo ""
     exit 4

--- a/tools/ijview.bat
+++ b/tools/ijview.bat
@@ -31,7 +31,7 @@ if "%BF_DEVEL%" == "" (
     echo Required JAR libraries not found. Please download:
     echo   bioformats_package.jar
     echo from:
-    echo   http://www.openmicroscopy.org/site/products/bio-formats/downloads
+    echo   https://www.openmicroscopy.org/bio-formats/downloads
     echo and place in the same directory as the command line tools.
     goto end
   )


### PR DESCRIPTION
See https://trello.com/c/UeQVAofv/3-docs-check-internal-urls-in-bf and https://github.com/openmicroscopy/bioformats/pull/2927

This PR reviews all references to www.openmicroscopy.org in the source code of Bio-Formats following the new website/URLs.

A couple of decisions/proposals:
- whenever possible, the versioned documentation URL is constructed using `FormatTools.VERSION`. This means the various URLs of development versions will read as docs.openmicroscopy.org/bio-formats/5.6.1-SNAPSHOT/xxx
- the documentation links in comments use the latest docs.openmicroscopy.org URLs to reduce the work on tokenization.
- the top-level `README.md` is updated to use relative links to the source files now we are using reStructuredText extension and they are rendered by GitHub

A few places should be reviewed:
- the various menus in the Bio-Formats plugins
- https://github.com/snoopycrimecop/bioformats/blob/develop/merge/daily/README.md 
- https://github.com/snoopycrimecop/bioformats/blob/develop/merge/daily/CONTRIBUTING.md