### PR TITLE
Update doc sidebar for previous version navigation

### DIFF
--- a/docs/sphinx/_templates/globalbftoc.html
+++ b/docs/sphinx/_templates/globalbftoc.html
@@ -1,4 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('Bio-Formats') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/bio-formats5.6/">{{ _('Bio-Formats Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/bio-formats/">{{ _('Downloads by version') }}</a></br>
+<a href="http://docs.openmicroscopy.org/bio-formats/">{{ _('Documentation by version') }}</a></br>
 <a href="https://www.openmicroscopy.org/licensing/">{{ _('Licensing') }}</a>


### PR DESCRIPTION
See https://trello.com/c/ALSwsNNV/91-add-previous-navigation and https://github.com/openmicroscopy/ome-documentation/pull/1734/

This PR updates the sphinx docs sidebar menu to match OMERO - linking to the downloads and documentation indexes to allow users to find previous versions as all the links on the new website are to the latest release only.