### PR TITLE
Plugins: Missing macro doc

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -725,6 +725,8 @@ public class LociFunctions extends MacroFunctions {
       IJ.log("-- dimension order.");
       IJ.log("Ext.getMetadataValue(field, value)");
       IJ.log("-- Obtains the specified metadata field's value.");
+      IJ.log("Ext.getSeriesMetadataValue(field, value)");
+      IJ.log("-- Obtains the specified series metadata field's value.");
       IJ.log("Ext.getSeriesName(seriesName)");
       IJ.log("-- Obtains the name of the current series.");
       IJ.log("Ext.getImageCreationDate(creationDate)");


### PR DESCRIPTION
Issue was discovered while investigating https://www.openmicroscopy.org/community/posting.php?mode=reply&f=13&t=8353

In ImageJ when you open the Bio-Formats Macro doc via:
`Plugins -> Bio-Formats -> Bio-Formats Macro Extensions`

The following function is missing:
`Ext.getSeriesMetadataValue(field, value)`

PR adds the missing function