### PR TITLE
Docs: Add new plugins options page

### DIFF
--- a/docs/sphinx/users/imagej/features.rst
+++ b/docs/sphinx/users/imagej/features.rst
@@ -40,7 +40,7 @@ following features:
 - The **Bio-Formats Plugins Configuration** dialog is a useful way to
   configure the behavior of the Bio-Formats plugin or each file format. 
   The general tab allows you to configure features of the Bio-Formats plugin 
-  such as the display of the slice label (see :doc:`/options`).
+  such as the display of the slice label (see :doc:`/users/imagej/options`).
   The Formats tab lists supported file formats and toggles each format on or off, 
   which is useful if your file is detected as the wrong format. 
   It also toggles whether each format bypasses the importer options dialog through 

--- a/docs/sphinx/users/imagej/features.rst
+++ b/docs/sphinx/users/imagej/features.rst
@@ -38,12 +38,14 @@ following features:
   planes or time points.
 
 - The **Bio-Formats Plugins Configuration** dialog is a useful way to
-  configure the behavior of each file format. The Formats tab lists supported
-  file formats and toggles each format on or off, which is useful if your file
-  is detected as the wrong format. It also toggles whether each format
-  bypasses the importer options dialog through the "Windowless" checkbox.
-  You can also configure any specific option for each format (see
-  :doc:`/formats/options`). The Libraries tab provides a list of available 
+  configure the behavior of the Bio-Formats plugin or each file format. 
+  The general tab allows you to configure features of the Bio-Formats plugin 
+  such as the display of the slice label (see :doc:`/options`).
+  The Formats tab lists supported file formats and toggles each format on or off, 
+  which is useful if your file is detected as the wrong format. 
+  It also toggles whether each format bypasses the importer options dialog through 
+  the "Windowless" checkbox. You can also configure any specific option for each format 
+  (see :doc:`/formats/options`). The Libraries tab provides a list of available 
   helper libraries used by Bio-Formats.
 
 - The **Bio-Formats Plugins Shortcut Window** opens a small window with a

--- a/docs/sphinx/users/imagej/options.rst
+++ b/docs/sphinx/users/imagej/options.rst
@@ -12,17 +12,15 @@ Configuring the slice label pattern
 The slice label is the text displayed at the top of the image window in ImageJ.
 The values displayed here can be modified by configuring the slice label pattern.
 
-The list of available parameters for configuration is as follows:
-::
+The list of available parameters for configuration is as follows::
+  :%s: series index
+  :%n: series name
+  :%c: channel index
+  :%w: channel name
+  :%z: Z index
+  :%t: T index
+  :%A: acquisition timestamp
 
-    %s - series index
-    %n - series name
-    %c - channel index
-    %w - channel name
-    %z - Z index
-    %t - T index
-    %A - acquisition timestamp
-
-Each index value will be 1 rather than 0 based. The index will be displayed 
+Each index value will be 1-based rather than 0-based. The index will be displayed 
 along with the total dimension count and with a prefix for the particular dimension. 
 For example using ``%c`` for channel index will result in the display ``c:1/3``.

--- a/docs/sphinx/users/imagej/options.rst
+++ b/docs/sphinx/users/imagej/options.rst
@@ -1,0 +1,28 @@
+Bio-Formats plugin configuration options
+========================================
+
+The Bio-Formats plugin can be configured by opening the **Bio-Formats Plugins 
+Configuration** dialog from the Plugin menu. The General tab allows for 
+configuration of features for the plugin such as upgrade checking or modifying 
+the slice label pattern.
+
+Configuring the slice label pattern
+-----------------------------------
+
+The slice label is the text displayed at the top of the image window in ImageJ.
+The values displayed here can be modified by configuring the slice label pattern.
+
+The list of available parameters for configuration is as follows:
+::
+
+    %s - series index
+    %n - series name
+    %c - channel index
+    %w - channel name
+    %z - Z index
+    %t - T index
+    %A - acquisition timestamp
+
+Each index value will be 1 rather than 0 based. The index will be displayed 
+along with the total dimension count and with a prefix for the particular dimension. 
+For example using ``%c`` for channel index will result in the display ``c:1/3``.

--- a/docs/sphinx/users/index.rst
+++ b/docs/sphinx/users/index.rst
@@ -19,6 +19,7 @@ it within ImageJ and Fiji:
     imagej/installing
     imagej/load-images
     imagej/managing-memory
+    imagej/options
 
 Command line tools
 ==================


### PR DESCRIPTION
This is a follow up to https://github.com/openmicroscopy/bioformats/pull/2891

Adds a new docs page for configuring of the Bio-Formats plugin, namely the slice label pattern.