### PR TITLE
try to get heap dump when automated tests are out of memory

### DIFF
--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -180,6 +180,7 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-Duser.country=${user.country}"/>
       <jvmarg value="-Dlogback.configurationFile=${logback.configurationFile}"/>
       <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError"/>
+      <jvmarg value="-XX:HeapDumpPath=target"/>
     </testng>
     <fail if="failedTest"/>
   </target>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -179,6 +179,7 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
       <jvmarg value="-Dlogback.configurationFile=${logback.configurationFile}"/>
+      <jvmarg value="-XX:+HeapDumpOnOutOfMemory"/>
     </testng>
     <fail if="failedTest"/>
   </target>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -179,7 +179,7 @@ Type "ant -p" for a list of targets.
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
       <jvmarg value="-Dlogback.configurationFile=${logback.configurationFile}"/>
-      <jvmarg value="-XX:+HeapDumpOnOutOfMemory"/>
+      <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError"/>
     </testng>
     <fail if="failedTest"/>
   </target>


### PR DESCRIPTION
Relates to recent failures in https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-full-repository/:

> java.lang.OutOfMemoryError: GC overhead limit exceeded

This PR attempts to obtain a heap dump in the above circumstance.