### PR TITLE
Reference format options page from user/developer pages

### DIFF
--- a/docs/sphinx/developers/index.rst
+++ b/docs/sphinx/developers/index.rst
@@ -46,6 +46,7 @@ Using Bio-Formats as a Java library
     matlab-dev
     python-dev
     non-java-code
+    /formats/options
 
 Using Bio-Formats as a native C++ library
 =========================================

--- a/docs/sphinx/developers/index.rst
+++ b/docs/sphinx/developers/index.rst
@@ -46,7 +46,9 @@ Using Bio-Formats as a Java library
     matlab-dev
     python-dev
     non-java-code
-    /formats/options
+
+.. seealso::
+   :doc:`/formats/options`
 
 Using Bio-Formats as a native C++ library
 =========================================

--- a/docs/sphinx/users/index.rst
+++ b/docs/sphinx/users/index.rst
@@ -20,7 +20,9 @@ it within ImageJ and Fiji:
     imagej/load-images
     imagej/managing-memory
     imagej/options
-    /formats/options
+
+.. seealso::
+   :doc:`/formats/options`
 
 Command line tools
 ==================
@@ -42,8 +44,9 @@ for carrying out a variety of tasks:
     comlinetools/ijview
     comlinetools/xmlindent
     comlinetools/mkfake
-    /formats/options
 
+.. seealso::
+   :doc:`/formats/options`
 
 OMERO
 =====

--- a/docs/sphinx/users/index.rst
+++ b/docs/sphinx/users/index.rst
@@ -20,6 +20,7 @@ it within ImageJ and Fiji:
     imagej/load-images
     imagej/managing-memory
     imagej/options
+    /formats/options
 
 Command line tools
 ==================
@@ -41,7 +42,7 @@ for carrying out a variety of tasks:
     comlinetools/ijview
     comlinetools/xmlindent
     comlinetools/mkfake
-
+    /formats/options
 
 
 OMERO


### PR DESCRIPTION
The format options page can be difficult to find if you don't already know it exists.  This adds links to the options page from the ```users``` and ```developers``` index pages, so that it's hopefully more accessible to newcomers.