### PR TITLE
Leica LIF: attach companion metadata files if present

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -167,6 +167,7 @@ public class LIFReader extends FormatReader {
   public LIFReader() {
     super("Leica Image File Format", "lif");
     suffixNecessary = false;
+    hasCompanionFiles = true;
     domains = new String[] {FormatTools.LM_DOMAIN};
   }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1727,6 +1727,10 @@ public class FormatReaderTest {
             continue;
           }
 
+          if (reader.getFormat().equals("Leica Image File Format")) {
+            continue;
+          }
+
           // pattern datasets can only be detected with the pattern file
           if (reader.getFormat().equals("File pattern")) {
             continue;
@@ -2395,6 +2399,13 @@ public class FormatReaderTest {
             // the pattern reader only picks up pattern files
             if (!result && !used[i].toLowerCase().endsWith(".pattern") &&
               r instanceof FilePatternReader)
+            {
+              continue;
+            }
+
+            // ignore companion files for Leica LIF
+            if (!used[i].toLowerCase().endsWith(".lif") &&
+              r instanceof LIFReader)
             {
               continue;
             }


### PR DESCRIPTION
Resolves http://trac.openmicroscopy.org/ome/ticket/4568

To test, use ```data_repo/curated/leica-lif/alex/2010-11-29-test-for-OME.lif```.  Without this change, ```showinf -nopix``` should show just one used file (the .lif itself).  With this change, ```LASAF_CP.xsl```, ```LeicaLogo.jpg```, and ```Pos002_S001.xml``` should also appear on the used files list.

The extra files are a result of exporting the XML metadata for a single series in the .lif file using Leica's LAS AF software.  The .xml file does not include any additional metadata that isn't already in the .lif, but it is nicely formatted and easier to read (and references the .xsl/.jpg).  None of the files are parsed; they are just attached as companion files.  ```showinf -nopix -trace``` can now be used to show the XML that is in the .lif for comparison.

The automated data tests are also updated to not use the companion files for setId/type checking.

Since there isn't any different metadata stored in the companion files, I don't feel 100% that we need this feature, but it might be useful to someone so opening for review/discussion.  If any major objections, feel free to close and I'll change the ticket to ```wontfix```.