### PR TITLE
Nikon ND2: Z dimension and position fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1854,6 +1854,7 @@ public class NativeND2Reader extends FormatReader {
    */
   private void iterateIn(RandomAccessInputStream in, Long stop) {
     Object value; // We don't know if attribute will be int, double, string....
+    Double zHigh = null, zLow = null;
 
     try {
       Integer currentColor = null;
@@ -1971,6 +1972,12 @@ public class NativeND2Reader extends FormatReader {
         else if (name.equals("dZStep")) {
           trueSizeZ = new Double(value.toString());
         }
+        else if (name.equals("dZHigh")) {
+          zHigh = DataTools.parseDouble(value.toString());
+        }
+        else if (name.equals("dZLow")) {
+          zLow = DataTools.parseDouble(value.toString());
+        }
         else if (name.equals("dPosX")) {
           positionCount++;
         }
@@ -1982,6 +1989,10 @@ public class NativeND2Reader extends FormatReader {
     }
     catch (Exception e) {
       LOGGER.debug("", e);
+    }
+
+    if (zHigh != null && zLow != null && trueSizeZ != null) {
+      core.get(0).sizeZ = (int) (Math.ceil(Math.abs(zHigh - zLow) / trueSizeZ)) + 1;
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1993,7 +1993,7 @@ public class NativeND2Reader extends FormatReader {
       LOGGER.debug("", e);
     }
 
-    if (zHigh != null && zLow != null && trueSizeZ != null) {
+    if (zHigh != null && zLow != null && trueSizeZ != null && trueSizeZ > 0) {
       core.get(0).sizeZ = (int) (Math.ceil(Math.abs(zHigh - zLow) / trueSizeZ)) + 1;
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -933,7 +933,9 @@ public class NativeND2Reader extends FormatReader {
             customDataLengths.add(new int[] {nameLength, (int) dataLength});
           }
           else if (blockType.startsWith("CustomData|Z")) {
-            zOffset = doubleOffset;
+            if (zOffset == 0) {
+              zOffset = doubleOffset;
+            }
             extraZDataCount++;
           }
           else if (blockType.startsWith("CustomData|X")) {


### PR DESCRIPTION
Ported from a private PR.  The original test case requiring these changes could not be shared, so a similar test case was manufactured by copying ```data_repo/curated/nd2/christian/CW002_3_rfp.nd2``` to ```data_repo/curated/nd2/christian/missing-dimensions-test.nd2``` and slightly modifying the ```ImageTextInfo``` block to remove Z dimension information.

To test 6174d49, use ```data_repo/curated/nd2/christian/missing-dimensions-test.nd2```.  Without this PR, ```showinf -nopix``` should report 60 series.  With this PR, the same test should show 61 Z sections, matching ```data_repo/curated/nd2/christian/CW002_3_rfp.nd2```.

To test 36c24de, use ```data_repo/curated/nd2/hallie/RNAi Plate 4.nd2``` and ```data_repo/curated/nd2/qa-17785/spc2493.nd2```.  Using ```showinf -nopix -omexml```, compare the ```PositionZ``` values on each ```Plane``` with and without this PR.  Without this PR, the positions should match the ```*PiezoZ Drive``` column in the ```Recorded Data``` tab of the image properties window in NIS Elements.  With this PR, the positions should match the ```Z Coord``` column in the same tab.  See also screenshots on forthcoming configuration PR.

This shouldn't break memo files, but I don't know if it qualifies as breaking due to the configuration change.  It can certainly wait for 5.8.0 if needed; I don't think this will resolve any of the other open issues with .nd2 files, so it's not critical.