### PR TITLE
TIFF: support >4GB ImageJ TIFFs with multiple channels

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -255,6 +255,7 @@ public class TiffReader extends BaseTiffReader {
 
     int z = 1, t = 1;
     int c = getSizeC();
+    int images = 1;
 
     CoreMetadata m = core.get(0);
 
@@ -273,6 +274,9 @@ public class TiffReader extends BaseTiffReader {
       if (token.startsWith("channels=")) c = parseInt(value);
       else if (token.startsWith("slices=")) z = parseInt(value);
       else if (token.startsWith("frames=")) t = parseInt(value);
+      else if (token.startsWith("images=")) {
+        images = parseInt(value);
+      }
       else if (token.startsWith("mode=")) {
         put("Color mode", value);
       }
@@ -318,10 +322,10 @@ public class TiffReader extends BaseTiffReader {
       m.sizeT = t;
       m.sizeC *= c;
     }
-    else if (ifds.size() == 1 && z * t > ifds.size() &&
+    else if (ifds.size() == 1 && images > ifds.size() &&
       ifds.get(0).getCompression() == TiffCompression.UNCOMPRESSED)
     {
-      // file is likely corrupt (missing end IFDs)
+      // file is likely corrupt or larger than 4GB (missing end IFDs)
       //
       // ImageJ writes TIFF files like this:
       // IFD #0


### PR DESCRIPTION
See https://trello.com/c/dmISsgn6/118-4gb-imagej-tiffs-not-supported

Without this PR, >4GB ImageJ TIFFs were only supported if multiple Z sections and/or timepoints were present.  This changes the ImageJ comment parser to check the IFD count against the total expected image count, not just the expected Z and T counts.

To test, use ```data_repo/curated/tiff/samples/melissa/imagej-4gb/4gb-imagej.tif``` (created by opening the ```.fake``` in the same directory in ImageJ, then selecting ```File > Save As > Tiff...```).  Without this PR, ```showinf -nopix``` should report a single plane.  With this PR, the same test should report 2050 channels, matching the ```.fake``` file.  All other dimensions and pixel data should also be the same between the two files.