### PR TITLE
Update documentation to reference support for ImageJ TIFFs

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -2245,9 +2245,22 @@ mif = true
 notes = Bio-Formats can also read BigTIFF files (TIFF files larger than 4 GB). \n
 Bio-Formats can save image stacks as TIFF or BigTIFF. \n
 \n
+TIFF files written by ImageJ are also supported, including ImageJ TIFFs larger \n
+than 4GB.  ImageJ TIFFs are detected based upon the text in the first IFD's \n
+"ImageDescription" tag; this tag's value is then used to determine Z, C, and T \n
+sizes as well as physical sizes and timestamps.  For ImageJ TIFFs larger than \n
+4GB, a single IFD is expected (instead of one IFD per image plane).  The \n
+"ImageDescription" is used to determine the number of images, the pixel data \n
+for which are expected to be stored contiguously at the offset indicated in \n
+the sole IFD.  This differs from standard TIFF and BigTIFF; if the \n
+"ImageDescription" tag is missing or invalid, only the first image will be \n
+read. \n
+\n
 .. seealso:: \n
   `TIFF technical overview <http://www.awaresystems.be/imaging/tiff/faq.html#q3>`_ \n
-  `BigTIFF technical overview <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
+  `BigTIFF technical overview <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`_ \n
+  `ImageJ TIFF overview <https://imagej.net/TIFF>`_ \n
+  `Source code for ImageJ's native TIFF reader <https://imagej.nih.gov/ij/developer/source/ij/io/TiffDecoder.java.html>`_
 
 [TillPhotonics TillVision]
 extensions = .vws

--- a/docs/sphinx/formats/tiff.rst
+++ b/docs/sphinx/formats/tiff.rst
@@ -57,6 +57,19 @@ Utility: |Fair|
 Bio-Formats can also read BigTIFF files (TIFF files larger than 4 GB). 
 Bio-Formats can save image stacks as TIFF or BigTIFF. 
 
+TIFF files written by ImageJ are also supported, including ImageJ TIFFs larger 
+than 4GB.  ImageJ TIFFs are detected based upon the text in the first IFD's 
+"ImageDescription" tag; this tag's value is then used to determine Z, C, and T 
+sizes as well as physical sizes and timestamps.  For ImageJ TIFFs larger than 
+4GB, a single IFD is expected (instead of one IFD per image plane).  The 
+"ImageDescription" is used to determine the number of images, the pixel data 
+for which are expected to be stored contiguously at the offset indicated in 
+the sole IFD.  This differs from standard TIFF and BigTIFF; if the 
+"ImageDescription" tag is missing or invalid, only the first image will be 
+read. 
+
 .. seealso:: 
   `TIFF technical overview <http://www.awaresystems.be/imaging/tiff/faq.html#q3>`_ 
-  `BigTIFF technical overview <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
+  `BigTIFF technical overview <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`_ 
+  `ImageJ TIFF overview <https://imagej.net/TIFF>`_ 
+  `Source code for ImageJ's native TIFF reader <https://imagej.nih.gov/ij/developer/source/ij/io/TiffDecoder.java.html>`_

--- a/docs/sphinx/users/imagej/index.rst
+++ b/docs/sphinx/users/imagej/index.rst
@@ -142,3 +142,10 @@ Usage tips
    is used, select :menuselection:`All files` or :menuselection:`All supported
    file types` in the ``Files of type`` box, as an extension will not be
    automatically added in those cases.
+
+-  Saving an open image using Bio-Formats must be done via
+   :menuselection:`Plugins > Bio-Formats > Bio-Formats Exporter` or the corresponding macro code.
+   :menuselection:`File > Save` and :menuselection:`File > Save As...` do not use Bio-Formats.
+   In particular, using :menuselection:`File > Save As...` to save a TIFF will result in an
+   ImageJ-specific TIFF being written.  While Bio-Formats can read ImageJ TIFFs, other software
+   may not; see :doc:`/formats/tiff` for additional information.


### PR DESCRIPTION
This updates the TIFF format page to include a brief description of support for ImageJ TIFFs and adds a corresponding export-related usage tip to the ImageJ user page.

See also https://github.com/openmicroscopy/bioformats/pull/2957