### PR TITLE
GIF: fix behavior of openBytes when reading planes out of order

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/GIFReader.java
+++ b/components/formats-bsd/src/loci/formats/in/GIFReader.java
@@ -34,6 +34,8 @@ package loci.formats.in;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Vector;
 
 import loci.common.RandomAccessInputStream;
@@ -101,6 +103,8 @@ public class GIFReader extends FormatReader {
   private Vector<byte[]> images;
   private Vector<int[]> colorTables;
 
+  private transient Set<Integer> planesRead = new HashSet<Integer>();
+
   // -- Constructor --
 
   /** Constructs a new GIF reader. */
@@ -144,8 +148,8 @@ public class GIFReader extends FormatReader {
     act = colorTables.get(no);
 
     byte[] b = images.get(no);
-    if (no > 0 && transparency) {
-      byte[] prev = images.get(no - 1);
+    if (no > 0 && transparency && !planesRead.contains(no)) {
+      byte[] prev = planesRead.contains(no - 1) ? images.get(no - 1) : openBytes(no - 1);
       int idx = transIndex;
       if (idx >= 127) idx = 0;
       for (int i=0; i<b.length; i++) {
@@ -155,6 +159,7 @@ public class GIFReader extends FormatReader {
       }
       images.setElementAt(b, no);
     }
+    planesRead.add(no);
 
     for (int row=0; row<h; row++) {
       System.arraycopy(b, (row + y) * getSizeX() + x, buf, row*w, w);


### PR DESCRIPTION
See https://trello.com/c/abmCVITh/149-animated-gif-in-omero and
https://trac.openmicroscopy.org/ome/ticket/12962

To test, use the file from QA 11167.  Without this change, compare ```showinf -range 3 3``` (or any range of planes not including 0) against the corresponding planes shown by just ```showinf```.  The plane shown by ```showinf -range 3 3``` should be obviously different, though ```showinf -range 0 0``` will match the first plane in ```showinf```.

With this PR, the same tests should result in all planes matching.

This should be safe for a patch release, as it should not break memoization.