### PR TITLE
ND2: Incorrect channel size

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1192,7 +1192,7 @@ public class NativeND2Reader extends FormatReader {
           availableBytes -= 4096;
         }
       }
-      if (planeSize > 0 &&
+      if (planeSize > 0 && imageOffsets.size() > 1 && 
         availableBytes > DataTools.safeMultiply64(planeSize, 3))
       {
         if (availableBytes < DataTools.safeMultiply64(planeSize, 6)) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1192,7 +1192,7 @@ public class NativeND2Reader extends FormatReader {
           availableBytes -= 4096;
         }
       }
-      if (planeSize > 0 && imageOffsets.size() > 1 && 
+      if (planeSize > 0 && imageOffsets.size() > 1 &&
         availableBytes > DataTools.safeMultiply64(planeSize, 3))
       {
         if (availableBytes < DataTools.safeMultiply64(planeSize, 6)) {


### PR DESCRIPTION
This PR is being used to test a fix for https://trello.com/c/RyXt2BAg/177-nd2-incorrect-channel-count

Essentially a single channel single plane image is being mistakenly read as a 3 channel rgb image.

When there is only a single image offset the availableBytes is based on `in.length` which is not an accurate measure of the true image size. As such for single plane images they can be mistakenly modified from single channel to rgb.