### PR TITLE
EPS: fix pixel data reading in the embedded TIFF case

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -116,6 +116,7 @@ public class EPSReader extends FormatReader {
 
     if (isTiff) {
       long[] offsets = ifds.get(0).getStripOffsets();
+      long[] byteCounts = ifds.get(0).getStripByteCounts();
       in.seek(offsets[0]);
 
       if (map == null) {
@@ -124,20 +125,26 @@ public class EPSReader extends FormatReader {
       }
 
       byte[] b = new byte[w * h];
-      in.skipBytes(2 * y * getSizeX());
+      int bpp = (int) (byteCounts[0] / (getSizeX() * getSizeY()));
+      in.skipBytes(bpp * y * getSizeX());
       for (int row=0; row<h; row++) {
-        in.skipBytes(x * 2);
+        in.skipBytes(x * bpp);
         for (int col=0; col<w; col++) {
-          b[row * w + col] = (byte) (in.readShort() & 0xff);
+          if (bpp == 1) {
+            b[row * w + col] = in.readByte();
+          }
+          else if (bpp == 2) {
+            b[row * w + col] = (byte) (in.readShort() & 0xff);
+          }
         }
-        in.skipBytes(2 * (getSizeX() - w - x));
+        in.skipBytes(bpp * (getSizeX() - w - x));
       }
 
       for (int i=0; i<b.length; i++) {
         int ndx = b[i] & 0xff;
         for (int j=0; j<getSizeC(); j++) {
           if (j < 3) {
-            buf[i*getSizeC() + j] = (byte) map[ndx + j*256];
+            buf[i*getSizeC() + j] = (byte) ((map[ndx + j*256] >> 8) & 0xff);
           }
           else {
             boolean zero =
@@ -236,6 +243,9 @@ public class EPSReader extends FormatReader {
       m.sizeZ = 1;
       m.sizeT = 1;
       m.sizeC = firstIFD.getSamplesPerPixel();
+      if (map != null && getSizeC() == 1) {
+        m.sizeC = 3;
+      }
       if (getSizeC() == 2) m.sizeC = 4;
       m.littleEndian = firstIFD.isLittleEndian();
       m.interleaved = true;


### PR DESCRIPTION
To test, use ```data_repo/curated/eps/melissa/sample.eps``` (created from ```data_repo/curated/tiff/pablo/sample.tif```).

Without this PR, ```showinf``` should result in an exception:

```
Exception in thread "main" java.io.EOFException: Attempting to read beyond end of file.
	at loci.common.ByteArrayHandle.readShort(ByteArrayHandle.java:333)
	at loci.common.RandomAccessInputStream.readShort(RandomAccessInputStream.java:573)
	at loci.formats.in.EPSReader.openBytes(EPSReader.java:131)
	at loci.formats.FormatReader.openBytes(FormatReader.java:886)
	at loci.formats.ImageReader.openBytes(ImageReader.java:441)
	at loci.formats.ReaderWrapper.openBytes(ReaderWrapper.java:334)
	at loci.formats.gui.BufferedImageReader.openImage(BufferedImageReader.java:86)
	at loci.formats.tools.ImageInfo.readPixels(ImageInfo.java:818)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1051)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1117)
```

With this PR, the same test should show an image that looks the same as the source image (```tiff/pablo/sample.tif```).  Existing EPS files should not be affected, so builds should remain green.

/cc @chris-allan 