### PR TITLE
bio-formats-plugins: LibraryChecker: Use safe version check

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
@@ -106,9 +106,7 @@ public final class LibraryChecker {
 
   /** Checks for a new enough version of the Java Runtime Environment. */
   public static boolean checkJava() {
-    String version = System.getProperty("java.version");
-    double ver = Double.parseDouble(version.substring(0, 3));
-    if (ver < 1.7) {
+    if (!IJ.isJava17()) {
       IJ.error("Bio-Formats Plugins",
         "Sorry, the Bio-Formats plugins require Java 1.7 or later.");
       return false;


### PR DESCRIPTION
`java.version` version comparison is broken with Java 9.  Use a safe comparison using functionality already built into ImageJ.

Testing: Run ImageJ with a build containing the fixes in this PR.  If you can open the importer dialogue, this is working correctly (with Java 7 or 8).  It should also open with Java 9 (with latest daily imagej build), but there may be other Java 9 issues, so working with Java 9 isn't strictly required.