### PR TITLE
CZI - Incorrect illuminations

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1635,6 +1635,9 @@ public class ZeissCZIReader extends FormatReader {
             if (dimension.start >= illuminations) {
               illuminations = dimension.start + 1;
             }
+            if (dimension.size < illuminations) {
+              illuminations = dimension.size;
+            }
             break;
           case 'B':
             if (dimension.start >= acquisitions) {
@@ -1785,6 +1788,9 @@ public class ZeissCZIReader extends FormatReader {
             break;
           case 'I':
             i = dimension.start;
+            if (i >= illuminations) {
+              i = illuminations - 1;
+            }
             break;
           case 'B':
             if (extraIndex >= 0) {


### PR DESCRIPTION
This PR is a follow up to https://github.com/openmicroscopy/bioformats/issues/2946

The issue occurring is that we have a series that is a tiled imaging of a single channel and was done with a dual illumination. The series were separated by illumination, thus, 'file.czi' = left illumination, 'file(1).czi' = right illumination, 'file(2).czi' - left again. When opening the files separately one half of the files opens correctly while the other opens with an incorrect illumination and channel count.

From the debugging the problem was that the reader was parsing an illumination dimension start value of 1 rather than 0 and incorrectly modifying the number of illuminations and channels.