### PR TITLE
JPEG-XR: allow non-interleaved data to be returned

### DIFF
--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -68,6 +68,11 @@ public class JPEGXRCodec extends BaseCodec {
   /**
    * The CodecOptions parameter should have the following fields set:
    *  {@link CodecOptions#maxBytes maxBytes}
+   *  {@link CodecOptions#interleaved interleaved}
+   *  {@link CodecOptions#bitsPerSample bitsPerSample}
+   *  {@link CodecOptions#littleEndian littleEndian}
+   *  {@link CodecOptions#width width}
+   *  {@link CodecOptions#height height}
    *
    * @see Codec#decompress(byte[], CodecOptions)
    */

--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -89,20 +89,20 @@ public class JPEGXRCodec extends BaseCodec {
 
     int bpp = options.bitsPerSample / 8;
     int pixels = options.width * options.height;
-    int c = uncompressed.length / (pixels * bpp);
+    int channels = uncompressed.length / (pixels * bpp);
 
-    if (c == 1) {
+    if (channels == 1) {
       return uncompressed;
     }
 
     byte[] deinterleaved = new byte[uncompressed.length];
 
     for (int p=0; p<pixels; p++) {
-      for (int channel=0; channel<c; channel++) {
+      for (int c=0; c<channels; c++) {
         for (int b=0; b<bpp; b++) {
           int bb = options.littleEndian ? b : bpp - b - 1;
-          deinterleaved[bpp * (channel * pixels + p) + bb] =
-            uncompressed[bpp * (p * c + channel) + b];
+          deinterleaved[bpp * (c * pixels + p) + bb] =
+            uncompressed[bpp * (p * channels + c) + b];
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
+++ b/components/formats-gpl/src/loci/formats/codec/JPEGXRCodec.java
@@ -31,7 +31,6 @@ import loci.common.RandomAccessInputStream;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceFactory;
 import loci.formats.FormatException;
-import loci.formats.ImageTools;
 import loci.formats.MissingLibraryException;
 import loci.formats.UnsupportedCompressionException;
 import loci.formats.services.JPEGXRService;

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3654,9 +3654,10 @@ public class ZeissCZIReader extends FormatReader {
           data = new LZWCodec().decompress(data, options);
           break;
         case JPEGXR:
-          options.maxBytes = directoryEntry.dimensionEntries[0].storedSize *
-            directoryEntry.dimensionEntries[1].storedSize *
-            getRGBChannelCount() * bpp;
+          options.width = directoryEntry.dimensionEntries[0].storedSize;
+          options.height = directoryEntry.dimensionEntries[1].storedSize;
+          options.maxBytes = options.width * options.height *
+            getRGBChannelCount() * FormatTools.getBytesPerPixel(getPixelType());
           data = new JPEGXRCodec().decompress(data, options);
           break;
         case 104: // camera-specific packed pixels

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3621,7 +3621,6 @@ public class ZeissCZIReader extends FormatReader {
       s.order(isLittleEndian());
       s.seek(dataOffset);
 
-      int bpp = FormatTools.getBytesPerPixel(getPixelType());
       if (directoryEntry.compression == UNCOMPRESSED) {
         if (buf == null) {
           buf = new byte[(int) dataSize];
@@ -3657,7 +3656,7 @@ public class ZeissCZIReader extends FormatReader {
           options.width = directoryEntry.dimensionEntries[0].storedSize;
           options.height = directoryEntry.dimensionEntries[1].storedSize;
           options.maxBytes = options.width * options.height *
-            getRGBChannelCount() * FormatTools.getBytesPerPixel(getPixelType());
+            getRGBChannelCount() * bytesPerPixel;
           data = new JPEGXRCodec().decompress(data, options);
           break;
         case 104: // camera-specific packed pixels

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3638,10 +3638,13 @@ public class ZeissCZIReader extends FormatReader {
       byte[] data = new byte[(int) dataSize];
       s.read(data);
 
+      int bytesPerPixel = FormatTools.getBytesPerPixel(getPixelType());
       CodecOptions options = new CodecOptions();
       options.interleaved = isInterleaved();
       options.littleEndian = isLittleEndian();
-      options.maxBytes = getSizeX() * getSizeY() * getRGBChannelCount() * bpp;
+      options.bitsPerSample = bytesPerPixel * 8;
+      options.maxBytes =
+          getSizeX() * getSizeY() * getRGBChannelCount() * bytesPerPixel;
 
       switch (directoryEntry.compression) {
         case JPEG:


### PR DESCRIPTION
As with several other codecs, ```JPEGXRCodec``` now uses ```options.interleaved``` to determine how pixel data should be returned.  This is useful for any future readers that might use ```JPEGXRCodec``` and expect non-interleaved images.  ```ZeissCZIReader``` expects interleaved images, but is updated to supply more parameters via ```CodecOptions```.  f00b70, 797dee8, and 6dc10da were backported from private PRs; the remaining commits are minor cleanup.

It looks like ```JPEGXRCodec``` was never migrated to https://github.com/ome/ome-codecs, which is why I haven't opened a PR there as well.

There should be no difference in functionality from the CZI perspective, so testing is a matter of code review and verifying that builds remain green.