### PR TITLE
Add java 7 reminders & fix downloads

### DIFF
--- a/docs/sphinx/about/bug-reporting.rst
+++ b/docs/sphinx/about/bug-reporting.rst
@@ -10,13 +10,21 @@ problem has already been addressed. The Fiji updater will automatically do
 this for you, while in ImageJ you can select
 :menuselection:`Plugins --> Bio-Formats --> Update Bio-Formats Plugins`.
 
-You can also download the :downloads:`latest version of Bio-Formats <>`.
-If you are not sure which version you need, select the latest build of the
-Bio-Formats package bundle from the components table.
+You can also download the `latest version of Bio-Formats <https://www.openmicroscopy.org/bio-formats/downloads/>`_ from
+the OME website.
 
 Common issues to check
 ----------------------
 
+-  If you get an error message similar to::
+
+       java.lang.UnsupportedClassVersionError: loci/plugins/LociImporter :
+       Unsupported major.minor version 51.0
+
+       This plugin requires Java 1.7 or later.
+
+   you need to upgrade your system Java version to Java 7 or above, or
+   download a new version of ImageJ/Fiji bundled with Java 8.
 -  If your 12, 14 or 16-bit images look all black when you open them,
    typically the problem is that the pixel values
    are very, very small relative to the maximum possible pixel value (4095,

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -147,8 +147,8 @@ extlinks = {
     'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/bio-formats/' + version + '/' + '%s', ''),
-    'javadoc' : (downloads_root + '/bio-formats/' + version + '/api/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats5.7/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats5.7/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
     'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_model_version + '/' + '%s', ''),
     'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_model_version + '/' + '%s', ''),

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -147,8 +147,8 @@ extlinks = {
     'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/bio-formats5.6/%s', ''),
-    'javadoc' : (downloads_root + '/latest/bio-formats5.6/api/%s', ''),
+    'downloads' : (downloads_root + '/bio-formats/' + version + '/' + '%s', ''),
+    'javadoc' : (downloads_root + '/bio-formats/' + version + '/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
     'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_model_version + '/' + '%s', ''),
     'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_model_version + '/' + '%s', ''),

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -118,10 +118,10 @@ bf_cpp = bf_github_blob + 'cpp/'
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
 trac_root = 'https://trac.openmicroscopy.org/ome'
-oo_root = 'http://www.openmicroscopy.org'
+oo_root = 'https://www.openmicroscopy.org'
 lists_root = 'http://lists.openmicroscopy.org.uk'
-downloads_root = 'http://downloads.openmicroscopy.org'
-docs_root = 'http://docs.openmicroscopy.org'
+downloads_root = 'https://downloads.openmicroscopy.org'
+docs_root = 'https://docs.openmicroscopy.org'
 
 extlinks = {
     # Trac links

--- a/docs/sphinx/developers/building-bioformats.rst
+++ b/docs/sphinx/developers/building-bioformats.rst
@@ -3,13 +3,16 @@
 Obtaining and building Bio-Formats
 ==================================
 
+.. note:: Bio-Formats requires Java 7 or above
+
 .. _source-code:
 
 Source code
 -----------
 
 The source code for this Bio-Formats release is available from the
-:downloads:`download page <>`.  This release and the latest
+:downloads:`downloads site <>`.
+This release and the latest
 Bio-Formats source code are also available from the Git repository.
 This may be accessed using the repository path::
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -18,8 +18,8 @@ supported by Bio-Formats.
 - :doc:`developers/index`
 - :doc:`formats/index`
 
-Bio-Formats |release| uses the *June 2016* release of the
-:model_doc:`OME Model <>`.
+Bio-Formats |release| requires Java 7 or above and uses the *June 2016*
+release of the :model_doc:`OME Model <>`.
     
 **Bio-Formats is a community project and we welcome your input.** You can
 find guidance on :doc:`about/bug-reporting`, upload files to our

--- a/docs/sphinx/users/focalpoint/index.rst
+++ b/docs/sphinx/users/focalpoint/index.rst
@@ -17,7 +17,7 @@ necessary.
 Upgrading
 ---------
 
-It should be possible to use a :downloads:`newer version of Bio-Formats <>` 
+It should be possible to use a `newer version of Bio-Formats <https://www.openmicroscopy.org/bio-formats/downloads/>`_
 by overwriting the old **loci\_tools.jar** within the FocalPoint
 distribution. For Mac OS X, you will have to control click the FocalPoint
 program icon, choose "Show Package Contents" and navigate into

--- a/docs/sphinx/users/idl/index.rst
+++ b/docs/sphinx/users/idl/index.rst
@@ -25,4 +25,4 @@ Upgrading
 ---------
 
 To use a newer version of Bio-Formats, overwrite the requisite JAR files
-with the :downloads:`newer version <>` and restart IDL.
+with the `newer version <https://www.openmicroscopy.org/bio-formats/downloads/>`_ and restart IDL.

--- a/docs/sphinx/users/imagej/index.rst
+++ b/docs/sphinx/users/imagej/index.rst
@@ -44,7 +44,7 @@ Upgrading
 ---------
 
 To upgrade, just overwrite the old **bioformats_package.jar** with the
-:downloads:`latest one <>`.
+`latest one <https://www.openmicroscopy.org/bio-formats/downloads/>`_.
 
 You can also upgrade the Bio-Formats plugin directly from ImageJ. Select
 :menuselection:`Plugins --> Bio-Formats --> Update Bio-Formats Plugins`

--- a/docs/sphinx/users/imagej/installing.rst
+++ b/docs/sphinx/users/imagej/installing.rst
@@ -12,7 +12,7 @@ Installing Bio-Formats in ImageJ
 
 Once you `download <http://rsbweb.nih.gov/ij/download.html>`__ and
 install ImageJ, you can install the Bio-Formats plugin by going to the
-Bio-Formats :downloads:`download page <>` and saving the
+Bio-Formats `download page <https://www.openmicroscopy.org/bio-formats/downloads/>`_ and saving the
 **bioformats\_package.jar** to the Plugins directory within ImageJ.
 
 .. figure:: /images/PluginDirectory.png

--- a/docs/sphinx/users/matlab/index.rst
+++ b/docs/sphinx/users/matlab/index.rst
@@ -14,8 +14,9 @@ Installation
 ------------
 
 Download the MATLAB toolbox from the Bio-Formats
-:downloads:`downloads page <>`. Unzip :file:`bfmatlab.zip` and add the
-unzipped :file:`bfmatlab` folder to your MATLAB path.
+`downloads page <https://www.openmicroscopy.org/bio-formats/downloads/>`_.
+Unzip :file:`bfmatlab.zip` and add the unzipped :file:`bfmatlab` folder to
+your MATLAB path.
 
 .. note:: As of Bio-Formats 5.0.0, this zip now contains the bundled jar
     and you no longer need to download :file:`loci_tools.jar` or the new
@@ -41,7 +42,7 @@ Upgrading
 ---------
 
 To use a newer version of Bio-Formats, overwrite the content of the
-:file:`bfmatlab` folder with the :downloads:`newer version <>` of the
+:file:`bfmatlab` folder with the `newer version <https://www.openmicroscopy.org/bio-formats/downloads/>`_ of the
 toolbox and restart MATLAB.
 
 Alternative scripts

--- a/docs/sphinx/users/mipav/index.rst
+++ b/docs/sphinx/users/mipav/index.rst
@@ -39,5 +39,6 @@ See the :source:`readme file <components/formats-bsd/utils/mipav/readme.txt>`
 for more information.
 
 To upgrade, just overwrite the old **bioformats\_package.jar** with the
-:downloads:`latest one <>`. You may want to download the latest version of MIPAV first, to take advantage of new
+`latest one <https://www.openmicroscopy.org/bio-formats/downloads/>`_. You may
+want to download the latest version of MIPAV first, to take advantage of new
 features and bug-fixes.

--- a/docs/sphinx/users/octave/index.rst
+++ b/docs/sphinx/users/octave/index.rst
@@ -33,7 +33,7 @@ Installation
    system-wide or user installation respectively).
 #. Add `bioformats_package.jar` to Octave's *static* javaclasspath (see
    `Octave's documentation <https://www.gnu.org/software/octave/doc/interpreter/Making-Java-Classes-Available.html>`_).
-#. Download the Octave package from the :downloads:`downloads page <>`.
+#. Download :downloads:`Octave package <artifacts/>`.
 #. Start octave and install the package with::
 
       >> pkg install path-to-bioformats-octave-version.tar.gz

--- a/docs/sphinx/users/octave/index.rst
+++ b/docs/sphinx/users/octave/index.rst
@@ -33,7 +33,7 @@ Installation
    system-wide or user installation respectively).
 #. Add `bioformats_package.jar` to Octave's *static* javaclasspath (see
    `Octave's documentation <https://www.gnu.org/software/octave/doc/interpreter/Making-Java-Classes-Available.html>`_).
-#. Download :downloads:`Octave package <artifacts/>`.
+#. Download the :downloads:`Octave package <artifacts/>`.
 #. Start octave and install the package with::
 
       >> pkg install path-to-bioformats-octave-version.tar.gz

--- a/docs/sphinx/users/visad/index.rst
+++ b/docs/sphinx/users/visad/index.rst
@@ -15,8 +15,8 @@ installation is necessary.
 Upgrading
 ---------
 
-It should be possible to use a newer version of Bio-Formats by putting
-the latest
+It should be possible to use a `newer version <https://www.openmicroscopy.org/bio-formats/downloads/>`_ of Bio-Formats by
+putting the latest
 :downloads:`bioformats_package.jar <artifacts/bioformats_package.jar>` or
 :downloads:`formats-gpl.jar <artifacts/formats-gpl.jar>` before **visad.jar**
 in the class path. Alternately, you can create a "VisAD Lite" using the

--- a/docs/sphinx/users/visbio/index.rst
+++ b/docs/sphinx/users/visbio/index.rst
@@ -16,7 +16,7 @@ necessary.
 Upgrading
 ---------
 
-It should be possible to use a :downloads:`newer version of Bio-Formats <>` 
+It should be possible to use a `newer version of Bio-Formats <https://www.openmicroscopy.org/bio-formats/downloads/>`_ 
 by overwriting the old **bio-formats.jar** and optional libraries within
 the VisBio distribution. For Mac OS X, you'll have to control click the
 VisBio program icon, choose "Show Package Contents" and navigate into


### PR DESCRIPTION
See https://trello.com/c/WnTLpmC6/4-make-bio-formats-prereqs-obvious

This adds reminders that BF requires Java 7 or above. 

While I was editing, i noticed the hardcoded 5.6 versioned downloads and API links - I've changed these to use the current version number so we don't have to keep updating them and also amended the various download links on pages to point at the latest downloads page on the new website where they are referring to latest or new versions (this does mean we have a slight mish-mash of 'this version' and 'latest version' links so I'm happy to change all of them to match if we can agree a preference between the two).