### PR TITLE
Bio rad gel format update

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -340,15 +340,29 @@ extensions = .1sc
 owner = `Bio-Rad <http://www.bio-rad.com>`_
 bsd = no
 weHave = * software that can read Bio-Rad Gel files \n
-* several Bio-Rad Gel files
-weWant = * a Bio-Rad Gel specification \n
-* more Bio-Rad Gel files
+* several Bio-Rad Gel files \n
+* reverse-engineered Bio-Rad Gel (1sc) file format specification \n
+* Bio-Rad's `Image Lab 5.2.1 <http://www.bio-rad.com/en-ch/product/image-lab-software>`_ software
+weWant = * more Bio-Rad Gel files
 pixelsRating = Good
 metadataRating = Fair
 opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = BioRadGelReader
+notes = * `Bio-Rad Gel Format (1sc) specification <http://biorad1sc-doc.readthedocs.io/>`_ \n
+* Python3 package of a Bio-Rad Gel Format (1sc) reader \n
+\n
+  * ``pip3 install biorad1sc_reader`` \n
+  * `biorad1sc_reader documentation <http://biorad1sc-reader.readthedocs.io/>`_ \n
+  * Includes command-line utilities \n
+\n
+    * bio1sc2tiff - convert 1sc file image to tiff \n
+    * bio1scmeta - report all metadata in a 1sc file \n
+    * bio1scread - report details on internal 1sc file structure \n
+\n
+  * `biorad1sc_reader on pypi <https://pypi.org/project/biorad1sc-reader/>`_ \n
+  * `biorad1sc_reader on github <https://github.com/itsayellow/biorad1sc_reader>`_
 
 [Bio-Rad PIC]
 extensions = .pic, .raw, .xml


### PR DESCRIPTION
For section [Bio-Rad Gel] I updated the fields: weHave, weWant, and notes.

Unfortunately, the documentation will not build for me using ant.  It complains of missing remote dependencies.

I have to the best of my knowledge written the ini file so it should make a valid .rst file.  I believe it should be ok.

This pull request is in reference to https://github.com/openmicroscopy/bioformats/issues/2971

The errors to: ```ant -f build.xml gen-format-page``` are below:
```
BUILD FAILED
/Users/itsayellow/git/bioformats/ant/java.xml:44: Unable to resolve artifact: Unable to get dependency information: Unable to read the metadata file for artifact 'edu.ucar:netcdf:jar': Cannot find parent: edu.ucar:thredds-parent for project: null:netcdf:jar:null for project null:netcdf:jar:null
  edu.ucar:netcdf:jar:4.3.22

from the specified remote repositories:
  central (http://repo.maven.apache.org/maven2),
  ome (http://artifacts.openmicroscopy.org/artifactory/maven/)

Path to dependency: 
	1) ome:bf-autogen:jar:5.7.2-SNAPSHOT
	2) ome:formats-gpl:jar:5.7.2-SNAPSHOT
```