### PR TITLE
Deltavision: parse more key/value pairs from the log file

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -990,7 +990,7 @@ public class DeltavisionReader extends FormatReader {
 
     for (String line : lines) {
       int colon = line.indexOf(':');
-      if (colon != -1 && !line.startsWith("Created")) {
+      if (colon >= 0 && colon < line.length() - 1 && !line.startsWith("Created")) {
         key = line.substring(0, colon).trim();
 
         value = line.substring(colon + 1).trim();
@@ -1226,6 +1226,24 @@ public class DeltavisionReader extends FormatReader {
         else {
           LOGGER.warn("Could not parse date '{}'", line);
         }
+      }
+      else if (line.startsWith("#KEY")) {
+        line = line.substring(line.indexOf(" ")).trim();
+        int split = line.indexOf(":");
+        if (split < 0) {
+          split = line.indexOf(" ");
+        }
+        key = line.substring(0, split).trim();
+        value = line.substring(split + 1).trim();
+        addGlobalMeta(key, value);
+      }
+      else if (line.endsWith(":")) {
+        prefix = line.substring(0, line.length() - 1);
+      }
+      else if (!line.startsWith("#") && !line.replace("-", "").isEmpty() &&
+        !prefix.isEmpty())
+      {
+        addGlobalMetaList(prefix, line);
       }
     }
 


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/13237

To test, use the dataset in ```data_repo/curated/deltavision/michael/ticket-13237/```.  This was created by copying ```data_repo/curated/deltavision/michael/mtools/CTR_centrosome_01_R3D.dv``` to ```01_R3D.dv``` and placing ```01_R3D.dv.log``` from the ticket attachment in the same directory.

Comparing ```showinf -nopix 01_R3D.dv``` with and without this change should show that there are more original metadata key/value pairs with this change.  The log file lines noted on the ticket should be represented by original metadata with this change.  There should be no difference in pixel data or image dimensions.