### PR TITLE
Metamorph TIFF: populate exposure times for all planes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphTiffReader.java
@@ -496,6 +496,9 @@ public class MetamorphTiffReader extends BaseTiffReader {
             if (dualCamera) {
               exposureIndex /= getEffectiveSizeC();
             }
+            if (exposures.size() == 1) {
+              exposureIndex = 0;
+            }
             if (exposureIndex < exposures.size() && exposures.get(exposureIndex) != null) {
               store.setPlaneExposureTime(new Time(exposures.get(exposureIndex), UNITS.SECOND), s, image);
             }


### PR DESCRIPTION
If only one exposure time is defined, use it for all planes.  See
https://trello.com/c/jAeCrkSt/27-metamorphreader-exposuretimes-test-failure

To test, compare the ```ExposureTime``` values shown by ```showinf -nopix -omexml data_repo/curated/metamorph/chris/Foo/exp1_w1_s1_t1.tif``` with and without this PR.  With this PR, every ```Plane``` should have a valid ```ExposureTime```.  Also review the corresponding configuration PR (forthcoming, based upon https://github.com/openmicroscopy/data_repo_config/pull/147) and verify that builds remain green.

This is not urgent at all, but should be safe for a patch release.