### PR TITLE
Fix data gallery link & add https to awaresystems

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -107,7 +107,7 @@ utilityRating = Fair
 reader = GelReader
 privateSpecification = true
 notes = .. seealso:: \n
-  `GEL Technical Overview <http://www.awaresystems.be/imaging/tiff/tifftags/docs/gel.html>`_
+  `GEL Technical Overview <https://www.awaresystems.be/imaging/tiff/tifftags/docs/gel.html>`_
 
 [Amira Mesh]
 extensions = .am, .amiramesh, .grey, .hx, .labels
@@ -2228,9 +2228,9 @@ extensions = .tiff, .tif, .tf2, .tf8, .btf
 owner = `Adobe <http://www.adobe.com>`_
 developer = Aldus and Microsoft
 bsd = yes
-samples = `LZW TIFF data gallery <http://marlin.life.utsa.edu/Data_Gallery.html>`_ \n
-`Big TIFF <http://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
-weHave = * a `TIFF specification document <http://www.awaresystems.be/imaging/tiff.html>`_ \n
+samples = `LZW TIFF data gallery <http://marlin.life.utsa.edu/marlin/Data_Gallery.html>`_ \n
+`Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
+weHave = * a `TIFF specification document <https://www.awaresystems.be/imaging/tiff.html>`_ \n
 * many TIFF datasets \n
 * a few BigTIFF datasets
 pixelsRating = Very good

--- a/docs/sphinx/formats/amersham-biosciences-gel.rst
+++ b/docs/sphinx/formats/amersham-biosciences-gel.rst
@@ -51,4 +51,4 @@ Utility: |Fair|
 format, we are not able to distribute them to third parties.**
 
 .. seealso:: 
-  `GEL Technical Overview <http://www.awaresystems.be/imaging/tiff/tifftags/docs/gel.html>`_
+  `GEL Technical Overview <https://www.awaresystems.be/imaging/tiff/tifftags/docs/gel.html>`_

--- a/docs/sphinx/formats/tiff.rst
+++ b/docs/sphinx/formats/tiff.rst
@@ -26,12 +26,12 @@ Writer: TiffWriter (:bsd-writer:`Source Code <TiffWriter.java>`)
 
 Sample Datasets:
 
-- `LZW TIFF data gallery <http://marlin.life.utsa.edu/Data_Gallery.html>`_ 
-- `Big TIFF <http://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
+- `LZW TIFF data gallery <http://marlin.life.utsa.edu/marlin/Data_Gallery.html>`_ 
+- `Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
 
 We currently have:
 
-* a `TIFF specification document <http://www.awaresystems.be/imaging/tiff.html>`_ 
+* a `TIFF specification document <https://www.awaresystems.be/imaging/tiff.html>`_ 
 * many TIFF datasets 
 * a few BigTIFF datasets
 


### PR DESCRIPTION
The Data Gallery had moved and was 404  and making the build yellow - https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/875/warnings3Result/

While I was updating that anyway I noticed the awaresystems links which auto-redirect to https and figured I may as well update them too as I did a similar fix on the Model docs -https://github.com/ome/ome-model/pull/56/commits/3abc2e9b53372c4190a3ccfd1c3ea16dbd9c072b