### PR TITLE
ZeissCZIReader: Pad scene numbers to order lexicographically

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1233,7 +1233,7 @@ public class ZeissCZIReader extends FormatReader {
           store.setImageName("", i);
         }
         else {
-          store.setImageName("Scene #" + i, i);
+          store.setImageName(String.format("Scene #%0" + ((int) Math.log10(positions - extraImages.size()) + 1) + "d", i), i);
         }
       }
       else if (extraIndex == 0) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1233,7 +1233,7 @@ public class ZeissCZIReader extends FormatReader {
           store.setImageName("", i);
         }
         else {
-          store.setImageName(String.format("Scene #%0" + ((int) Math.log10(positions - extraImages.size()) + 1) + "d", i), i);
+          store.setImageName(String.format("scene position #%0" + ((int) Math.log10(positions - extraImages.size()) + 1) + "d", i), i);
         }
       }
       else if (extraIndex == 0) {


### PR DESCRIPTION
See https://trello.com/c/52uaFv3n/194-czi-scene-ordering for original bug report and sample files.

This PR ensures that an appropriate amount of zero padding is used for scene numbers.

Testing:

```
./tools/showinf -noflat -nopix -omexml 18097/2017_10_13__4052-1_offline_fuse_jpegXR_lossy85.czi > new1-noflat.log
./tools/showinf -noflat -nopix -omexml -novalid 18097/2017_10_13__4064_none_JpegXR_lossy85percentdefault.czi > new2-noflat.log
```

Then look for `Scene #` in the output.  Without this PR, scene numbers will be the minimum number of digits.  With the PR, scene numbers will be left padded with zeros for the maximum number of digits used by all scenes.