### PR TITLE
FlexReader: Remove fieldCount check

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1695,9 +1695,9 @@ public class FlexReader extends FormatReader {
 
         // trust firstWellPlanes() if we know that the fields are not
         // split across multiple files
-        if (fieldNo > fieldCount && ((thisField < 0 && fieldCount < firstWellPlanes()) ||
-          fieldCount < (thisField * firstWellPlanes())))
-        {
+        if (fieldNo > fieldCount &&
+            (thisField < 0 ||
+             fieldCount < (thisField * firstWellPlanes()))) {
           fieldCount++;
         }
       }


### PR DESCRIPTION
See [QA 18096](https://www.openmicroscopy.org/qa2/qa/feedback/18096/).

Remove potentially incorrect fieldCount check.

Testing: Run the full-repo-subset job for flex.

--breaking