### PR TITLE
Add support for Avizo binary files

### DIFF
--- a/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
+++ b/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
@@ -87,7 +87,7 @@ public class AmiraParameters {
     throws FormatException, IOException
   {
     String firstLine = inputStream.readLine();
-    Matcher amiraMeshDef = Pattern.compile("#\\s+AmiraMesh.*?" +
+    Matcher amiraMeshDef = Pattern.compile("#\\s+(AmiraMesh|Avizo).*?" +
       "(BINARY|ASCII)(-LITTLE-ENDIAN)*").matcher(firstLine);
     if (amiraMeshDef.find()) {
       if (amiraMeshDef.group(1).equals("BINARY")) {


### PR DESCRIPTION
This is a follow up to https://github.com/openmicroscopy/bioformats/issues/2982

Both of the following should be recognised as a Binary file and read:
```
# Avizo BINARY-LITTLE-ENDIAN 2.1
# AmiraMesh BINARY-LITTLE-ENDIAN 2.1
```

To test:
- Ensure all builds and tests are green
- Ensure that sample files in the repo are green with both variations of the header above

Fixes #2982 