### PR TITLE
AmiraReader: Handle 'Avizo' in the file header

### DIFF
--- a/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
+++ b/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
@@ -87,13 +87,13 @@ public class AmiraParameters {
     throws FormatException, IOException
   {
     String firstLine = inputStream.readLine();
-    Matcher amiraMeshDef = Pattern.compile("#\\s+AmiraMesh.*?" +
+    Matcher amiraMeshDef = Pattern.compile("#\\s+(AmiraMesh|Avizo).*?" +
       "(BINARY|ASCII)(-LITTLE-ENDIAN)*").matcher(firstLine);
     if (amiraMeshDef.find()) {
-      if (amiraMeshDef.group(1).equals("BINARY")) {
-        littleEndian = amiraMeshDef.group(2) != null;
+      if (amiraMeshDef.group(2).equals("BINARY")) {
+        littleEndian = amiraMeshDef.group(3) != null;
       }
-      else if (amiraMeshDef.group(1).equals("ASCII")) {
+      else if (amiraMeshDef.group(2).equals("ASCII")) {
         ascii = true;
       }
       else {

--- a/components/formats-gpl/src/loci/formats/in/AmiraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AmiraReader.java
@@ -272,7 +272,7 @@ public class AmiraReader extends FormatReader {
     if (!FormatTools.validStream(stream, 50, false)) return false;
     String c = stream.readLine();
 
-    Matcher amiraMeshDef = Pattern.compile("#\\s+AmiraMesh.*?" +
+    Matcher amiraMeshDef = Pattern.compile("#\\s+(AmiraMesh|Avizo).*?" +
       "(BINARY|ASCII)(-LITTLE-ENDIAN)*").matcher(c);
     return amiraMeshDef.find();
   }


### PR DESCRIPTION
Closes #2982

Allow `AmiraMesh` or `Avizo` in the file header.

Testing: see #2982 for sample file.

Test configuration in https://github.com/openmicroscopy/data_repo_config/pull/245