### PR TITLE
ScreenReader: fix channel names population

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,46 @@
+environment:
+  AV_PROJECTS: 'c:\projects'
+  AV_BF_M2: 'c:\projects\m2'
+  AV_BF_PYTHON: 'c:\projects\python'
+  AV_BF_SOURCE: 'c:\projects\bioformats'
+
+  matrix:
+    - java: 1.8
+      build: maven
+    - java: 1.7
+      build: maven
+    - java: 1.8
+      build: ant
+
+cache:
+  - '%AV_BF_M2% -> appveyor.yml'
+  - '%AV_BF_PYTHON% -> appveyor.yml'
+
+os: 'Visual Studio 2015'
+clone_folder: '%AV_BF_SOURCE%'
+clone_depth: 5
+platform: x64
+
+init:
+  - git config --global core.autocrlf input
+  - if [%build%] == [ant] appveyor-retry cinst -y ant
+  - refreshenv
+  - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
+  - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
+  - PATH=%JAVA_HOME%\bin;%PATH%
+  - 'if NOT EXIST "c:\projects\%java%\%build%\" mkdir "c:\projects\%java%\%build%\"'
+  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m pip install virtualenv'
+  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
+  - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
+  - python -m pip install sphinx
+  - 'if [%build%] == [maven] set "MAVEN_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
+  - 'if [%build%] == [ant] set "ANT_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
+
+build_script:
+  - tools\test-build %build%
+
+artifacts:
+  - path: 'components\**\*.zip'
+  - path: 'components\**\*.jar'
+  - path: 'components\**\*.tar.*'
+  - path: 'artifacts\*'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,10 @@ environment:
       build: ant
       ant_version: 1.9.9
 
+branches:
+  except:
+    - /metadata.*/
+
 cache:
   - '%AV_BF_M2% -> appveyor.yml'
   - '%AV_BF_PYTHON% -> appveyor.yml'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ build_script:
   - 'if [%AV_BF_CREATE_VENV%] == [true] C:\Python36-x64\python -m pip install virtualenv'
   - 'if [%AV_BF_CREATE_VENV%] == [true] C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
   - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
-  - 'if [%AV_BF_CREATE_VENV%] == [true] python -m pip install sphinx'
+  - 'if [%AV_BF_CREATE_VENV%] == [true] python -m pip install sphinx==1.2.3'
   - tools\test-build %build%
 
 #artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,11 +4,18 @@ environment:
   AV_BF_PYTHON: 'c:\projects\python'
   AV_BF_SOURCE: 'c:\projects\bioformats'
 
+# Note that only Oracle JDK is provided.
   matrix:
     - java: 1.8
       build: maven
     - java: 1.8
       build: ant
+      ant_version: 1.10.1
+    - java: 1.7
+      build: maven
+    - java: 1.7
+      build: ant
+      ant_version: 1.9.9
 
 cache:
   - '%AV_BF_M2% -> appveyor.yml'
@@ -21,27 +28,28 @@ platform: x64
 
 init:
   - git config --global core.autocrlf input
-  - if [%build%] == [ant] appveyor-retry cinst -y ant
+  - if [%build%] == [ant] appveyor-retry cinst -y ant --version %ant_version%
   - refreshenv
   - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
   - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
   - PATH=%JAVA_HOME%\bin;%PATH%
-  - 'if NOT EXIST "c:\projects\%java%\%build%\" mkdir "c:\projects\%java%\%build%\"'
-  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m pip install virtualenv'
-  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
-  - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
-  - python -m pip install sphinx
   - 'if [%build%] == [maven] set "MAVEN_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
   - 'if [%build%] == [ant] set "ANT_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
 
 build_script:
+  # Cached venv is available from this point.
+  - 'if NOT EXIST "%AV_BF_PYTHON%\" set AV_BF_CREATE_VENV=true'
+  - 'if [%AV_BF_CREATE_VENV%] == [true] C:\Python36-x64\python -m pip install virtualenv'
+  - 'if [%AV_BF_CREATE_VENV%] == [true] C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
+  - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
+  - 'if [%AV_BF_CREATE_VENV%] == [true] python -m pip install sphinx'
   - tools\test-build %build%
 
-artifacts:
-  - path: 'components\bundles\bioformats_package\target\*.zip'
-  - path: 'components\bundles\bioformats_package\target\*.jar'
-  - path: 'components\bundles\bioformats_package\target\*.tar.*'
-  - path: 'artifacts\bioformats_package.jar'
-  - path: 'artifacts\bftools.zip'
-  - path: 'artifacts\bfmatlab.zip'
-  - path: 'artifacts\bioformats-octave*.tar.*'
+#artifacts:
+#  - path: 'components\bundles\bioformats_package\target\*.zip'
+#  - path: 'components\bundles\bioformats_package\target\*.jar'
+#  - path: 'components\bundles\bioformats_package\target\*.tar.*'
+#  - path: 'artifacts\bioformats_package.jar'
+#  - path: 'artifacts\bftools.zip'
+#  - path: 'artifacts\bfmatlab.zip'
+#  - path: 'artifacts\bioformats-octave*.tar.*'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,6 @@ environment:
   matrix:
     - java: 1.8
       build: maven
-    - java: 1.7
-      build: maven
     - java: 1.8
       build: ant
 
@@ -40,7 +38,10 @@ build_script:
   - tools\test-build %build%
 
 artifacts:
-  - path: 'components\**\*.zip'
-  - path: 'components\**\*.jar'
-  - path: 'components\**\*.tar.*'
-  - path: 'artifacts\*'
+  - path: 'components\bundles\bioformats_package\target\*.zip'
+  - path: 'components\bundles\bioformats_package\target\*.jar'
+  - path: 'components\bundles\bioformats_package\target\*.tar.*'
+  - path: 'artifacts\bioformats_package.jar'
+  - path: 'artifacts\bftools.zip'
+  - path: 'artifacts\bfmatlab.zip'
+  - path: 'artifacts\bioformats-octave*.tar.*'

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -377,17 +377,17 @@
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
       <id>unidata.releases</id>
-      <url>http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
       <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
       <id>ome</id>
       <name>OME Artifactory</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/maven/</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
   </repositories>
 </project>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -382,6 +382,7 @@
     <repository>
       <id>unidata.releases</id>
       <url>http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
       <id>ome</id>

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -490,9 +490,9 @@ public class ScreenReader extends FormatReader {
             store.setWellSampleImageRef(imageID, 0, well, nextWellSample);
             store.setWellSampleIndex(
               new NonNegativeInteger(seriesIndex), 0, well, nextWellSample);
-            if (null != channelNames[well]) {
-              for (int i = 0; i < channelNames[well].length; i++) {
-                store.setChannelName(channelNames[well][i], seriesIndex, i);
+            if (null != channelNames[spotIndex]) {
+              for (int i = 0; i < channelNames[spotIndex].length; i++) {
+                store.setChannelName(channelNames[spotIndex][i], seriesIndex, i);
               }
             }
             nextWellSample++;

--- a/components/formats-gpl/test/loci/formats/utests/in/4W2F.screen
+++ b/components/formats-gpl/test/loci/formats/utests/in/4W2F.screen
@@ -6,23 +6,27 @@ Fields = 2
 [Well 0]
 Row = 0
 Column = 0
-Field_0 = A01_f1.fake
-Field_1 = A01_f2.fake
+ChannelNames = A,B,C
+Field_0 = A01_f1&sizeC=3.fake
+Field_1 = A01_f2&sizeC=3.fake
 
 [Well 1]
 Row = 0
 Column = 1
-Field_0 = A02_f1.fake
-Field_1 = A02_f2.fake
+ChannelNames = A,B,C
+Field_0 = A02_f1&sizeC=3.fake
+Field_1 = A02_f2&sizeC=3.fake
 
 [Well 2]
 Row = 1
 Column = 0
-Field_0 = B01_f1.fake
-Field_1 = B01_f2.fake
+ChannelNames = A,B,C
+Field_0 = B01_f1&sizeC=3.fake
+Field_1 = B01_f2&sizeC=3.fake
 
 [Well 3]
 Row = 1
 Column = 1
-Field_0 = B02_f1.fake
-Field_1 = B02_f1.fake
+ChannelNames = A,B,C
+Field_0 = B02_f1&sizeC=3.fake
+Field_1 = B02_f1&sizeC=3.fake

--- a/components/formats-gpl/test/loci/formats/utests/in/4W2F.screen
+++ b/components/formats-gpl/test/loci/formats/utests/in/4W2F.screen
@@ -1,0 +1,28 @@
+[Plate]
+Rows = 2
+Columns = 2
+Fields = 2
+
+[Well 0]
+Row = 0
+Column = 0
+Field_0 = A01_f1.fake
+Field_1 = A01_f2.fake
+
+[Well 1]
+Row = 0
+Column = 1
+Field_0 = A02_f1.fake
+Field_1 = A02_f2.fake
+
+[Well 2]
+Row = 1
+Column = 0
+Field_0 = B01_f1.fake
+Field_1 = B01_f2.fake
+
+[Well 3]
+Row = 1
+Column = 1
+Field_0 = B02_f1.fake
+Field_1 = B02_f1.fake

--- a/components/formats-gpl/test/loci/formats/utests/in/4W2Fsparse.screen
+++ b/components/formats-gpl/test/loci/formats/utests/in/4W2Fsparse.screen
@@ -1,0 +1,23 @@
+[Plate]
+Rows = 2
+Columns = 2
+Fields = 2
+
+[Well 0]
+Row = 0
+Column = 0
+
+[Well 1]
+Row = 0
+Column = 1
+
+[Well 2]
+Row = 1
+Column = 0
+
+[Well 3]
+Row = 1
+Column = 1
+ChannelNames = A,B,C
+Field_0 = B02_f1&sizeC=3.fake
+Field_1 = B02_f1&sizeC=3.fake

--- a/components/formats-gpl/test/loci/formats/utests/in/ScreenReaderTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/in/ScreenReaderTest.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.utests.in;
+
+import java.io.File;
+import java.io.IOException;
+
+import loci.formats.in.ScreenReader;
+import loci.formats.FormatException;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.services.OMEXMLService;
+import loci.common.services.ServiceFactory;
+
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link ScreenReader}.
+ */
+public class ScreenReaderTest {
+
+  public ScreenReader reader;
+  public File file;
+  private OMEXMLService service;
+  private MetadataRetrieve m;
+ 
+  @BeforeMethod
+  public void setUp() throws Exception {
+    reader = new ScreenReader();
+    ServiceFactory sf = new ServiceFactory();
+    service = sf.getInstance(OMEXMLService.class);
+    reader.setMetadataStore(service.createOMEXMLMetadata());
+  }
+
+  @Test
+  public void testMinimalScreen() throws FormatException, IOException {
+    file = new File(this.getClass().getResource("minimal.screen").getFile());
+    System.out.println(file.getAbsolutePath());
+    reader.setId(file.getAbsolutePath());
+    m = service.asRetrieve(reader.getMetadataStore());
+    
+    assertEquals(m.getPlateCount(), 1);
+    assertEquals(m.getWellCount(0), 1);
+    assertEquals(m.getWellSampleCount(0, 0), 1);
+  }
+}

--- a/components/formats-gpl/test/loci/formats/utests/in/ScreenReaderTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/in/ScreenReaderTest.java
@@ -79,5 +79,33 @@ public class ScreenReaderTest {
     assertEquals(m.getPlateCount(), 1);
     assertEquals(m.getWellCount(0), 4);
     for (int i=0; i<4; i++) assertEquals(m.getWellSampleCount(0, i), 2);
+    assertEquals(m.getImageCount(), 8);
+    for (int i=0; i<8; i++) {
+      assertEquals(m.getChannelCount(i), 3);
+      assertEquals(m.getChannelName(i, 0), "A");
+      assertEquals(m.getChannelName(i, 1), "B");
+      assertEquals(m.getChannelName(i, 2), "C");
+    }
+  }
+
+  @Test
+  public void test4Wells2FieldsSparse() throws FormatException, IOException {
+    file = new File(this.getClass().getResource("4W2Fsparse.screen").getFile());
+    System.out.println(file.getAbsolutePath());
+    reader.setId(file.getAbsolutePath());
+    m = service.asRetrieve(reader.getMetadataStore());
+
+    assertEquals(m.getPlateCount(), 1);
+    assertEquals(m.getWellCount(0), 4);
+    assertEquals(m.getImageCount(), 2);
+    for (int i=0; i<3; i++) assertEquals(m.getWellSampleCount(0, i), 0);
+    assertEquals(m.getWellSampleCount(0, 3), 2);
+
+    for (int i=0; i<2; i++) {
+      assertEquals(m.getChannelCount(i), 3);
+      assertEquals(m.getChannelName(i, 0), "A");
+      assertEquals(m.getChannelName(i, 1), "B");
+      assertEquals(m.getChannelName(i, 2), "C");
+    }
   }
 }

--- a/components/formats-gpl/test/loci/formats/utests/in/ScreenReaderTest.java
+++ b/components/formats-gpl/test/loci/formats/utests/in/ScreenReaderTest.java
@@ -63,9 +63,21 @@ public class ScreenReaderTest {
     System.out.println(file.getAbsolutePath());
     reader.setId(file.getAbsolutePath());
     m = service.asRetrieve(reader.getMetadataStore());
-    
+
     assertEquals(m.getPlateCount(), 1);
     assertEquals(m.getWellCount(0), 1);
     assertEquals(m.getWellSampleCount(0, 0), 1);
+  }
+
+  @Test
+  public void test4Wells2Fields() throws FormatException, IOException {
+    file = new File(this.getClass().getResource("4W2F.screen").getFile());
+    System.out.println(file.getAbsolutePath());
+    reader.setId(file.getAbsolutePath());
+    m = service.asRetrieve(reader.getMetadataStore());
+
+    assertEquals(m.getPlateCount(), 1);
+    assertEquals(m.getWellCount(0), 4);
+    for (int i=0; i<4; i++) assertEquals(m.getWellSampleCount(0, i), 2);
   }
 }

--- a/components/formats-gpl/test/loci/formats/utests/in/minimal.screen
+++ b/components/formats-gpl/test/loci/formats/utests/in/minimal.screen
@@ -1,0 +1,9 @@
+[Plate]
+Rows = 1
+Columns = 1
+Fields = 1
+
+[Well 0]
+Row = 0
+Column = 0
+Field_0 = A01.fake

--- a/components/formats-gpl/test/loci/formats/utests/testng.xml
+++ b/components/formats-gpl/test/loci/formats/utests/testng.xml
@@ -66,4 +66,10 @@
         <class name="loci.formats.utests.XMLAnnotationTest"/>
       </classes>
     </test>
+    <test name="ReaderTests">
+      <groups/>
+      <packages>
+        <package name="loci.formats.utests.in"/>
+      </packages>
+    </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -543,12 +543,12 @@
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
       <id>ome</id>
       <name>OME Artifactory</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/maven/</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
   </repositories>
 
@@ -556,7 +556,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
     </pluginRepository>
   </pluginRepositories>
@@ -565,12 +565,12 @@
     <repository>
       <id>ome.staging</id>
       <name>OME Staging Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
     </repository>
     <snapshotRepository>
       <id>ome.snapshots</id>
       <name>OME Snapshots Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/tools/test-build
+++ b/tools/test-build
@@ -36,8 +36,6 @@ antbuild()
       # Do not clean here so that we can potentially archive both
       # docs and java archives.
       ant tools dist-bftools dist-matlab dist-octave
-      # Finally, run the unit tests.
-      ant test
     )
 }
 

--- a/tools/test-build
+++ b/tools/test-build
@@ -14,7 +14,7 @@ clean()
 # Test maven build
 maven()
 {
-    mvn
+    mvn install
 }
 
 # Test Ant build targets
@@ -32,7 +32,12 @@ antbuild()
       ant clean compile-tests
       ant clean compile-turbojpeg
       ant clean utils
-      ant -Dsphinx.warnopts=$SPHINXOPTS clean-docs-sphinx docs-sphinx
+      ant -Dsphinx.warnopts="-W" clean-docs-sphinx docs-sphinx
+      # Do not clean here so that we can potentially archive both
+      # docs and java archives.
+      ant tools dist-bftools dist-matlab dist-octave
+      # Finally, run the unit tests.
+      ant test
     )
 }
 

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -26,6 +26,4 @@ if [%build%] == [ant] (
   REM don't clean, so that the docs zip will be archived along with
   REM the other zips and jars.
   ant tools dist-bftools dist-matlab dist-octave || exit /b 1
-  REM Finally, run the unit tests.
-  ant test || exit /b 1
 )

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -23,7 +23,7 @@ if [%build%] == [ant] (
   ant clean compile-turbojpeg || exit /b 1
   ant clean utils || exit /b 1
   ant -Dsphinx.warnopts="-W" clean-docs-sphinx docs-sphinx || exit /b 1
-  REM don't clean, so that the docs zip will be archived along with
-  REM the other zips and jars.
+  REM Do not clean here so that we can potentially archive both
+  REM docs and java archives.
   ant tools dist-bftools dist-matlab dist-octave || exit /b 1
 )

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -1,0 +1,30 @@
+REM This script is used for testing the build, primarily for use
+REM with appveyor, but may be used by hand as well.
+
+set build=%1
+
+if [%build%] == [] exit /b 2
+
+if [%build%] == [maven] (
+  REM Test the maven build
+  mvn install || exit /b 1
+)
+
+if [%build%] == [ant] (
+  REM Test the ant build
+  ant clean compile || exit /b 1
+  ant clean compile-autogen || exit /b 1
+  ant clean compile-formats-api || exit /b 1
+  ant clean compile-bio-formats-plugins || exit /b 1
+  ant clean compile-formats-bsd || exit /b 1
+  ant clean compile-formats-gpl || exit /b 1
+  ant clean compile-bio-formats-tools || exit /b 1
+  ant clean compile-tests || exit /b 1
+  ant clean compile-turbojpeg || exit /b 1
+  ant clean utils || exit /b 1
+  ant -Dsphinx.warnopts="-W" clean-docs-sphinx docs-sphinx || exit /b 1
+  REM don't clean, so that the docs zip will be archived along with
+  REM the other zips and jars.
+  ant tools dist-bftools dist-matlab dist-octave || exit /b 1
+  ant test || exit /b 1
+)

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -26,5 +26,6 @@ if [%build%] == [ant] (
   REM don't clean, so that the docs zip will be archived along with
   REM the other zips and jars.
   ant tools dist-bftools dist-matlab dist-octave || exit /b 1
+  REM Finally, run the unit tests.
   ant test || exit /b 1
 )


### PR DESCRIPTION
See https://trello.com/c/oP1oQobf/612-idr0035-caie-drugresponse-bbbc021 

The import of IDR 0035 revealed an issue when populating the channel names using the `ChannelNames` value of the `.screen` files. The bug mostly arose in the case of sparse screens i.e. when not all wells and fields are populated.

This PR should include the fix (using the well-sample index rather the well index) as well as a minimum set of unit tests for `ScreenReader` including a test of the minimum specification for screen files as well as a screen file reproducing the issue 13588b7 .

With this PR, Travis should remain green and including the new `ScreenReaderTest` unit tests. Additionally, the screen files generated in https://github.com/IDR/idr-metadata/pull/255 should properly populate the channel names for all individual well samples of the BBBC021 plates.