### PR TITLE
Disable snapshots for the unidata-releases Nexus repository

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -361,6 +361,7 @@
     <repository>
       <id>unidata.releases</id>
       <url>http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
       <id>ome</id>


### PR DESCRIPTION
Following upstream deployment changes on the http://artifacts.unidata.ucar.edu repository, the Ant build of Bio-Formats is seemngly broken during the `mvn-ant-tasks:dependencies` build step of the `formats-gpl` component. The Maven build seems to be unaffected by these changes.

This commit tries to fix these issues by disabling the snapshots retrieval from the Unidata repository. In practice, there should be no harm in doing so as the only dependency we are consuming is the netcdf and we should not use SNAPSHOTS with the unidata-releases repository.

To test this PR:
- [Travis builds](https://travis-ci.org/openmicroscopy/bioformats/builds/300148474) also affected by these changes should be green with these changes
- the Bio-Formats Jenkins jobs on the [OME CI](https://ci.openmicroscopy.org/) should also turn green
- it might be worth testing the impact of this PR locally using a clean Maven repository both via the Ant and the Maven build system i.e.

   ```
   ant clean jars -Dmaven.repo.local=/tmp/repo1/.m2/repository
   mvn clean install -Dmaven.repo.local=/tmp/repo2/.m2/repository
   ```
