### PR TITLE
Review all repositories to use HTTPS rather than HTTP

### DIFF
--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -356,17 +356,17 @@
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
       <id>unidata.releases</id>
-      <url>http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
       <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
       <id>ome</id>
       <name>OME Artifactory</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/maven/</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -544,12 +544,12 @@
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
       <id>ome</id>
       <name>OME Artifactory</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/maven/</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
   </repositories>
 
@@ -557,7 +557,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
     </pluginRepository>
   </pluginRepositories>
@@ -566,12 +566,12 @@
     <repository>
       <id>ome.staging</id>
       <name>OME Staging Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
     </repository>
     <snapshotRepository>
       <id>ome.snapshots</id>
       <name>OME Snapshots Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
Follow-up of https://github.com/openmicroscopy/bioformats/pull/2991

Reproducing the last reported failures with an Ant-based build from a clean Maven repository locally and looking at the details of the faulty artifacts, I realized there was a permanent redirect from http to https when retrieving dependencies from http://artifacts.unidata.ucar.edu/.

This PR review the URLs of all `repositories` and `snapshotRepositories` declared in the various  `pom.xml` (Central, Unidata & OME Artifactory) to use HTTPS consistently. This change is expected to fix the issues raised in https://github.com/openmicroscopy/bioformats/pull/2991#issuecomment-344055075 and https://github.com/openmicroscopy/bioformats/pull/2991#issuecomment-344056024.

Similarly to https://github.com/openmicroscopy/bioformats/pull/2991, both Travis and Jenkins should remain green with these changes. Additionally, both Ant-based and Maven-based builds using a clean Maven repository (either cleaning `~/.m2` or passing `-Dmaven.repo.local`) should pass with this change.
 

NB: as an aside, https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/reference/BuildDependencies.html is now recommending https://artifacts.unidata.ucar.edu/repository/unidata-all/ rather than unidata-releases and we could consider updating the URL to match this recommendation.