### PR TITLE
Replace sphinx-ignore-list repo with list in conf.py.in

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -368,5 +368,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'http://www.mathworks.com/matlabcentral/answers/92813',
     'https://www.olympus-global.com',
     'https://code.google.com/archive/p/jj2000/',
-    'https://support.apple.com/downloads/quicktime'
+    'https://support.apple.com/downloads/quicktime',
+    'https://support.apple.com/quicktime'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -369,5 +369,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
     'https://code.google.com/archive/p/jj2000/',
     'https://support.apple.com/downloads/quicktime',
-    'https://support.apple.com/quicktime'
+    'https://support.apple.com/quicktime',
+    'https://www.micro-manager.org'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -368,4 +368,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'http://www.mathworks.com/matlabcentral/answers/92813',
     'https://www.olympus-global.com',
     'https://code.google.com/archive/p/jj2000/',
+    'https://support.apple.com/downloads/quicktime'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -366,4 +366,5 @@ texinfo_documents = [
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'http://www.mathworks.com/matlabcentral/answers/92813',
+    'https://www.olympus-global.com',
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -367,4 +367,5 @@ texinfo_documents = [
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'http://www.mathworks.com/matlabcentral/answers/92813',
     'https://www.olympus-global.com',
+    'https://code.google.com/archive/p/jj2000/',
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -364,4 +364,6 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ['https://imspector.mpibpc.mpg.de']
+linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
+    'http://www.mathworks.com/matlabcentral/answers/92813',
+]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -365,10 +365,3 @@ texinfo_documents = [
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = []
-try:
-    import urllib
-    brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
-    brokenlinks = urllib.urlopen(brokenfiles_url)
-    linkcheck_ignore.extend(brokenlinks.read().splitlines())
-except IOError:
-    print "Could not open list of broken links."

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -364,4 +364,4 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = []
+linkcheck_ignore = ['https://imspector.mpibpc.mpg.de']


### PR DESCRIPTION
Re: https://github.com/openmicroscopy/sphinx-ignore-links/issues/1

This removes use of the ignore list repo and adds links that are working but failing the linkchecker to a list in the conf.py.in instead.