### PR TITLE
Detect and fix Findbugs' SBSC_USE_STRINGBUFFER_CONCATENATION

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -127,7 +127,7 @@ Type "ant -p" for a list of targets.
       <then>
         <findbugs home="${findbugs.home}" jvmargs="-Xmx512m"
           output="xml:withMessages" outputFile="${build.dir}/findbugs.xml"
-          excludeFilter="${root.dir}/excludebugs.xml" reportLevel="high"
+          excludeFilter="${root.dir}/excludebugs.xml" reportLevel="medium"
           errorProperty="findbugsErrors"
           warningsProperty="findbugsWarnings">
           <auxClasspath refid="runtime.classpath"/>

--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -207,7 +207,7 @@ public class FilePatternDialog extends ImporterDialog {
       }
     }
     else if (useRanges) {
-      StringBuffer pattern = new StringBuffer();
+      StringBuilder pattern = new StringBuilder();
       for (int i=0; i<counts.length; i++) {
         BigInteger first = new BigInteger(firsts[i]);
         BigInteger fileCount = new BigInteger(counts[i]);

--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -207,7 +207,7 @@ public class FilePatternDialog extends ImporterDialog {
       }
     }
     else if (useRanges) {
-      String pattern = "";
+      StringBuffer pattern = new StringBuffer();
       for (int i=0; i<counts.length; i++) {
         BigInteger first = new BigInteger(firsts[i]);
         BigInteger fileCount = new BigInteger(counts[i]);
@@ -219,24 +219,24 @@ public class FilePatternDialog extends ImporterDialog {
         // (number of images - 1) * axis increment + axis first image
         fileCount = fileCount.subtract(BigInteger.ONE).multiply(increment).add(first);
 
-        pattern += fp.getPrefix(i);
-        pattern += '<';
+        pattern.append(fp.getPrefix(i));
+        pattern.append('<');
         int firstPadding = paddingZeros[i] - first.toString().length() + 1;
         for (int zero=0; zero<firstPadding; zero++) {
-          pattern += '0';
+          pattern.append('0');
         }
-        pattern += first;
-        pattern += '-';
+        pattern.append(first);
+        pattern.append('-');
         int lastPadding = paddingZeros[i] - fileCount.toString().length() + 1;
         for (int zero=0; zero<lastPadding; zero++) {
-          pattern += '0';
+          pattern.append('0');
         }
-        pattern += fileCount;
-        pattern += ':';
-        pattern += increment;
-        pattern += '>';
+        pattern.append(fileCount);
+        pattern.append(':');
+        pattern.append(increment);
+        pattern.append('>');
       }
-      id = pattern + fp.getSuffix();
+      id = pattern.toString() + fp.getSuffix();
     }
 
     options.setId(id);

--- a/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/FilePatternDialog.java
@@ -236,7 +236,8 @@ public class FilePatternDialog extends ImporterDialog {
         pattern.append(increment);
         pattern.append('>');
       }
-      id = pattern.toString() + fp.getSuffix();
+      pattern.append(fp.getSuffix());
+      id = pattern.toString();
     }
 
     options.setId(id);

--- a/components/bio-formats-plugins/src/loci/plugins/util/DataBrowser.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/DataBrowser.java
@@ -143,13 +143,15 @@ public class DataBrowser extends StackWindow {
       "5dlu, right:pref, 3dlu, pref:grow, 5dlu, pref, 5dlu, pref, 5dlu";
     //       <-labels->        <------sliders------>       <misc>
 
-    String rows = "4dlu, pref, 3dlu, pref";
+    StringBuffer rows = new StringBuffer("4dlu, pref, 3dlu, pref");
     //                   <Z->        <T->        <C->
 
-    for (int i=0; i<channels.length; i++) rows += ", 3dlu, pref";
-    rows += ", 6dlu";
+    for (int i=0; i<channels.length; i++) {
+      rows.append(", 3dlu, pref");
+    }
+    rows.append(", 6dlu");
 
-    controls.setLayout(new FormLayout(cols, rows));
+    controls.setLayout(new FormLayout(cols, rows.toString()));
     controls.setBackground(Color.white);
 
     int c = imp.getNChannels();

--- a/components/bio-formats-plugins/src/loci/plugins/util/DataBrowser.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/DataBrowser.java
@@ -143,7 +143,7 @@ public class DataBrowser extends StackWindow {
       "5dlu, right:pref, 3dlu, pref:grow, 5dlu, pref, 5dlu, pref, 5dlu";
     //       <-labels->        <------sliders------>       <misc>
 
-    StringBuffer rows = new StringBuffer("4dlu, pref, 3dlu, pref");
+    StringBuilder rows = new StringBuilder("4dlu, pref, 3dlu, pref");
     //                   <Z->        <T->        <C->
 
     for (int i=0; i<channels.length; i++) {

--- a/components/bio-formats-tools/src/loci/formats/tools/PrintFormatTable.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/PrintFormatTable.java
@@ -219,7 +219,7 @@ public class PrintFormatTable {
       }
 
       String[] extensions = readers[i].getSuffixes();
-      StringBuffer ext = new StringBuffer();
+      StringBuilder ext = new StringBuilder();
       for (int j=0; j<extensions.length; j++) {
         ext.append(extensions[j]);
         if (j < extensions.length - 1) {

--- a/components/bio-formats-tools/src/loci/formats/tools/PrintFormatTable.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/PrintFormatTable.java
@@ -197,7 +197,6 @@ public class PrintFormatTable {
 
     for (int i=0; i<readers.length; i++) {
       String readerFormatName = readers[i].getFormat();
-      String ext = "";
       boolean read = true;
       boolean write = false;
       boolean wmp = false;
@@ -220,14 +219,17 @@ public class PrintFormatTable {
       }
 
       String[] extensions = readers[i].getSuffixes();
+      StringBuffer ext = new StringBuffer();
       for (int j=0; j<extensions.length; j++) {
-        ext += extensions[j];
-        if (j < extensions.length - 1) ext += (", ");
+        ext.append(extensions[j]);
+        if (j < extensions.length - 1) {
+          ext.append(", ");
+        }
       }
 
       // display information about the format
       LOGGER.info(
-        getFormatLine(printStyle, readerFormatName, read, write, wmp, ext));
+        getFormatLine(printStyle, readerFormatName, read, write, wmp, ext.toString()));
     }
 
     LOGGER.info(getFooter(printStyle));

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1072,7 +1072,7 @@ public class DicomReader extends FormatReader {
       case US:
         if (elementLength == 2) value = Integer.toString(in.readShort());
         else {
-          StringBuffer sb = new StringBuffer();
+          StringBuilder sb = new StringBuilder();
           int n = elementLength / 2;
           for (int i=0; i<n; i++) {
             sb.append(in.readShort());

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1072,11 +1072,13 @@ public class DicomReader extends FormatReader {
       case US:
         if (elementLength == 2) value = Integer.toString(in.readShort());
         else {
-          value = "";
+          StringBuffer sb = new StringBuffer();
           int n = elementLength / 2;
           for (int i=0; i<n; i++) {
-            value += Integer.toString(in.readShort()) + " ";
+            sb.append(in.readShort());
+            sb.append(" ");
           }
+          value = sb.toString();
         }
         break;
       case IMPLICIT_VR:

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -531,13 +531,14 @@ public class MicromanagerReader extends FormatReader {
               (key != null && value == null))
             {
               if (value == null && (propType == null || !propType.equals("PropType"))) {
-                value = token;
+                StringBuffer sb = new StringBuffer(token);
 
                 while (q + 1 < tokens.length && tokens[q + 1].trim().length() > 0) {
-                  value += ':';
-                  value += tokens[q + 1];
+                  sb.append(':');
+                  sb.append(tokens[q + 1]);
                   q++;
                 }
+                value = sb.toString();
               }
               if (!value.equals("PropVal")) {
                 parseKeyAndValue(key, value, digits, plane + i, 1);
@@ -776,7 +777,8 @@ public class MicromanagerReader extends FormatReader {
           token.indexOf("\"", dash)));
 
         token = st.nextToken().trim();
-        String key = "", value = "";
+        String key = "";
+        StringBuffer valueBuffer = new StringBuffer();
         boolean valueArray = false;
         int nestedCount = 0;
 
@@ -798,7 +800,7 @@ public class MicromanagerReader extends FormatReader {
               valueArray = false;
             }
             else {
-              value += token.trim().replaceAll("\"", "");
+              valueBuffer.append(token.trim().replaceAll("\"", ""));
               token = st.nextToken().trim();
               continue;
             }
@@ -806,10 +808,10 @@ public class MicromanagerReader extends FormatReader {
           else {
             int colon = token.indexOf(':');
             key = token.substring(1, colon).trim();
-            value = token.substring(colon + 1, token.length() - 1).trim();
+            valueBuffer.delete(0, valueBuffer.length());
+            valueBuffer.append(token.substring(colon + 1, token.length() - 1).trim().replaceAll("\"", ""));
 
             key = key.replaceAll("\"", "");
-            value = value.replaceAll("\"", "");
 
             if (token.trim().endsWith("[")) {
               valueArray = true;
@@ -818,6 +820,7 @@ public class MicromanagerReader extends FormatReader {
             }
           }
 
+          String value = valueBuffer.toString();
           addSeriesMeta(key, value);
 
           if (key.equals("Exposure-ms")) {

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -531,7 +531,7 @@ public class MicromanagerReader extends FormatReader {
               (key != null && value == null))
             {
               if (value == null && (propType == null || !propType.equals("PropType"))) {
-                StringBuffer sb = new StringBuffer(token);
+                StringBuilder sb = new StringBuilder(token);
 
                 while (q + 1 < tokens.length && tokens[q + 1].trim().length() > 0) {
                   sb.append(':');
@@ -778,7 +778,7 @@ public class MicromanagerReader extends FormatReader {
 
         token = st.nextToken().trim();
         String key = "";
-        StringBuffer valueBuffer = new StringBuffer();
+        StringBuilder valueBuffer = new StringBuilder();
         boolean valueArray = false;
         int nestedCount = 0;
 

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -808,7 +808,7 @@ public class MicromanagerReader extends FormatReader {
           else {
             int colon = token.indexOf(':');
             key = token.substring(1, colon).trim();
-            valueBuffer.delete(0, valueBuffer.length());
+            valueBuffer.setLength(0);
             valueBuffer.append(token.substring(colon + 1, token.length() - 1).trim().replaceAll("\"", ""));
 
             key = key.replaceAll("\"", "");

--- a/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
+++ b/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
@@ -244,27 +244,27 @@ public class AmiraParameters {
   }
 
   protected String readKey() throws IOException {
-    String result = "";
+    StringBuffer result = new StringBuffer();
     while (c >= '0' || c == '-') {
-      result += c;
+      result.append(c);
       readByte();
     }
-    return result;
+    return result.toString();
   }
 
   protected Number readNumber() throws FormatException, IOException {
-    String string = "";
+    StringBuffer string = new StringBuffer();
     while ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' ||
       c == 'e')
     {
-      string += c;
+      string.append(c);
       readByte();
     }
     try {
-      if (string.indexOf('.') < 0 && string.indexOf('e') < 0) {
-        return Integer.valueOf(string);
+      if (string.indexOf(".") < 0 && string.indexOf("e") < 0) {
+        return Integer.valueOf(string.toString());
       }
-      return Double.valueOf(string);
+      return Double.valueOf(string.toString());
     }
     catch (NumberFormatException e) {
       syntaxError(e.getMessage());
@@ -348,17 +348,17 @@ public class AmiraParameters {
     else if (quote != '"' && quote != '\'') {
       syntaxError("Invalid quote: " + c);
     }
-    String result = "";
+    StringBuffer result = new StringBuffer();
     for (;;) {
       readByte();
       if (c == quote) {
         readByte();
-        return result;
+        return result.toString();
       }
       if (quote == '"' && c == '\\') {
         readByte();
       }
-      result += c;
+      result.append(c);
     }
   }
 
@@ -454,7 +454,8 @@ public class AmiraParameters {
       return object.toString();
     }
     if (object instanceof String) {
-      String string = (String) object, result = "\"";
+      String string = (String) object;
+      StringBuffer result = new StringBuffer("\"");
       int offset = 0;
       for (;;) {
         int nextOffset = string.indexOf('"', offset + 1);
@@ -462,41 +463,51 @@ public class AmiraParameters {
           break;
         }
         if (nextOffset > offset + 1) {
-          result += string.substring(offset, nextOffset);
+          result.append(string, offset, nextOffset);
         }
-        result += "\\";
+        result.append("\\");
         offset = nextOffset;
       }
       if (offset + 1 < string.length()) {
-        result += string.substring(offset);
+        result.append(string, offset, string.length());
       }
-      return result + "\"";
+      result.append("\"");
+      return result.toString();
     }
     if (object instanceof Integer[]) {
       Integer[] array = (Integer[]) object;
-      String result = null;
+      StringBuffer result = new StringBuffer();
       for (int i = 0; i < array.length; i++) {
-        result = (i > 0 ? result + " " : "") + array[i];
+        if (i > 0) {
+          result.append(" ");
+        }
+        result.append(array[i]);
       }
-      return result;
+      return result.toString();
     }
     if (object instanceof Double[]) {
       Double[] array = (Double[]) object;
-      String result = null;
+      StringBuffer result = new StringBuffer();
       for (int i = 0; i < array.length; i++) {
-        result = (i > 0 ? result + " " : "") + array[i];
+        if (i > 0) {
+          result.append(" ");
+        }
+        result.append(array[i]);
       }
-      return result;
+      return result.toString();
     }
     if (object instanceof Map) {
       return "{\n" + toString((Map) object, indent + "\t") + indent + "}";
     }
     if (object instanceof ArrayList) {
-      String result = "{\n";
+      StringBuffer result = new StringBuffer("{\n");
       for (Object item : (ArrayList) object) {
-        result += entryToString(item, indent + "\t") + "\n";
+        result.append(entryToString(item, indent + "\t"));
+        result.append("\n");
       }
-      return result + indent + "}";
+      result.append(indent);
+      result.append("}");
+      return result.toString();
     }
     throw new FormatException("Illegal value type: " +
       object.getClass().getName());

--- a/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
+++ b/components/formats-bsd/src/loci/formats/tools/AmiraParameters.java
@@ -244,7 +244,7 @@ public class AmiraParameters {
   }
 
   protected String readKey() throws IOException {
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     while (c >= '0' || c == '-') {
       result.append(c);
       readByte();
@@ -253,7 +253,7 @@ public class AmiraParameters {
   }
 
   protected Number readNumber() throws FormatException, IOException {
-    StringBuffer string = new StringBuffer();
+    StringBuilder string = new StringBuilder();
     while ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' ||
       c == 'e')
     {
@@ -348,7 +348,7 @@ public class AmiraParameters {
     else if (quote != '"' && quote != '\'') {
       syntaxError("Invalid quote: " + c);
     }
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     for (;;) {
       readByte();
       if (c == quote) {
@@ -455,7 +455,7 @@ public class AmiraParameters {
     }
     if (object instanceof String) {
       String string = (String) object;
-      StringBuffer result = new StringBuffer("\"");
+      StringBuilder result = new StringBuilder("\"");
       int offset = 0;
       for (;;) {
         int nextOffset = string.indexOf('"', offset + 1);
@@ -476,7 +476,7 @@ public class AmiraParameters {
     }
     if (object instanceof Integer[]) {
       Integer[] array = (Integer[]) object;
-      StringBuffer result = new StringBuffer();
+      StringBuilder result = new StringBuilder();
       for (int i = 0; i < array.length; i++) {
         if (i > 0) {
           result.append(" ");
@@ -487,7 +487,7 @@ public class AmiraParameters {
     }
     if (object instanceof Double[]) {
       Double[] array = (Double[]) object;
-      StringBuffer result = new StringBuffer();
+      StringBuilder result = new StringBuilder();
       for (int i = 0; i < array.length; i++) {
         if (i > 0) {
           result.append(" ");
@@ -500,7 +500,7 @@ public class AmiraParameters {
       return "{\n" + toString((Map) object, indent + "\t") + indent + "}";
     }
     if (object instanceof ArrayList) {
-      StringBuffer result = new StringBuffer("{\n");
+      StringBuilder result = new StringBuilder("{\n");
       for (Object item : (ArrayList) object) {
         result.append(entryToString(item, indent + "\t"));
         result.append("\n");

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -2120,7 +2120,7 @@ public abstract class BaseZeissReader extends FormatReader {
 
     @Override
     public String toString() {
-      StringBuffer s = new StringBuffer("  SHAPE: ");
+      StringBuilder s = new StringBuilder("  SHAPE: ");
       s.append(id);
       appendValue(s, "    Type=", type);
       appendHexValue(s, "    Unknown1=", unknown1);
@@ -2182,11 +2182,11 @@ public abstract class BaseZeissReader extends FormatReader {
       return s.toString();
     }
 
-    private void appendHexValue(StringBuffer s, String key, int i) {
+    private void appendHexValue(StringBuilder s, String key, int i) {
       appendValue(s, key, formatHex(i));
     }
 
-    private void appendValue(StringBuffer s, String key, Object value) {
+    private void appendValue(StringBuilder s, String key, Object value) {
       s.append(key);
       s.append(value);
     }
@@ -2209,7 +2209,7 @@ public abstract class BaseZeissReader extends FormatReader {
 
     @Override
     public String toString() {
-      StringBuffer s = new StringBuffer("LAYER: ");
+      StringBuilder s = new StringBuilder("LAYER: ");
       s.append(key);
       if (name != null) {
         s.append(" (");

--- a/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BaseZeissReader.java
@@ -2120,36 +2120,79 @@ public abstract class BaseZeissReader extends FormatReader {
 
     @Override
     public String toString() {
-      String s = new String();
-      s += "  SHAPE: " + id;
-      s += "    Type=" + type;
-      s += "    Unknown1=" + Long.toHexString(unknown1&0xFFFFFFFFL) + " Unknown2=" + Long.toHexString(unknown2&0xFFFFFFFFL) + " Unknown3=" + Long.toHexString(unknown3&0xFFFFFFFFL) + "\n";
-      s += "    Bbox=" + x1 + "," + y1 + "  " + x2 + "," + y2 + "\n";
-      s += "    Unknown4=" + Long.toHexString(unknown4&0xFFFFFFFFL) + " Unknown5=" + Long.toHexString(unknown5&0xFFFFFFFFL) + " Unknown6=" + Long.toHexString(unknown6&0xFFFFFFFFL) + " Unknown7=" + Long.toHexString(unknown7&0xFFFFFFFFL) + "\n";
-      s += "    Unknown8=" + Long.toHexString(unknown8&0xFFFFFFFFL) + "\n";
-      s += "    Unknown10=" + Long.toHexString(unknown10&0xFFFFFFFFL) + " Unknown11=" + Long.toHexString(unknown11&0xFFFFFFFFL) + " Unknown12=" + Long.toHexString(unknown12&0xFFFFFFFFL) + "\n";
-      s += "    Unknown13=" + Long.toHexString(unknown13&0xFFFFFFFFL) + " Unknown14=" + Long.toHexString(unknown14&0xFFFFFFFFL) + " Unknown15=" + Long.toHexString(unknown15&0xFFFFFFFFL) + " Unknown16=" + Long.toHexString(unknown16&0xFFFFFFFFL) + "\n";
-      s += "    Unknown17=" + Long.toHexString(unknown17&0xFFFFFFFFL) + " Unknown18=" + Long.toHexString(unknown18&0xFFFFFFFFL) + " Unknown19=" + Long.toHexString(unknown19&0xFFFFFFFFL) + "\n";
-      s += "    fillColour=" + Long.toHexString(fillColour&0xFFFFFFFFL)
-          + " textColour=" + Long.toHexString((textColour&0xFFFFFFFFL))
-          + " drawColour=" + Long.toHexString((drawColour&0xFFFFFFFFL)) + "\n";
-      s += "    drawStyle=" + drawStyle
-          +  " fillStyle=" + fillStyle
-          +  " lineEndStyle=" + lineEndStyle
-          +  " lineEndSize=" + lineEndSize
-          +  " lineEndPositions=" + lineEndPositions + "\n";
-      s += "displayTag=" + displayTag + "\n";
-      s += "  fontName=" + fontName + " size="+fontSize + " weight="+fontWeight + " bold="+bold + " italic=" + italic + " underline="+underline + " strikeout="+strikeout + " alignment=" + textAlignment + " charset=" + charset + "\n";
-      s += "  name: " + name + "\n";
-      s += "  text: " + text + "\n";
+      StringBuffer s = new StringBuffer("  SHAPE: ");
+      s.append(id);
+      appendValue(s, "    Type=", type);
+      appendHexValue(s, "    Unknown1=", unknown1);
+      appendHexValue(s, " Unknown2=", unknown2);
+      appendHexValue(s, " Unknown3=", unknown3);
+      s.append("\n    Bbox=");
+      s.append(x1);
+      s.append(",");
+      s.append(y1);
+      s.append("  ");
+      s.append(x2);
+      s.append(",");
+      s.append(y2);
+      appendHexValue(s, "\n    Unknown4=", unknown4);
+      appendHexValue(s, " Unknown5=", unknown5);
+      appendHexValue(s, " Unknown6=", unknown6);
+      appendHexValue(s, " Unknown7=", unknown7);
+      appendHexValue(s, "\n    Unknown8=", unknown8);
+      appendHexValue(s, "\n    Unknown10=", unknown10);
+      appendHexValue(s, " Unknown11=", unknown11);
+      appendHexValue(s, " Unknown12=", unknown12);
+      appendHexValue(s, "\n    Unknown13=", unknown13);
+      appendHexValue(s, " Unknown14=", unknown14);
+      appendHexValue(s, " Unknown15=", unknown15);
+      appendHexValue(s, " Unknown16=", unknown16);
+      appendHexValue(s, "\n    Unknown17=", unknown17);
+      appendHexValue(s, " Unknown18=", unknown18);
+      appendHexValue(s, " Unknown19=", unknown19);
+      appendHexValue(s, "\n    fillColour=", fillColour);
+      appendHexValue(s, " textColour=", textColour);
+      appendHexValue(s, " drawColour=", drawColour);
+      appendValue(s, "\n    drawStyle=", drawStyle);
+      appendValue(s, " fillStyle=", fillStyle);
+      appendValue(s, " lineEndStyle=", lineEndStyle);
+      appendValue(s, " lineEndSize=", lineEndSize);
+      appendValue(s, " lineEndPositions=", lineEndPositions);
+      appendValue(s, "\ndisplayTag=", displayTag);
+      appendValue(s, "\n  fontName=", fontName);
+      appendValue(s, " size=", fontSize);
+      appendValue(s, " weight=", fontWeight);
+      appendValue(s, " bold=", bold);
+      appendValue(s, " italic=", italic);
+      appendValue(s, " underline=", underline);
+      appendValue(s, " strikeout=", strikeout);
+      appendValue(s, " alignment=", textAlignment);
+      appendValue(s, " charset=", charset);
+      appendValue(s, "\n  name: ", name);
+      appendValue(s, "\n  text: ", text);
       //s += "  Zpos: " + zpos;
-      s += "  tagID: " + tagID.getKey() + "\n";
-      s += "  handleSize:" + handleSize + "\n";
-      s += "  pointCount:" + pointCount + "\n    ";
-      for (double point : points)
-        s+=point + ", ";
-      s+= "\n";
-      return s;
+      appendValue(s, "\n  tagID: ", tagID.getKey());
+      appendValue(s, "\n  handleSize:", handleSize);
+      appendValue(s, "\n  pointCount:", pointCount);
+      s.append("\n    ");
+      for (double point : points) {
+        s.append(point);
+        s.append(", ");
+      }
+      s.append("\n");
+      return s.toString();
+    }
+
+    private void appendHexValue(StringBuffer s, String key, int i) {
+      appendValue(s, key, formatHex(i));
+    }
+
+    private void appendValue(StringBuffer s, String key, Object value) {
+      s.append(key);
+      s.append(value);
+    }
+
+    private String formatHex(int i) {
+      return Long.toHexString(i & 0xFFFFFFFFL);
     }
   }
 
@@ -2166,15 +2209,18 @@ public abstract class BaseZeissReader extends FormatReader {
 
     @Override
     public String toString() {
-      String s = new String();
-      s += "LAYER: " + key;
-      if (name != null)
-        s += " (" + name + ")";
-      s+= "\n";
-      for (Shape shape : shapes) {
-        s += shape;
+      StringBuffer s = new StringBuffer("LAYER: ");
+      s.append(key);
+      if (name != null) {
+        s.append(" (");
+        s.append(name);
+        s.append(")");
       }
-      return s;
+      s.append("\n");
+      for (Shape shape : shapes) {
+        s.append(shape);
+      }
+      return s.toString();
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1554,7 +1554,7 @@ public class CellSensReader extends FormatReader {
               case PIXEL_INFO_TYPE:
                 int nIntValues = dataSize / 4;
                 int[] intValues = new int[nIntValues];
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 if (nIntValues > 1) {
                   sb.append("(");
                 }
@@ -1590,7 +1590,7 @@ public class CellSensReader extends FormatReader {
               case DOUBLE_4_4:
                 int nDoubleValues = dataSize / 8;
                 double[] doubleValues = new double[nDoubleValues];
-                sb = new StringBuffer();
+                sb = new StringBuilder();
                 if (nDoubleValues > 1) {
                   sb.append("(");
                 }

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -1554,17 +1554,21 @@ public class CellSensReader extends FormatReader {
               case PIXEL_INFO_TYPE:
                 int nIntValues = dataSize / 4;
                 int[] intValues = new int[nIntValues];
-                value = nIntValues > 1 ? "(" : "";
+                StringBuffer sb = new StringBuffer();
+                if (nIntValues > 1) {
+                  sb.append("(");
+                }
                 for (int v=0; v<nIntValues; v++) {
                   intValues[v] = vsi.readInt();
-                  value += intValues[v];
+                  sb.append(intValues[v]);
                   if (v < nIntValues - 1) {
-                    value += ", ";
+                    sb.append(", ");
                   }
                 }
                 if (nIntValues > 1) {
-                  value += ')';
+                  sb.append(")");
                 }
+                value = sb.toString();
 
                 if (tag == IMAGE_BOUNDARY) {
                   if (pyramid != null && pyramid.width == null) {
@@ -1586,17 +1590,21 @@ public class CellSensReader extends FormatReader {
               case DOUBLE_4_4:
                 int nDoubleValues = dataSize / 8;
                 double[] doubleValues = new double[nDoubleValues];
-                value = nDoubleValues > 1 ? "(" : "";
+                sb = new StringBuffer();
+                if (nDoubleValues > 1) {
+                  sb.append("(");
+                }
                 for (int v=0; v<nDoubleValues; v++) {
                   doubleValues[v] = vsi.readDouble();
-                  value += doubleValues[v];
+                  sb.append(doubleValues[v]);
                   if (v < nDoubleValues - 1) {
-                    value += ", ";
+                    sb.append(", ");
                   }
                 }
                 if (nDoubleValues > 1) {
-                  value += ')';
+                  sb.append(')');
                 }
+                value = sb.toString();
 
                 if (tag == RWC_FRAME_SCALE) {
                   if (pyramid != null && pyramid.physicalSizeX == null) {

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -797,6 +797,7 @@ public class LeicaReader extends FormatReader {
 
       String lei =
         baseFile.substring(0, baseFile.lastIndexOf(File.separator) + 1);
+      StringBuffer suffix = new StringBuffer();
 
       StringTokenizer lines = new StringTokenizer(descr, "\n");
       String line = null, key = null, value = null;
@@ -807,8 +808,11 @@ public class LeicaReader extends FormatReader {
         value = line.substring(line.indexOf('=') + 1).trim();
         addGlobalMeta(key, value);
 
-        if (key.startsWith("Series Name")) lei += value;
+        if (key.startsWith("Series Name")) {
+          suffix.append(value);
+        }
       }
+      lei += suffix.toString();
 
       // now open the LEI file
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -797,7 +797,7 @@ public class LeicaReader extends FormatReader {
 
       String lei =
         baseFile.substring(0, baseFile.lastIndexOf(File.separator) + 1);
-      StringBuffer suffix = new StringBuffer();
+      StringBuilder suffix = new StringBuilder();
 
       StringTokenizer lines = new StringTokenizer(descr, "\n");
       String line = null, key = null, value = null;

--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -145,7 +145,7 @@ public class MetamorphHandler extends BaseHandler {
 
         String k = null, v = null;
         boolean freeform = true;
-        String freeformDescription = "";
+        StringBuffer freeformDescription = new StringBuffer();
 
         if (value.indexOf(delim) != -1) {
           int currentIndex = -delim.length();
@@ -165,13 +165,13 @@ public class MetamorphHandler extends BaseHandler {
             if (line.startsWith("Exposure: ")) {
               freeform = false;
               if (metadata != null) {
-                metadata.put("User Description", freeformDescription.trim());
+                metadata.put("User Description", freeformDescription.toString().trim());
               }
             }
 
             if (freeform) {
-              freeformDescription += line;
-              freeformDescription += "\n";
+              freeformDescription.append(line);
+              freeformDescription.append("\n");
             }
             else {
               int colon = line.indexOf(':');

--- a/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphHandler.java
@@ -145,7 +145,7 @@ public class MetamorphHandler extends BaseHandler {
 
         String k = null, v = null;
         boolean freeform = true;
-        StringBuffer freeformDescription = new StringBuffer();
+        StringBuilder freeformDescription = new StringBuilder();
 
         if (value.indexOf(delim) != -1) {
           int currentIndex = -delim.length();

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1522,10 +1522,13 @@ public class MetamorphReader extends BaseTiffReader {
 
   /** Create an appropriate name for the given series. */
   private String makeImageName(int i) {
-    String name = "";
+    StringBuffer name = new StringBuffer();
     if (stageNames != null && stageNames.size() > 0) {
       int stagePosition = i / (getSeriesCount() / stageNames.size());
-      name += "Stage" + (stagePosition + 1) + " " + stageNames.get(stagePosition);
+      name.append("Stage");
+      name.append(stagePosition + 1);
+      name.append(" ");
+      name.append(stageNames.get(stagePosition));
     }
 
     if (firstSeriesChannels != null &&
@@ -1533,21 +1536,22 @@ public class MetamorphReader extends BaseTiffReader {
       stageNames.size() != getSeriesCount()))
     {
       if (name.length() > 0) {
-        name += "; ";
+        name.append("; ");
       }
       for (int c=0; c<firstSeriesChannels.length; c++) {
         if (firstSeriesChannels[c] == ((i % 2) == 0) && c < waveNames.size()) {
-          name += waveNames.get(c) + "/";
+          name.append(waveNames.get(c));
+          name.append("/");
         }
       }
       if (name.length() > 0) {
-        name = name.substring(0, name.length() - 1);
+        return name.substring(0, name.length() - 1);
       }
     }
     if (name.length() == 0 && isHCS) {
-      name = stageLabels[i];
+      return stageLabels[i];
     }
-    return name;
+    return name.toString();
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1522,7 +1522,7 @@ public class MetamorphReader extends BaseTiffReader {
 
   /** Create an appropriate name for the given series. */
   private String makeImageName(int i) {
-    StringBuffer name = new StringBuffer();
+    StringBuilder name = new StringBuilder();
     if (stageNames != null && stageNames.size() > 0) {
       int stagePosition = i / (getSeriesCount() / stageNames.size());
       name.append("Stage");

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2412,9 +2412,10 @@ public class NativeND2Reader extends FormatReader {
 
       lines = textString.split(" ");
       for (int i=0; i<lines.length; i++) {
-        String key = lines[i++];
-        while (!key.endsWith(":") && key.indexOf('_') < 0 && i < lines.length) {
-          key += " " + lines[i++];
+        StringBuffer sb = new StringBuffer(lines[i++]);
+        while (sb.charAt(sb.length() - 1) != ':' && sb.indexOf("_") < 0 && i < lines.length) {
+          sb.append(" ");
+          sb.append(lines[i++]);
           if (i >= lines.length) {
             break;
           }
@@ -2423,10 +2424,13 @@ public class NativeND2Reader extends FormatReader {
         if (i >= lines.length) {
           break;
         }
+        String key = sb.toString();
 
-        String value = lines[i++];
+        sb.delete(0, sb.length());
+        sb.append(lines[i++]);
         while (i < lines.length && lines[i].trim().length() > 0) {
-          value += " " + lines[i++];
+          sb.append(' ');
+          sb.append(lines[i++]);
           if (i >= lines.length) {
             break;
           }
@@ -2434,7 +2438,7 @@ public class NativeND2Reader extends FormatReader {
 
         key = key.trim();
         key = key.substring(0, key.length() - 1);
-        value = value.trim();
+        String value = sb.toString().trim();
 
         if (key.startsWith("- Step")) {
           int end = key.indexOf(" ", 8);

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2426,7 +2426,7 @@ public class NativeND2Reader extends FormatReader {
         }
         String key = sb.toString();
 
-        sb.delete(0, sb.length());
+        sb.setLength(0);
         sb.append(lines[i++]);
         while (i < lines.length && lines[i].trim().length() > 0) {
           sb.append(' ');

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2413,7 +2413,7 @@ public class NativeND2Reader extends FormatReader {
       lines = textString.split(" ");
       for (int i=0; i<lines.length; i++) {
         StringBuffer sb = new StringBuffer(lines[i++]);
-        while (sb.charAt(sb.length() - 1) != ':' && sb.indexOf("_") < 0 && i < lines.length) {
+        while ((sb.length() == 0 || sb.charAt(sb.length() - 1) != ':') && sb.indexOf("_") < 0 && i < lines.length) {
           sb.append(" ");
           sb.append(lines[i++]);
           if (i >= lines.length) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2412,7 +2412,7 @@ public class NativeND2Reader extends FormatReader {
 
       lines = textString.split(" ");
       for (int i=0; i<lines.length; i++) {
-        StringBuffer sb = new StringBuffer(lines[i++]);
+        StringBuilder sb = new StringBuilder(lines[i++]);
         while ((sb.length() == 0 || sb.charAt(sb.length() - 1) != ':') && sb.indexOf("_") < 0 && i < lines.length) {
           sb.append(" ");
           sb.append(lines[i++]);

--- a/components/formats-gpl/src/loci/formats/in/SEQReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SEQReader.java
@@ -97,7 +97,7 @@ public class SEQReader extends BaseTiffReader {
         short[] tag1 = (short[]) ifd.getIFDValue(IMAGE_PRO_TAG_1);
 
         if (tag1 != null) {
-          StringBuffer seqId = new StringBuffer();
+          StringBuilder seqId = new StringBuilder();
           for (int i=0; i<tag1.length; i++) {
             seqId.append(tag1[i]);
           }

--- a/components/formats-gpl/src/loci/formats/in/SEQReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SEQReader.java
@@ -97,9 +97,11 @@ public class SEQReader extends BaseTiffReader {
         short[] tag1 = (short[]) ifd.getIFDValue(IMAGE_PRO_TAG_1);
 
         if (tag1 != null) {
-          String seqId = "";
-          for (int i=0; i<tag1.length; i++) seqId = seqId + tag1[i];
-          addGlobalMeta("Image-Pro SEQ ID", seqId);
+          StringBuffer seqId = new StringBuffer();
+          for (int i=0; i<tag1.length; i++) {
+            seqId.append(tag1[i]);
+          }
+          addGlobalMeta("Image-Pro SEQ ID", seqId.toString());
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3949,7 +3949,7 @@ public class ZeissCZIReader extends FormatReader {
         ", pyramidType = " + pyramidType + ", dimensionCount = " + dimensionCount;
       if (dimensionCount > 0) {
         s += ", dimensions = [";
-        StringBuffer sb = new StringBuffer(s);
+        StringBuilder sb = new StringBuilder(s);
         for (int i=0; i<dimensionCount; i++) {
           sb.append(dimensionEntries[i]);
           if (i < dimensionCount - 1) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3948,8 +3948,8 @@ public class ZeissCZIReader extends FormatReader {
         filePosition + ", filePart = " + filePart + ", compression = " + compression +
         ", pyramidType = " + pyramidType + ", dimensionCount = " + dimensionCount;
       if (dimensionCount > 0) {
-        s += ", dimensions = [";
         StringBuilder sb = new StringBuilder(s);
+        sb.append(", dimensions = [");
         for (int i=0; i<dimensionCount; i++) {
           sb.append(dimensionEntries[i]);
           if (i < dimensionCount - 1) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3949,13 +3949,15 @@ public class ZeissCZIReader extends FormatReader {
         ", pyramidType = " + pyramidType + ", dimensionCount = " + dimensionCount;
       if (dimensionCount > 0) {
         s += ", dimensions = [";
+        StringBuffer sb = new StringBuffer(s);
         for (int i=0; i<dimensionCount; i++) {
-          s += dimensionEntries[i];
+          sb.append(dimensionEntries[i]);
           if (i < dimensionCount - 1) {
-            s += "; ";
+            sb.append("; ");
           }
         }
-        s += ']';
+        sb.append(']');
+        s = sb.toString();
       }
       return s;
     }

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
@@ -107,18 +107,18 @@ public class ZeissTIFFHandler extends DefaultHandler {
   @Override
   public String toString()
   {
-    String s = new String("TIFF-XML parsing\n");
-    s += main_tagset;
-    s += '\n';
+    StringBuffer s = new StringBuffer("TIFF-XML parsing\n");
+    s.append(main_tagset);
+    s.append('\n');
     for (Scaling sc : scalings ) {
-      s += sc;
-      s += '\n';
+      s.append(sc);
+      s.append('\n');
     }
     for (Plane p : planes ) {
-      s += p;
-      s += '\n';
+      s.append(p);
+      s.append('\n');
     }
-    return s;
+    return s.toString();
   }
 
   // -- DefaultHandler API methods --
@@ -584,12 +584,12 @@ public class ZeissTIFFHandler extends DefaultHandler {
 
     @Override
     public String toString() {
-      String s = new String("  Tags(" + count + "):\n");
+      StringBuffer s = new StringBuffer("  Tags(" + count + "):\n");
       for (BaseZeissReader.Tag t : tags) {
-        s += t;
-        s += '\n';
+        s.append(t);
+        s.append('\n');
       }
-      return s;
+      return s.toString();
     }
   }
 
@@ -661,27 +661,36 @@ public class ZeissTIFFHandler extends DefaultHandler {
 
     @Override
     public String toString() {
-      String s = new String("Scaling\n");
-      s += "  Key=" + key + "\n";
-      s += "  Cat=" + category + "\n";
+      StringBuffer s = new StringBuffer("Scaling\n");
+      s.append("  Key=");
+      s.append(key);
+      s.append("\n  Cat=");
+      s.append(category);
+      s.append("\n");
 
       List<Integer> dimarray = new LinkedList<Integer>(dims.keySet());
       Collections.sort(dimarray);
       for (Integer dim : dimarray)
       {
         Dimension d = dims.get(dim);
-        s += "  Dim" + dim + "=\n"
-            + "    Ftr=" + d.factor + "\n"
-            + "    Typ=" + d.type + "\n"
-            + "    Unt=" + d.unit + "\n"
-            + "    Org=" + d.origin + "\n"
-            + "    Ang=" + d.angle + "\n";
-
+        s.append("  Dim");
+        s.append(dim);
+        s.append("=\n    Ftr=");
+        s.append(d.factor);
+        s.append("\n    Typ=");
+        s.append(d.type);
+        s.append("\n    Unt=");
+        s.append(d.unit);
+        s.append("\n    Org=");
+        s.append(d.origin);
+        s.append("\n    Ang=");
+        s.append(d.angle);
+        s.append("\n");
       }
-      s += tagset;
-      s+= '\n';
+      s.append(tagset);
+      s.append('\n');
 
-      return s;
+      return s.toString();
     }
 
     /**

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFHandler.java
@@ -107,7 +107,7 @@ public class ZeissTIFFHandler extends DefaultHandler {
   @Override
   public String toString()
   {
-    StringBuffer s = new StringBuffer("TIFF-XML parsing\n");
+    StringBuilder s = new StringBuilder("TIFF-XML parsing\n");
     s.append(main_tagset);
     s.append('\n');
     for (Scaling sc : scalings ) {
@@ -584,7 +584,7 @@ public class ZeissTIFFHandler extends DefaultHandler {
 
     @Override
     public String toString() {
-      StringBuffer s = new StringBuffer("  Tags(" + count + "):\n");
+      StringBuilder s = new StringBuilder("  Tags(" + count + "):\n");
       for (BaseZeissReader.Tag t : tags) {
         s.append(t);
         s.append('\n');
@@ -661,7 +661,7 @@ public class ZeissTIFFHandler extends DefaultHandler {
 
     @Override
     public String toString() {
-      StringBuffer s = new StringBuffer("Scaling\n");
+      StringBuilder s = new StringBuilder("Scaling\n");
       s.append("  Key=");
       s.append(key);
       s.append("\n  Cat=");

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -620,12 +620,17 @@ public class ZeissTIFFReader extends BaseZeissReader {
     public String
     toString()
     {
-      String s = new String("---Plane---\n");
-      s += "  file=" + filename + "\n keys=\n";
+      StringBuffer s = new StringBuffer("---Plane---\n  file=");
+      s.append(filename);
+      s.append("\n keys=\n");
       for (String k : tags.keySet()) {
-        s += "    " + k + "=" + tags.get(k) + "\n";
+        s.append("    ");
+        s.append(k);
+        s.append("=");
+        s.append(tags.get(k));
+        s.append("\n");
       }
-      return s;
+      return s.toString();
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissTIFFReader.java
@@ -620,7 +620,7 @@ public class ZeissTIFFReader extends BaseZeissReader {
     public String
     toString()
     {
-      StringBuffer s = new StringBuffer("---Plane---\n  file=");
+      StringBuilder s = new StringBuilder("---Plane---\n  file=");
       s.append(filename);
       s.append("\n keys=\n");
       for (String k : tags.keySet()) {

--- a/excludebugs.xml
+++ b/excludebugs.xml
@@ -11,6 +11,13 @@
   </Match>
 
   <Match>
+    <Confidence value="2"/>
+    <Not>
+      <Bug pattern="SBSC_USE_STRINGBUFFER_CONCATENATION"/>
+    </Not>
+  </Match>
+
+  <Match>
     <Class name="~loci\.common\..*"/>
     <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS,NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
   </Match>


### PR DESCRIPTION
See https://trello.com/c/5E3itceq/179-findbugs-sbscusestringbufferconcatenation

7913cae alone updates the Findbugs configuration to detect ```SBSC_USE_STRINGBUFFER_CONCATENATION``` (http://findbugs.sourceforge.net/bugDescriptions.html#SBSC_USE_STRINGBUFFER_CONCATENATION).  This is done by changing the reporting level to ```medium``` but filtering out all ```medium``` priority bugs apart from ```SBSC_USE_STRINGBUFFER_CONCATENATION```.  Using ```medium``` priority with no filtering results in thousands of additional bugs being detected.

The remaining commits address bugs reported by ```ant -Dfindbugs.home=/path/to/findbugs-3.0.0 findbugs``` with 7913cae included in the build.  Actual functionality should not be affected, so I would expect builds to remain green.

I would also expect this to be safe for a patch release, but it's very low priority and can be closed/excluded if too distracting.