### PR TITLE
MRC: read the ISPG field and store in original metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -274,7 +274,9 @@ public class MRCReader extends FormatReader {
       }
     }
 
-    in.skipBytes(4);
+    int ispg = in.readInt();
+    addGlobalMeta("ISPG", ispg);
+    addGlobalMeta("Is data cube", ispg == 1);
 
     extHeaderSize = in.readInt();
 


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/8688

To test, choose any file from ```data_repo/curated/mrc/``` and verify that ```showinf -nopix``` with this change shows ```ISPG``` and ```Is data cube``` entries in the original metadata table.  The location of the ISPG field was determined from http://www.ccp4.ac.uk/html/maplib.html#description

I would expect builds to remain green and memo files to be unaffected, so this should be safe for a patch release.