### PR TITLE
Fix or remove broken links

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1096,7 +1096,7 @@ reader = JEOLReader
 extensions = .jp2
 developer = `Independent JPEG Group <http://www.ijg.org/>`_
 bsd = yes
-software = `JJ2000 (JPEG 2000 library for Java) <http://code.google.com/p/jj2000/>`_
+software = `JJ2000 (JPEG 2000 library for Java) <https://code.google.com/archive/p/jj2000/>`_
 weHave = * a JPEG 2000 specification document (free draft from 2000, no longer available online) \n
 * a few .jp2 files
 pixelsRating = Very good

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -487,7 +487,7 @@ mif = true
 
 [cellSens VSI]
 extensions = .vsi
-developer = `Olympus <http://www.olympus.com/>`_
+developer = `Olympus <https://www.olympus-global.com>`_
 bsd = no
 weHave = * a few example datasets \n
 * a VSI specification document (v1.6, 2012 November 27, in PDF) \n
@@ -1108,7 +1108,7 @@ pyramid = yes
 reader = JPEG2000Reader
 writer = JPEG2000Writer
 mif = true
-notes = Bio-Formats uses the `JAI Image I/O Tools <https://java.net/projects/jai-imageio>`_ library to read JP2 files. \n
+notes = Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ library to read JP2 files. \n
 JPEG stands for "Joint Photographic Experts Group".
 
 [JPEG]
@@ -1165,7 +1165,7 @@ mif = true
 pagename = khoros-viff-bitmap
 extensions = .xv
 owner = `AccuSoft <http://www.accusoft.com/company/>`_
-developer = `Khoral <http://www.khoral.com/company/>`_
+developer = Khoral
 bsd = no
 samples = `VIFF Images <http://netghost.narod.ru/gff/sample/images/viff/index.htm>`_
 weHave = * several VIFF datasets
@@ -1188,8 +1188,6 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = KodakReader
-notes = .. seealso:: \n
-  `Information on Image Station systems <http://carestream.com/PublicContent.aspx?langType=1033&id=448953>`_
 
 [Lambert Instruments FLIM]
 extensions = .fli
@@ -1590,7 +1588,7 @@ JPEG-2000 compression, and a new version which is either uncompressed or \n
 Zip-compressed.  We are not aware of the version number or release date \n
 for either format. \n
 \n
-Bio-Formats uses the `JAI Image I/O Tools <http://java.net/projects/jai-imageio>`_ \n
+Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ \n
 library to read ND2 files compressed with JPEG-2000. \n
 \n
 There is also a **legacy** ND2 reader that uses Nikon's native libraries. \n
@@ -1620,7 +1618,7 @@ reader = NRRDReader
 
 [Olympus CellR/APL]
 extensions = .apl, .mtb, .tnb, .tif, .obsep
-owner = `Olympus <http://www.olympus.com/>`_
+owner = `Olympus <https://www.olympus-global.com>`_
 bsd = no
 weHave = * a few CellR datasets
 weWant = * more Cellr datasets \n
@@ -1635,7 +1633,7 @@ mif = true
 
 [Olympus FluoView FV1000]
 extensions = .oib, .oif
-owner = `Olympus <http://www.olympus.com/>`_
+owner = `Olympus <https://www.olympus-global.com>`_
 bsd = no
 versions = 1.0, 2.0
 software = `FV-Viewer from Olympus <http://www.olympus-lifescience.com/en/>`_
@@ -1671,7 +1669,7 @@ Commercial applications that support this format include: \n
 
 [Olympus FluoView TIFF]
 extensions = .tif
-owner = `Olympus <http://www.olympus.com/>`_
+owner = `Olympus <https://www.olympus-global.com>`_
 bsd = no
 software = `DIMIN <http://www.dimin.net/>`_
 weHave = * a FluoView specification document (from 2002 November 14, in DOC) \n
@@ -1692,7 +1690,7 @@ notes = Commercial applications that support this format include: \n
 
 [Olympus OIR]
 extensions = .oir
-owner = `Olympus <http://www.olympus.com/>`_
+owner = `Olympus <https://www.olympus-global.com>`_
 bsd = no
 software = `Olympus Viewer Plugin for ImageJ <http://imagej.net/OlympusImageJPlugin>`_
 weHave = * several OIR datasets \n
@@ -1707,8 +1705,8 @@ notes = Support for this format was added in partnership with OLYMPUS EUROPA SE 
 
 [Olympus ScanR]
 extensions = .xml, .dat, .tif
-owner = `Olympus <http://www.olympus.com/>`_
-developer = `Olympus <http://www.olympus.com/>`_
+owner = `Olympus <https://www.olympus-global.com>`_
+developer = `Olympus <https://www.olympus-global.com>`_
 bsd = no
 versions = Up to 2.5.1
 weHave = * several ScanR datasets
@@ -2200,7 +2198,7 @@ reader = SpiderReader
 
 [Targa]
 extensions = .tga
-developer = `Truevision <http://www.truevision.com>`_
+developer = `Truevision <https://en.wikipedia.org/wiki/Truevision>`_
 bsd = no
 weHave = * a Targa specification document \n
 * a few Targa files
@@ -2228,8 +2226,7 @@ extensions = .tiff, .tif, .tf2, .tf8, .btf
 owner = `Adobe <http://www.adobe.com>`_
 developer = Aldus and Microsoft
 bsd = yes
-samples = `LZW TIFF data gallery <http://marlin.life.utsa.edu/marlin/Data_Gallery.html>`_ \n
-`Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
+samples = `Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
 weHave = * a `TIFF specification document <https://www.awaresystems.be/imaging/tiff.html>`_ \n
 * many TIFF datasets \n
 * a few BigTIFF datasets

--- a/docs/sphinx/about/whats-new.rst
+++ b/docs/sphinx/about/whats-new.rst
@@ -1342,7 +1342,8 @@ Java bug fixes:
 
 * Updated to :model_doc:`2013-06 OME-XML schema <>`
 * Improved the performance in tiled formats
-* Added caching of Reader metadata using http://code.google.com/p/kryo/
+* Added caching of Reader metadata using
+  https://github.com/EsotericSoftware/kryo
 * Added support for:
    - :doc:`Aperio AFI </formats/aperio-afi>`
    - :doc:`Inveon </formats/inveon>`

--- a/docs/sphinx/formats/cellsens-vsi.rst
+++ b/docs/sphinx/formats/cellsens-vsi.rst
@@ -6,7 +6,7 @@ cellSens VSI
 
 Extensions: .vsi
 
-Developer: `Olympus <http://www.olympus.com/>`_
+Developer: `Olympus <https://www.olympus-global.com>`_
 
 
 **Support**

--- a/docs/sphinx/formats/jpeg-2000.rst
+++ b/docs/sphinx/formats/jpeg-2000.rst
@@ -24,7 +24,7 @@ Writer: JPEG2000Writer (:bsd-writer:`Source Code <JPEG2000Writer.java>`)
 
 Freely Available Software:
 
-- `JJ2000 (JPEG 2000 library for Java) <http://code.google.com/p/jj2000/>`_
+- `JJ2000 (JPEG 2000 library for Java) <https://code.google.com/archive/p/jj2000/>`_
 
 
 We currently have:

--- a/docs/sphinx/formats/jpeg-2000.rst
+++ b/docs/sphinx/formats/jpeg-2000.rst
@@ -51,5 +51,5 @@ Utility: |Poor|
 **Additional Information**
 
 
-Bio-Formats uses the `JAI Image I/O Tools <https://java.net/projects/jai-imageio>`_ library to read JP2 files. 
+Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ library to read JP2 files. 
 JPEG stands for "Joint Photographic Experts Group".

--- a/docs/sphinx/formats/khoros-viff-bitmap.rst
+++ b/docs/sphinx/formats/khoros-viff-bitmap.rst
@@ -6,7 +6,7 @@ Khoros VIFF (Visualization Image File Format) Bitmap
 
 Extensions: .xv
 
-Developer: `Khoral <http://www.khoral.com/company/>`_
+Developer: Khoral
 
 Owner: `AccuSoft <http://www.accusoft.com/company/>`_
 

--- a/docs/sphinx/formats/kodak-bip.rst
+++ b/docs/sphinx/formats/kodak-bip.rst
@@ -44,8 +44,5 @@ Presence: |Poor|
 
 Utility: |Fair|
 
-**Additional Information**
 
 
-.. seealso:: 
-  `Information on Image Station systems <http://carestream.com/PublicContent.aspx?langType=1033&id=448953>`_

--- a/docs/sphinx/formats/nikon-nis-elements-nd2.rst
+++ b/docs/sphinx/formats/nikon-nis-elements-nd2.rst
@@ -61,7 +61,7 @@ JPEG-2000 compression, and a new version which is either uncompressed or
 Zip-compressed.  We are not aware of the version number or release date 
 for either format. 
 
-Bio-Formats uses the `JAI Image I/O Tools <http://java.net/projects/jai-imageio>`_ 
+Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ 
 library to read ND2 files compressed with JPEG-2000. 
 
 There is also a **legacy** ND2 reader that uses Nikon's native libraries. 

--- a/docs/sphinx/formats/olympus-cellrapl.rst
+++ b/docs/sphinx/formats/olympus-cellrapl.rst
@@ -7,7 +7,7 @@ Olympus CellR/APL
 Extensions: .apl, .mtb, .tnb, .tif, .obsep
 
 
-Owner: `Olympus <http://www.olympus.com/>`_
+Owner: `Olympus <https://www.olympus-global.com>`_
 
 **Support**
 

--- a/docs/sphinx/formats/olympus-fluoview-fv1000.rst
+++ b/docs/sphinx/formats/olympus-fluoview-fv1000.rst
@@ -7,7 +7,7 @@ Olympus FluoView FV1000
 Extensions: .oib, .oif
 
 
-Owner: `Olympus <http://www.olympus.com/>`_
+Owner: `Olympus <https://www.olympus-global.com>`_
 
 **Support**
 

--- a/docs/sphinx/formats/olympus-fluoview-tiff.rst
+++ b/docs/sphinx/formats/olympus-fluoview-tiff.rst
@@ -7,7 +7,7 @@ Olympus FluoView TIFF
 Extensions: .tif
 
 
-Owner: `Olympus <http://www.olympus.com/>`_
+Owner: `Olympus <https://www.olympus-global.com>`_
 
 **Support**
 

--- a/docs/sphinx/formats/olympus-oir.rst
+++ b/docs/sphinx/formats/olympus-oir.rst
@@ -7,7 +7,7 @@ Olympus OIR
 Extensions: .oir
 
 
-Owner: `Olympus <http://www.olympus.com/>`_
+Owner: `Olympus <https://www.olympus-global.com>`_
 
 **Support**
 

--- a/docs/sphinx/formats/olympus-scanr.rst
+++ b/docs/sphinx/formats/olympus-scanr.rst
@@ -6,9 +6,9 @@ Olympus ScanR
 
 Extensions: .xml, .dat, .tif
 
-Developer: `Olympus <http://www.olympus.com/>`_
+Developer: `Olympus <https://www.olympus-global.com>`_
 
-Owner: `Olympus <http://www.olympus.com/>`_
+Owner: `Olympus <https://www.olympus-global.com>`_
 
 **Support**
 

--- a/docs/sphinx/formats/targa.rst
+++ b/docs/sphinx/formats/targa.rst
@@ -6,7 +6,7 @@ Targa
 
 Extensions: .tga
 
-Developer: `Truevision <http://www.truevision.com>`_
+Developer: `Truevision <https://en.wikipedia.org/wiki/Truevision>`_
 
 
 **Support**

--- a/docs/sphinx/formats/tiff.rst
+++ b/docs/sphinx/formats/tiff.rst
@@ -26,7 +26,6 @@ Writer: TiffWriter (:bsd-writer:`Source Code <TiffWriter.java>`)
 
 Sample Datasets:
 
-- `LZW TIFF data gallery <http://marlin.life.utsa.edu/marlin/Data_Gallery.html>`_ 
 - `Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
 
 We currently have:

--- a/docs/sphinx/users/micromanager/index.rst
+++ b/docs/sphinx/users/micromanager/index.rst
@@ -1,7 +1,7 @@
 Micro-Manager
 =============
 
-`Micro-Manager <https://www.micro-manager.org/wiki/Micro-Manager>`_ is a
+`Micro-Manager <https://www.micro-manager.org>`_ is a
 software framework for implementing advanced and novel imaging procedures,
 extending functionality, customization and rapid development of specialized
 imaging applications.


### PR DESCRIPTION
In conjunction with #2995 this should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/ green again.

Deleted links are currently broken and either never expected to be fixed or have been broken repeatedly in the past and therefore don't seem worth the effort to try and maintain even if the current breakage is temporary.