### PR TITLE
ant: Remove broken utils-formats-api target

### DIFF
--- a/ant/toplevel.xml
+++ b/ant/toplevel.xml
@@ -131,11 +131,6 @@ Type "ant -p" for a list of targets.
     <ant dir="components/formats-api" target="formats-api.clean"/>
   </target>
 
-  <target name="utils-formats-api" depends="jar-formats-api"
-    description="compile extra utilities for reader and writer APIs">
-    <ant dir="components/formats-api" target="formats-api.utils"/>
-  </target>
-
   <target name="test-formats-api" depends="jar-formats-api, testing-deps"
     description="compile and run tests for reader and writer APIs">
     <ant dir="components/formats-api" target="test"/>


### PR DESCRIPTION
While looking at other targets, I noticed this one was broken because this component no longer has any utilties at all.  This PR removes the unused and broken target.

Testing: Check builds remain green.  There are no remaining uses of this target, so nothing should break.