### PR TITLE
appveyor: Add appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,46 @@
+environment:
+  AV_PROJECTS: 'c:\projects'
+  AV_BF_M2: 'c:\projects\m2'
+  AV_BF_PYTHON: 'c:\projects\python'
+  AV_BF_SOURCE: 'c:\projects\bioformats'
+
+  matrix:
+    - java: 1.8
+      build: maven
+    - java: 1.7
+      build: maven
+    - java: 1.8
+      build: ant
+
+cache:
+  - '%AV_BF_M2% -> appveyor.yml'
+  - '%AV_BF_PYTHON% -> appveyor.yml'
+
+os: 'Visual Studio 2015'
+clone_folder: '%AV_BF_SOURCE%'
+clone_depth: 5
+platform: x64
+
+init:
+  - git config --global core.autocrlf input
+  - if [%build%] == [ant] appveyor-retry cinst -y ant
+  - refreshenv
+  - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
+  - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
+  - PATH=%JAVA_HOME%\bin;%PATH%
+  - 'if NOT EXIST "c:\projects\%java%\%build%\" mkdir "c:\projects\%java%\%build%\"'
+  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m pip install virtualenv'
+  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
+  - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
+  - python -m pip install sphinx
+  - 'if [%build%] == [maven] set "MAVEN_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
+  - 'if [%build%] == [ant] set "ANT_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
+
+build_script:
+  - tools\test-build %build%
+
+artifacts:
+  - path: 'components\**\*.zip'
+  - path: 'components\**\*.jar'
+  - path: 'components\**\*.tar.*'
+  - path: 'artifacts\*'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,11 +4,18 @@ environment:
   AV_BF_PYTHON: 'c:\projects\python'
   AV_BF_SOURCE: 'c:\projects\bioformats'
 
+# Note that only Oracle JDK is provided.
   matrix:
     - java: 1.8
       build: maven
     - java: 1.8
       build: ant
+      ant_version: 1.10.1
+    - java: 1.7
+      build: maven
+    - java: 1.7
+      build: ant
+      ant_version: 1.9.9
 
 cache:
   - '%AV_BF_M2% -> appveyor.yml'
@@ -21,27 +28,28 @@ platform: x64
 
 init:
   - git config --global core.autocrlf input
-  - if [%build%] == [ant] appveyor-retry cinst -y ant
+  - if [%build%] == [ant] appveyor-retry cinst -y ant --version %ant_version%
   - refreshenv
   - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
   - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
   - PATH=%JAVA_HOME%\bin;%PATH%
-  - 'if NOT EXIST "c:\projects\%java%\%build%\" mkdir "c:\projects\%java%\%build%\"'
-  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m pip install virtualenv'
-  - 'if NOT EXIST "%AV_BF_PYTHON%\" C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
-  - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
-  - python -m pip install sphinx
   - 'if [%build%] == [maven] set "MAVEN_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
   - 'if [%build%] == [ant] set "ANT_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
 
 build_script:
+  # Cached venv is available from this point.
+  - 'if NOT EXIST "%AV_BF_PYTHON%\" set AV_BF_CREATE_VENV=true'
+  - 'if [%AV_BF_CREATE_VENV%] == [true] C:\Python36-x64\python -m pip install virtualenv'
+  - 'if [%AV_BF_CREATE_VENV%] == [true] C:\Python36-x64\python -m virtualenv %AV_BF_PYTHON%'
+  - PATH=%AV_BF_PYTHON%;%AV_BF_PYTHON%\scripts;%PATH%
+  - 'if [%AV_BF_CREATE_VENV%] == [true] python -m pip install sphinx'
   - tools\test-build %build%
 
-artifacts:
-  - path: 'components\bundles\bioformats_package\target\*.zip'
-  - path: 'components\bundles\bioformats_package\target\*.jar'
-  - path: 'components\bundles\bioformats_package\target\*.tar.*'
-  - path: 'artifacts\bioformats_package.jar'
-  - path: 'artifacts\bftools.zip'
-  - path: 'artifacts\bfmatlab.zip'
-  - path: 'artifacts\bioformats-octave*.tar.*'
+#artifacts:
+#  - path: 'components\bundles\bioformats_package\target\*.zip'
+#  - path: 'components\bundles\bioformats_package\target\*.jar'
+#  - path: 'components\bundles\bioformats_package\target\*.tar.*'
+#  - path: 'artifacts\bioformats_package.jar'
+#  - path: 'artifacts\bftools.zip'
+#  - path: 'artifacts\bfmatlab.zip'
+#  - path: 'artifacts\bioformats-octave*.tar.*'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,6 @@ environment:
   matrix:
     - java: 1.8
       build: maven
-    - java: 1.7
-      build: maven
     - java: 1.8
       build: ant
 
@@ -40,7 +38,10 @@ build_script:
   - tools\test-build %build%
 
 artifacts:
-  - path: 'components\**\*.zip'
-  - path: 'components\**\*.jar'
-  - path: 'components\**\*.tar.*'
-  - path: 'artifacts\*'
+  - path: 'components\bundles\bioformats_package\target\*.zip'
+  - path: 'components\bundles\bioformats_package\target\*.jar'
+  - path: 'components\bundles\bioformats_package\target\*.tar.*'
+  - path: 'artifacts\bioformats_package.jar'
+  - path: 'artifacts\bftools.zip'
+  - path: 'artifacts\bfmatlab.zip'
+  - path: 'artifacts\bioformats-octave*.tar.*'

--- a/tools/test-build
+++ b/tools/test-build
@@ -35,8 +35,6 @@ antbuild()
       # Do not clean here so that we can potentially archive both
       # docs and java archives.
       ant tools dist-bftools dist-matlab dist-octave
-      # Finally, run the unit tests.
-      ant test
     )
 }
 

--- a/tools/test-build
+++ b/tools/test-build
@@ -14,7 +14,7 @@ clean()
 # Test maven build
 maven()
 {
-    mvn
+    mvn install
 }
 
 # Test Ant build targets
@@ -32,6 +32,11 @@ antbuild()
       ant clean compile-turbojpeg
       ant clean utils
       ant -Dsphinx.warnopts="-W" clean-docs-sphinx docs-sphinx
+      # Do not clean here so that we can potentially archive both
+      # docs and java archives.
+      ant tools dist-bftools dist-matlab dist-octave
+      # Finally, run the unit tests.
+      ant test
     )
 }
 

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -26,6 +26,4 @@ if [%build%] == [ant] (
   REM don't clean, so that the docs zip will be archived along with
   REM the other zips and jars.
   ant tools dist-bftools dist-matlab dist-octave || exit /b 1
-  REM Finally, run the unit tests.
-  ant test || exit /b 1
 )

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -23,7 +23,7 @@ if [%build%] == [ant] (
   ant clean compile-turbojpeg || exit /b 1
   ant clean utils || exit /b 1
   ant -Dsphinx.warnopts="-W" clean-docs-sphinx docs-sphinx || exit /b 1
-  REM don't clean, so that the docs zip will be archived along with
-  REM the other zips and jars.
+  REM Do not clean here so that we can potentially archive both
+  REM docs and java archives.
   ant tools dist-bftools dist-matlab dist-octave || exit /b 1
 )

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -1,0 +1,30 @@
+REM This script is used for testing the build, primarily for use
+REM with appveyor, but may be used by hand as well.
+
+set build=%1
+
+if [%build%] == [] exit /b 2
+
+if [%build%] == [maven] (
+  REM Test the maven build
+  mvn install || exit /b 1
+)
+
+if [%build%] == [ant] (
+  REM Test the ant build
+  ant clean compile || exit /b 1
+  ant clean compile-autogen || exit /b 1
+  ant clean compile-formats-api || exit /b 1
+  ant clean compile-bio-formats-plugins || exit /b 1
+  ant clean compile-formats-bsd || exit /b 1
+  ant clean compile-formats-gpl || exit /b 1
+  ant clean compile-bio-formats-tools || exit /b 1
+  ant clean compile-tests || exit /b 1
+  ant clean compile-turbojpeg || exit /b 1
+  ant clean utils || exit /b 1
+  ant -Dsphinx.warnopts="-W" clean-docs-sphinx docs-sphinx || exit /b 1
+  REM don't clean, so that the docs zip will be archived along with
+  REM the other zips and jars.
+  ant tools dist-bftools dist-matlab dist-octave || exit /b 1
+  ant test || exit /b 1
+)

--- a/tools/test-build.bat
+++ b/tools/test-build.bat
@@ -26,5 +26,6 @@ if [%build%] == [ant] (
   REM don't clean, so that the docs zip will be archived along with
   REM the other zips and jars.
   ant tools dist-bftools dist-matlab dist-octave || exit /b 1
+  REM Finally, run the unit tests.
   ant test || exit /b 1
 )


### PR DESCRIPTION
This is a Windows equivalent to the existing travis support: a top-level `.appveyor.yml` and a `tools/test-build.bat` script.  A test matrix tests the maven and ant builds with Java 1.7 and 1.8 (1.7/ant excluded because current Ant releases don't work with Java 1.7 anymore).  `.m2` and python virtualenv are cached between runs (though I'm not entirely certain the venv caching is working between runs); the m2 caching is.

While I'm sure we can improve this further, this is an initial working example of how we could improve our CI testing by building routinely on Windows for every open PR.

This can be tested by enabling Appveyor support for the snoopy bioformats git branch and then running the merge-push job.  See https://ci.appveyor.com/project/rleigh-codelibre/bioformats/build/1.0.19 for an example.  Also note that this archives the built zip/tar/jar files for later download, including bftools and documentation.  Appveyor may be enabled for individual developer accounts as well, as for travis.