### PR TITLE
Use HTTPS for link to Unidata site

### DIFF
--- a/docs/sphinx/developers/java-library.rst
+++ b/docs/sphinx/developers/java-library.rst
@@ -84,7 +84,7 @@ The complete list of current dependencies is as follows:
     * - `Commons Logging v1.1.1 <http://commons.apache.org/logging/>`_
       - commons-logging:commons-logging:1.1.1
       - `Apache License v2.0`_
-    * - `NetCDF-Java Library v4.3.22 <http://www.unidata.ucar.edu/software/netcdf-java/documentation.htm>`_
+    * - `NetCDF-Java Library v4.3.22 <https://www.unidata.ucar.edu/software/netcdf-java/documentation.htm>`_
       - edu.ucar:netcdf:4.3.22
       - `MIT-Style License`_
     * - `Joda time v2.2 <http://github.com/JodaOrg/joda-time>`_


### PR DESCRIPTION
This is a fix for the docs build https://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-DEV-merge-docs/928/

The original link not longer works and tries to incorrectly redirect. The https link functions as before:
Old link -   http://www.unidata.ucar.edu/software/netcdf-java/documentation.htm
New link - https://www.unidata.ucar.edu/software/netcdf-java/documentation.htm

To test:
- Ensure that the docs builds remain green