### PR TITLE
Fix NPEs when an OME-TIFF is in the root directory

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellVoyagerReader.java
@@ -252,7 +252,10 @@ public class CellVoyagerReader extends FormatReader
     if ( localName.equals( "MeasurementResult.xml" ) ) { return true; }
     final Location parent = new Location( name ).getAbsoluteFile().getParentFile();
     Location xml = new Location( parent, "MeasurementResult.xml" );
-    if (!xml.exists()) {
+    if (!xml.exists() && parent != null) {
+      if (parent.getParent() == null) {
+        return false;
+      }
       xml = new Location(parent.getParentFile(), "MeasurementResult.xml");
       if (!xml.exists()) {
         return false;

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -598,9 +598,11 @@ public class ColumbusReader extends FormatReader {
     if (xml.exists()) {
       return xml;
     }
-    xml = new Location(parent.getParentFile(), XML_FILE);
-    if (xml.exists()) {
-      return xml;
+    if (parent.getParent() != null) {
+      xml = new Location(parent.getParentFile(), XML_FILE);
+      if (xml.exists()) {
+        return xml;
+      }
     }
     return null;
   }


### PR DESCRIPTION
CellVoyagerReader and ColumbusReader both assumed that the file passed to ```isThisType``` was not in the root directory.  This caused problems for TIFF/OME-TIFF files that were placed in the root directory.  

To test, copy any OME-TIFF to ```/``` on Linux/OS X or ```C:\``` (or equivalent) on Windows.  I used ```data_repo/curated/ome-tiff/ome-schemas/2016-06/MitoCheck/00001_01.ome.tiff```.

Without this change, ```showinf -nopix /00001_01.ome.tiff``` should result in the following exception:

```
Exception in thread "main" java.lang.NullPointerException
	at loci.common.Location.<init>(Location.java:104)
	at loci.common.Location.getParentFile(Location.java:623)
	at loci.formats.in.CellVoyagerReader.isThisType(CellVoyagerReader.java:256)
	at loci.formats.ImageReader.getReader(ImageReader.java:185)
	at loci.formats.ImageReader.getFormat(ImageReader.java:156)
	at loci.formats.tools.ImageInfo.configureReaderPreInit(ImageInfo.java:433)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1026)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1117)
```

With this change, the same test should result in successful initialization and output matching ```showinf -nopix``` on the file's original (non-root) location.

https://github.com/ome/ome-common-java/pull/12 (now reverted) and https://github.com/openmicroscopy/bioformats/pull/2914 (closed without merging) are related.

All builds should remain green.  I would expect this to be safe for a patch release.