### PR TITLE
ScreenReader enhancements (rebased onto develop)

### DIFF
--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -1179,7 +1179,7 @@ public class FileStitcher extends ReaderWrapper {
    *
    * @return An array of size 2, dimensioned {file index, image index}.
    */
-  protected int[] computeIndices(int no) throws FormatException, IOException {
+  public int[] computeIndices(int no) throws FormatException, IOException {
     if (noStitch) return new int[] {0, no};
     int sno = getCoreIndex();
     ExternalSeries s = externals[getExternalSeries()];

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -489,9 +489,6 @@ public class FileStitcher extends ReaderWrapper {
 
     if (ino < r.getImageCount()) {
       byte[] b = r.openBytes(ino, buf, x, y, w, h);
-      if (!noStitch && ino == r.getImageCount() - 1) {
-        r.close();
-      }
       return b;
     }
 
@@ -695,21 +692,11 @@ public class FileStitcher extends ReaderWrapper {
 
       DimensionSwapper[] readers = s.getReaders();
       for (int i=0; i<readers.length; i++) {
-        try {
-          readers[i].setId(f[i]);
           String[] used = readers[i].getUsedFiles();
           for (String file : used) {
             String path = new Location(file).getAbsolutePath();
             files.add(path);
           }
-          readers[i].close();
-        }
-        catch (FormatException e) {
-          LOGGER.debug("", e);
-        }
-        catch (IOException e) {
-          LOGGER.debug("", e);
-        }
       }
     }
     return files.toArray(new String[files.size()]);
@@ -1241,11 +1228,9 @@ public class FileStitcher extends ReaderWrapper {
   protected void initReader(int sno, int fno) {
     int external = getExternalSeries(sno);
     DimensionSwapper r = externals[external].getReader(fno);
-    try {
       if (r.getCurrentFile() == null) {
         r.setGroupFiles(false);
       }
-      r.setId(externals[external].getFiles()[fno]);
       r.setSeries(reader.getSeriesCount() > 1 ? sno : 0);
       String newOrder = ((DimensionSwapper) reader).getInputOrder();
       if ((externals[external].getFiles().length > 1 || !r.isOrderCertain()) &&
@@ -1255,13 +1240,6 @@ public class FileStitcher extends ReaderWrapper {
         r.swapDimensions(newOrder);
       }
       r.setOutputOrder(newOrder);
-    }
-    catch (FormatException e) {
-      LOGGER.debug("", e);
-    }
-    catch (IOException e) {
-      LOGGER.debug("", e);
-    }
   }
 
   // -- Helper classes --

--- a/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/AxisGuesserTest.java
@@ -147,6 +147,16 @@ public class AxisGuesserTest {
     checkAxisCount(ag, types);
   }
 
+  private void checkAlt(
+      int[] types, String order, int sZ, int sT, int sC, boolean cert,  // IN
+      String newOrder) {                                                // OUT
+    AxisGuesser ag = new AxisGuesser(types, order, sZ, sT, sC, cert);
+    assertEquals(ag.getOriginalOrder(), order);
+    assertEquals(ag.getAdjustedOrder(), newOrder);
+    assertEquals(ag.getAxisTypes(), types);
+    checkAxisCount(ag, types);
+  }
+
   private String mkPrefix(String baseTag, Boolean upperCase) {
     if (upperCase) {
       baseTag = baseTag.toUpperCase();
@@ -206,6 +216,7 @@ public class AxisGuesserTest {
     String order = "XYZCT";
     String newOrder = isCertain ? order : "XYTCZ";
     check(pattern, order, sZ, sT, 1, isCertain, newOrder, types);
+    checkAlt(types, order, sZ, sT, 1, isCertain, newOrder);
   }
 
   @Test(dataProvider = "fillInCases")


### PR DESCRIPTION
This is the same as gh-2389 but rebased onto develop.

----

...ScreenReader items removed...

Also adds a new `overrideAxisTypes` method to `FileStitcher`, which allows to externally set the axis types before `setId` is called. In this case, `FileStitcher` uses the new `AxisGuesser(int[], ...)` (see 19ef8e25d6a8244575a78d031c8715331da6e337) that sidesteps axis types guessing (i.e., the `AxisGuesser` is only used for `getAdjustedOrder`).

Note that, without `overrideAxisTypes`, `ScreenReader` would have to call `FileStitcher.setAxisTypes` _after_ the call to `setId`, so `AxisGuesser` would perform its guessing work for nothing. After that, `ScreenReader` would have to call `reader.setId` again to make the wrapping `DimensionSwapper` pick up the changes, with an additional performance hit.


                