### PR TITLE
Add first version of Dockerfile for running the tests standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ USER bf
 WORKDIR /opt/bioformats
 RUN /opt/ant/bin/ant clean jars tools
 
+ENV TZ "Europe/London"
+
 WORKDIR /opt/bioformats/components/test-suite
 ENTRYPOINT ["/opt/ant/bin/ant", "test-automated", "-Dtestng.directory=/opt/data", "-Dtestng.configDirectory=/opt/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN chown -R bf /opt/bioformats
 
 USER bf
 WORKDIR /opt/bioformats
-RUN /opt/ant/bin/ant clean jars
-
+RUN /opt/ant/bin/ant clean jars tools
 
 WORKDIR /opt/bioformats/components/test-suite
 ENTRYPOINT ["/opt/ant/bin/ant", "test-automated", "-Dtestng.directory=/opt/data", "-Dtestng.configDirectory=/opt/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+# Installs Ant
+ENV ANT_VERSION 1.9.4
+RUN wget -q http://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.zip && \
+  unzip apache-ant-${ANT_VERSION}-bin.zip && \
+  mv apache-ant-${ANT_VERSION} /opt/ant && \
+  rm apache-ant-${ANT_VERSION}-bin.zip
+
+RUN useradd -m bf
+COPY . /opt/bioformats/
+RUN chown -R bf /opt/bioformats
+
+USER bf
+WORKDIR /opt/bioformats
+RUN /opt/ant/bin/ant clean jars
+
+
+WORKDIR /opt/bioformats/components/test-suite
+ENTRYPOINT ["/opt/ant/bin/ant", "test-automated", "-Dtestng.directory=/opt/data", "-Dtestng.configDirectory=/opt/config"]


### PR DESCRIPTION
- use the jdk:8 image as the base
- builds Bio-Formats using the Ant build system
- defines the test-automated target as the entry-point
- defines expected paths for the image data and configuration files

With the assumptions above, an image can be built and tested as follows
$ docker build -t bf .
$ docker run -v /path/to/data:/opt/data -v /path/to/config:/opt/config bf