### PR TITLE
Add flaky nifti link to ignore list

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -370,5 +370,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://code.google.com/archive/p/jj2000/',
     'https://support.apple.com/downloads/quicktime',
     'https://support.apple.com/quicktime',
-    'https://www.micro-manager.org'
+    'https://www.micro-manager.org',
+    'https://nifti.nimh.nih.gov/nifti-1/*'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -371,5 +371,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://support.apple.com/downloads/quicktime',
     'https://support.apple.com/quicktime',
     'https://www.micro-manager.org',
-    'https://nifti.nimh.nih.gov/nifti-1/*'
+    'https://nifti.nimh.nih.gov/nifti-1/'
 ]


### PR DESCRIPTION
This link has been very flaky recently but the consensus is to leave it in place and make the linkchecker ignore it rather than delete it from the docs. Issue maybe connected to US funding and go away again in future.

Should make https://ci.openmicroscopy.org/view/Docs/job/BIOFORMATS-DEV-merge-docs/ green again