### PR TITLE
Add support for PerkinElmer Vectra/QPTIFF files

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ThumbLoader.java
@@ -40,6 +40,7 @@ import javax.swing.JLabel;
 import loci.common.DebugTools;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
+import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.gui.AWTImageTools;
 import loci.formats.gui.BufferedImageReader;
@@ -144,7 +145,10 @@ public class ThumbLoader implements Runnable {
     Exception exc = null;
     try {
       BufferedImage thumb = thumbReader.openThumbImage(ndx);
-      thumb = AWTImageTools.autoscale(thumb);
+      // autoscaling floating point thumbnails typically results in a black image
+      if (!FormatTools.isFloatingPoint(thumbReader.getPixelType())) {
+        thumb = AWTImageTools.autoscale(thumb);
+      }
       ImageIcon icon = new ImageIcon(thumb);
       panel.removeAll();
       panel.add(new JLabel(icon));

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -1310,7 +1310,10 @@ public final class FormatTools {
       r.setVar("thumbSizeX", reader.getThumbSizeX());
       r.setVar("thumbSizeY", reader.getThumbSizeY());
       r.setVar("little", reader.isLittleEndian());
-      r.exec("img = AWTImageTools.openImage(plane, reader, sizeX, sizeY)");
+
+      // always normalize floating point images, otherwise scaling will fail
+      r.setVar("normal", true);
+      r.exec("img = AWTImageTools.openImage(plane, reader, sizeX, sizeY, normal)");
       r.exec("img = AWTImageTools.makeUnsigned(img)");
       r.exec("thumb = AWTImageTools.scale(img, thumbSizeX, thumbSizeY, false)");
       bytes = (byte[][]) r.exec("AWTImageTools.getPixelBytes(thumb, little)");

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -170,8 +170,8 @@ loci.formats.in.SISReader             # tif
 loci.formats.in.DNGReader             # cr2, crw, jpg, thm, wav, tif?
 loci.formats.in.ZeissTIFFReader # tif
 loci.formats.in.LeicaSCNReader        # scn
-loci.formats.in.SlidebookTiffReader   # tiff
 loci.formats.in.VectraReader          # tif, tiff, qptiff
+loci.formats.in.SlidebookTiffReader   # tiff
 
 # standard TIFF reader must go last (it accepts any TIFF)
 loci.formats.in.TiffDelegateReader    # tif, tiff

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -171,6 +171,7 @@ loci.formats.in.DNGReader             # cr2, crw, jpg, thm, wav, tif?
 loci.formats.in.ZeissTIFFReader # tif
 loci.formats.in.LeicaSCNReader        # scn
 loci.formats.in.SlidebookTiffReader   # tiff
+loci.formats.in.VectraReader          # tif, tiff, qptiff
 
 # standard TIFF reader must go last (it accepts any TIFF)
 loci.formats.in.TiffDelegateReader    # tif, tiff

--- a/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
+++ b/components/formats-bsd/src/loci/formats/gui/AWTImageTools.java
@@ -744,9 +744,20 @@ public final class AWTImageTools {
   public static BufferedImage openImage(byte[] buf, IFormatReader r,
     int w, int h) throws FormatException, IOException
   {
+    return openImage(buf, r, w, h, r.isNormalized());
+  }
+
+  /**
+   * Creates an image from the given byte array, using the given
+   * IFormatReader to retrieve additional information.
+   * The floating point normalization setting is specified by 'normal',
+   * which allows the reader's normalization setting to be overridden.
+   */
+  public static BufferedImage openImage(byte[] buf, IFormatReader r,
+    int w, int h, boolean normal) throws FormatException, IOException
+  {
     int pixelType = r.getPixelType();
     boolean little = r.isLittleEndian();
-    boolean normal = r.isNormalized();
     int rgbChanCount = r.getRGBChannelCount();
     boolean interleaved = r.isInterleaved();
     boolean indexed = r.isIndexed();

--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -1,0 +1,418 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import loci.common.Constants;
+import loci.common.DataTools;
+import loci.common.DateTools;
+import loci.common.RandomAccessInputStream;
+import loci.common.xml.XMLTools;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.meta.MetadataStore;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.PhotoInterp;
+import loci.formats.tiff.TiffParser;
+import ome.xml.model.primitives.Color;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.Timestamp;
+
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+import ome.units.UNITS;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * VectraReader is the reader for PerkinElmer Vectra QPTIFF data
+ */
+public class VectraReader extends BaseTiffReader {
+
+  // -- Constants --
+
+  /** Logger for this class. */
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(VectraReader.class);
+
+  /** TIFF image description prefix for PerkinElmer Vectra/QPTIFF files. */
+  private static final String SOFTWARE_CHECK = "PerkinElmer-QPI";
+
+  // -- Fields --
+
+  private int pyramidDepth = 1;
+
+  // -- Constructor --
+
+  /** Constructs a new Vectra reader. */
+  public VectraReader() {
+    super("PerkinElmer Vectra/QPTIFF", new String[] {"tiff", "tif", "qptiff"});
+    domains = new String[] {FormatTools.HISTOLOGY_DOMAIN, FormatTools.LM_DOMAIN};
+    noSubresolutions = true;
+  }
+
+  // -- IFormatReader API methods --
+
+  /* (non-Javadoc)
+   * @see loci.formats.FormatReader#isThisType(java.lang.String, boolean)
+   */
+  @Override
+  public boolean isThisType(String name, boolean open) {
+    boolean isThisType = super.isThisType(name, open);
+    if (!isThisType && open) {
+      RandomAccessInputStream stream = null;
+      try {
+        stream = new RandomAccessInputStream(name);
+        TiffParser tiffParser = new TiffParser(stream);
+        tiffParser.setDoCaching(false);
+        if (!tiffParser.isValidHeader()) {
+          return false;
+        }
+        IFD ifd = tiffParser.getFirstIFD();
+        if (ifd == null) {
+          return false;
+        }
+        String software = ifd.getIFDTextValue(IFD.SOFTWARE);
+        return software != null && software.startsWith(SOFTWARE_CHECK);
+      }
+      catch (IOException e) {
+        LOGGER.debug("I/O exception during isThisType() evaluation.", e);
+        return false;
+      }
+      finally {
+        try {
+          if (stream != null) {
+            stream.close();
+          }
+        }
+        catch (IOException e) {
+          LOGGER.debug("I/O exception during stream closure.", e);
+        }
+      }
+    }
+    return isThisType;
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    if (tiffParser == null) {
+      initTiffParser();
+    }
+    int ifd = getIFDIndex(getCoreIndex(), no);
+    tiffParser.getSamples(ifds.get(ifd), buf, x, y, w, h);
+    return buf;
+  }
+
+  /* @see loci.formats.IFormatReader#openThumbBytes(int) */
+  @Override
+  public byte[] openThumbBytes(int no) throws FormatException, IOException {
+    if (getCoreIndex() < pyramidDepth - 1) {
+      int currentIndex = getCoreIndex();
+      setCoreIndex(pyramidDepth - 1);
+      byte[] thumb = openThumbBytes(no);
+      setCoreIndex(currentIndex);
+      return thumb;
+    }
+    return super.openThumbBytes(no);
+  }
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      pyramidDepth = 1;
+    }
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    try {
+      int ifd = getIFDIndex(getCoreIndex(), 0);
+      return (int) ifds.get(ifd).getTileWidth();
+    }
+    catch (FormatException e) {
+      LOGGER.debug("", e);
+    }
+    return super.getOptimalTileWidth();
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    try {
+      int ifd = getIFDIndex(getCoreIndex(), 0);
+      return (int) ifds.get(ifd).getTileLength();
+    }
+    catch (FormatException e) {
+      LOGGER.debug("", e);
+    }
+    return super.getOptimalTileHeight();
+  }
+
+  // -- Internal BaseTiffReader API methods --
+
+  /* @see loci.formats.BaseTiffReader#initStandardMetadata() */
+  @Override
+  protected void initStandardMetadata() throws FormatException, IOException {
+    super.initStandardMetadata();
+
+    ifds = tiffParser.getIFDs();
+    thumbnailIFDs = null;
+
+    for (IFD ifd : ifds) {
+      tiffParser.fillInIFD(ifd);
+    }
+
+    // count number of channels
+
+    CoreMetadata m = core.get(0);
+    m.sizeC = 1;
+
+    if (ifds.get(0).getSamplesPerPixel() == 1) {
+      long width = ifds.get(0).getImageWidth();
+      long height = ifds.get(0).getImageLength();
+      int ifd = 1;
+      while (ifds.get(ifd).getImageWidth() == width &&
+        ifds.get(ifd).getImageLength() == height)
+      {
+        m.sizeC++;
+        ifd++;
+      }
+    }
+
+    // count number of pyramid resolutions
+
+    for (int start=m.sizeC+1; start<ifds.size(); start+=m.sizeC) {
+      IFD ifd = ifds.get(start);
+      if (ifd.getIFDIntValue(IFD.NEW_SUBFILE_TYPE) == 1) {
+        pyramidDepth++;
+      }
+      else break;
+    }
+
+    int coreSize = ifds.size() - (pyramidDepth * (m.sizeC - 1));
+
+    // repopulate core metadata
+
+    core.clear();
+    for (int s=0; s<coreSize; s++) {
+      CoreMetadata ms = new CoreMetadata(m);
+      if (s == 0) {
+        ms.resolutionCount = pyramidDepth;
+      }
+      core.add(ms);
+    }
+
+    for (int s=0; s<core.size(); s++) {
+      CoreMetadata ms = core.get(s);
+      int index = getIFDIndex(s, 0);
+      IFD ifd = ifds.get(index);
+      PhotoInterp p = ifd.getPhotometricInterpretation();
+      int samples = ifd.getSamplesPerPixel();
+      ms.rgb = samples > 1 || p == PhotoInterp.RGB;
+
+      ms.sizeX = (int) ifd.getImageWidth();
+      ms.sizeY = (int) ifd.getImageLength();
+      ms.sizeZ = 1;
+      ms.sizeT = 1;
+      if (ms.rgb) {
+        ms.sizeC = samples;
+      }
+      ms.littleEndian = ifd.isLittleEndian();
+      ms.indexed = p == PhotoInterp.RGB_PALETTE &&
+        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+      ms.imageCount = ms.sizeC / samples;
+      ms.pixelType = ifd.getPixelType();
+      ms.metadataComplete = true;
+      ms.interleaved = false;
+      ms.falseColor = false;
+      ms.dimensionOrder = "XYCZT";
+      ms.thumbnail = s != 0;
+    }
+  }
+
+  /* @see loci.formats.BaseTiffReader#initMetadataStore() */
+  @Override
+  protected void initMetadataStore() throws FormatException {
+    super.initMetadataStore();
+
+    MetadataStore store = makeFilterMetadata();
+
+    for (int i=0; i<getSeriesCount(); i++) {
+      store.setImageName(getImageName(seriesToCoreIndex(i)), i);
+      store.setImageDescription("", i);
+    }
+
+    // each high-resolution IFD has an XML description that needs to be parsed
+
+    for (int c=0; c<getSizeC(); c++) {
+      String xml = getIFDComment(c);
+      try {
+        Element root = XMLTools.parseDOM(xml).getDocumentElement();
+        NodeList children = root.getChildNodes();
+        for (int i=0; i<children.getLength(); i++) {
+          if (!(children.item(i) instanceof Element)) {
+            continue;
+          }
+          Element e = (Element) children.item(i);
+
+          String name = e.getNodeName();
+          String value = e.getTextContent();
+          if (name.equals("ScanProfile")) {
+            //addGlobalMeta(name, XMLTools.getXML(e));
+          }
+          else {
+            addGlobalMetaList(name, value);
+          }
+
+          if (name.equals("Name")) {
+            if (hasFlattenedResolutions()) {
+              for (int series=0; series<pyramidDepth; series++) {
+                store.setChannelName(value, series, c);
+              }
+            }
+            else {
+              store.setChannelName(value, 0, c);
+            }
+          }
+          else if (name.equals("Color")) {
+            String[] components = value.split(",");
+            Color color = new Color(Integer.parseInt(components[0]),
+              Integer.parseInt(components[1]), Integer.parseInt(components[2]), 255);
+            if (hasFlattenedResolutions()) {
+              for (int series=0; series<pyramidDepth; series++) {
+                store.setChannelColor(color, series, c);
+              }
+            }
+            else {
+              store.setChannelColor(color, 0, c);
+            }
+          }
+          else if (name.equals("Objective") && c == 0) {
+            String instrument = MetadataTools.createLSID("Instrument", 0);
+            String objective = MetadataTools.createLSID("Objective", 0, 0);
+
+            store.setInstrumentID(instrument, 0);
+            store.setObjectiveID(objective, 0, 0);
+            store.setObjectiveModel(value, 0, 0);
+
+            for (int series=0; series<getSeriesCount(); series++) {
+              store.setImageInstrumentRef(instrument, series);
+              store.setObjectiveSettingsID(objective, series);
+            }
+          }
+          else if (name.equals("ExposureTime")) {
+            Time exposure = new Time(DataTools.parseDouble(value), UNITS.MICROSECOND);
+            store.setPlaneExposureTime(exposure, 0, c);
+            store.setPlaneTheZ(new NonNegativeInteger(0), 0, c);
+            store.setPlaneTheT(new NonNegativeInteger(0), 0, c);
+            store.setPlaneTheC(new NonNegativeInteger(c), 0, c);
+          }
+        }
+      }
+      catch (ParserConfigurationException|SAXException|IOException e) {
+        LOGGER.warn("Could not parse XML for channel {}", c);
+        LOGGER.debug("", e);
+      }
+    }
+  }
+
+  private String getImageName(int coreIndex) {
+    if (coreIndex < pyramidDepth) {
+      return "resolution #" + (coreIndex + 1);
+    }
+    if (coreIndex == pyramidDepth) {
+      return "thumbnail";
+    }
+    String name = getImageType(getIFDIndex(coreIndex, 0));
+    if (name != null) {
+      return name;
+    }
+    return core.size() == ifds.size() - 1 ? "label" : "macro";
+  }
+
+  private String getIFDComment(int ifdIndex) {
+    String xml = ifds.get(ifdIndex).getComment().trim();
+    xml = xml.replace("utf-16", "utf-8");
+    return xml;
+  }
+
+  private String getImageType(int ifdIndex) {
+    String xml = getIFDComment(ifdIndex);
+    try {
+      Element root = XMLTools.parseDOM(xml).getDocumentElement();
+      NodeList types = root.getElementsByTagName("ImageType");
+      if (types.getLength() > 0) {
+        return types.item(0).getTextContent();
+      }
+    }
+    catch (ParserConfigurationException|SAXException|IOException e) {
+      LOGGER.debug("Could not determine image type for IFD #" + ifdIndex, e);
+    }
+    return null;
+  }
+
+  private int getIFDIndex(int coreIndex, int no) {
+    if (coreIndex == 0) {
+      return no;
+    }
+    if (coreIndex < pyramidDepth) {
+      return getImageCount() * coreIndex + 1 + no;
+    }
+    if (coreIndex == pyramidDepth) {
+      // this is always the RGB thumbnail, which is stored between the
+      // largest resolution and the rest of the pyramid
+      return core.get(0).imageCount;
+
+    }
+    // optional extra macro or label image
+    return ifds.size() - (core.size() - coreIndex);
+  }
+
+}


### PR DESCRIPTION
See https://trello.com/c/bRR5zfc7/200-add-support-for-perkinelmer-vectra-qptiff-files

This will require a minor release, as it introduces a new reader and adds an API method to ```loci.formats.gui.AWTImageTools```.

Vectra/QPTIFF is a pyramid TIFF format used for both whole slide scans (fluorescence or brightfield) and multispectral images with smaller (< 2k x 2k) XY dimensions.  Whole slide scans typically use the file extension ```.qptiff``` while other data types use the extension ```.tif```.

To test use, the sample files from https://github.com/openmicroscopy/data_repo_config/pull/248.  The image and series counts reported by ```showinf``` should be such that the sum of the image counts matches the number of IFDs (i.e. ```tiffinfo /path/to/file | grep -c "TIFF Directory"```).  Verify that opening each file in ImageJ results in at least 2 series, each with a valid thumbnail in the ```Bio-Formats Series Options``` window.  We do not have other software that opens these files, so testing is mainly verifying that there is nothing that looks obviously wrong or strange.

b9c3284 fixes long-standing issues with thumbnails for floating point images in ImageJ.  It is needed to improve the user experience when working with these files in ImageJ, as many of the multispectral datasets contain 32-bit float data, and all have at least 2 series.  I can split this commit into a separate PR if desired.