### PR TITLE
Add setFilePatternIds method to ImporterOptions

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -48,6 +48,7 @@ import loci.formats.ChannelFiller;
 import loci.formats.ChannelSeparator;
 import loci.formats.ClassList;
 import loci.formats.DimensionSwapper;
+import loci.formats.FilePattern;
 import loci.formats.FileStitcher;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
@@ -495,7 +496,8 @@ public class ImportProcess implements StatusReporter {
       baseReader.getMetadataOptions().setMetadataLevel(
           MetadataLevel.NO_OVERLAYS);
     }
-    baseReader.setId(options.getId());
+    baseReader.setId(options.isUsingPatternIds() ?
+      new FilePattern(options.getId()).getFiles()[0] : options.getId());
     
     boolean mustGroup = baseReader.fileGroupOption(options.getId()) == FormatTools.MUST_GROUP;
     options.setMustGroup(mustGroup);
@@ -615,7 +617,8 @@ public class ImportProcess implements StatusReporter {
     if (options.isLocal() || options.isHTTP()) {
       BF.status(options.isQuiet(), "Identifying " + idName);
       imageReader = LociPrefs.makeImageReader();
-      baseReader = imageReader.getReader(options.getId());
+      baseReader = imageReader.getReader(options.isUsingPatternIds() ?
+        new FilePattern(options.getId()).getFiles()[0] : options.getId());
     }
     else if (options.isOMERO()) {
       BF.status(options.isQuiet(), "Establishing server connection");

--- a/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImporterOptions.java
@@ -154,6 +154,9 @@ public class ImporterOptions extends OptionsList {
   private List<List<DoubleOption>> customColors =
     new ArrayList<List<DoubleOption>>();
 
+  // whether to treat the given id as a file pattern directly
+  private boolean usePatternIds;
+
   // -- Constructor --
 
   public ImporterOptions() throws IOException {
@@ -509,6 +512,9 @@ public class ImporterOptions extends OptionsList {
   public String getCustomColorKey(int s, int c) {
     return s + "_" + c;
   }
+
+  public boolean isUsingPatternIds() { return usePatternIds; }
+  public void setUsingPatternIds(boolean b) { usePatternIds = b; }
 
   // -- Helper methods --
 


### PR DESCRIPTION
When coupled with `setGroupFiles(true)`, this lets you pass a file pattern directly to the `ImporterOptions` as an id, similarly to what you can do with the interactive `FilePatternDialog`.

See:

* http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-December/006824.html
* http://forum.imagej.net/t/group-images-with-bioformats-in-java-code/7893

The following code now works in my tests:

```java
final String id = "/Users/curtis/data/mri-stack/slice00<05-24>_mri-stack.tif";

ImporterOptions options = new ImporterOptions();
options.setUsingPatternIds(true);
options.setGroupFiles(true);
options.setId(id);

ImagePlus[] imps = BF.openImagePlus(options);
for (final ImagePlus imp : imps)
  imp.show();
```

(The TIFFs were created by splitting the MRI Stack sample and saving each as a separate slice.)

There is still some weirdness: the title bar reads `slice00<01-27>_mri-stack.tif` even though we used a narrower range; I guess a file pattern is still computed from the first file of the above pattern, even if it is not ultimately used. This same behavior can be seen when specifying the above pattern via the UI dialogs.
