### PR TITLE
Configuration: Use raw physicalSize values not FormatTools

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -262,7 +262,8 @@ public class Configuration {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_X);
     String sizeXUnits = currentTable.get(PHYSICAL_SIZE_X_UNIT);
     try {
-      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), UnitsLength.fromString(sizeXUnits)); 
+      UnitsLength xUnits = sizeXUnits == null ? UnitsLength.MICROMETER : UnitsLength.fromString(sizeXUnits);
+      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), xUnits); 
     }
     catch (NumberFormatException e) { }
     catch (EnumerationException e) { }
@@ -273,7 +274,8 @@ public class Configuration {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Y);
     String sizeYUnits = currentTable.get(PHYSICAL_SIZE_Y_UNIT);
     try {
-      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), UnitsLength.fromString(sizeYUnits));
+      UnitsLength yUnits = sizeYUnits == null ? UnitsLength.MICROMETER : UnitsLength.fromString(sizeYUnits);
+      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), yUnits);
     }
     catch (NumberFormatException e) { }
     catch (EnumerationException e) { }
@@ -284,7 +286,8 @@ public class Configuration {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Z);
     String sizeZUnits = currentTable.get(PHYSICAL_SIZE_Z_UNIT);
     try {
-      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), UnitsLength.fromString(sizeZUnits));
+      UnitsLength zUnits = sizeZUnits == null ? UnitsLength.MICROMETER : UnitsLength.fromString(sizeZUnits);
+      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), zUnits);
     }
     catch (NumberFormatException e) { }
     catch (EnumerationException e) { }

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -46,6 +46,8 @@ import loci.formats.ReaderWrapper;
 import loci.formats.meta.IMetadata;
 
 import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.enums.EnumerationException;
+import ome.xml.model.enums.UnitsLength;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.Timestamp;
 
@@ -260,20 +262,21 @@ public class Configuration {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_X);
     String sizeXUnits = currentTable.get(PHYSICAL_SIZE_X_UNIT);
     try {
-      return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeXUnits);
+      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), UnitsLength.fromString(sizeXUnits)); 
     }
-    catch (NumberFormatException e) {
-      return null;
-    }
+    catch (NumberFormatException e) { }
+    catch (EnumerationException e) { }
+    return null;
   }
 
   public Length getPhysicalSizeY() {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Y);
     String sizeYUnits = currentTable.get(PHYSICAL_SIZE_Y_UNIT);
     try {
-      return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeYUnits);
+      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), UnitsLength.fromString(sizeYUnits));
     }
     catch (NumberFormatException e) { }
+    catch (EnumerationException e) { }
     return null;
   }
 
@@ -281,11 +284,11 @@ public class Configuration {
     String physicalSize = currentTable.get(PHYSICAL_SIZE_Z);
     String sizeZUnits = currentTable.get(PHYSICAL_SIZE_Z_UNIT);
     try {
-      return physicalSize == null ? null : FormatTools.getPhysicalSize(new Double(physicalSize), sizeZUnits);
+      return physicalSize == null ? null : UnitsLength.create(new Double(physicalSize), UnitsLength.fromString(sizeZUnits));
     }
-    catch (NumberFormatException e) { 
-      return null;
-    } 
+    catch (NumberFormatException e) { }
+    catch (EnumerationException e) { }
+    return null;
   }
 
   public Time getTimeIncrement() {


### PR DESCRIPTION
Using FormatTools for the physicalSize values was applying rounding which was inconsistent with the values stored in the readers under certain scenarios. 

Other FormatTools functions such as getTime and getWavelength do not apply any such rounding and as such should not have any impact.