### PR TITLE
Improve precision of isThisType(RandomAccessInputStream) for MRC, I2I, and Zeiss LSM

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/I2IReader.java
+++ b/components/formats-gpl/src/loci/formats/in/I2IReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.IOException;
 
+import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -172,12 +173,8 @@ public class I2IReader extends FormatReader {
 
   private int getDimension(RandomAccessInputStream stream) throws IOException {
     String dim = stream.readString(6).trim();
-    try {
-      return Integer.parseInt(dim);
-    }
-    catch (NumberFormatException e) {
-    }
-    return 0;
+    Integer dimension = DataTools.parseInteger(dim);
+    return dimension == null ? 0 : dimension;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -81,7 +81,26 @@ public class MRCReader extends FormatReader {
   /** @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */
   @Override
   public boolean isThisType(RandomAccessInputStream stream) throws IOException {
-    return FormatTools.validStream(stream, HEADER_SIZE, false);
+    if (!FormatTools.validStream(stream, HEADER_SIZE, false)) {
+      return false;
+    }
+    stream.seek(ENDIANNESS_OFFSET);
+    stream.order(stream.read() == 68);
+    stream.seek(0);
+
+    int x = stream.readInt();
+    if (x <= 0 || x >= stream.length()) {
+      return false;
+    }
+    int y = stream.readInt();
+    if (y <= 0 || y >= stream.length()) {
+      return false;
+    }
+    int z = stream.readInt();
+    if (z <= 0 || z >= stream.length()) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -290,7 +290,7 @@ public class ZeissLSMReader extends FormatReader {
     if (!FormatTools.validStream(stream, blockLen, false)) return false;
     TiffParser parser = new TiffParser(stream);
     if (parser.isValidHeader()) {
-      return true;
+      return parser.getIFDOffsets().length > 1;
     }
     stream.seek(4);
     if (stream.readShort() == 0x5374) {


### PR DESCRIPTION
This fixes exceptions reported by @emilroz and @chris-allan when reading extensionless TIFFs with CellProfiler/python-bioformats.  A minimal test case that mimics use of Bio-Formats in CellProfiler/python-bioformats is here:

https://gist.github.com/melissalinkert/f6df0c5efe58c8c0500697727df5a096

To test, copy ```data_repo/curated/tiff/carolyn/tumor_1.tif``` to ```~/pr-test``` and download and compile the above class.  ```java -mx1024m CPTest ~/pr-test``` without this PR should throw:

```
Exception in thread "main" java.lang.IllegalArgumentException: -33551872 must not be null or non-negative.
	at ome.xml.model.primitives.NonNegativeInteger.<init>(NonNegativeInteger.java:48)
	at ome.xml.model.primitives.PositiveInteger.<init>(PositiveInteger.java:46)
	at loci.formats.MetadataTools.populatePixelsOnly(MetadataTools.java:290)
	at loci.formats.MetadataTools.populateMetadata(MetadataTools.java:251)
	at loci.formats.MetadataTools.populatePixels(MetadataTools.java:151)
	at loci.formats.MetadataTools.populatePixels(MetadataTools.java:97)
	at loci.formats.in.MRCReader.initFile(MRCReader.java:322)
	at loci.formats.FormatReader.setId(FormatReader.java:1397)
	at CPTest.main(CPTest.java:89)
```

and with this PR should not throw an exception, but rather print the correct image width.

This should not impact tests or memo files, and should be safe for a patch release.