### PR TITLE
TillVision: sort the .pst directory listing

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TillVisionReader.java
@@ -435,6 +435,7 @@ public class TillVisionReader extends FormatReader {
           Location pst = new Location(directory, f);
           if (pst.isDirectory() && f.startsWith(name)) {
             String[] subfiles = pst.list(true);
+            Arrays.sort(subfiles);
             for (String q : subfiles) {
               if (checkSuffix(q, "pst") && nextFile < nImages) {
                 pixelsFile[nextFile++] = f + File.separator + q;


### PR DESCRIPTION
This should resolve potential test failures as noted on
https://trello.com/c/cTcGjV4m/511-distributed-repository-tests

See also https://web-proxy.openmicroscopy.org/next-ci/job/BIOFORMATS-full-repo/245/console

To test, verify that the BIOFORMATS-full-repo for the ```tillvision``` directory turns green.  BIOFORMATS-merge-full-repository should be unaffected.