### PR TITLE
Use UUID for generating unique memo file directories

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -2437,7 +2438,7 @@ public class FormatReaderTest {
       // this should prevent conflicts when running multiple tests
       // on the same system and/or in multiple threads
       String tmpdir = System.getProperty("java.io.tmpdir");
-      memoDir = new File(tmpdir, System.currentTimeMillis() + ".memo");
+      memoDir = new File(tmpdir, UUID.randomUUID().toString() + ".memo");
       memoDir.mkdir();
       Memoizer memo = new Memoizer(0, memoDir);
       memo.setId(reader.getCurrentFile());


### PR DESCRIPTION
With the current implementation of `FormatReaderTest.testMemoFileUsage()`, it is possible that two independent tests started at the same time against filesets in the same directory will use the same cache directory for creating serialization files leading to possible race conditions and sporadic failures.

With the ongoing work to run distributed automated test per format folder, this scenario is becoming increasingly possible. To reduce this risk, this commit is now generating unique directories using UUID.randomUUID() rather that System.currentTimeMillis().

To test this PR, I would expect no negative import on the [full repository job](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-full-repository/) while in the meantime this should remove intermittent failures in the distributed repository tests over a few consecutive runs.