### PR TITLE
Document conflicting JAI-imageIO issues

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1123,6 +1123,9 @@ reader = JPEG2000Reader
 writer = JPEG2000Writer
 mif = true
 notes = Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ library to read JP2 files. \n
+Conflicting versions of this no-longer maintained library may cause errors, \n
+see :ref:`JAI ImageIO component <forks-jai>` for details. \n
+\n
 JPEG stands for "Joint Photographic Experts Group".
 
 [JPEG]

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1123,7 +1123,7 @@ reader = JPEG2000Reader
 writer = JPEG2000Writer
 mif = true
 notes = Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ library to read JP2 files. \n
-Conflicting versions of this no-longer maintained library may cause errors, \n
+Conflicting versions of this no-longer-maintained library may cause errors, \n
 see :ref:`JAI ImageIO component <forks-jai>` for details. \n
 \n
 JPEG stands for "Joint Photographic Experts Group".

--- a/docs/sphinx/developers/components.rst
+++ b/docs/sphinx/developers/components.rst
@@ -101,9 +101,9 @@ formats in :ref:`formats-gpl <formats-gpl>`.  There are no dependencies
 on other components.
 
 The status of this component means that you may encounter errors due to
-conflicting jars e.g. between Bio-Formats and other toolboxes within Fiji or
+conflicting JARs e.g. between Bio-Formats and other toolboxes within Fiji or
 MATLAB, especially when trying to open JPEG-2000 data. In this case, you will
-need to remove the conflicting jar(s) as a workaround.
+need to remove the conflicting JAR(s) as a workaround.
 
 .. _forks-turbojpeg:
 

--- a/docs/sphinx/developers/components.rst
+++ b/docs/sphinx/developers/components.rst
@@ -100,6 +100,11 @@ This is primarily needed for reading images from histology/pathology
 formats in :ref:`formats-gpl <formats-gpl>`.  There are no dependencies
 on other components.
 
+The status of this component means that you may encounter errors due to
+conflicting jars e.g. between Bio-Formats and other toolboxes within Fiji or
+MATLAB, especially when trying to open JPEG-2000 data. In this case, you will
+need to remove the conflicting jar(s) as a workaround.
+
 .. _forks-turbojpeg:
 
 :source:`forks/turbojpeg (libjpeg-turbo Java bindings) <components/forks/turbojpeg>`:

--- a/docs/sphinx/formats/jpeg-2000.rst
+++ b/docs/sphinx/formats/jpeg-2000.rst
@@ -52,4 +52,7 @@ Utility: |Poor|
 
 
 Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ library to read JP2 files. 
+Conflicting versions of this no-longer maintained library may cause errors, 
+see :ref:`JAI ImageIO component <forks-jai>` for details. 
+
 JPEG stands for "Joint Photographic Experts Group".

--- a/docs/sphinx/formats/jpeg-2000.rst
+++ b/docs/sphinx/formats/jpeg-2000.rst
@@ -52,7 +52,7 @@ Utility: |Poor|
 
 
 Bio-Formats uses the `JAI Image I/O Tools <https://github.com/jai-imageio/jai-imageio-core>`_ library to read JP2 files. 
-Conflicting versions of this no-longer maintained library may cause errors, 
+Conflicting versions of this no-longer-maintained library may cause errors, 
 see :ref:`JAI ImageIO component <forks-jai>` for details. 
 
 JPEG stands for "Joint Photographic Experts Group".

--- a/docs/sphinx/users/matlab/index.rst
+++ b/docs/sphinx/users/matlab/index.rst
@@ -38,6 +38,15 @@ approximately half the speed of our
 :doc:`showinf command line tool </users/comlinetools/index>`, due to
 overhead from copying arrays.
 
+Troubleshooting
+---------------
+
+If you encounter an error trying to open JPEG-2000 data in MATLAB but the file
+will open e.g. in Fiji using Bio-Formats, it may be due to conflicting
+versions of JAI ImageIO in different jars. As discussed on the component page,
+:ref:`JAI ImageIO <forks-jai>` is no longer maintained and you will likely
+need to remove the conflicting jar(s) as a work around.
+
 Upgrading
 ---------
 

--- a/docs/sphinx/users/matlab/index.rst
+++ b/docs/sphinx/users/matlab/index.rst
@@ -43,9 +43,9 @@ Troubleshooting
 
 If you encounter an error trying to open JPEG-2000 data in MATLAB but the file
 will open e.g. in Fiji using Bio-Formats, it may be due to conflicting
-versions of JAI ImageIO in different jars. As discussed on the component page,
+versions of JAI ImageIO in different JARs. As discussed on the component page,
 :ref:`JAI ImageIO <forks-jai>` is no longer maintained and you will likely
-need to remove the conflicting jar(s) as a work around.
+need to remove the conflicting JAR(s) as a workaround.
 
 Upgrading
 ---------


### PR DESCRIPTION
See https://trello.com/c/ZEetFk4Z/4-document-conflicting-matlab-jars-re-bug-report-cannot-open-jp2-file-created-by-stereoinvestigator