### PR TITLE
Metamorph: sort the directory listing during initFile()

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -374,6 +374,7 @@ public class MetamorphReader extends BaseTiffReader {
       Location parent = new Location(id).getAbsoluteFile().getParentFile();
       LOGGER.info("Looking for STK file in {}", parent.getAbsolutePath());
       String[] dirList = parent.list(true);
+      Arrays.sort(dirList);
       for (String f : dirList) {
         int underscore = f.indexOf('_');
         if (underscore < 0) underscore = f.indexOf('.');


### PR DESCRIPTION
See https://trello.com/c/cTcGjV4m/511-distributed-repository-tests

Similar to 896adaf1d2dacf275100c87a2e23b1dfe05b86bc, this commit should sortthe directory listing so that the `reader.getCurrentFile()` returns the same master file for a Metamorph fileset independently of the environment.

With this PR, both the non-distributed and the distributed automated tests are expected to pass against the `metamorph` folder