### PR TITLE
Update reference URLs for the Aperio ImageScope and Micro-Manager

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1422,7 +1422,7 @@ extensions = .tif, .txt, .xml
 developer = `Vale Lab <http://valelab.ucsf.edu/>`_
 bsd = yes
 versions = Up to 1.4.22
-software = `Micro-Manager <http://micro-manager.org/>`_
+software = `Micro-Manager <https://micro-manager.org/>`_
 weHave = * many Micro-manager datasets\n
 * `public sample images <http://downloads.openmicroscopy.org/images/Micro-Manager/>`__
 pixelsRating = Outstanding

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1222,10 +1222,10 @@ mif = true
 pagename = leica-lif
 extensions = .lif
 owner = `Leica <http://www.leica.com/>`_
-developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
+developer = `Leica Microsystems CMS GmbH <https://www.leica-microsystems.com/>`_
 bsd = no
 versions = 1.0, 2.0
-software = `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
+software = `Leica LAS AF Lite <https://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
 weHave = * a LIF/XLLF/XLEF/LOF specification document (version 3.2, from no later than 2016 December 15, in PDF) \n
 * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
 * a LIF specification document (version 1, from no later than 2006 April 3, in PDF) \n
@@ -1275,7 +1275,7 @@ mif = true
 [Leica LCS LEI]
 extensions = .lei, .tif
 owner = `Leica <http://www.leica.com/>`_
-developer = `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
+developer = `Leica Microsystems CMS GmbH <https://www.leica-microsystems.com/>`_
 bsd = no
 software = `Leica LCS Lite <ftp://ftp.llt.de/softlib/LCSLite/LCSLite2611537.exe>`_
 weHave = * an LEI specification document (beta 2.000, from no later than 2004 February 17, in PDF) \n
@@ -1299,7 +1299,7 @@ Commercial applications that support LEI include: \n
 
 [Leica SCN]
 extensions = .scn
-developer = `Leica Microsystems <http://www.leica-microsystems.com/>`_
+developer = `Leica Microsystems <https://www.leica-microsystems.com/>`_
 bsd = no
 software = `OpenSlide <http://openslide.org>`_
 versions = 2012-03-10

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -1225,7 +1225,7 @@ owner = `Leica <http://www.leica.com/>`_
 developer = `Leica Microsystems CMS GmbH <https://www.leica-microsystems.com/>`_
 bsd = no
 versions = 1.0, 2.0
-software = `Leica LAS AF Lite <https://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
+software = `Leica LAS AF Lite <https://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (see Downloads section)
 weHave = * a LIF/XLLF/XLEF/LOF specification document (version 3.2, from no later than 2016 December 15, in PDF) \n
 * a LIF specification document (version 2, from no later than 2007 July 26, in PDF) \n
 * a LIF specification document (version 1, from no later than 2006 April 3, in PDF) \n

--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -200,7 +200,7 @@ pyramid = yes
 reader = AFIReader
 mif = true
 notes = .. seealso:: \n
-  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
+  `Aperio ImageScope <https://www.leicabiosystems.com/digital-pathology/manage/aperio-imagescope/>`_
 
 [Aperio SVS TIFF]
 extensions = .svs
@@ -222,7 +222,7 @@ pyramid = yes
 reader = SVSReader
 mif = true
 notes = .. seealso:: \n
-  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
+  `Aperio ImageScope <https://www.leicabiosystems.com/digital-pathology/manage/aperio-imagescope/>`_
 
 [Applied Precision CellWorX]
 extensions = .htd, .pnl

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -370,7 +370,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://code.google.com/archive/p/jj2000/',
     'https://support.apple.com/downloads/quicktime',
     'https://support.apple.com/quicktime',
-    'https://www.micro-manager.org',
     'https://nifti.nimh.nih.gov/nifti-1/',
     'https://www.leica-microsystems.com'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -371,5 +371,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://support.apple.com/downloads/quicktime',
     'https://support.apple.com/quicktime',
     'https://www.micro-manager.org',
-    'https://nifti.nimh.nih.gov/nifti-1/'
+    'https://nifti.nimh.nih.gov/nifti-1/',
+    'https://www.leica-microsystems.com'
 ]

--- a/docs/sphinx/formats/aperio-afi.rst
+++ b/docs/sphinx/formats/aperio-afi.rst
@@ -47,4 +47,4 @@ Utility: |Good|
 
 
 .. seealso:: 
-  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
+  `Aperio ImageScope <https://www.leicabiosystems.com/digital-pathology/manage/aperio-imagescope/>`_

--- a/docs/sphinx/formats/aperio-svs-tiff.rst
+++ b/docs/sphinx/formats/aperio-svs-tiff.rst
@@ -55,4 +55,4 @@ Utility: |Good|
 format, we are not able to distribute them to third parties.**
 
 .. seealso:: 
-  `Aperio ImageScope <http://www.leicabiosystems.com/index.php?id=8991>`_
+  `Aperio ImageScope <https://www.leicabiosystems.com/digital-pathology/manage/aperio-imagescope/>`_

--- a/docs/sphinx/formats/leica-lcs-lei.rst
+++ b/docs/sphinx/formats/leica-lcs-lei.rst
@@ -6,7 +6,7 @@ Leica LCS LEI
 
 Extensions: .lei, .tif
 
-Developer: `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
+Developer: `Leica Microsystems CMS GmbH <https://www.leica-microsystems.com/>`_
 
 Owner: `Leica <http://www.leica.com/>`_
 

--- a/docs/sphinx/formats/leica-lif.rst
+++ b/docs/sphinx/formats/leica-lif.rst
@@ -6,7 +6,7 @@ Leica LAS AF LIF (Leica Image File Format)
 
 Extensions: .lif
 
-Developer: `Leica Microsystems CMS GmbH <http://www.leica-microsystems.com/>`_
+Developer: `Leica Microsystems CMS GmbH <https://www.leica-microsystems.com/>`_
 
 Owner: `Leica <http://www.leica.com/>`_
 
@@ -24,7 +24,7 @@ Reader: LIFReader (:bfreader:`Source Code <LIFReader.java>`, :doc:`Supported Met
 
 Freely Available Software:
 
-- `Leica LAS AF Lite <http://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
+- `Leica LAS AF Lite <https://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
 
 
 We currently have:

--- a/docs/sphinx/formats/leica-lif.rst
+++ b/docs/sphinx/formats/leica-lif.rst
@@ -24,7 +24,7 @@ Reader: LIFReader (:bfreader:`Source Code <LIFReader.java>`, :doc:`Supported Met
 
 Freely Available Software:
 
-- `Leica LAS AF Lite <https://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (links at bottom of page)
+- `Leica LAS AF Lite <https://www.leica-microsystems.com/products/microscope-software/software-for-life-science-research/las-x/>`_ (see Downloads section)
 
 
 We currently have:

--- a/docs/sphinx/formats/leica-scn.rst
+++ b/docs/sphinx/formats/leica-scn.rst
@@ -6,7 +6,7 @@ Leica SCN
 
 Extensions: .scn
 
-Developer: `Leica Microsystems <http://www.leica-microsystems.com/>`_
+Developer: `Leica Microsystems <https://www.leica-microsystems.com/>`_
 
 
 **Support**

--- a/docs/sphinx/formats/micro-manager.rst
+++ b/docs/sphinx/formats/micro-manager.rst
@@ -23,7 +23,7 @@ Reader: MicromanagerReader (:bsd-reader:`Source Code <MicromanagerReader.java>`,
 
 Freely Available Software:
 
-- `Micro-Manager <http://micro-manager.org/>`_
+- `Micro-Manager <https://micro-manager.org/>`_
 
 
 We currently have:

--- a/docs/sphinx/users/micromanager/index.rst
+++ b/docs/sphinx/users/micromanager/index.rst
@@ -1,7 +1,7 @@
 Micro-Manager
 =============
 
-`Micro-Manager <https://www.micro-manager.org>`_ is a
+`Micro-Manager <https://micro-manager.org>`_ is a
 software framework for implementing advanced and novel imaging procedures,
 extending functionality, customization and rapid development of specialized
 imaging applications.


### PR DESCRIPTION
Fixes recent issues with broken external links in the Bio-Formats documentation

- Leica Microsystems: the previous Aperioscope page seems to have been removed without being redirected. c194270 fixes the broken URLs by pointing to the landing page of `Digital Pathlogy>Manage` instead.
- Micro-Manager: consistently use https://micro-manager.org/

 To test this PR:
- check BIOFORMATS-DEV-merge-docs passes
- manually check the individual Leica links. The Leica Microsystems URL has been added to the `linkcheck_ignore` blacklist list due to an issue with the SSL certificate (see https://github.com/ome/ome-model/pull/63#issuecomment-353068173)
  