### PR TITLE
OME-TIFF: try harder to preserve metadata when files are ungrouped

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -558,6 +558,7 @@ public class OMETiffReader extends FormatReader {
       IFormatReader reader = new MinimalTiffReader();
       reader.setId(currentId);
       core.set(0, reader.getCoreMetadataList().get(0));
+      int ifdCount = reader.getImageCount();
       reader.close();
       int maxSeries = 0;
       info = new OMETiffPlane[meta.getImageCount()][];
@@ -592,8 +593,8 @@ public class OMETiffReader extends FormatReader {
             filename = meta.getUUIDFileName(i, td);
           }
           catch (NullPointerException e) { }
-          if ((uuid != null && !uuid.equals(currentUUID)) ||
-            (filename != null && !currentId.endsWith(filename)))
+          if ((uuid == null || !uuid.equals(currentUUID)) &&
+            (filename == null || !currentId.endsWith(filename)))
           {
             // this plane doesn't appear to be in the current file
             continue;
@@ -609,11 +610,15 @@ public class OMETiffReader extends FormatReader {
           NonNegativeInteger firstT = meta.getTiffDataFirstT(i, td);
 
           int realCount = count == null ? 1 : count.getValue();
+          if (ifd == null && count == null) {
+            realCount = ifdCount;
+          }
           for (int q=0; q<realCount; q++) {
             OMETiffPlane p = new OMETiffPlane();
             p.id = currentId;
+            p.ifd = q;
             if (ifd != null) {
-              p.ifd = ifd.getValue() + q;
+              p.ifd += ifd.getValue();
             }
             p.reader = reader;
             info[i][next++] = p;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -683,9 +683,14 @@ public class OMETiffReader extends FormatReader {
         Image img = images.get(i);
         Pixels pix = img.getPixels();
         List<Plane> planes = pix.copyPlaneList();
-        int count = core.get(i).imageCount;
-        for (int p=count; p<planes.size(); p++) {
-          pix.removePlane(planes.get(p));
+        for (int p=0; p<planes.size(); p++) {
+          Plane plane = planes.get(p);
+          if (plane.getTheZ().getValue() >= core.get(i).sizeZ ||
+            plane.getTheC().getValue() >= core.get(i).sizeC ||
+            plane.getTheT().getValue() >= core.get(i).sizeT)
+          {
+            pix.removePlane(planes.get(p));
+          }
         }
         pix.setMetadataOnly(null);
 


### PR DESCRIPTION
This should only affect multi-file OME-TIFF datasets, and only when file grouping is disabled (e.g. via the ```-nogroup``` option to ```showinf```). 

To test, use the ```tubhiswt-4D``` dataset from http://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/

Without this change, ```showinf -nogroup -omexml``` with ```tubhiswt_C0_TP0.ome.tif``` and ```tubhiswt_C1_TP0.ome.tif``` should show 10 timepoints and 1 Z section, with OME-XML that does not represent everything in the file's OME-XML comment.  ```showinf -nopix tubhiswt_C0_TP0.ome.tif``` should show that the entire dataset's dimensions are 43 timepoints, 10 Z sections, and 2 channels; each file contains all Z sections for a single timepoint and channel.

With this change, ```showinf -nogroup -omexml``` with ```tubhiswt_C0_TP0.ome.tif``` and ```tubhiswt_C1_TP0.ome.tif``` should correctly show 1 channel, 1 timepoint, and 10 Z sections.  The OME-XML should largely match what is in the file, apart from ```Pixels.SizeZ```, ```Pixels.SizeC``` and ```Pixels.SizeT```.

I would expect all tests to remain green.  I think this should be safe for a patch release, but it is not critical for 5.7.3.