### PR TITLE
VSI: Add support for Lossless JPEG

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -609,6 +609,7 @@ public class CellSensReader extends FormatReader {
       metadataIndex = -1;
       previousTag = 0;
       expectETS = false;
+      pyramids.clear();
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -46,6 +46,7 @@ import loci.formats.MetadataTools;
 import loci.formats.codec.Codec;
 import loci.formats.codec.CodecOptions;
 import loci.formats.codec.JPEGCodec;
+import loci.formats.codec.LosslessJPEGCodec;
 import loci.formats.codec.JPEG2000Codec;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -70,6 +71,7 @@ public class CellSensReader extends FormatReader {
   private static final int RAW = 0;
   private static final int JPEG = 2;
   private static final int JPEG_2000 = 3;
+  private static final int JPEG_LOSSLESS = 5;
   private static final int PNG = 8;
   private static final int BMP = 9;
 
@@ -1007,6 +1009,10 @@ public class CellSensReader extends FormatReader {
         break;
       case JPEG_2000:
         codec = new JPEG2000Codec();
+        buf = codec.decompress(ets, options);
+        break;
+      case JPEG_LOSSLESS:
+        codec = new LosslessJPEGCodec();
         buf = codec.decompress(ets, options);
         break;
       case PNG:


### PR DESCRIPTION
This PR is in relation to https://www.openmicroscopy.org/community/viewtopic.php?t=8425&p=18953
The associated Trello card is https://trello.com/c/fUhH0Cxo/141-cellsens-vsi-npe-in-openbytes

Sample files can be found in QA-18870 and QA-17728

The issue was caused by an unknown compression type of value 5. From the user feedback this has been identified as Lossless JPEG. This PR adds support using the existing LosslessJPEG codec.

To test:
- All builds and tests should remain green
- With this PR opening QA-18870 should result in a NullPointerException
- With this PR opening QA-18870 should display the images correctly without error