### PR TITLE
Add lavisionbiotech.com to ignore list

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -371,5 +371,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://support.apple.com/downloads/quicktime',
     'https://support.apple.com/quicktime',
     'https://nifti.nimh.nih.gov/nifti-1/',
-    'https://www.leica-microsystems.com'
+    'https://www.leica-microsystems.com',
+    'http://www.lavisionbiotec.com'
 ]


### PR DESCRIPTION
This link is breaking the merge docs currently but I'd assume the failure is temporary given the last thing on their twitter account is news of a new website design at this same URL. Adding it to the ignore list for now to get the build green for the release review.