### PR TITLE
CZI: preserve DisplaySetting metadata in the original metadata table

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3120,9 +3120,6 @@ public class ZeissCZIReader extends FormatReader {
 
   private void populateOriginalMetadata(Element root, Deque<String> nameStack) {
     String name = root.getNodeName();
-    if (name.equals("DisplaySetting")) {
-      return;
-    }
     nameStack.push(name);
 
     final StringBuilder key = new StringBuilder();
@@ -3143,7 +3140,12 @@ public class ZeissCZIReader extends FormatReader {
         if (s.endsWith("|")){
           s = s.substring(0, s.length() - 1);
         }
-        addGlobalMetaList(s, value);
+        if (s.startsWith("DisplaySetting")) {
+          addGlobalMeta(s, value);
+        }
+        else {
+          addGlobalMetaList(s, value);
+        }
 
         if (key.toString().endsWith("|Rotations|")) {
           rotationLabels = value.split(" ");
@@ -3171,7 +3173,12 @@ public class ZeissCZIReader extends FormatReader {
         keyString = keyString.substring(0, keyString.length() - 1);
       }
 
-      addGlobalMetaList(keyString + attrName, attrValue);
+      if (keyString.startsWith("DisplaySetting")) {
+        addGlobalMeta(keyString + attrName, attrValue);
+      }
+      else {
+        addGlobalMetaList(keyString + attrName, attrValue);
+      }
     }
 
     NodeList children = root.getChildNodes();


### PR DESCRIPTION
Only one set of ```DisplaySetting``` data is preserved, so that datasets with
one set of settings per plane or tile do not cause the original metadata
table to be too big.  Most of these values are available elsewhere, but the optional display gamma value is only stored under ```DisplaySetting```.

See https://github.com/openmicroscopy/bioformats/commit/169ae85ec4cb8282ad03310714f44a0eaf51ced8 for the original commit disabling ```DisplaySetting``` population.

To test, use pretty much any dataset from ```data_repo/curated/zeiss-czi```; I used ```greg/Experiment-519.czi``` and ```silke/White_574.czi```.  Without this change, ```showinf -nopix``` should not show any original metadata keys beginning with ```DisplaySetting```.  With this change, the same test should show several keys beginning with ```DisplaySetting|Channel```.  The number of ```DisplaySetting``` keys should not vary with the number of planes or tiles.