### PR TITLE
Olympus OIR: add support for datasets with multiple files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -572,10 +572,10 @@ public class OIRReader extends FormatReader {
         continue;
       }
       LOGGER.trace("xml = {}", xml);
-      if (channels.size() == 0 || getSizeX() == 0 || getSizeY() == 0) {
-        if (file.endsWith(currentId)) {
-          parseXML(s, xml, fp);
-        }
+      if (((channels.size() == 0 || getSizeX() == 0 || getSizeY() == 0) &&
+        file.endsWith(currentId)) || xml.indexOf("lut:LUT") > 0)
+      {
+        parseXML(s, xml, fp);
       }
       boolean expectPixelBlock = xml.endsWith(":frameProperties>");
       if (expectPixelBlock) {
@@ -637,7 +637,7 @@ public class OIRReader extends FormatReader {
       long fp = s.getFilePointer();
       String xml = s.readString(xmlLength).trim();
       LOGGER.trace("xml = {}", xml);
-      if (file.endsWith(currentId)) {
+      if (file.endsWith(currentId) || xml.indexOf("lut:LUT") > 0) {
         parseXML(s, xml, fp);
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -414,7 +414,7 @@ public class OIRReader extends FormatReader {
       addMetaList("Detector gain", detector.gain, tmpMeta);
     }
     // this ensures that global metadata keys will be sorted before series keys
-    MetadataTools.merge(tmpMeta, metadata, "\0");
+    MetadataTools.merge(tmpMeta, metadata, "- ");
 
     // populate MetadataStore
 

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -64,6 +64,7 @@ public class OIRReader extends FormatReader {
   // -- Constants --
 
   private static final String IDENTIFIER = "OLYMPUSRAWFORMAT";
+  private static final int BUFFER_SIZE = 8192;
 
   // -- Fields --
 
@@ -199,7 +200,7 @@ public class OIRReader extends FormatReader {
           if (s != null) {
             s.close();
           }
-          s = new RandomAccessInputStream(block.file);
+          s = new RandomAccessInputStream(block.file, BUFFER_SIZE);
           openFile = block.file;
         }
         pixels = readPixelBlock(s, block.offset);
@@ -299,12 +300,12 @@ public class OIRReader extends FormatReader {
     m.indexed = true;
     m.falseColor = true;
 
-    try (RandomAccessInputStream s = new RandomAccessInputStream(currentId)) {
+    try (RandomAccessInputStream s = new RandomAccessInputStream(currentId, BUFFER_SIZE)) {
       readPixelsFile(current.getAbsolutePath(), s);
     }
 
     for (String file : extraFiles) {
-      try (RandomAccessInputStream s = new RandomAccessInputStream(file)) {
+      try (RandomAccessInputStream s = new RandomAccessInputStream(file, BUFFER_SIZE)) {
         readPixelsFile(file, s);
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -100,13 +100,15 @@ public class OIRReader extends FormatReader {
   /* @see loci.formats.IFormatReader#fileGroupOption(String) */
   @Override
   public int fileGroupOption(String id) throws FormatException, IOException {
-    return FormatTools.MUST_GROUP;
+    return isSingleFile(id) ? FormatTools.CAN_GROUP : FormatTools.MUST_GROUP;
   }
 
   /* @see loci.formats.IFormatReader#isSingleFile(String) */
   @Override
   public boolean isSingleFile(String id) throws FormatException, IOException {
-    return false;
+    // files with .oir extension that are less than 1 GB should be self-contained
+    Location file = new Location(id);
+    return checkSuffix(id, "oir") && file.length() < 1024 * 1024 * 1024;
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -265,10 +265,10 @@ public class OIRReader extends FormatReader {
       Arrays.sort(fileList);
       String prefix = current.getName();
       if (prefix.indexOf(".") > 0) {
-        prefix = prefix.substring(0, prefix.indexOf("."));
+        prefix = prefix.substring(0, prefix.lastIndexOf("."));
       }
       else if (!checkSuffix(id, "oir")) {
-        prefix = prefix.substring(0, prefix.indexOf("_"));
+        prefix = prefix.substring(0, prefix.lastIndexOf("_"));
       }
 
       for (String file : fileList) {

--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -97,6 +97,18 @@ public class OIRReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  @Override
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
+  }
+
+  /* @see loci.formats.IFormatReader#isSingleFile(String) */
+  @Override
+  public boolean isSingleFile(String id) throws FormatException, IOException {
+    return false;
+  }
+
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {


### PR DESCRIPTION
See https://trello.com/c/Ka8DVIjp/22-oir-support-for-sub-files

There are 8 new datasets to test in ```data_repo/curated/olympus-oir```:

```
martin/20170824_JupGFP_HisRFP_wL3_30xSI_4xzoom_0p5z_A01_G001_0001.oir
olympus/2017-11-20/fish_overview/fish-overview-night.oir
olympus/2017-11-20/stimulation_exp/stimulation_exp.oir
olympus/2017-11-20/xytz_golgi/xytz_golgi.oir
qa-17917/f10010.oir
qa-17919/f10187.oir
qa-17922/example_multipart.oir
qa-18802/20171020_JupGFPHisRFP_L3_30xSI_galvo_p5z_p1xy_better_than_nyquist.oir
```

For each, open in the Olympus ImageJ plugin (https://imagej.net/OlympusImageJPlugin) and compare with using Bio-Formats in ImageJ.  Dimensions, channel names, colors, and physical pixel sizes should be the same.  ```showinf -omexml -nopix``` on each file should also show valid OME-XML without throwing an exception.

Builds should remain green, but this will affect memo files.