### PR TITLE
Zeiss CZI: use Z step when Z positions are not enumerated

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1339,9 +1339,19 @@ public class ZeissCZIReader extends FormatReader {
         }
         else if (positionsZ != null && i < positionsZ.length) {
           int zIndex = getZCTCoords(plane)[0];
-          double step = zIndex * zStep.value().doubleValue();
-          Length pos = new Length(step + positionsZ[i].value(zStep.unit()).doubleValue(), zStep.unit());
-          store.setPlanePositionZ(pos, i, plane);
+          if (positionsZ[i] != null) {
+            if (zStep != null) {
+              double value = positionsZ[i].value(zStep.unit()).doubleValue();
+              if (zStep != null) {
+                value += zIndex * zStep.value().doubleValue();
+              }
+              Length pos = new Length(value, zStep.unit());
+              store.setPlanePositionZ(pos, i, plane);
+            }
+            else {
+              store.setPlanePositionZ(positionsZ[i], i, plane);
+            }
+          }
         }
 
         if (p.timestamp != null) {

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3001,19 +3001,19 @@ public class ZeissCZIReader extends FormatReader {
                   positionsX[i] = null;
                 } else {
                   final Double number = Double.valueOf(x);
-                  positionsX[i] = new Length(number, UNITS.METRE);
+                  positionsX[i] = new Length(number, UNITS.MICROMETER);
                 }
                 if (y == null) {
                   positionsY[i] = null;
                 } else {
                   final Double number = Double.valueOf(y);
-                  positionsY[i] = new Length(number, UNITS.METRE);
+                  positionsY[i] = new Length(number, UNITS.MICROMETER);
                 }
                 if (z == null) {
                   positionsZ[i] = null;
                 } else {
                   final Double number = Double.valueOf(z);
-                  positionsZ[i] = new Length(number, UNITS.METRE);
+                  positionsZ[i] = new Length(number, UNITS.MICROMETER);
                 }
               }
             }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -174,6 +174,8 @@ public class ZeissCZIReader extends FormatReader {
   private int[] tileHeight;
   private int scaleFactor;
 
+  private transient Length zStep;
+
   // -- Constructor --
 
   /** Constructs a new Zeiss .czi reader. */
@@ -535,6 +537,7 @@ public class ZeissCZIReader extends FormatReader {
       tileWidth = null;
       tileHeight = null;
       scaleFactor = 0;
+      zStep = null;
     }
   }
 
@@ -1335,7 +1338,10 @@ public class ZeissCZIReader extends FormatReader {
           store.setPlanePositionZ(p.stageZ, i, plane);
         }
         else if (positionsZ != null && i < positionsZ.length) {
-          store.setPlanePositionZ(positionsZ[i], i, plane);
+          int zIndex = getZCTCoords(plane)[0];
+          double step = zIndex * zStep.value().doubleValue();
+          Length pos = new Length(step + positionsZ[i].value(zStep.unit()).doubleValue(), zStep.unit());
+          store.setPlanePositionZ(pos, i, plane);
         }
 
         if (p.timestamp != null) {
@@ -2447,8 +2453,9 @@ public class ZeissCZIReader extends FormatReader {
             }
           }
           else if (id.equals("Z")) {
+            zStep = FormatTools.createLength(size, UNITS.MICROM);
             for (int series=0; series<getSeriesCount(); series++) {
-              store.setPixelsPhysicalSizeZ(FormatTools.createLength(size, UNITS.MICROMETER), series);
+              store.setPixelsPhysicalSizeZ(zStep, series);
             }
           }
         }
@@ -2931,13 +2938,28 @@ public class ZeissCZIReader extends FormatReader {
           String y = position.getAttribute("Y");
           String z = position.getAttribute("Z");
 
-          Length xPos = FormatTools.getStagePosition(DataTools.parseDouble(x), UNITS.REFERENCEFRAME);
-          Length yPos = FormatTools.getStagePosition(DataTools.parseDouble(y), UNITS.REFERENCEFRAME);
-          Length zPos = FormatTools.getStagePosition(DataTools.parseDouble(z), UNITS.REFERENCEFRAME);
+          Length xPos = null;
+          try {
+            xPos = new Length(Double.valueOf(x), UNITS.METRE);
+          }
+          catch (NumberFormatException e) { }
+          Length yPos = null;
+          try {
+            yPos = new Length(Double.valueOf(y), UNITS.METRE);
+          }
+          catch (NumberFormatException e) { }
+          Length zPos = null;
+          try {
+            zPos = new Length(Double.valueOf(z), UNITS.METRE);
+          }
+          catch (NumberFormatException e) { }
 
           int numTiles = (tilesX == null || tilesY == null) ? 0 : tilesX * tilesY;
           for (int tile=0; tile<numTiles; tile++) {
             int index = i * tilesX * tilesY + tile;
+            if (groups.getLength() == core.size()) {
+              index = i;
+            }
             if (index < positionsX.length) {
               positionsX[index] = xPos;
               positionsY[index] = yPos;
@@ -2969,27 +2991,25 @@ public class ZeissCZIReader extends FormatReader {
                   positionsX[i] = null;
                 } else {
                   final Double number = Double.valueOf(x);
-                  positionsX[i] = new Length(number, UNITS.REFERENCEFRAME);
+                  positionsX[i] = new Length(number, UNITS.METRE);
                 }
                 if (y == null) {
                   positionsY[i] = null;
                 } else {
                   final Double number = Double.valueOf(y);
-                  positionsY[i] = new Length(number, UNITS.REFERENCEFRAME);
+                  positionsY[i] = new Length(number, UNITS.METRE);
                 }
                 if (z == null) {
                   positionsZ[i] = null;
                 } else {
                   final Double number = Double.valueOf(z);
-                  positionsZ[i] = new Length(number, UNITS.REFERENCEFRAME);
+                  positionsZ[i] = new Length(number, UNITS.METRE);
                 }
               }
             }
           }
         }
       }
-
-
     }
 
     NodeList detectors = getGrandchildren(acquisition, "Detector");


### PR DESCRIPTION
Backported from private PRs.  If a Z step is present, then the values for ```Plane.PositionZ``` are calculated by using the first plane's position and the Z step.  This prevents ```Plane.PositionZ``` from being set to the same value for all Z slices in a dataset.  This is typically a problem in datasets with fused tiles.

To test, use the files whose configurations are updated in https://github.com/openmicroscopy/data_repo_config/pull/258.  Open each in ZEN, and note the relative Z position and units for each plane by mousing over the ```Z-Position``` slider in the bottom left portion of the window.  ```showinf -omexml -nopix``` should show absolute positions in ```PositionZ``` on ```Plane```, with the same spacing and units as the relative Z positions in ZEN.
