### PR TITLE
ImagePro: add support for .ips files

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1732,6 +1732,12 @@ public class FormatReaderTest {
             continue;
           }
 
+          if (reader.getFormat().equals("Image-Pro Sequence") &&
+            file.toLowerCase().endsWith(".ips"))
+          {
+            continue;
+          }
+
           r.setId(base[i]);
 
           String[] comp = r.getUsedFiles();


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/4180

The .ips file is an optional binary metadata file that supplies channel names and a list of ImagePro TIFF files to be grouped together.  There is one test dataset in ```data_repo/curated/imagepro/alex```.  With this change, ```showinf -omexml``` on the .ips file should show 2 series (positions), 2 channels, 3 timepoints, and 10 Z sections (consistent with the TIFF file names).  The OME-XML should be valid and should contain non-null channel names for both channels in each series.  All TIFF files should appear on the used file list.

The behavior of ```showinf``` on one of the TIFF files should not be affected by this PR, as the reader will not attempt to find an .ips file if a TIFF file was passed to ```setId```.  This could be changed if desired, but would slow down initialization for datasets without an .ips file (which is the majority of what we have).