### PR TITLE
formats-bsd: tiff: Handle OnDemandLongArray in IFD.printIFD()

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/IFD.java
+++ b/components/formats-bsd/src/loci/formats/tiff/IFD.java
@@ -971,6 +971,21 @@ public class IFD extends HashMap<Integer, Object> {
         v = value.toString();
         LOGGER.trace("\t{}={}", getIFDTagName(tag.intValue()), v);
       }
+      else if (value instanceof OnDemandLongArray) {
+        // this is an array of primitive types, Strings, or TiffRationals
+        LOGGER.trace("\t{}=", getIFDTagName(tag.intValue()));
+        try {
+          OnDemandLongArray dvalue = (OnDemandLongArray) value;
+          long nElements = dvalue.size();
+          long[] darray = dvalue.toArray();
+          for (long i=0; i<nElements; i++) {
+            LOGGER.trace("\t\t{}", Array.get(darray, (int) i));
+          }
+        }
+        catch (IOException e) {
+          LOGGER.trace("Error reading array", e);
+        }
+      }
       else {
         // this is an array of primitive types, Strings, or TiffRationals
         LOGGER.trace("\t{}=", getIFDTagName(tag.intValue()));


### PR DESCRIPTION
Trello: https://trello.com/c/ylVCzWR0/24-crash-with-trace-log-level

This missing case broke TRACE log output.

Testing:
- set `level=TRACE` in `tools/logback.xml`
- run showinf on a tiled TIFF
- will throw when it hits the offsets/byte count fields calling `printIFD` in `TiffParser`.
- will stop throwing and correctly dump the IFD values with this patch applied