### PR TITLE
tools: ImageInfo: Report tile size in core metadata

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -573,6 +573,8 @@ public class ImageInfo {
       Modulo moduloT = reader.getModuloT();
       int thumbSizeX = reader.getThumbSizeX();
       int thumbSizeY = reader.getThumbSizeY();
+      int tileSizeX = reader.getOptimalTileWidth();
+      int tileSizeY = reader.getOptimalTileHeight();
       boolean little = reader.isLittleEndian();
       String dimOrder = reader.getDimensionOrder();
       boolean orderCertain = reader.isOrderCertain();
@@ -636,6 +638,7 @@ public class ImageInfo {
       if (imageCount != sizeZ * effSizeC * sizeT) {
         LOGGER.info("\t************ ZCT mismatch ************");
       }
+      LOGGER.info("\tTile size = {} x {}", tileSizeX, tileSizeY);
       LOGGER.info("\tThumbnail size = {} x {}", thumbSizeX, thumbSizeY);
       LOGGER.info("\tEndianness = {}",
         little ? "intel (little)" : "motorola (big)");


### PR DESCRIPTION
Trello: https://trello.com/c/v6sJ0mQ2/25-showinf-report-tile-sizes-for-each-series

Useful for checking the tile size for any reader to ensure the tile sizes are correct.

Testing:
- run showinf with a tiled tiff and an untiled tiff.  Both should report the "optimal" tile size values for each series.