### PR TITLE
TiffWriter: Don't split planes when using nonstandard SamplesPerPixel

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -316,24 +316,6 @@ public class TiffWriter extends FormatWriter {
       c = buf.length / (w * h * bytesPerPixel);
     }
 
-    if (bytesPerPixel > 1 && c != 1 && c != 3) {
-      // split channels
-      checkParams = false;
-
-      if (no == 0) {
-        initialized[series] = new boolean[initialized[series].length * c];
-      }
-
-      for (int i=0; i<c; i++) {
-        byte[] b = ImageTools.splitChannels(buf, i, c, bytesPerPixel,
-          false, interleaved);
-
-        saveBytes(no * c + i, b, (IFD) ifd.clone(), x, y, w, h);
-      }
-      checkParams = true;
-      return -1;
-    }
-
     formatCompression(ifd);
     byte[][] lut = AWTImageTools.get8BitLookupTable(cm);
     if (lut != null) {
@@ -445,20 +427,6 @@ public class TiffWriter extends FormatWriter {
     return getPlaneCount(series);
   }
   
-  @Override
-  protected int getPlaneCount(int series) {
-    MetadataRetrieve retrieve = getMetadataRetrieve();
-    int c = getSamplesPerPixel(series);
-    int type = FormatTools.pixelTypeFromString(
-      retrieve.getPixelsType(series).toString());
-    int bytesPerPixel = FormatTools.getBytesPerPixel(type);
-
-    if (bytesPerPixel > 1 && c != 1 && c != 3) {
-      return super.getPlaneCount(series) * c;
-    }
-    return super.getPlaneCount(series);
-  }
-
   // -- IFormatWriter API methods --
 
   /**

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -848,9 +848,13 @@ public class TiffSaver {
       ifd.putIFDValue(IFD.COMPRESSION, TiffCompression.UNCOMPRESSED.getCode());
     }
 
-    boolean indexed = nChannels == 1 && ifd.getIFDValue(IFD.COLOR_MAP) != null;
-    PhotoInterp pi = indexed ? PhotoInterp.RGB_PALETTE :
-      nChannels == 1 ? PhotoInterp.BLACK_IS_ZERO : PhotoInterp.RGB;
+    PhotoInterp pi = PhotoInterp.BLACK_IS_ZERO;
+    if (nChannels == 1 && ifd.getIFDValue(IFD.COLOR_MAP) != null) {
+      pi = PhotoInterp.RGB_PALETTE;
+    }
+    else if (nChannels == 3) {
+      pi = PhotoInterp.RGB;
+    }
     ifd.putIFDValue(IFD.PHOTOMETRIC_INTERPRETATION, pi.getCode());
 
     ifd.putIFDValue(IFD.SAMPLES_PER_PIXEL, nChannels);


### PR DESCRIPTION
Trello card: https://trello.com/c/Mn05nSBh/29-remove-dangerous-tiffwriter-special-case

The existing behaviour seems rather ad-hoc and potentially dangerous.

- We ignore the SPP the user specified and write out something completely different, silently
- `ChannelSeparator` and `bfconvert` already provide the means to do this explicitly and intentionally
- While the aim of this appears to be as an aid toward greater interoperability with other software, it prevents the user writing out e.g. images with 2 or 4 samples per pixel.  If the user is writing out an OME-TIFF, the `TiffData` elements won't be able to represent the altered structure (the separated planes), and the file will not be readable as an OME-TIFF because the OME-XML metadata will not match the TIFF `SamplesPerPixel`

This logic also breaks a loop in the writer:
  `saveBytes` → `prepareToWriteImage` → `saveBytes`
Combined with tiling, this could result in calling `saveBytes` with the wrong series index (because `prepareToWrite` image is called with both series and tile indexes depending upon the context, and it's not clear how this is disabiguated).  This removal makes the code easier to understand, and removes some dangerous assumptions to make it safer.

The default `PhotometricInterpretation` is adjusted to be correct with the special case removed.

This simplification will also make it easier to work on Pyramid support.  The writer complexity, particularly for tiling, makes this very complex to work on, and removing unnecessarily complex and unneeded logic makes it a bit more manageable to work with.

Testing: The main testing is done by the unit tests.  The only class inheriting `TiffWriter` is `OMETiffWriter`.  Sample images, test script testing conversion to TIFF and OME-TIFF and converted images are here: `/ome/team/rleigh/3057-testing`.

Try the above without the PR, and again with the PR merged.  Also test conversion to `.ome.tiff` and with and without tiling.  Then use `tiffinfo` to check the number of IFDs and the Samples/Pixel value and the Photometic Interpretation.  You can repeat with a 3-channel image and 1-channel image to test the `PhotometricInterpretation` change.  Sample images are provided for 1-4 channels in the above location.  The `test` script provided should automate all the conversions.  Test that they open with ImageJ (worked for me automatically with 4-sample images with and without `-merge`; the ImageJ metadata was correct in both cases for plain TIFF).

See [results spreadsheet](https://docs.google.com/spreadsheets/d/1wp9AVcOFKEMuDxMYQEBG3rMDFzoP0wZpkwCnvOkNeTE/edit#gid=0) for a summary of the above test script.  It clearly shows where the breakage is with combinations of tiling and merging with 2 and 4 samples/pixel, and demonstrates that this PR fixes these problems.