### PR TITLE
Vectra QPTIFF: use try-with-resources in isThisType

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -101,9 +101,7 @@ public class VectraReader extends BaseTiffReader {
     if (!open) {
       return checkSuffix(name, "qptiff");
     }
-    RandomAccessInputStream stream = null;
-    try {
-      stream = new RandomAccessInputStream(name);
+    try (RandomAccessInputStream stream = new RandomAccessInputStream(name)) {
       TiffParser tiffParser = new TiffParser(stream);
       tiffParser.setDoCaching(false);
       if (!tiffParser.isValidHeader()) {
@@ -120,16 +118,6 @@ public class VectraReader extends BaseTiffReader {
     catch (IOException e) {
       LOGGER.debug("I/O exception during isThisType() evaluation.", e);
       return false;
-    }
-    finally {
-      try {
-        if (stream != null) {
-          stream.close();
-        }
-      }
-      catch (IOException e) {
-        LOGGER.debug("I/O exception during stream closure.", e);
-      }
     }
   }
 


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/pull/3017/files#r164682665

There should be no difference in functionality, so builds should remain green.  Apart from build status checks and code review, no other testing is required.

This should be safe for a patch release, so could be pushed to 5.8.1+ as needed.