### PR TITLE
Inveon: attempt to find renamed data files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InveonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InveonReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 
 import loci.common.DataTools;
@@ -271,8 +272,10 @@ public class InveonReader extends FormatReader {
           else {
             // usually this means that the files were renamed
             String[] allFiles = header.getParentFile().list(true);
+            Arrays.sort(allFiles);
+            String headerName = header.getName();
             for (String file : allFiles) {
-              if (header.getName().startsWith(file)) {
+              if (!headerName.equals(file) && headerName.startsWith(file)) {
                 datFile = new Location(header.getParent(), file).getAbsolutePath();
               }
             }

--- a/components/formats-gpl/src/loci/formats/in/InveonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InveonReader.java
@@ -264,7 +264,19 @@ public class InveonReader extends FormatReader {
           value = value.substring(value.lastIndexOf(File.separator) + 1);
 
           Location header = new Location(currentId).getAbsoluteFile();
-          datFile = new Location(header.getParent(), value).getAbsolutePath();
+          Location dat = new Location(header.getParent(), value);
+          if (dat.exists()) {
+            datFile = dat.getAbsolutePath();
+          }
+          else {
+            // usually this means that the files were renamed
+            String[] allFiles = header.getParentFile().list(true);
+            for (String file : allFiles) {
+              if (header.getName().startsWith(file)) {
+                datFile = new Location(header.getParent(), file).getAbsolutePath();
+              }
+            }
+          }
         }
         else if (key.equals("time_frames")) {
           int sizeT = Integer.parseInt(value);

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1733,13 +1733,13 @@ public class FormatReaderTest {
             continue;
           }
 
-          // pattern datasets can only be detected with the pattern file
-          if (reader.getFormat().equals("File pattern")) {
+          // Inveon only reliably detected from header file
+          if (reader.getFormat().equals("Inveon")) {
             continue;
           }
 
-          // Inveon only reliably detected from header file
-          if (reader.getFormat().equals("Inveon")) {
+          // pattern datasets can only be detected with the pattern file
+          if (reader.getFormat().equals("File pattern")) {
             continue;
           }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1738,6 +1738,11 @@ public class FormatReaderTest {
             continue;
           }
 
+          // Inveon only reliably detected from header file
+          if (reader.getFormat().equals("Inveon")) {
+            continue;
+          }
+
           r.setId(base[i]);
 
           String[] comp = r.getUsedFiles();
@@ -2409,6 +2414,11 @@ public class FormatReaderTest {
             if (!used[i].toLowerCase().endsWith(".lif") &&
               r instanceof LIFReader)
             {
+              continue;
+            }
+
+            // Inveon only reliably detected from header file
+            if (!result && r instanceof InveonReader) {
               continue;
             }
 


### PR DESCRIPTION
Backported from a private PR.  The data file name stored in the header is not updated if the header and
data files are renamed. If the stored data file name does not exist,
then a file whose name is similar to the header file's name will be used
(if such a file is present).

To test, use the dataset in ```data_repo/curated/inveon/samples/rename-test```.  Without this PR, ```showinf batch1_v1.ct.img.hdr``` should throw a ```FileNotFoundException```.  With this PR, the same test should display images and metadata matching ```showinf data_repo/curated/inveon/samples/batch1_v1.ct.img.hdr```.  The used file list should contain two files, both of which exist.