### PR TITLE
Fake: allow per-plane ExposureTime/Position{X,Y,Z} keys in the INI file

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1138,7 +1138,7 @@ public class FakeReader extends FormatReader {
 
       if (exposureTime != null) {
         try {
-          Double v = new Double(exposureTime);
+          Double v = Double.valueOf(exposureTime);
           Time exposure = FormatTools.getTime(v, exposureTimeUnit);
           if (exposure != null) {
             store.setPlaneExposureTime(exposure, newSeries, i);
@@ -1149,80 +1149,20 @@ public class FakeReader extends FormatReader {
         }
       }
 
-      String positionX = table.get("PositionX_" + i);
-      String positionXUnit = table.get("PositionXUnit_" + i);
-
-      if (positionX != null) {
-        try {
-          Double v = new Double(positionX);
-
-          Length x = new Length(v, UNITS.MICROM);
-          if (positionXUnit != null) {
-            try {
-              UnitsLength ul = UnitsLength.fromString(positionXUnit);
-              x = UnitsLength.create(v, ul);
-            }
-            catch (EnumerationException e) {
-              LOGGER.trace("Could not parse PositionXUnit for series #" + s + " plane #" + i);
-            }
-          }
-          if (x != null) {
-            store.setPlanePositionX(x, newSeries, i);
-          }
-        }
-        catch (NumberFormatException e) {
-          LOGGER.trace("Could not parse PositionX for series #" + s + " plane #" + i, e);
-        }
+      // TODO: could be cleaned up further when Java 8 is the minimum version
+      Length x = parsePosition("X", s, i, table);
+      if (x != null) {
+        store.setPlanePositionX(x, newSeries, i);
       }
 
-      String positionY = table.get("PositionY_" + i);
-      String positionYUnit = table.get("PositionYUnit_" + i);
-
-      if (positionY != null) {
-        try {
-          Double v = new Double(positionY);
-          Length y = new Length(v, UNITS.MICROM);
-          if (positionYUnit != null) {
-            try {
-              UnitsLength ul = UnitsLength.fromString(positionYUnit);
-              y = UnitsLength.create(v, ul);
-            }
-            catch (EnumerationException e) {
-              LOGGER.trace("Could not parse PositionYUnit for series #" + s + " plane #" + i);
-            }
-          }
-          if (y != null) {
-            store.setPlanePositionY(y, newSeries, i);
-          }
-        }
-        catch (NumberFormatException e) {
-          LOGGER.trace("Could not parse PositionY for series #" + s + " plane #" + i, e);
-        }
+      Length y = parsePosition("Y", s, i, table);
+      if (y != null) {
+        store.setPlanePositionY(y, newSeries, i);
       }
 
-      String positionZ = table.get("PositionZ_" + i);
-      String positionZUnit = table.get("PositionZUnit_" + i);
-
-      if (positionZ != null) {
-        try {
-          Double v = new Double(positionZ);
-          Length z = new Length(v, UNITS.MICROM);
-          if (positionZUnit != null) {
-            try {
-              UnitsLength ul = UnitsLength.fromString(positionZUnit);
-              z = UnitsLength.create(v, ul);
-            }
-            catch (EnumerationException e) {
-              LOGGER.trace("Could not parse PositionZUnit for series #" + s + " plane #" + i);
-            }
-          }
-          if (z != null) {
-            store.setPlanePositionZ(z, newSeries, i);
-          }
-        }
-        catch (NumberFormatException e) {
-          LOGGER.trace("Could not parse PositionZ for series #" + s + " plane #" + i, e);
-        }
+      Length z = parsePosition("Z", s, i, table);
+      if (z != null) {
+        store.setPlanePositionZ(z, newSeries, i);
       }
     }
 
@@ -1397,4 +1337,32 @@ public class FakeReader extends FormatReader {
       }
       return null;
   }
+
+  private Length parsePosition(String axis, int s, int index, IniTable table) {
+    String position = table.get("Position" + axis + "_" + index);
+    String positionUnit = table.get("Position" + axis + "Unit_" + index);
+
+    if (position != null) {
+      try {
+        Double v = Double.valueOf(position);
+        Length size = new Length(v, UNITS.MICROM);
+        if (positionUnit != null) {
+          try {
+            UnitsLength ul = UnitsLength.fromString(positionUnit);
+            size = UnitsLength.create(v, ul);
+          }
+          catch (EnumerationException e) {
+            LOGGER.trace("Could not parse Position" + axis + "Unit for series #" + s + " plane #" + index);
+          }
+        }
+        return size;
+      }
+      catch (NumberFormatException e) {
+        LOGGER.trace("Could not parse Position" + axis + " for series #" + s + " plane #" + index, e);
+      }
+    }
+
+    return null;
+  }
+
 }

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1352,7 +1352,7 @@ public class FakeReader extends FormatReader {
             size = UnitsLength.create(v, ul);
           }
           catch (EnumerationException e) {
-            LOGGER.trace("Could not parse Position" + axis + "Unit for series #" + s + " plane #" + index);
+            LOGGER.trace("Could not parse Position" + axis + "Unit for series #" + s + " plane #" + index, e);
           }
         }
         return size;

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -1155,7 +1155,17 @@ public class FakeReader extends FormatReader {
       if (positionX != null) {
         try {
           Double v = new Double(positionX);
-          Length x = FormatTools.getPhysicalSize(v, positionXUnit);
+
+          Length x = new Length(v, UNITS.MICROM);
+          if (positionXUnit != null) {
+            try {
+              UnitsLength ul = UnitsLength.fromString(positionXUnit);
+              x = UnitsLength.create(v, ul);
+            }
+            catch (EnumerationException e) {
+              LOGGER.trace("Could not parse PositionXUnit for series #" + s + " plane #" + i);
+            }
+          }
           if (x != null) {
             store.setPlanePositionX(x, newSeries, i);
           }
@@ -1171,7 +1181,16 @@ public class FakeReader extends FormatReader {
       if (positionY != null) {
         try {
           Double v = new Double(positionY);
-          Length y = FormatTools.getPhysicalSize(v, positionYUnit);
+          Length y = new Length(v, UNITS.MICROM);
+          if (positionYUnit != null) {
+            try {
+              UnitsLength ul = UnitsLength.fromString(positionYUnit);
+              y = UnitsLength.create(v, ul);
+            }
+            catch (EnumerationException e) {
+              LOGGER.trace("Could not parse PositionYUnit for series #" + s + " plane #" + i);
+            }
+          }
           if (y != null) {
             store.setPlanePositionY(y, newSeries, i);
           }
@@ -1187,7 +1206,16 @@ public class FakeReader extends FormatReader {
       if (positionZ != null) {
         try {
           Double v = new Double(positionZ);
-          Length z = FormatTools.getPhysicalSize(v, positionZUnit);
+          Length z = new Length(v, UNITS.MICROM);
+          if (positionZUnit != null) {
+            try {
+              UnitsLength ul = UnitsLength.fromString(positionZUnit);
+              z = UnitsLength.create(v, ul);
+            }
+            catch (EnumerationException e) {
+              LOGGER.trace("Could not parse PositionZUnit for series #" + s + " plane #" + i);
+            }
+          }
           if (z != null) {
             store.setPlanePositionZ(z, newSeries, i);
           }

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -799,7 +799,9 @@ public class FakeReader extends FormatReader {
     fillExposureTime(store);
     fillPhysicalSizes(store);
     for (int currentImageIndex=0; currentImageIndex<seriesCount; currentImageIndex++) {
-      parseSeriesTable(seriesTables.get(currentImageIndex), store, currentImageIndex);
+      if (currentImageIndex < seriesTables.size()) {
+        parseSeriesTable(seriesTables.get(currentImageIndex), store, currentImageIndex);
+      }
 
       String imageName = currentImageIndex > 0 ? name + " " + (currentImageIndex + 1) : name;
       store.setImageName(imageName, currentImageIndex);

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -56,6 +56,7 @@ import loci.common.services.ServiceFactory;
 
 import ome.units.UNITS;
 import ome.units.quantity.Length;
+import ome.units.quantity.Time;
 
 import ome.xml.model.primitives.Timestamp;
 
@@ -359,6 +360,29 @@ public class FakeReaderTest {
     reader.setId(fakeIni.getAbsolutePath());
     assertTrue(service.validateOMEXML(service.getOMEXML(m)));
     assertEquals(reader.getGlobalMetadata().get("foo"), "bar");
+  }
+
+  @Test
+  public void testPlaneMetadata() throws Exception {
+    File fakeIni = mkIni("foo.fake.ini", "sizeC=2",
+      "[series_0]", "ExposureTime_0=100.0", "ExposureTimeUnit_0=ms",
+      "ExposureTime_1=50.0", "ExposureTimeUnit_1=ns",
+      "PositionX_0=10.0", "PositionY_0=20.0", "PositionZ_0=30.0",
+      "PositionXUnit_0=mm", "PositionYUnit_0=mm", "PositionZUnit_0=mm",
+      "PositionX_1=5.0", "PositionY_1=10.0", "PositionZ_1=15.0",
+      "PositionXUnit_1=nm", "PositionYUnit_1=nm", "PositionZUnit_1=nm");
+    reader.setId(fakeIni.getAbsolutePath());
+    m = service.asRetrieve(reader.getMetadataStore());
+
+    assertEquals(m.getPixelsSizeC(0).getNumberValue(), 2);
+    assertEquals(m.getPlaneExposureTime(0, 0), new Time(100.0, UNITS.MILLISECOND));
+    assertEquals(m.getPlaneExposureTime(0, 1), new Time(50.0, UNITS.NANOSECOND));
+    assertEquals(m.getPlanePositionX(0, 0), new Length(10.0, UNITS.MM));
+    assertEquals(m.getPlanePositionY(0, 0), new Length(20.0, UNITS.MM));
+    assertEquals(m.getPlanePositionZ(0, 0), new Length(30.0, UNITS.MM));
+    assertEquals(m.getPlanePositionX(0, 1), new Length(5.0, UNITS.NM));
+    assertEquals(m.getPlanePositionY(0, 1), new Length(10.0, UNITS.NM));
+    assertEquals(m.getPlanePositionZ(0, 1), new Length(15.0, UNITS.NM));
   }
 
   @Test(dataProvider = "physical sizes")

--- a/docs/sphinx/developers/generating-test-images.rst
+++ b/docs/sphinx/developers/generating-test-images.rst
@@ -39,6 +39,21 @@ global metadata map:
     echo "[GlobalMetadata]" >> my-special-test-file.fake.ini
     echo "my.key=some.value" >> my-special-test-file.fake.ini
 
+The :file:`.ini` file can also contain one section for each series, which allows metadata such as
+exposure times and positions to be set for each plane:
+
+::
+
+    echo "[series_0]" >> my-special-test-file.fake.ini
+    echo "ExposureTime_0=10" >> my-special-test-file.fake.ini
+    echo "ExposureTimeUnit_0=ms" >> my-special-test-file.fake.ini
+    echo "PositionX_0=5" >> my-special-test-file.fake.ini
+    echo "PositionY_0=-5" >> my-special-test-file.fake.ini
+    echo "PositionZ_0=1" >> my-special-test-file.fake.ini
+    echo "PositionXUnit_0=mm" >> my-special-test-file.fake.ini
+    echo "PositionYUnit_0=mm" >> my-special-test-file.fake.ini
+    echo "PositionZUnit_0=mm" >> my-special-test-file.fake.ini
+
 
 Several keys have support for units and can be expressed as ``KEY=VALUE UNIT`` where ``UNIT`` is the symbol of the desired unit::
 
@@ -228,10 +243,37 @@ with their default values, is shown below.
     - * ellipses, labels, lines, points, polygons, polylines, rectangles
       * the number of ROIs containing one shape of the given type to generate
       *
+    - * ExposureTime_x
+      * floating point exposure time for plane ``x`` [2]_
+      *
+    - * ExposureTimeUnit_x
+      * string defining the units for the corresponding ``ExposureTime_x`` [2]_
+      * seconds
+    - * PositionX_x
+      * floating point X position for plane ``x`` [2]_
+      *
+    - * PositionXUnit_x
+      * string defining the units for the corresponding ``PositionX_x`` [2]_
+      * microns
+    - * PositionY_x
+      * floating point Y position for plane ``x`` [2]_
+      *
+    - * PositionYUnit_x
+      * string defining the units for the corresponding ``PositionY_x`` [2]_
+      * microns
+    - * PositionZ_x
+      * floating point Z position for plane ``x`` [2]_
+      *
+    - * PositionZUnit_x
+      * string defining the units for the corresponding ``PositionZ_x`` [2]_
+      * microns
+
 
 .. [1] Default value set to 1 if any of the ``screens``, ``plates``,
        ``plateAcqs``, ``plateRows``, ``plateCols`` or ``fields`` values is set
        to a value greater than zero.
+
+.. [2] Must be stored in the INI file under a ``[series_n]`` section, where ``n`` is the 0-based series index.
 
 For full details of these keys, how unset and default values are handled and
 further examples see :source:`loci.formats.in.FakeReader <components/formats-bsd/src/loci/formats/in/FakeReader.java>`.


### PR DESCRIPTION
Backported from a private PR.

The INI file can now optionally contain one table per series, named "series_n"
(where n is the 0-based series index).  Each table can describe the
exposure time, X position, Y position, and Z position for any subset of
the planes in the series, using the following keys (where i is the
0-based plane index):

```
ExposureTime_i
ExposureTimeUnit_i
PositionX_i
PositionXUnit_i
PositionY_i
PositionYUnit_i
PositionZ_i
PositionZUnit_i
```

This corresponds to the keys used by the ```.bioformats``` files used for data
testing.

To test, use the new example in ```data_repo/curated/fake/samples/ini```.  ```showinf -nopix -omexml multiSeries-metadata.fake``` with this change should show exposure times and plane positions populated according to the key/value pairs in ```multiSeries-metadata.fake.ini``` (each plane/series will be a little different).  The new configuration file can also be compared to ```multiSeries-metadata.fake.ini```, as the exposure time and plane position key/values should be nearly identical.

This should be safe for a patch release if needed; memo files and builds should be unaffected.

Semi-related ```FakeReader``` cards:

https://trello.com/c/t6McetbQ/261-unify-key-value-parsing-between-fake-files-and-bioformats
https://trello.com/c/l2bTBOik/265-fake-series-of-different-sizes
