### PR TITLE
Add bio3d.colorado.edu to ignore list

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -365,5 +365,6 @@ texinfo_documents = [
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
-    'https://www.olympus-global.com'
+    'https://www.olympus-global.com',
+    'http://bio3d.colorado.edu/'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -366,5 +366,5 @@ texinfo_documents = [
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
-    'http://bio3d.colorado.edu/'
+    'http://bio3d.colorado.edu'
 ]


### PR DESCRIPTION
This should get the docs build green. Likely the link failure is temporary and this PR won't need to be merged.