### PR TITLE
File patterns: expanded support for multi-channel pyramids

### DIFF
--- a/components/formats-bsd/src/loci/formats/AxisGuesser.java
+++ b/components/formats-bsd/src/loci/formats/AxisGuesser.java
@@ -215,10 +215,22 @@ public class AxisGuesser {
         char third = elements[i].length == 2 ? 'b' :
           elements[i][2].toLowerCase().charAt(0);
 
-        if ((first == 'r' || second == 'r' || third == 'r') &&
-          (first == 'g' || second == 'g' || third == 'g') &&
-          (first == 'b' || second == 'b' || third == 'b'))
-        {
+        boolean hasRed = first == 'r' || second == 'r' || third == 'r';
+        boolean hasGreen = first == 'g' || second == 'g' || third == 'g';
+        boolean hasBlue = first == 'b' || second == 'b' || third == 'b';
+
+        int rgbChannels = 0;
+        if (hasRed) {
+          rgbChannels++;
+        }
+        if (hasGreen) {
+          rgbChannels++;
+        }
+        if (hasBlue) {
+          rgbChannels++;
+        }
+
+        if (rgbChannels >= 2) {
           axisTypes[i] = C_AXIS;
           continue;
         }

--- a/components/formats-bsd/src/loci/formats/FileStitcher.java
+++ b/components/formats-bsd/src/loci/formats/FileStitcher.java
@@ -567,7 +567,12 @@ public class FileStitcher extends ReaderWrapper {
   @Override
   public void setSeries(int no) {
     FormatTools.assertId(getCurrentFile(), true, 2);
+    int n = reader.getCoreMetadataList().size();
+    if (n > 1 || noStitch) {
+      reader.setSeries(no);
+    }
     setCoreIndex(seriesToCoreIndex(no));
+    reader.setResolution(0);
   }
 
   /* @see IFormatReader#getSeries() */
@@ -575,6 +580,27 @@ public class FileStitcher extends ReaderWrapper {
   public int getSeries() {
     FormatTools.assertId(getCurrentFile(), true, 2);
     return reader.getSeries() > 0 ? reader.getSeries() : series;
+  }
+
+  /* @see IFormatReader#setResolution(int) */
+  @Override
+  public void setResolution(int no) {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    coreIndex = (coreIndex - getResolution()) + no;
+    reader.setResolution(no);
+    reader.setCoreIndex(coreIndex);
+  }
+
+  /* @see IFormatReader#getResolution() */
+  @Override
+  public int getResolution() {
+    FormatTools.assertId(getCurrentFile(), true, 2);
+    int n = reader.getCoreMetadataList().size();
+    if (n > 1 || noStitch) return reader.getResolution();
+    if (hasFlattenedResolutions()) {
+      return 0;
+    }
+    return getCoreIndex() - coreIndexToSeries(getCoreIndex());
   }
 
   /* @see IFormatReader#seriesToCoreIndex(int) */
@@ -600,9 +626,9 @@ public class FileStitcher extends ReaderWrapper {
     int n = reader.getCoreMetadataList().size();
     if (n > 1 || noStitch) reader.setCoreIndex(no);
     else {
-      coreIndex = no;
       series = no;
     }
+    coreIndex = no;
   }
 
   /* @see IFormatReader#getCoreIndex() */

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -82,6 +82,11 @@ public class FilePatternReader extends FormatReader {
   // -- IFormatReader methods --
 
   @Override
+  public void reopenFile() throws IOException {
+    helper.reopenFile();
+  }
+
+  @Override
   public int getImageCount() {
     return helper.getImageCount();
   }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2399,7 +2399,7 @@ public class FormatReaderTest {
             }
 
             // the pattern reader only picks up pattern files
-            if (!result && !used[i].toLowerCase().endsWith(".pattern") &&
+            if (!used[i].toLowerCase().endsWith(".pattern") &&
               r instanceof FilePatternReader)
             {
               continue;


### PR DESCRIPTION
Backported from a private PR.

This expands the case for detecting a channel axis based upon ```red```, ```green```, and ```blue``` in the file names.  Matching at least two of ```r```, ```g```, and ```b``` is now sufficient instead of all three.  Stitching of files containing a pyramid is also fixed.

To test, use ```data_repo/curated/fake/samples/multi-channel-pattern/channels.pattern```, which contains:

```<red,green,greenyellow>.fake```

Without this PR, ```showinf -nopix channels.pattern``` should result in 3 Z sections and 1 channel, despite the fact that the file names indicate channel colors.  With this PR, the same test should show 1 Z section and 3 channels as expected.

To test pyramid stitching changes, use ```data_repo/curated/pyramid/pattern/channels.pattern```, which contains:

```<red,green>```

Without this PR, ```showinf -nopix -noflat channels.pattern``` should throw an ```IndexOutOfBoundsException```.  With this PR, the same test should show a pyramid with 2 channels.