### PR TITLE
Update API & downloads links to 5.8

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -147,8 +147,8 @@ extlinks = {
     'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/bio-formats5.7/%s', ''),
-    'javadoc' : (downloads_root + '/latest/bio-formats5.7/api/%s', ''),
+    'downloads' : (downloads_root + '/latest/bio-formats5.8/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats5.8/api/%s', ''),
     'common_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-common/' + ome_common_version + '/' + '%s', ''),
     'xml_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-xml/' + ome_model_version + '/' + '%s', ''),
     'specification_javadoc' : ('http://static.javadoc.io/org.openmicroscopy/ome-specification/' + ome_model_version + '/' + '%s', ''),


### PR DESCRIPTION
See https://trello.com/c/u46NyzEK/204-versioned-api-downloads-links-in-configpyin

This won't pass the linkchecker until the 5.8.x links exist when there's a release build ready so adding an exclude label

EDITED to remove label - redirects added now