### PR TITLE
MicroManagerReader: Minor fix to handle metadata block closing (rebased onto metadata54)

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -779,7 +779,6 @@ public class MicromanagerReader extends FormatReader {
         String key = "", value = "";
         boolean valueArray = false;
         int nestedCount = 0;
-
         while (!token.startsWith("}") || nestedCount > 0) {
 
           if (token.trim().endsWith("{")) {
@@ -793,7 +792,7 @@ public class MicromanagerReader extends FormatReader {
             continue;
           }
 
-          if (valueArray) {
+          if (valueArray || token.trim().equals("],")) {
             if (token.trim().equals("],")) {
               valueArray = false;
             }

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -779,6 +779,7 @@ public class MicromanagerReader extends FormatReader {
         String key = "", value = "";
         boolean valueArray = false;
         int nestedCount = 0;
+
         while (!token.startsWith("}") || nestedCount > 0) {
 
           if (token.trim().endsWith("{")) {


### PR DESCRIPTION

This is the same as gh-3065 but rebased onto metadata54.

----

ref: https://trello.com/c/dqTlLuXf/637-serge-pelet-single-cell-data#comment-5a783cf80e00f887aa369c3f

Testing Instructions:
1) Test via Fiji, Command line tools and check if the file opens appropriately via Bio-Formats.
Without this PR you should get an exception (as shown in the trello card).
2) Check if the subset job listed below is green.

@sbesson 

                