### PR TITLE
Ignore mdbtools link

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -366,6 +366,7 @@ texinfo_documents = [
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
+    'http://www.lavisionbiotec.com/',
     r'http://mdbtools.cvs.sourceforge.net/.*',
     'https://nifti.nimh.nih.gov/nifti-1/'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -365,5 +365,6 @@ texinfo_documents = [
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
-    'https://www.olympus-global.com'
+    'https://www.olympus-global.com',
+    r'http://mdbtools.cvs.sourceforge.net/.*'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -366,5 +366,6 @@ texinfo_documents = [
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
-    r'http://mdbtools.cvs.sourceforge.net/.*'
+    r'http://mdbtools.cvs.sourceforge.net/.*',
+    r'http://www.bio-rad.com/.*'
 ]

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -367,5 +367,5 @@ texinfo_documents = [
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
     r'http://mdbtools.cvs.sourceforge.net/.*',
-    r'http://www.bio-rad.com/.*'
+    'https://nifti.nimh.nih.gov/nifti-1/'
 ]


### PR DESCRIPTION
Added this link to the ignore list as it's currently breaking the docs build. Assume this is temporary and we'll be able to close next week but if not this can be merged for 5.8.0 and I'll revisit the ignore list again for 5.8.1 as needed.