### PR TITLE
IonpathMIBITiffReader: clear initialized variables on close()

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
@@ -232,4 +232,17 @@ public class IonpathMIBITiffReader extends BaseTiffReader {
   private static String formatMetadata(String key, String value) {
     return key + ":" + value.replaceAll("\\s", "_");
   }
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      seriesTypes.clear();
+      seriesIFDs.clear();
+      channelIDs.clear();
+      channelNames.clear();
+      simsDescription .clear();
+    }
+  }
 }


### PR DESCRIPTION
This commit closes the variables initialized by `setId` on `close`.

Without this commit, testing 2 IonPath MIBI files using `test-suite`, or recycling an existing `ImageReader` to reopen a second sample file should fail with an `IndexOutOfBoundsException` or similar (see [log](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-repository-subset/548/console)). With this commit, the automated tests should pass against multiple samples of the new format. 