### PR TITLE
Check the last IFD for an ImageJ comment

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/TiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffReader.java
@@ -127,6 +127,7 @@ public class TiffReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
     String comment = ifds.get(0).getComment();
+    String lastComment = ifds.get(ifds.size() - 1).getComment();
 
     LOGGER.info("Checking comment style");
 
@@ -180,7 +181,15 @@ public class TiffReader extends BaseTiffReader {
 
     // check for ImageJ-style TIFF comment
     boolean ij = checkCommentImageJ(comment);
-    if (ij) parseCommentImageJ(comment);
+    if (ij) {
+      parseCommentImageJ(comment);
+    }
+    else {
+      ij = checkCommentImageJ(lastComment);
+      if (ij) {
+        parseCommentImageJ(lastComment);
+      }
+    }
 
     // check for MetaMorph-style TIFF comment
     boolean metamorph = checkCommentMetamorph(comment);


### PR DESCRIPTION
Backported from a private PR.

This corrects for the case where the file was processed by some other
software after being saved in ImageJ, which overwrites the first IFD's
ImageJ comment but not the comments from subsequent IFDs.

To test, use the sample dataset in ```data_repo/curated/tiff/samples/melissa/imagej-last-ifd/```.  As noted in the readme, this was generated by opening ImageJ, clicking ```File > Open Samples > Neuron```, then ```File > Save As > Tiff...``` resulting in ```Rat_Hippocampal_Neuron.tif```.  The following commands were then run:

```
echo "original comment deleted" > comment
tiffset -sf 270 comment Rat_Hippocampal_Neuron.tif
```

```tiffinfo Rat_Hippocampal_Neuron.tif``` will confirm that the first IFD's comment is ```original comment deleted``` and the remaining IFDs' comments contain ImageJ metadata.

Without this PR, ```showinf -nopix Rat_Hippocampal_Neuron.tif``` should indicate 5 timepoints, 1 channel, and 1 Z section.  With this PR, the same test should indicate 5 channels, 1 timepoint, and 1 Z section, which matches the dimensions of the original ```Neuron``` dataset in ImageJ.

This should be safe for a patch release.  I tested the ```data_repo/curated/tiff/``` directory locally with this PR and did not see any failures, but there is a small chance that some other directory contains an ImageJ TIFF which would be affected by this.