### PR TITLE
Scanr fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -518,7 +518,7 @@ public class ScanrReader extends FormatReader {
       if (next == originalIndex &&
         missingWellFiles == nSlices * nTimepoints * nChannels * nPos)
       {
-        wellNumbers.remove(well);
+        next += nSlices * nTimepoints * nChannels * nPos;
       }
     }
     nWells = wellNumbers.size();

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -544,7 +544,12 @@ public class ScanrReader extends FormatReader {
     }
 
     reader = new MinimalTiffReader();
-    reader.setId(tiffs[0]);
+    for (String tiff : tiffs) {
+      if (tiff != null) {
+        reader.setId(tiff);
+	break;
+      }
+    }
     int sizeX = reader.getSizeX();
     int sizeY = reader.getSizeY();
     int pixelType = reader.getPixelType();


### PR DESCRIPTION
Changes brought to the `ScanrReader` on the `metadata` branch have been lost (presumably during the large rebase of the `metadata` branch onto `v5.4.0`. This PR cherry-picks individual changes and should restore the access to some datasets imported into IDR.

## Issue
See https://github.com/idr-contrib/community/issues/5

The bugs can be reproduced by trying to access the pixel data of the images in some of the plate acquisition of `idr0009`. Two examples of failures can be found:

- last well from https://idr.openmicroscopy.org/webclient/?show=run-3761 e.g. https://idr.openmicroscopy.org/webclient/img_detail/1345039/
- last wells from https://idr.openmicroscopy.org/webclient/?show=run-4151 e.g. https://idr.openmicroscopy.org/webclient/img_detail/1482028/

## Testing

After deployment on the testing server, check the webclient URLs above. They should all resolve.

