### PR TITLE
Flex: read image offsets when a single tile is used

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1307,10 +1307,16 @@ public class FlexReader extends FormatReader {
             compressed =
               firstIFD.getCompression() != TiffCompression.UNCOMPRESSED;
 
-            if (compressed || firstIFD.getStripOffsets()[0] == 16) {
+            if (compressed || firstIFD.getStripOffsets()[0] == 16 ||
+              firstIFD.getStripOffsets().length == 1)
+            {
               tp.setDoCaching(false);
               file.ifds = tp.getIFDs();
               file.ifds.set(0, firstIFD);
+              if (firstIFD.getStripOffsets().length == 1) {
+                // used to ensure that image offsets are read, not calculated
+                compressed = true;
+              }
             }
             else {
               // if the pixel data is uncompressed and the IFD is stored

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -288,6 +288,7 @@ public class FlexReader extends FormatReader {
 
     tp.getSamples(ifd, buf, x, y, w, h);
     factor = file.factors == null ? 1d : file.factors[imageNumber];
+    LOGGER.trace("  using factor = {}", factor);
     tp.getStream().close();
 
     // expand pixel values with multiplication by factor[no]

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -282,6 +282,10 @@ public class FlexReader extends FormatReader {
     // read pixels from the file
     TiffParser tp = new TiffParser(s);
     tp.fillInIFD(ifd);
+
+    // log the first offset used
+    LOGGER.trace("first offset for series={} no={}: {}", getCoreIndex(), no, ifd.getStripOffsets()[0]);
+
     tp.getSamples(ifd, buf, x, y, w, h);
     factor = file.factors == null ? 1d : file.factors[imageNumber];
     tp.getStream().close();


### PR DESCRIPTION
Backported from a private PR.

If every image is contained in a single tile, we likely can't reliably calculate the image offsets.  Reading all of the offsets is a little slower, but is more accurate.

To test, use the three single-file datasets referenced in the config PR:

```
data_repo/curated/flex/qa-7469/002002.flex
data_repo/curated/flex/lee/RLM1 SSN3 300308 008015000.flex
data_repo/curated/flex/tony/001001000_objects.flex
```

Open each in ImageJ with and without this PR, and note the obvious differences for ```qa-7649``` and ```tony``` especially.  With this PR, ```showinf -trace``` on each file and series should log the scaling factor and offset to the first strip for each plane.  The logged offsets should match what ```tiffdump``` reports for the ```StripOffsets``` tags, and the logged factor should match the plane's factor in the original metadata table.