### PR TITLE
TIFF: make sure IFDs are filled in before being used

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -455,6 +455,7 @@ public class MinimalTiffReader extends FormatReader {
     thumbnailIFDs = new IFDList();
     subResolutionIFDs = new ArrayList<IFDList>();
     for (IFD ifd : allIFDs) {
+      tiffParser.fillInIFD(ifd);
       Number subfile = (Number) ifd.getIFDValue(IFD.NEW_SUBFILE_TYPE);
       int subfileType = subfile == null ? 0 : subfile.intValue();
       if (subfileType != 1 || allIFDs.size() <= 1) {
@@ -473,7 +474,6 @@ public class MinimalTiffReader extends FormatReader {
 
     tiffParser.setAssumeEqualStrips(equalStrips);
     for (IFD ifd : ifds) {
-      tiffParser.fillInIFD(ifd);
       if ((ifd.getCompression() == TiffCompression.JPEG_2000
           || ifd.getCompression() == TiffCompression.JPEG_2000_LOSSY) &&
           ifd.getImageWidth() == ifds.get(0).getImageWidth()) {


### PR DESCRIPTION
Backported from a private PR.

If the ```NEW_SUBFILE_TYPE``` tag has a non-standard type or count such that the value is not inlined, then casting its value to ```Number``` without explicitly filling in the IFD will result in an exception.

To test, use the new ```data_repo/curated/tiff/samples/melissa/long8-subfiletype/Cell_Colony.tif``` file, which was generated from ImageJ sample data as described in the readme.  ```tiffdump``` should confirm that the type for tag 254 (```NEW_SUBFILE_TYPE```) is 16 (```LONG8```) and that the value is 1.

Without this PR, ```showinf Cell_Colony.tif``` should result in this exception:

```
Exception in thread "main" java.lang.ClassCastException: loci.formats.tiff.TiffIFDEntry cannot be cast to java.lang.Number
	at loci.formats.in.MinimalTiffReader.initFile(MinimalTiffReader.java:458)
	at loci.formats.in.BaseTiffReader.initFile(BaseTiffReader.java:583)
	at loci.formats.FormatReader.setId(FormatReader.java:1397)
	at loci.formats.DelegateReader.setId(DelegateReader.java:291)
	at loci.formats.ImageReader.setId(ImageReader.java:839)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1034)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1120)
```

With this PR, the same test should result in successful initialization without an exception.