### PR TITLE
Cellomics: fix indexing when the field counts are variable

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -210,10 +210,6 @@ public class CellomicsReader extends FormatReader {
     wellRows = uniqueRows.size();
     wellColumns = uniqueCols.size();
 
-    if (fields * wellRows * wellColumns > files.length) {
-      files = new String[] {id};
-    }
-
     Arrays.sort(files, new Comparator<String>() {
         @Override
         public int compare(String f1, String f2) {
@@ -250,7 +246,6 @@ public class CellomicsReader extends FormatReader {
 
         }
     });
-
 
     core.clear();
 
@@ -360,7 +355,7 @@ public class CellomicsReader extends FormatReader {
       store.setImageName(
         String.format("Well %s%02d, Field #%02d",
                       new String(Character.toChars(row+'A')),
-                      col, fieldIndex), i);
+                      col + 1, fieldIndex), i);
 
       if (files.length == 1) {
         row = 0;
@@ -477,7 +472,7 @@ public class CellomicsReader extends FormatReader {
     if ((wellName == null) || (wellName.length() <= 2)) return 0;
     if (! Character.isDigit(wellName.charAt(1))) return 0;
     if (! Character.isDigit(wellName.charAt(2))) return 0;
-    return Integer.parseInt(wellName.substring(1, 3));
+    return Integer.parseInt(wellName.substring(1, 3)) - 1;
   }
 
   private int getField(String filename) {


### PR DESCRIPTION
Backported from a private PR.

This fixes file grouping and well/field indexing when the field count is not consistent for every well.

To test, use the example plate in ```data_repo/curated/cellomics/samples/different-field-count```, which was constructed by copying/renaming ```data_repo/curated/cellomics/omar/FB03f00d0.C01``` as described in the readme.

Without this PR, ```showinf -nopix -omexml plate_B03f00d0.C01``` should have a single series representing one well and field.  The used file list should contain only ```plate_B03f00d0.C01```.  With this PR, the same test should detect all 3 files in the plate, and represent them as 3 series (1 for well B03 and 2 for well C03).

One additional configuration change was necessary to change the well name from A00 to A01 for single file plates where the plate name cannot be detected by the regex; only the files in ```data_repo/curated/cellomics/omar``` are impacted.