### PR TITLE
ImageJ exporter: stop plugin when unsupported pixel type is found

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -609,6 +609,7 @@ public class Exporter {
             if (notSupportedType) {
                 IJ.error("Pixel type (" + FormatTools.getPixelTypeString(thisType) +
                         ") not supported by this format.");
+                return;
             }
 
             if (codecs != null && codecs.length > 1) {


### PR DESCRIPTION
See https://trello.com/c/FDmPiqW5/225-imagej-plugin-too-many-dialog-boxes-when-attempting-to-export-images-with-an-unsupported-pixel-type

To test, use the macro code on the Trello card.  Without this PR, an initial unsupported pixel type error message is shown, followed by one message per plane in the ```ImagePlus``` being exported (as described in the card).  With this PR, a single unsupported pixel type error is shown and then the exporter plugin finishes immediately.