### PR TITLE
MicroManager: use PositionName key/value for storing the ImageName

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -317,9 +317,13 @@ public class MicromanagerReader extends FormatReader {
         }
       }
 
-      if (positions.size() > 1) {
-        Location parent = new Location(p.metadataFile).getParentFile();
-        store.setImageName(parent.getName(), i);
+      if (p.name != null) {
+        store.setImageName(p.name, i);
+      } else {
+        if (positions.size() > 1) {
+          Location parent = new Location(p.metadataFile).getParentFile();
+          store.setImageName(parent.getName(), i);
+        }
       }
 
       if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
@@ -853,6 +857,9 @@ public class MicromanagerReader extends FormatReader {
           else if (key.startsWith("DAC-") && key.endsWith("-Volts")) {
             p.voltage.add(new Double(value));
           }
+          else if (key.equals("PositionName")) {
+            p.name = value;
+          }
           else if (key.equals("FileName")) {
             p.fileNameMap.put(new Index(slice), value);
             Location realFile = new Location(parent, value);
@@ -1100,6 +1107,7 @@ public class MicromanagerReader extends FormatReader {
 
     public String metadataFile;
     public String xmlFile;
+    public String name;
 
     public String[] channels;
 

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -857,7 +857,7 @@ public class MicromanagerReader extends FormatReader {
           else if (key.startsWith("DAC-") && key.endsWith("-Volts")) {
             p.voltage.add(new Double(value));
           }
-          else if (key.equals("PositionName")) {
+          else if (key.equals("PositionName") && !value.equals("null")) {
             p.name = value;
           }
           else if (key.equals("FileName")) {

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -1107,7 +1107,7 @@ public class MicromanagerReader extends FormatReader {
 
     public String metadataFile;
     public String xmlFile;
-    public String name;
+    public transient String name;
 
     public String[] channels;
 


### PR DESCRIPTION
See https://trello.com/c/5KT3Bvie/1-idr0040-aymoz-singlecell

Currently the Micro-Manager reader uses one of the TIFF filename for populating the ImageName metadata. For typical replica experiments across multiple positions (Pos0, Pos1,...), this results in duplicate image names. This commit now parses the PositionName key/value in the metadata JSON and use it if available to fill the ImageName.

This PR will probably affect the metadata of existing filesets, require a configuration change in which case it might  be more suitable for a minor release increment.

/cc @dominikl 