### PR TITLE
TIFF tile index fix

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -243,7 +243,7 @@ public class TiffWriter extends FormatWriter {
           synchronized (this) {
             // This operation is synchronized against the TIFF saver.
             synchronized (tiffSaver) {
-              index = prepareToWriteImage(tileNo++, tileBuf, ifd, tileParams.x, tileParams.y, tileParams.width, tileParams.height);
+              index = prepareToWriteImage(no, tileNo++, tileBuf, ifd, tileParams.x, tileParams.y, tileParams.width, tileParams.height);
               if (index == -1) {
                 return;
               }
@@ -260,7 +260,7 @@ public class TiffWriter extends FormatWriter {
       synchronized (this) {
         // This operation is synchronized against the TIFF saver.
         synchronized (tiffSaver) {
-          index = prepareToWriteImage(no, buf, ifd, x, y, w, h);
+          index = prepareToWriteImage(no, 0, buf, ifd, x, y, w, h);
           if (index == -1) {
             return;
           }
@@ -278,7 +278,7 @@ public class TiffWriter extends FormatWriter {
    * ensure thread safety.
    */
   protected int prepareToWriteImage(
-      int no, byte[] buf, IFD ifd, int x, int y, int w, int h)
+      int no, int tileno, byte[] buf, IFD ifd, int x, int y, int w, int h)
   throws IOException, FormatException {
     MetadataRetrieve retrieve = getMetadataRetrieve();
     boolean littleEndian = false;

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -227,7 +227,6 @@ public class TiffWriter extends FormatWriter {
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(currentTileSizeY));
     }
     if (currentTileSizeX < w || currentTileSizeY < h) {
-      int tileNo = no;
       int numTilesX = (w + (x % currentTileSizeX) + currentTileSizeX - 1) / currentTileSizeX;
       int numTilesY = (h + (y % currentTileSizeY) + currentTileSizeY - 1) / currentTileSizeY;
       for (int yTileIndex = 0; yTileIndex < numTilesY; yTileIndex++) {
@@ -243,7 +242,7 @@ public class TiffWriter extends FormatWriter {
           synchronized (this) {
             // This operation is synchronized against the TIFF saver.
             synchronized (tiffSaver) {
-              index = prepareToWriteImage(no, tileNo++, tileBuf, ifd, tileParams.x, tileParams.y, tileParams.width, tileParams.height);
+              index = prepareToWriteImage(no, tileBuf, ifd, tileParams.x, tileParams.y, tileParams.width, tileParams.height);
               if (index == -1) {
                 return;
               }
@@ -260,7 +259,7 @@ public class TiffWriter extends FormatWriter {
       synchronized (this) {
         // This operation is synchronized against the TIFF saver.
         synchronized (tiffSaver) {
-          index = prepareToWriteImage(no, 0, buf, ifd, x, y, w, h);
+          index = prepareToWriteImage(no, buf, ifd, x, y, w, h);
           if (index == -1) {
             return;
           }
@@ -278,7 +277,7 @@ public class TiffWriter extends FormatWriter {
    * ensure thread safety.
    */
   protected int prepareToWriteImage(
-      int no, int tileno, byte[] buf, IFD ifd, int x, int y, int w, int h)
+      int no, byte[] buf, IFD ifd, int x, int y, int w, int h)
   throws IOException, FormatException {
     MetadataRetrieve retrieve = getMetadataRetrieve();
     boolean littleEndian = false;
@@ -292,7 +291,7 @@ public class TiffWriter extends FormatWriter {
     // Ensure that no more than one thread manipulated the initialized array
     // at one time.
     synchronized (this) {
-      if (no < initialized[series].length && !initialized[series][no]) {
+      if (!initialized[series][no]) {
         initialized[series][no] = true;
 
         RandomAccessInputStream tmp = createInputStream();


### PR DESCRIPTION
[Trello](https://trello.com/c/jzajo8mX/226-tile-writing-logic-bug)

This change removes what appears to be an unused parameter.  `TiffWriter` has a `prepareToWriteImage` method which has a [plane] `no` parameter.  However, when writing a tiled image, this was being called with the `tileNo` [the tile number on a plane; actually the tile number within the area being written].  This inconsistent calling behaviour meant that `prepareToWriteImage` could not tell whether a plane number or a tile number had been passed.  Looking at the usage of `no` in this function, the `initialized[][]` array indexing looks broken when called with a tile number, because it's sized by the plane count for each series, and it looks like it will potentially misbehave when writing tiles--there's some logic to prevent an index out of bounds error, but it's misusing the array despite that.  `no` is also used for computing the return value.  The return value looks like it's unused; it's checked for equality to -1, but since I can't see any way that a negative value could ever be returned, this looks completely pointless as well.  Edit: since the returned number is the IFD index to pass to `TiffSaver.writeImage`, using a tile index is actively dangerous since it could potentially access the wrong IFD.

/cc @dgault 