### PR TITLE
NDPI: update Image names to be more meaningful when resolutions are not flattened

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -487,7 +487,22 @@ public class NDPIReader extends BaseTiffReader {
     }
 
     for (int i=0; i<getSeriesCount(); i++) {
-      store.setImageName("Series " + (i + 1), i);
+      if (hasFlattenedResolutions() || i > 2) {
+        store.setImageName("Series " + (i + 1), i);
+      }
+      else {
+        switch (i) {
+          case 0:
+            store.setImageName("", i);
+            break;
+          case 1:
+            store.setImageName("macro image", i);
+            break;
+          case 2:
+            store.setImageName("macro mask image", i);
+            break;
+        }
+      }
 
       store.setImageInstrumentRef(instrumentID, i);
       store.setObjectiveSettingsID(objectiveID, i);


### PR DESCRIPTION
Backported from a private PR.

Assumes that the first Image after the pyramid is the macro, and the second (if present) is the macro ROI.  As the commit message suggests, there is a separate private PR with similar changes for SVS and AFI, but I don't plan to backport this until 5.9.0 as it contains other changes which will break memo files.  The Zeiss CZI and CellSens readers on develop use a similar approach to image name population as is used here.

To test, verify that repository builds pass to confirm that image names remain unchanged when resolutions are unflattened.  Also spot check a few .ndpi files from ```data_repo/curated/hamamatsu``` with ```showinf -nopix -noflat -omexml``` to see that the pyramid has a blank image name, and the two extra images are named ```macro image``` and ```macro mask image```.  This will primarily impact naming upon import into OMERO, as most other applications use flattened resolutions (at least by default).

If desired, an extra commit could be added to change the names independent of the resolution flattening, but this will require a configuration change for each existing .ndpi file.