### PR TITLE
InCell 2000/6000 well and field indexing improvements

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -566,7 +566,7 @@ public class InCellReader extends FormatReader {
       }
 
       int well = getWellFromSeries(i);
-      int field = getFieldFromSeries(i) + 1;
+      int field = getFieldFromSeries(i);
       int totalTimepoints =
         oneTimepointPerSeries ? channelsPerTimepoint.size() : 1;
       int timepoint = oneTimepointPerSeries ? (i % totalTimepoints) + 1 : -1;
@@ -594,7 +594,7 @@ public class InCellReader extends FormatReader {
       }
       else col += (char) (colChar + wellCol);
 
-      String imageName = "Well " + row + "-" + col + ", Field #" + field;
+      String imageName = "Well " + row + "-" + col + ", Field #" + (field + 1);
       if (timepoint >= 0) {
         imageName += ", Timepoint #" + timepoint;
       }
@@ -606,7 +606,7 @@ public class InCellReader extends FormatReader {
 
       timepoint--;
       if (timepoint < 0) timepoint = 0;
-      int sampleIndex = (field - 1) * totalTimepoints + timepoint;
+      int sampleIndex = field * totalTimepoints + timepoint;
 
       String wellSampleID =
         MetadataTools.createLSID("WellSample", 0, well, sampleIndex);

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -604,7 +604,7 @@ public class InCellReader extends FormatReader {
 
       int wellRow = well / wellCols;
       int wellCol = well % wellCols;
-      wellIndex = i / fieldCount;
+      wellIndex = i / (fieldCount * totalTimepoints);
 
       if (well != prevWell) {
         String wellID = MetadataTools.createLSID("Well", 0, wellIndex);
@@ -644,15 +644,15 @@ public class InCellReader extends FormatReader {
       int sampleIndex = field * totalTimepoints + timepoint;
 
       String wellSampleID =
-        MetadataTools.createLSID("WellSample", 0, well, sampleIndex);
+        MetadataTools.createLSID("WellSample", 0, wellIndex, sampleIndex);
       store.setWellSampleID(wellSampleID, 0, wellIndex, sampleIndex);
       store.setWellSampleIndex(new NonNegativeInteger(i), 0, wellIndex, sampleIndex);
       store.setWellSampleImageRef(imageID, 0, wellIndex, sampleIndex);
-      if (posX.containsKey(field - 1)) {
-        store.setWellSamplePositionX(posX.get(field - 1), 0, wellIndex, sampleIndex);
+      if (posX.containsKey(field)) {
+        store.setWellSamplePositionX(posX.get(field), 0, wellIndex, sampleIndex);
       }
-      if (posY.containsKey(field - 1)) {
-        store.setWellSamplePositionY(posY.get(field - 1), 0, wellIndex, sampleIndex);
+      if (posY.containsKey(field)) {
+        store.setWellSamplePositionY(posY.get(field), 0, wellIndex, sampleIndex);
       }
 
       store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, i);

--- a/components/formats-gpl/src/loci/formats/in/InCellReader.java
+++ b/components/formats-gpl/src/loci/formats/in/InCellReader.java
@@ -520,16 +520,8 @@ public class InCellReader extends FormatReader {
     store.setPlateName(plateName, 0);
     store.setPlateRowNamingConvention(getNamingConvention(rowNaming), 0);
     store.setPlateColumnNamingConvention(getNamingConvention(colNaming), 0);
-
-    for (int r=0; r<wellRows; r++) {
-      for (int c=0; c<wellCols; c++) {
-        int well = r * wellCols + c;
-        String wellID = MetadataTools.createLSID("Well", 0, well);
-        store.setWellID(wellID, 0, well);
-        store.setWellRow(new NonNegativeInteger(r), 0, well);
-        store.setWellColumn(new NonNegativeInteger(c), 0, well);
-      }
-    }
+    store.setPlateRows(new PositiveInteger(wellRows), 0);
+    store.setPlateColumns(new PositiveInteger(wellCols), 0);
 
     String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, 0);
     store.setPlateAcquisitionID(plateAcqID, 0, 0);
@@ -552,6 +544,7 @@ public class InCellReader extends FormatReader {
     String detectorID = MetadataTools.createLSID("Detector", 0, 0);
     store.setDetectorID(detectorID, 0, 0);
 
+    int prevWell = -1;
     for (int i=0; i<seriesCount; i++) {
       store.setObjectiveSettingsID(objectiveID, i);
 
@@ -578,6 +571,14 @@ public class InCellReader extends FormatReader {
 
       int wellRow = well / wellCols;
       int wellCol = well % wellCols;
+
+      if (well != prevWell) {
+        String wellID = MetadataTools.createLSID("Well", 0, well);
+        store.setWellID(wellID, 0, well);
+        store.setWellRow(new NonNegativeInteger(wellRow), 0, well);
+        store.setWellColumn(new NonNegativeInteger(wellCol), 0, well);
+        prevWell = well;
+      }
 
       char rowChar = rowName.charAt(rowName.length() - 1);
       char colChar = colName.charAt(colName.length() - 1);


### PR DESCRIPTION
87f5c29, a06013d, and 6b9cea3 backported from two private PRs.  59d5d4f is a new commit to reconcile divergences between develop and private PRs, so that tests continue to pass.

To test, use the new ```data_repo/curated/incell/samples/test.xdce```.  Without this PR, ```showinf -omexml -nopix``` should result in an ```IllegalArgumentException``` indicating that the series count is 0.  With this PR, the same test should show 11 series represented as 4 fields for well C2, 4 fields for well C3 and 3 fields for well C4 (the middle field being blank as no TIFF file is present).  The OME-XML should not contain any ```Well``` elements that do not have a ```WellSample```, and the well row and column counts should be present on ```Plate```.

Spot checking a few of the series with ```showinf -series``` should result in images with the 1-based field index in the upper-left corner (as noted in the readme).  Each series should have a single plane, despite multiple timepoints being defined in the .xdce.

Tests should continue to pass without additional configuration (apart from the new ```test.xdce```).  I think this would be safe for a patch release, but have not explicitly tested memo files.
