### PR TITLE
AVI: fix padding for RGB images

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -195,7 +195,7 @@ public class AVIReader extends FormatReader {
     }
 
     long fileOff = offsets.get(no).longValue();
-    long end = no < offsets.size() - 1 ? offsets.get(no + 1) : in.length();
+    long end = no < offsets.size() - 1 ? offsets.get(no + 1) : fileOff + lengths.get(no);
     long maxBytes = end - fileOff;
     in.seek(fileOff);
 

--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -233,6 +233,10 @@ public class AVIReader extends FormatReader {
     int pad = (bmpScanLineSize / getRGBChannelCount()) - getSizeX() * bytes;
     int scanline = w * bytes * (isInterleaved() ? getRGBChannelCount() : 1);
 
+    if (bmpBitsPerPixel > 8 && pad == getRGBChannelCount()) {
+      pad = bytes;
+    }
+
     in.skipBytes((getSizeX() + pad) * (bmpBitsPerPixel / 8) * (getSizeY() - h - y));
 
     if (getSizeX() == w && pad == 0) {


### PR DESCRIPTION
d5fce6a backported from a private PR; 1feb70c added to fix issues with the last plane of the new test file.

To test, use the new ```data_repo/curated/avi/sample-avis/rgb-odd-width/HyperStack.avi```.  As noted in the readme, this is generated by ImageJ and each plane should contain its own 4 digit 1-based index.  Without this PR, ```showinf HyperStack.avi``` should result in each plane being skewed.  With this PR, the same test should show all 4 planes correctly aligned.

The impact of d5fce6a can be assessed from existing tests, but as 1feb70c affects the last plane it would be a good idea to check the last plane of at least a few existing AVIs (RGB or otherwise).  Assuming tests pass, I would expect this to be safe for a patch release.