### PR TITLE
Plugin: Update the button layout for series options window

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/SeriesDialog.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/SeriesDialog.java
@@ -273,9 +273,8 @@ public class SeriesDialog extends ImporterDialog implements ActionListener {
     buttons.add(select);
     buttons.add(deselect);
 
-    gbc.gridx = 2;
     gbc.gridy = buttonRow;
-    gbc.anchor = GridBagConstraints.EAST;
+    gbc.anchor = GridBagConstraints.WEST;
     gbc.insets = new Insets(15, 0, 0, 0);
     gdl.setConstraints(buttons, gbc);
     gd.add(buttons);


### PR DESCRIPTION
This PR is in response to an issue raised in http://forum.imagej.net/t/missing-ok-and-cancel-buttons-on-bioformats-importer-dialog-box/9822/2

Further details can be seen in https://trello.com/c/fLfam2fx/17-plugin-missing-ok-and-cancel-buttons-on-series-options