### PR TITLE
TiffParser: Don't add SUBIFDS to main IFD list

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -229,14 +229,6 @@ public class TiffParser {
         subOffsets = ifd.getIFDLongArray(IFD.SUB_IFD);
       }
       catch (FormatException e) { }
-      if (subOffsets != null) {
-        for (long subOffset : subOffsets) {
-          IFD sub = getIFD(subOffset);
-          if (sub != null) {
-            ifds.add(sub);
-          }
-        }
-      }
     }
     if (doCaching) ifdList = ifds;
 


### PR DESCRIPTION
This is a test to determine which readers are reliant upon this behaviour, so that we can parse images with SUBIFDS without this behaviour.