### PR TITLE
Have Memoizer.getMemoFile use an isWritableDirectory helper.

### DIFF
--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -755,7 +755,7 @@ public class Memoizer extends ReaderWrapper {
     return service;
   }
   protected Slf4JStopWatch stopWatch() {
-      return new Slf4JStopWatch(LOGGER, Slf4JStopWatch.DEBUG_LEVEL);
+    return new Slf4JStopWatch(LOGGER, Slf4JStopWatch.DEBUG_LEVEL);
   }
 
   /**
@@ -816,7 +816,7 @@ public class Memoizer extends ReaderWrapper {
    * @return if the given {@link File} is indeed a writable directory
    */
   protected boolean isWritableDirectory(File writeDirectory) {
-      return writeDirectory.canWrite() && writeDirectory.isDirectory();
+    return writeDirectory.canWrite() && writeDirectory.isDirectory();
   }
 
   /**

--- a/components/formats-bsd/src/loci/formats/Memoizer.java
+++ b/components/formats-bsd/src/loci/formats/Memoizer.java
@@ -797,7 +797,7 @@ public class Memoizer extends ReaderWrapper {
 
       // Check either the in-place folder or the main memoizer directory
       // exists and is writeable
-      if (!writeDirectory.exists() || !writeDirectory.canWrite()) {
+      if (!isWritableDirectory(writeDirectory)) {
         LOGGER.warn("skipping memo: directory not writeable - {}",
           writeDirectory);
         return null;
@@ -808,6 +808,15 @@ public class Memoizer extends ReaderWrapper {
     String p = f.getParent();
     String n = f.getName();
     return new File(p, "." + n + ".bfmemo");
+  }
+
+  /**
+   * Test if the given {@link File} instance is a writable directory.
+   * @param writeDirectory a possible writable directory
+   * @return if the given {@link File} is indeed a writable directory
+   */
+  protected boolean isWritableDirectory(File writeDirectory) {
+      return writeDirectory.canWrite() && writeDirectory.isDirectory();
   }
 
   /**


### PR DESCRIPTION
Introduces an overridable method that can be used to work around https://trello.com/c/q5L39XPZ/5-bioformatscache-is-expecting-read-write until Memoizer officially supports read-only access to its memos. Should not change Memoizer's behavior in any material way.

Currently open only for comment, **not for merging**.