### PR TITLE
Flex: fix incorrect field count for ticket 13238

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -973,6 +973,10 @@ public class FlexReader extends FormatReader {
 
     ms0.imageCount = getSizeZ() * getSizeC() * getSizeT();
 
+    if (getImageCount() == imageNames.size()) {
+      fieldCount = 1;
+    }
+
     // if the calculated image count is the same as the number of planes
     // in the file, then we can assume one field per file
     // otherwise assume that fields are stored within the files


### PR DESCRIPTION
See https://trac.openmicroscopy.org/ome/ticket/13238

To test, use the file from QA 17190.  Without this PR, ```showinf 002002011.flex``` should show 3 series as indicated in the original comment on QA.  With this PR, the same test should show a single series with 3 channels.

I would expect builds to pass with no configuration changes apart from adding QA 17190.  This should be safe for a patch release, but is not especially urgent as the original ticket is nearly 2 years old.