### PR TITLE
Zeiss CZI: fix handling of files with no extension

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -583,7 +583,8 @@ public class ZeissCZIReader extends FormatReader {
     parser = XMLTools.createBuilder();
 
     // switch to the master file if this is part of a multi-file dataset
-    String base = id.substring(0, id.lastIndexOf("."));
+    int lastDot = id.lastIndexOf(".");
+    String base = lastDot < 0 ? id : id.substring(0, lastDot);
     if (base.endsWith(")") && isGroupFiles()) {
       LOGGER.info("Checking for master file");
       int lastFileSeparator = base.lastIndexOf(File.separator);
@@ -625,7 +626,10 @@ public class ZeissCZIReader extends FormatReader {
 
     Location file = new Location(id).getAbsoluteFile();
     base = file.getName();
-    base = base.substring(0, base.lastIndexOf("."));
+    lastDot = base.lastIndexOf(".");
+    if (lastDot >= 0) {
+      base = base.substring(0, lastDot);
+    }
 
     Location parent = file.getParentFile();
     String[] list = parent.list(true);


### PR DESCRIPTION
See https://trello.com/c/m7LqcpdM/167-czi-reader-fails-when-the-extension-is-missing and #2916.

As noted in the card and original PR, use an existing .czi file from ```data_repo/curated/zeiss-czi/``` to test.  I used ```data_repo/curated/zeiss-czi/aaron/101post.czi```, but you may wish to use something different.  Copy the file to a different directory and remove the extension. e.g.:

```
$ cp data_repo/curated/zeiss-czi/aaron/101post.czi ~/101post
```

Without this PR, ```showinf ~/101post``` should throw ```StringIndexOutOfBoundsException``` as noted in the original bug report: https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8336

With this PR, the same test should result in successful initialization and images being displayed.  Apart from file names, there should be no difference between ```showinf ~/101post``` and ```showinf data_repo/curated/zeiss-czi/aaron/101post.czi```.

Tests should continue to pass without any configuration change, and I would expect this to be safe for a patch release.