### PR TITLE
ImageReader: log an ERROR-level message when finding a reader for an empty file

### DIFF
--- a/components/formats-api/src/loci/formats/ImageReader.java
+++ b/components/formats-api/src/loci/formats/ImageReader.java
@@ -175,6 +175,9 @@ public class ImageReader implements IFormatReader {
    // e.g., for files, this will throw an exception if the file is missing.
    if (!fake && !omero) {
      Location.checkValidId(id);
+     if (new Location(id).length() == 0) {
+       LOGGER.error("File has length 0 and may be corrupt");
+     }
    }
 
     if (!id.equals(currentId)) {


### PR DESCRIPTION
This won't prevent initialization from being attempted, but alerts the user that the file may be corrupt before any calls to isThisType(...).  Fake files and files initialized via a specific format reader
(e.g. TiffDelegateReader) will not show this message.

See https://trello.com/c/AjjsuGr3/54-change-error-msg-for-empty-file

An exception could be thrown instead of logging at ```ERROR```, but I decided to start with the lower impact option, minimally so that this is sure to be safe for a patch release.

To test, use the steps noted in the card:

```
$ touch empty.tif
$ showinf -nopix -debug empty.tif
```

Without this PR, a ```FormatException``` is logged and ```MissingLibraryException``` is thrown without any immediate indication that the file is empty.  The output suggests that installing JAI will allow the file to be read.  With this PR, the same exceptions are logged and thrown, but there should be an ```ERROR```-level message indicating that the file is empty.

Fake files should be unaffected; with this PR ```touch empty.fake && showinf -nopix empty.fake``` should not display the empty file message.