### PR TITLE
Prevent NPE in Bio-Formats ImageJ macro extensions

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
+++ b/components/bio-formats-plugins/src/loci/plugins/macro/LociFunctions.java
@@ -467,7 +467,10 @@ public class LociFunctions extends MacroFunctions {
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
     Double val = null;
     if (planeIndex >= 0) {
-      val = retrieve.getPlaneExposureTime(imageIndex, planeIndex).value(UNITS.SECOND).doubleValue();
+      Time valTime = retrieve.getPlaneExposureTime(imageIndex, planeIndex);
+      if (valTime != null) {
+        val = valTime.value(UNITS.SECOND).doubleValue();
+      }
     }
     exposureTime[0] = val == null ? new Double(Double.NaN) : val;
   }


### PR DESCRIPTION
See http://forum.imagej.net/t/macro-error-when-using-planetimings-txt-from-bioformats/10080/ for a description of the issue

## Changes

This commit adds a null check for the retrieved exposure time before trying to retrieve the value in seconds in the `Ext.getPlaneTimingExposureTime` macro extension like other `Time` and `Length` quantities retrieved by this API.

## Testing

Running the script provided in the [ImageJ forum post](http://forum.imagej.net/t/macro-error-when-using-planetimings-txt-from-bioformats/10080) above should fail with the current version of Bio-Formats (5.8.1) when using an image with `Plane` elements but no `Plane.ExposureTime` e.g. https://downloads.openmicroscopy.org/images/DICOM/samples/CR-MONO1-10-chest.dcm 
With this PR included, the macro should execute successfully.
