### PR TITLE
test-suite: Add testng.allow-missing property

### DIFF
--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -110,6 +110,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -139,6 +140,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -172,6 +174,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -203,6 +206,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -233,6 +237,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -263,6 +268,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
@@ -293,6 +299,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.omexmlDirectory" value="${testng.omexmlDirectory}"/>
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -268,32 +268,31 @@ public class FormatReaderTestFactory {
 
     // create test class instances
     System.out.println("Building list of tests...");
-    Object[] tests = new Object[files.size()];
-    for (int i=0; i<tests.length; i++) {
-      String id = (String) files.get(i);
+    List<Object> tests = new ArrayList<>();
+    for (String id : files) {
       try {
         boolean found = true;
         if (FormatReaderTest.configTree.get(id) == null) {
           found = false;
           if (allowMissing) {
-            LOGGER.warn("{} not configured.", id);
+            LOGGER.warn("{} not configured (skipping).", id);
           }
           else {
             LOGGER.error("{} not configured.", id);
           }
         }
         if (found || !allowMissing) {
-          tests[i] = new FormatReaderTest(id, multiplier, inMemory);
+          tests.add(new FormatReaderTest(id, multiplier, inMemory));
         }
       }
       catch (Exception e) {
         LOGGER.warn("", e);
       }
     }
-    if (tests.length == 1) System.out.println("Ready to test " + files.get(0));
-    else System.out.println("Ready to test " + tests.length + " files");
+    if (tests.size() == 1) System.out.println("Ready to test " + files.get(0));
+    else System.out.println("Ready to test " + tests.size() + " files");
 
-    return tests;
+    return tests.toArray(new Object[tests.size()]);
   }
 
 }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -252,14 +252,34 @@ public class FormatReaderTestFactory {
       }
     }
     if (!failingIds.isEmpty()) {
-      String msg = String.format("setId failed on %s", failingIds);
       if (!allowMissing) {
+        String msg = String.format("setId failed on %s", failingIds);
         LOGGER.error(msg);
         throw new RuntimeException(msg);
       }
       else {
-       msg += " (skipping)";
-       LOGGER.warn(msg);
+        for (String id : failingIds) {
+          boolean found = false;
+          try {
+            if (FormatReaderTest.configTree.get(id) != null) {
+              found = true;
+              }
+            }
+          catch (Exception e) {
+            LOGGER.warn("", e);
+          }
+          if (found) {
+            // setId failed and configuration present
+            String msg = String.format("setId failed on %s", id);
+            LOGGER.error(msg);
+            throw new RuntimeException(msg);
+          }
+          else {
+            // setId failed and configuration missing
+            String msg = String.format("setId failed on %s (skipping)", id);
+            LOGGER.warn(msg);
+          }
+        }
       }
     }
     files = new ArrayList<String>();

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -162,6 +162,12 @@ public class FormatReaderTestFactory {
       configSuffix = "";
     }
 
+    // detect whether or not to ignore missing configuration
+    final String allowMissingProp = "testng.allow-missing";
+    String allowMissingValue = getProperty(allowMissingProp);
+    boolean allowMissing = Boolean.parseBoolean(allowMissingValue);
+    LOGGER.info("testng.allow-missing = {}", allowMissing);
+
     // display local information
     LOGGER.info("user.language = {}", System.getProperty("user.language"));
     LOGGER.info("user.country = {}", System.getProperty("user.country"));
@@ -266,14 +272,23 @@ public class FormatReaderTestFactory {
     for (int i=0; i<tests.length; i++) {
       String id = (String) files.get(i);
       try {
+        boolean found = true;
         if (FormatReaderTest.configTree.get(id) == null) {
-          LOGGER.error("{} not configured.", id);
+          found = false;
+          if (allowMissing) {
+            LOGGER.warn("{} not configured.", id);
+          }
+          else {
+            LOGGER.error("{} not configured.", id);
+          }
+        }
+        if (found || !allowMissing) {
+          tests[i] = new FormatReaderTest(id, multiplier, inMemory);
         }
       }
       catch (Exception e) {
         LOGGER.warn("", e);
       }
-      tests[i] = new FormatReaderTest(id, multiplier, inMemory);
     }
     if (tests.length == 1) System.out.println("Ready to test " + files.get(0));
     else System.out.println("Ready to test " + tests.length + " files");

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -253,8 +253,14 @@ public class FormatReaderTestFactory {
     }
     if (!failingIds.isEmpty()) {
       String msg = String.format("setId failed on %s", failingIds);
-      LOGGER.error(msg);
-      throw new RuntimeException(msg);
+      if (!allowMissing) {
+        LOGGER.error(msg);
+        throw new RuntimeException(msg);
+      }
+      else {
+       msg += " (skipping)";
+       LOGGER.warn(msg);
+      }
     }
     files = new ArrayList<String>();
     for (String s: minimalFiles) {


### PR DESCRIPTION
This allows unconfigured files to be skipped, which previously caused the build to fail; now it ignores these files and succeeds.

Sample output for cellomics from https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-test-folder/6667/console (from https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-test-repo/49/flowGraphTable/), which was previously failing:

```
[testng] [2018-04-05 22:28:34,319] [main] testng.allow-missing = true
...
[testng] [2018-04-05 22:28:53,117] [main] /data/samples/different-field-count/plate_B03f00d0.C01 not configured (skipping).
   [testng] [2018-04-05 22:28:53,118] [main] /data/samples/different-field-count/plate_C03f00d0.C01 not configured (skipping).
   [testng] [2018-04-05 22:28:53,118] [main] /data/samples/different-field-count/plate_C03f01d0.C01 not configured (skipping).
```

i.e. the unconfigured files are being deliberately ignored due to settings testng.allow-missing=true which can also be seen in the log.

Testing: check test-repo job is green.