### PR TITLE
switch modifier order to "static final" in readers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellH5Reader.java
@@ -54,20 +54,20 @@ public class CellH5Reader extends FormatReader {
   public static final String HDF_MAGIC_STRING = "HDF";
 
   public class CellH5Constants {
-      public final static String PREFIX_PATH = "/sample/0/";
-      public final static String IMAGE_PATH = "image/channel/";
-      public final static String SEGMENTATION_PATH = "image/region/";
+      public static final String PREFIX_PATH = "/sample/0/";
+      public static final String IMAGE_PATH = "image/channel/";
+      public static final String SEGMENTATION_PATH = "image/region/";
 
-      public final static String PLATE = "plate/";
-      public final static String WELL = "/experiment/";
-      public final static String SITE = "/position/";
-      public final static String DEFINITION = "/definition/";
-      public final static String OBJECT = "object/";
-      public final static String FEATURE = "feature/";
-      public final static String IMAGE = "image/";
-      public final static String BBOX = "bounding_box/";
-      public final static String CLASS_LABELS = "object_classification/class_labels/";
-      public final static String PREDICTED_CLASS_LABELS = "object_classification/prediction";
+      public static final String PLATE = "plate/";
+      public static final String WELL = "/experiment/";
+      public static final String SITE = "/position/";
+      public static final String DEFINITION = "/definition/";
+      public static final String OBJECT = "object/";
+      public static final String FEATURE = "feature/";
+      public static final String IMAGE = "image/";
+      public static final String BBOX = "bounding_box/";
+      public static final String CLASS_LABELS = "object_classification/class_labels/";
+      public static final String PREDICTED_CLASS_LABELS = "object_classification/prediction";
   }
 
   public class CellH5Coordinate {

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -60,8 +60,8 @@ public class NDPISReader extends FormatReader {
   private String[] ndpiFiles;
   private ChannelSeparator[] readers;
   private int[] bandUsed;
-  private final static int TAG_CHANNEL = 65434;
-  private final static int TAG_EMISSION_WAVELENGTH = 65451;
+  private static final int TAG_CHANNEL = 65434;
+  private static final int TAG_EMISSION_WAVELENGTH = 65451;
 
   // -- Constructor --
 


### PR DESCRIPTION
Matches Oracle's recommendations and convention. Should not change behavior at all.