### PR TITLE
Zeiss CZI: fix big image edge case when tiling is present but a pyramid is not

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -890,7 +890,7 @@ public class ZeissCZIReader extends FormatReader {
         plane.pixelTypeIndex = pixelTypes.indexOf(plane.directoryEntry.pixelType);
       }
 
-      if (seriesCount * pixelTypes.size() > 1) {
+      if (core.size() * pixelTypes.size() > 1) {
         core.clear();
         for (int j=0; j<pixelTypes.size(); j++) {
           for (int i=0; i<seriesCount; i++) {
@@ -906,6 +906,14 @@ public class ZeissCZIReader extends FormatReader {
           }
         }
       }
+    }
+
+    // usually this indicates a big image for which a pyramid is
+    // expected but not present
+    if ((prestitched != null && prestitched) &&
+      seriesCount == mosaics && maxResolution == 0)
+    {
+      seriesCount = 1;
     }
 
     if (seriesCount > 1 || maxResolution > 0) {
@@ -924,7 +932,7 @@ public class ZeissCZIReader extends FormatReader {
 
     assignPlaneIndices();
 
-    if (maxResolution > 0) {
+    if (maxResolution > 0 || (mosaics > 1 && seriesCount == 1)) {
       tileWidth = new int[core.size()];
       tileHeight = new int[core.size()];
       for (int s=0; s<core.size();) {


### PR DESCRIPTION
See https://trello.com/c/3AHJeUPc/236-czi-compressed-pyramidal-error

To test, use the file from QA 20612.  Without this PR, opening the file using ImageJ or ```showinf``` will result in 14 series, most of which look corrupted (as noted on the card).

With this PR, ImageJ or ```showinf``` should report 3 series - one full resolution image, one label, and one macro/overview.  There is no stored pyramid, so there should be no subresolutions detected.  The image dimensions and pixel data should match what is shown in ZEN.

Builds should remain green with this change.  This should be safe for a patch release, so is low priority for 5.9.0 as it could be deferred to 5.9.1.