### PR TITLE
Remove implicit SUBIFD flattening in TiffParser

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -387,7 +387,6 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
       resolutionLevels = null;
       j2kCodecOptions = null;
       seriesToIFD = false;
-      mergeSubIFDs = false;
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -94,6 +94,8 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
 
   protected boolean seriesToIFD = false;
 
+  protected boolean mergeSubIFDs = false;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -384,6 +386,7 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
       resolutionLevels = null;
       j2kCodecOptions = null;
       seriesToIFD = false;
+      mergeSubIFDs = false;
     }
   }
 
@@ -445,7 +448,19 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
 
     LOGGER.info("Reading IFDs");
 
-    IFDList allIFDs = tiffParser.getIFDs();
+    IFDList allIFDs = null;
+    if (!mergeSubIFDs) {
+      allIFDs = tiffParser.getIFDs();
+    }
+    else {
+      allIFDs = new IFDList();
+      for (IFD ifd : tiffParser.getIFDs()) {
+        allIFDs.add(ifd);
+        for (IFD subifd : tiffParser.getSubIFDs(ifd)) {
+          allIFDs.add(subifd);
+        }
+      }
+    }
 
     if (allIFDs == null || allIFDs.size() == 0) {
       throw new FormatException("No IFDs found");

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -94,6 +94,7 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
 
   protected boolean seriesToIFD = false;
 
+  /** Merge SubIFDs into the main IFD list. */
   protected boolean mergeSubIFDs = false;
 
   /** Number of JPEG 2000 resolution levels. */

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -229,14 +229,6 @@ public class TiffParser {
         subOffsets = ifd.getIFDLongArray(IFD.SUB_IFD);
       }
       catch (FormatException e) { }
-      if (subOffsets != null) {
-        for (long subOffset : subOffsets) {
-          IFD sub = getIFD(subOffset);
-          if (sub != null) {
-            ifds.add(sub);
-          }
-        }
-      }
     }
     if (doCaching) ifdList = ifds;
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1284,4 +1284,22 @@ public class TiffParser {
     return new TiffIFDEntry(entryTag, entryType, valueCount, offset);
   }
 
+  public IFDList getSubIFDs(IFD ifd) throws IOException {
+    IFDList list = new IFDList();
+    long[] offsets = null;
+    try {
+      fillInIFD(ifd);
+      offsets = ifd.getIFDLongArray(IFD.SUB_IFD);
+    } catch (FormatException e) {
+    }
+
+    if (offsets != null) {
+      for (long offset : offsets) {
+        list.add(getIFD(offset));
+      }
+    }
+
+    return list;
+  }
+
 }

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -83,6 +83,7 @@ public class DNGReader extends BaseTiffReader {
       new String[] {"cr2", "crw", "jpg", "thm", "wav", "tif", "tiff"});
     suffixSufficient = false;
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
+    mergeSubIFDs = true;
   }
 
   // -- IFormatReader API methods --
@@ -338,8 +339,6 @@ public class DNGReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
-    mergeSubIFDs = true;
-
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -338,6 +338,8 @@ public class DNGReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    mergeSubIFDs = true;
+
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -437,6 +437,8 @@ public class NikonReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    mergeSubIFDs = true;
+
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -116,6 +116,7 @@ public class NikonReader extends BaseTiffReader {
     super("Nikon NEF", new String[] {"nef", "tif", "tiff"});
     suffixSufficient = false;
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
+    mergeSubIFDs = true;
   }
 
   // -- IFormatReader API methods --
@@ -437,8 +438,6 @@ public class NikonReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
-    mergeSubIFDs = true;
-
     super.initFile(id);
 
     original = ifds.get(0);


### PR DESCRIPTION
In order to support the use of sub-resolutions as intended, remove merging of SubIFDs into the main IFD list by default, by making it a configurable option in MinimalTiffReader as for other options.  This is required by the Canon DNG and Nikon TIFF readers only.

Testing: check all builds are green, including the full repo test.