### PR TITLE
OMETiffReader extends SubResolutionFormatReader

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -94,6 +94,8 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
 
   protected boolean seriesToIFD = false;
 
+  protected boolean mergeSubIFDs = false;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -384,6 +386,7 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
       resolutionLevels = null;
       j2kCodecOptions = null;
       seriesToIFD = false;
+      mergeSubIFDs = false;
     }
   }
 
@@ -445,7 +448,19 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
 
     LOGGER.info("Reading IFDs");
 
-    IFDList allIFDs = tiffParser.getIFDs();
+    IFDList allIFDs = null;
+    if (!mergeSubIFDs) {
+      allIFDs = tiffParser.getIFDs();
+    }
+    else {
+      allIFDs = new IFDList();
+      for (IFD ifd : tiffParser.getIFDs()) {
+        allIFDs.add(ifd);
+        for (IFD subifd : tiffParser.getSubIFDs(ifd)) {
+          allIFDs.add(subifd);
+        }
+      }
+    }
 
     if (allIFDs == null || allIFDs.size() == 0) {
       throw new FormatException("No IFDs found");

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -456,9 +456,7 @@ public class MinimalTiffReader extends SubResolutionFormatReader {
       allIFDs = new IFDList();
       for (IFD ifd : tiffParser.getIFDs()) {
         allIFDs.add(ifd);
-        for (IFD subifd : tiffParser.getSubIFDs(ifd)) {
-          allIFDs.add(subifd);
-        }
+        allIFDs.addAll(tiffParser.getSubIFDs(ifd));
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -184,9 +184,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
       } catch (ServiceException se) {
         LOGGER.debug("OME-XML parsing failed", se);
         return false;
-      } catch (IOException e) {
-        return false;
-      } catch (NullPointerException e) {
+      } catch (IOException | NullPointerException e) {
         return false;
       }
     }
@@ -255,17 +253,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
       }
       return meta.getImageCount() > 0;
     }
-    catch (ServiceException se) {
+    catch (ServiceException | NullPointerException | FormatException | IndexOutOfBoundsException se) {
       LOGGER.debug("OME-XML parsing failed", se);
-    }
-    catch (NullPointerException e) {
-      LOGGER.debug("OME-XML parsing failed", e);
-    }
-    catch (FormatException e) {
-      LOGGER.debug("OME-XML parsing failed", e);
-    }
-    catch (IndexOutOfBoundsException e) {
-      LOGGER.debug("OME-XML parsing failed", e);
     }
     return false;
   }
@@ -393,10 +382,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
       boolean single = isSingleFile(id);
       return single ? FormatTools.CAN_GROUP : FormatTools.MUST_GROUP;
     }
-    catch (FormatException e) {
-      LOGGER.debug("", e);
-    }
-    catch (IOException e) {
+    catch (FormatException | IOException e) {
       LOGGER.debug("", e);
     }
     return FormatTools.CAN_GROUP;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -513,7 +513,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
     hasSPW = meta.getPlateCount() > 0;
 
     for (int i=0; i<meta.getImageCount(); i++) {
-      int sizeC = meta.getPixelsSizeC(i).getValue().intValue();
+      int sizeC = meta.getPixelsSizeC(i).getValue();
       service.removeChannels(meta, i, sizeC);
     }
 
@@ -810,16 +810,16 @@ public class OMETiffReader extends SubResolutionFormatReader {
         adjustedSamples = false;
       }
 
-      int effSizeC = meta.getPixelsSizeC(i).getValue().intValue();
+      int effSizeC = meta.getPixelsSizeC(i).getValue();
       if (!adjustedSamples) {
         effSizeC /= samples;
       }
       if (effSizeC == 0) effSizeC = 1;
-      if (effSizeC * samples != meta.getPixelsSizeC(i).getValue().intValue()) {
-        effSizeC = meta.getPixelsSizeC(i).getValue().intValue();
+      if (effSizeC * samples != meta.getPixelsSizeC(i).getValue()) {
+        effSizeC = meta.getPixelsSizeC(i).getValue();
       }
-      int sizeT = meta.getPixelsSizeT(i).getValue().intValue();
-      int sizeZ = meta.getPixelsSizeZ(i).getValue().intValue();
+      int sizeT = meta.getPixelsSizeT(i).getValue();
+      int sizeZ = meta.getPixelsSizeZ(i).getValue();
       int num = effSizeC * sizeT * sizeZ;
 
       OMETiffPlane[] planes = new OMETiffPlane[num];
@@ -1035,21 +1035,21 @@ public class OMETiffReader extends SubResolutionFormatReader {
         tileWidth[s] = info[s][0].reader.getOptimalTileWidth();
         tileHeight[s] = info[s][0].reader.getOptimalTileHeight();
 
-        m.sizeX = meta.getPixelsSizeX(i).getValue().intValue();
+        m.sizeX = meta.getPixelsSizeX(i).getValue();
         int tiffWidth = (int) firstIFD.getImageWidth();
         if (m.sizeX != tiffWidth && s == 0) {
           LOGGER.warn("SizeX mismatch: OME={}, TIFF={}",
             m.sizeX, tiffWidth);
         }
-        m.sizeY = meta.getPixelsSizeY(i).getValue().intValue();
+        m.sizeY = meta.getPixelsSizeY(i).getValue();
         int tiffHeight = (int) firstIFD.getImageLength();
         if (m.sizeY != tiffHeight && s ==  0) {
           LOGGER.warn("SizeY mismatch: OME={}, TIFF={}",
             m.sizeY, tiffHeight);
         }
-        m.sizeZ = meta.getPixelsSizeZ(i).getValue().intValue();
-        m.sizeC = meta.getPixelsSizeC(i).getValue().intValue();
-        m.sizeT = meta.getPixelsSizeT(i).getValue().intValue();
+        m.sizeZ = meta.getPixelsSizeZ(i).getValue();
+        m.sizeC = meta.getPixelsSizeC(i).getValue();
+        m.sizeT = meta.getPixelsSizeT(i).getValue();
         m.pixelType = FormatTools.pixelTypeFromString(
           meta.getPixelsType(i).toString());
         int tiffPixelType = firstIFD.getPixelType();

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -49,13 +49,14 @@ import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
 import loci.formats.CoreMetadata;
+import loci.formats.CoreMetadataList;
 import loci.formats.FormatException;
-import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.IFormatReader;
 import loci.formats.MetadataTools;
 import loci.formats.MissingLibraryException;
 import loci.formats.Modulo;
+import loci.formats.SubResolutionFormatReader;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
 import loci.formats.services.OMEXMLService;
@@ -80,7 +81,7 @@ import ome.xml.model.primitives.Timestamp;
  * <a href="https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/">OME-TIFF</a>
  * files.
  */
-public class OMETiffReader extends FormatReader {
+public class OMETiffReader extends SubResolutionFormatReader {
 
   // -- Fields --
 
@@ -117,7 +118,7 @@ public class OMETiffReader extends FormatReader {
 
   // -- IFormatReader API methods --
 
-  /* @see loci.formats.IFormatReader#isSingleFile(String) */
+  /* @see loci.formats.SubResolutionFormatReader#isSingleFile(String) */
   @Override
   public boolean isSingleFile(String id) throws FormatException, IOException {
     // companion files in a binary-only dataset should always have additional files
@@ -152,14 +153,14 @@ public class OMETiffReader extends FormatReader {
     for (int i=0; i<meta.getImageCount(); i++) {
       int nChannels = meta.getChannelCount(i);
       if (nChannels == 0) nChannels = 1;
-      int z = meta.getPixelsSizeZ(i).getValue().intValue();
-      int t = meta.getPixelsSizeT(i).getValue().intValue();
+      int z = meta.getPixelsSizeZ(i).getValue();
+      int t = meta.getPixelsSizeT(i).getValue();
       nImages += z * t * nChannels;
     }
     return nImages > 0 && nImages <= ifdOffsets.length;
   }
 
-  /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
+  /* @see loci.formats.SubResolutionFormatReader#isThisType(String, boolean) */
   @Override
   public boolean isThisType(String name, boolean open) {
     if (checkSuffix(name, "companion.ome")) {
@@ -192,7 +193,7 @@ public class OMETiffReader extends FormatReader {
     return valid;
   }
 
-  /* @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */
+  /* @see loci.formats.SubResolutionFormatReader#isThisType(RandomAccessInputStream) */
   @Override
   public boolean isThisType(RandomAccessInputStream stream) throws IOException {
     TiffParser tp = new TiffParser(stream);
@@ -269,7 +270,7 @@ public class OMETiffReader extends FormatReader {
     return false;
   }
 
-  /* @see loci.formats.IFormatReader#getDomains() */
+  /* @see loci.formats.SubResolutionFormatReader#getDomains() */
   @Override
   public String[] getDomains() {
     FormatTools.assertId(currentId, true, 1);
@@ -277,7 +278,7 @@ public class OMETiffReader extends FormatReader {
       FormatTools.NON_SPECIAL_DOMAINS;
   }
 
-  /* @see loci.formats.IFormatReader#get8BitLookupTable() */
+  /* @see loci.formats.SubResolutionFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
     int series = getSeries();
@@ -291,7 +292,7 @@ public class OMETiffReader extends FormatReader {
     return info[series][lastPlane].reader.get8BitLookupTable();
   }
 
-  /* @see loci.formats.IFormatReader#get16BitLookupTable() */
+  /* @see loci.formats.SubResolutionFormatReader#get16BitLookupTable() */
   @Override
   public short[][] get16BitLookupTable() throws FormatException, IOException {
     int series = getSeries();
@@ -305,7 +306,7 @@ public class OMETiffReader extends FormatReader {
     return info[series][lastPlane].reader.get16BitLookupTable();
   }
 
-  /* @see loci.formats.IFormatReader#reopenFile() */
+  /* @see loci.formats.SubResolutionFormatReader#reopenFile() */
   @Override
   public void reopenFile() throws IOException {
     super.reopenFile();
@@ -322,7 +323,7 @@ public class OMETiffReader extends FormatReader {
   }
 
   /*
-   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   * @see loci.formats.SubResolutionFormatReader#openBytes(int, byte[], int, int, int, int)
    */
   @Override
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
@@ -363,7 +364,7 @@ public class OMETiffReader extends FormatReader {
     return buf;
   }
 
-  /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
+  /* @see loci.formats.SubResolutionFormatReader#getSeriesUsedFiles(boolean) */
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
@@ -385,7 +386,7 @@ public class OMETiffReader extends FormatReader {
     return usedFiles.toArray(new String[usedFiles.size()]);
   }
 
-  /* @see loci.formats.IFormatReader#fileGroupOption() */
+  /* @see loci.formats.SubResolutionFormatReader#fileGroupOption() */
   @Override
   public int fileGroupOption(String id) {
     try {
@@ -401,7 +402,7 @@ public class OMETiffReader extends FormatReader {
     return FormatTools.CAN_GROUP;
   }
 
-  /* @see loci.formats.IFormatReader#close(boolean) */
+  /* @see loci.formats.SubResolutionFormatReader#close(boolean) */
   @Override
   public void close(boolean fileOnly) throws IOException {
     super.close(fileOnly);
@@ -430,14 +431,14 @@ public class OMETiffReader extends FormatReader {
     }
   }
 
-  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  /* @see loci.formats.SubResolutionFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
     FormatTools.assertId(currentId, true, 1);
     return tileWidth[getSeries()];
   }
 
-  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  /* @see loci.formats.SubResolutionFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
@@ -446,7 +447,7 @@ public class OMETiffReader extends FormatReader {
 
   // -- Internal FormatReader API methods --
 
-  /* @see loci.formats.FormatReader#initFile(String) */
+  /* @see loci.formats.SubResolutionFormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
     // normalize file name
@@ -557,7 +558,7 @@ public class OMETiffReader extends FormatReader {
     if (!isGroupFiles() && !isSingleFile(currentId)) {
       IFormatReader reader = new MinimalTiffReader();
       reader.setId(currentId);
-      core.set(0, reader.getCoreMetadataList().get(0));
+      core.set(0, 0, reader.getCoreMetadataList().get(0));
       int ifdCount = reader.getImageCount();
       reader.close();
       int maxSeries = 0;
@@ -577,7 +578,7 @@ public class OMETiffReader extends FormatReader {
         int sizeT = meta.getPixelsSizeT(i).getValue();
         String order = meta.getPixelsDimensionOrder(i).getValue();
         int num = sizeZ * sizeC * sizeT;
-        CoreMetadata m = i < core.size() ? core.get(i) : new CoreMetadata(core.get(0));
+        CoreMetadata m = i < core.size() ? core.get(i, 0) : new CoreMetadata(core.get(0, 0));
         m.dimensionOrder = order;
 
         info[i] = new OMETiffPlane[meta.getTiffDataCount(i)];
@@ -685,9 +686,9 @@ public class OMETiffReader extends FormatReader {
         List<Plane> planes = pix.copyPlaneList();
         for (int p=0; p<planes.size(); p++) {
           Plane plane = planes.get(p);
-          if (plane.getTheZ().getValue() >= core.get(i).sizeZ ||
-            plane.getTheC().getValue() >= core.get(i).sizeC ||
-            plane.getTheT().getValue() >= core.get(i).sizeT)
+          if (plane.getTheZ().getValue() >= core.get(i, 0).sizeZ ||
+            plane.getTheC().getValue() >= core.get(i, 0).sizeC ||
+            plane.getTheT().getValue() >= core.get(i, 0).sizeT)
           {
             pix.removePlane(planes.get(p));
           }
@@ -914,7 +915,7 @@ public class OMETiffReader extends FormatReader {
           sizeZ, effSizeC, sizeT, num, z, c, t);
         int count = numPlanes == null ? 1 : numPlanes.getValue();
         if (count == 0) {
-          core.set(s, null);
+          core.set(s, 0, null);
           break;
         }
 
@@ -984,7 +985,7 @@ public class OMETiffReader extends FormatReader {
         LOGGER.debug("    }");
       }
 
-      if (core.get(s) == null) continue;
+      if (core.get(s, 0) == null) continue;
 
       // verify that all planes are available
       LOGGER.debug("    --------------------------------");
@@ -1015,7 +1016,7 @@ public class OMETiffReader extends FormatReader {
       LOGGER.debug("  }");
 
       // populate core metadata
-      CoreMetadata m = core.get(s);
+      CoreMetadata m = core.get(s, 0);
       info[s] = planes;
       try {
         RandomAccessInputStream testFile = new RandomAccessInputStream(info[s][0].id, 16);
@@ -1142,19 +1143,25 @@ public class OMETiffReader extends FormatReader {
 
     // remove null CoreMetadata entries
 
-    ArrayList<CoreMetadata> series = new ArrayList<CoreMetadata>();
-    final List<OMETiffPlane[]> planeInfo = new ArrayList<OMETiffPlane[]>();
+    CoreMetadataList series = new CoreMetadataList();
+    final List<OMETiffPlane[]> planeInfo = new ArrayList<>();
+    int currentSeries = 0;
     for (int i=0; i<core.size(); i++) {
-      if (core.get(i) != null) {
-        series.add(core.get(i));
-        planeInfo.add(info[i]);
+      if (core.get(i, 0) == null) {
+        continue;
       }
+      series.add();
+      planeInfo.add(info[i]);
+      for (int j=0; j<core.size(i); j++) {
+        series.add(currentSeries, core.get(i, j));
+      }
+      currentSeries++;
     }
     core = series;
     info = planeInfo.toArray(new OMETiffPlane[0][0]);
 
     if (getImageCount() == 1) {
-      CoreMetadata ms0 = core.get(0);
+      CoreMetadata ms0 = core.get(0, 0);
       ms0.sizeZ = 1;
       if (!ms0.rgb) {
         ms0.sizeC = 1;
@@ -1163,7 +1170,7 @@ public class OMETiffReader extends FormatReader {
     }
 
     for (int i=0; i<core.size(); i++) {
-      CoreMetadata m = core.get(i);
+      CoreMetadata m = core.get(i, 0);
       Modulo z = service.getModuloAlongZ(meta, i);
       if (z != null) {
         m.moduloZ = z;
@@ -1220,12 +1227,12 @@ public class OMETiffReader extends FormatReader {
    * for display purposes and was not be suitable for use with
    * FormatWriter due to not containing required BinData
    * BigEndian attributes. This is no longer the case; the general
-   * {@link FormatReader#getMetadataStore()} method will always create
+   * {@link SubResolutionFormatReader#getMetadataStore()} method will always create
    * valid metadata which is suitable for both display and use
    * with FormatWriter, and so should be used instead.
    *
    * @return the metadata store.
-   * @deprecated Use the general {@link FormatReader#getMetadataStore()} method.
+   * @deprecated Use the general {@link SubResolutionFormatReader#getMetadataStore()} method.
    */
   public MetadataStore getMetadataStoreForDisplay() {
     return getMetadataStore();
@@ -1238,12 +1245,12 @@ public class OMETiffReader extends FormatReader {
    * for use with FormatWriter, but would possibly not generate
    * valid OME-XML if both BinData and TiffData elements were
    * present.  This is no longer the case; the general
-   * {@link FormatReader#getMetadataStore()} method will always create
+   * {@link SubResolutionFormatReader#getMetadataStore()} method will always create
    * valid metadata which is suitable for use with FormatWriter,
    * and so should be used instead.
    *
    * @return the metadata store.
-   * @deprecated Use the general {@link FormatReader#getMetadataStore()} method.
+   * @deprecated Use the general {@link SubResolutionFormatReader#getMetadataStore()} method.
    */
   public MetadataStore getMetadataStoreForConversion() {
     return getMetadataStore();

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -359,7 +359,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
     FormatTools.assertId(currentId, true, 1);
     int series = getSeries();
     if (noPixels) return null;
-    final List<String> usedFiles = new ArrayList<String>();
+    final List<String> usedFiles = new ArrayList<>();
     if (metadataFile != null) {
       usedFiles.add(metadataFile);
     }
@@ -549,8 +549,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
       reader.close();
       int maxSeries = 0;
       info = new OMETiffPlane[meta.getImageCount()][];
-      ArrayList<Integer> imagesToRemove = new ArrayList<Integer>();
-      ArrayList<int[]> cBounds = new ArrayList<int[]>();
+      ArrayList<Integer> imagesToRemove = new ArrayList<>();
+      ArrayList<int[]> cBounds = new ArrayList<>();
       for (int i=0; i<meta.getImageCount(); i++) {
         int maxZ = 0;
         int maxC = 0;
@@ -709,7 +709,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
     tileWidth = new int[seriesCount];
     tileHeight = new int[seriesCount];
     // compile list of file/UUID mappings
-    Hashtable<String, String> files = new Hashtable<String, String>();
+    Hashtable<String, String> files = new Hashtable<>();
     boolean needSearch = false;
     for (int i=0; i<seriesCount; i++) {
       int tiffDataCount = meta.getTiffDataCount(i);
@@ -778,8 +778,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
     for (int i=0; i<used.length; i++) used[i] = (String) iter.next();
 
     // process TiffData elements
-    Hashtable<String, IFormatReader> readers =
-      new Hashtable<String, IFormatReader>();
+    Hashtable<String, IFormatReader> readers = new Hashtable<>();
     boolean adjustedSamples = false;
     for (int i=0; i<seriesCount; i++) {
       int s = i;

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -229,14 +229,6 @@ public class TiffParser {
         subOffsets = ifd.getIFDLongArray(IFD.SUB_IFD);
       }
       catch (FormatException e) { }
-      if (subOffsets != null) {
-        for (long subOffset : subOffsets) {
-          IFD sub = getIFD(subOffset);
-          if (sub != null) {
-            ifds.add(sub);
-          }
-        }
-      }
     }
     if (doCaching) ifdList = ifds;
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1284,4 +1284,22 @@ public class TiffParser {
     return new TiffIFDEntry(entryTag, entryType, valueCount, offset);
   }
 
+  public IFDList getSubIFDs(IFD ifd) throws IOException {
+    IFDList list = new IFDList();
+    long[] offsets = null;
+    try {
+      fillInIFD(ifd);
+      offsets = ifd.getIFDLongArray(IFD.SUB_IFD);
+    } catch (FormatException e) {
+    }
+
+    if (offsets != null) {
+      for (long offset : offsets) {
+        list.add(getIFD(offset));
+      }
+    }
+
+    return list;
+  }
+
 }

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -338,6 +338,8 @@ public class DNGReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    mergeSubIFDs = true;
+
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -437,6 +437,8 @@ public class NikonReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    mergeSubIFDs = true;
+
     super.initFile(id);
 
     original = ifds.get(0);


### PR DESCRIPTION
In preparation for sub-resolutions, make the OME-TIFF reader work with the sub-resolution-specific format reader.  There are no behaviour changes with this PR, only a change of base class (and some small cleanups to make it easier to spot real bugs).  This is essentially the same reader changes as in https://github.com/openmicroscopy/bioformats/pull/3119.

Note: Ignore first two commits, which are from https://github.com/openmicroscopy/bioformats/pull/3133 (they will disappear once it's merged).

Testing: make sure that the data repo tests remain green.