### PR TITLE
Improve AFI and SVS metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -59,7 +59,7 @@ public class AFIReader extends FormatReader {
 
   // -- Constants --
 
-  private static final int EXTRA_IMAGES = 3;
+  private static final int EXTRA_IMAGES = 2;
 
   // -- Fields --
 
@@ -110,7 +110,7 @@ public class AFIReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader[0].setCoreIndex(getCoreIndex());
+      reader[0].setCoreIndex(getCoreIndex() + 1);
       return reader[0].openThumbBytes(no);
     }
 
@@ -132,7 +132,7 @@ public class AFIReader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     if (getCoreIndex() >= core.size() - EXTRA_IMAGES) {
-      reader[0].setCoreIndex(getCoreIndex());
+      reader[0].setCoreIndex(getCoreIndex() + 1);
       return reader[0].openBytes(no, buf, x, y, w, h);
     }
 
@@ -223,6 +223,7 @@ public class AFIReader extends FormatReader {
     }
 
     core = reader[0].getCoreMetadataList();
+    core.remove(core.size() - EXTRA_IMAGES - 1);
 
     for (int i=0; i<core.size() - EXTRA_IMAGES; i++) {
       CoreMetadata c = core.get(i);

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -258,6 +258,11 @@ public class AFIReader extends FormatReader {
       reader[i] = new ChannelSeparator(new SVSReader());
       reader[i].setFlattenedResolutions(hasFlattenedResolutions());
       reader[i].setId(pixels.get(i));
+
+      ArrayList<String> dyeNames = ((SVSReader) reader[i].getReader()).getDyeNames();
+      if (dyeNames.size() > 0) {
+        channelNames[i] = dyeNames.get(0);
+      }
     }
 
     core = reader[0].getCoreMetadataList();
@@ -293,10 +298,17 @@ public class AFIReader extends FormatReader {
       getMetadataOptions().getMetadataLevel() == MetadataLevel.MINIMUM;
     MetadataTools.populatePixels(store, this, !minimalMetadata);
 
-    String fileID = currentId.substring(
-      currentId.lastIndexOf(File.separator) + 1, currentId.lastIndexOf("."));
-    for (int i=0; i<getSeriesCount(); i++) {
-      store.setImageName(fileID + " - image #" + (i + 1), i);
+    String fileID = currentId.substring(currentId.lastIndexOf(File.separator) + 1);
+
+    if (hasFlattenedResolutions()) {
+      for (int i=0; i<getSeriesCount(); i++) {
+        store.setImageName(fileID + " - image #" + (i + 1), i);
+      }
+    }
+    else {
+      store.setImageName(fileID, 0);
+      store.setImageName(fileID + " [label image]", 1);
+      store.setImageName(fileID + " [macro image]", 2);
     }
 
     if (!minimalMetadata) {

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Hashtable;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -232,6 +233,19 @@ public class AFIReader extends FormatReader {
         c.resolutionCount = core.size() - EXTRA_IMAGES;
       }
     }
+
+    for (int s=0; s<core.size(); s++) {
+      setCoreIndex(s);
+      core.get(s).seriesMetadata = new Hashtable<String, Object>();
+      for (int i=0; i<reader.length; i++) {
+        reader[i].setCoreIndex(s);
+        Hashtable<String, Object> m = reader[i].getSeriesMetadata();
+        for (String key : m.keySet()) {
+          addSeriesMetaList(key, m.get(key));
+        }
+      }
+    }
+    setCoreIndex(0);
 
     MetadataStore store = makeFilterMetadata();
     boolean minimalMetadata =

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -306,9 +306,9 @@ public class AFIReader extends FormatReader {
       }
     }
     else {
-      store.setImageName(fileID, 0);
-      store.setImageName(fileID + " [label image]", 1);
-      store.setImageName(fileID + " [macro image]", 2);
+      store.setImageName("", 0);
+      store.setImageName("label image", 1);
+      store.setImageName("macro image", 2);
     }
 
     if (!minimalMetadata) {

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -27,6 +27,7 @@ package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Hashtable;
@@ -167,6 +168,14 @@ public class AFIReader extends FormatReader {
             buf[dest + destBytes - j - 1] = tmp[i + srcBytes - j - 1];
           }
         }
+      }
+      Object s = DataTools.makeDataArray(
+        buf, destBytes, FormatTools.isFloatingPoint(getPixelType()), isLittleEndian());
+      long max = (long) Math.pow(2, destBytes * 8) - 1;
+      for (int i=0; i<Array.getLength(s); i++) {
+        double scale = Array.getDouble(s, i) / 255;
+        DataTools.unpackBytes(
+          (long) (scale * max), buf, i * destBytes, destBytes, isLittleEndian());
       }
       return buf;
     }

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -45,6 +45,7 @@ import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
@@ -318,6 +319,7 @@ public class AFIReader extends FormatReader {
       Timestamp[] datestamp = new Timestamp[pixels.size()];
       Length[] physicalSizes = null;
       double magnification = Double.NaN;
+      Color[] displayColor = new Color[pixels.size()];
 
       for (int c=0; c<pixels.size(); c++) {
         SVSReader baseReader = (SVSReader) reader[c].getReader();
@@ -326,6 +328,7 @@ public class AFIReader extends FormatReader {
         exposure[c] = baseReader.getExposureTime();
         datestamp[c] = baseReader.getDatestamp();
         physicalSizes = baseReader.getPhysicalSizes();
+        displayColor[c] = baseReader.getDisplayColor();
 
         if (c == 0) {
           magnification = baseReader.getMagnification();
@@ -362,6 +365,9 @@ public class AFIReader extends FormatReader {
           }
           if (excitation[c] != null) {
             store.setChannelExcitationWavelength(excitation[c], i, c);
+          }
+          if (displayColor[c] != null) {
+            store.setChannelColor(displayColor[c], i, c);
           }
 
           store.setPlaneExposureTime(FormatTools.createTime(exposure[c], UNITS.SECOND), i, c);

--- a/components/formats-gpl/src/loci/formats/in/AFIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/AFIReader.java
@@ -95,12 +95,14 @@ public class AFIReader extends FormatReader {
   /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
   @Override
   public int getOptimalTileWidth() {
+    reader[0].setCoreIndex(getCoreIndex());
     return reader[0].getOptimalTileWidth();
   }
 
   /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
   @Override
   public int getOptimalTileHeight() {
+    reader[0].setCoreIndex(getCoreIndex());
     return reader[0].getOptimalTileHeight();
   }
 

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -78,6 +78,7 @@ public class SVSReader extends BaseTiffReader {
   private Double exposureTime, exposureScale;
   private Double magnification;
   private String date, time;
+  private ArrayList<String> dyeNames = new ArrayList<String>();
 
   // -- Constructor --
 
@@ -212,6 +213,7 @@ public class SVSReader extends BaseTiffReader {
       magnification = null;
       date = null;
       time = null;
+      dyeNames.clear();
     }
   }
 
@@ -309,6 +311,9 @@ public class SVSReader extends BaseTiffReader {
               }
               else if (key.equals("AppMag")) {
                 magnification = DataTools.parseDouble(value);
+              }
+              else if (key.equals("Dye")) {
+                dyeNames.add(value);
               }
             }
           }
@@ -470,6 +475,10 @@ public class SVSReader extends BaseTiffReader {
 
   protected double getMagnification() {
     return magnification;
+  }
+
+  protected ArrayList<String> getDyeNames() {
+    return dyeNames;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -47,6 +47,7 @@ import loci.formats.tiff.IFD;
 import loci.formats.tiff.PhotoInterp;
 import loci.formats.tiff.TiffIFDEntry;
 import loci.formats.tiff.TiffParser;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
@@ -79,6 +80,8 @@ public class SVSReader extends BaseTiffReader {
   private Double magnification;
   private String date, time;
   private ArrayList<String> dyeNames = new ArrayList<String>();
+
+  private transient Color displayColor = null;
 
   // -- Constructor --
 
@@ -214,6 +217,7 @@ public class SVSReader extends BaseTiffReader {
       date = null;
       time = null;
       dyeNames.clear();
+      displayColor = null;
     }
   }
 
@@ -314,6 +318,11 @@ public class SVSReader extends BaseTiffReader {
               }
               else if (key.equals("Dye")) {
                 dyeNames.add(value);
+              }
+              else if (key.equals("DisplayColor")) {
+                // stored color is RGB, Color expects RGBA
+                int color = Integer.parseInt(value);
+                displayColor = new Color((color << 8) | 0xff);
               }
             }
           }
@@ -430,6 +439,10 @@ public class SVSReader extends BaseTiffReader {
           store.setChannelExcitationWavelength(getExcitation(), i, c);
         }
 
+        // display color not set here as investigation with Aperio ImageScope
+        // indicates that the display color is only used when there is an
+        // .afi file (see AFIReader)
+
         if (c < dyeNames.size()) {
           store.setChannelName(dyeNames.get(c), i, c);
         }
@@ -525,6 +538,10 @@ public class SVSReader extends BaseTiffReader {
 
   protected ArrayList<String> getDyeNames() {
     return dyeNames;
+  }
+
+  protected Color getDisplayColor() {
+    return displayColor;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -402,6 +402,10 @@ public class SVSReader extends BaseTiffReader {
         if (getExcitation() != null) {
           store.setChannelExcitationWavelength(getExcitation(), i, c);
         }
+
+        if (c < dyeNames.size()) {
+          store.setChannelName(dyeNames.get(c), i, c);
+        }
       }
 
       if (i < pixelSize.length && pixelSize[i] != null && pixelSize[i].value(UNITS.MICROMETER).doubleValue() - Constants.EPSILON > 0) {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -448,7 +448,7 @@ public class SVSReader extends BaseTiffReader {
   }
 
   protected Double getExposureTime() {
-    return exposureTime;
+    return exposureTime * exposureScale * 1000;
   }
 
   protected Timestamp getDatestamp() {

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -372,7 +372,22 @@ public class SVSReader extends BaseTiffReader {
       store.setImageInstrumentRef(instrument, i);
       store.setObjectiveSettingsID(objective, i);
 
-      store.setImageName("Series " + (i + 1), i);
+      if (hasFlattenedResolutions() || i > 2) {
+        store.setImageName("Series " + (i + 1), i);
+      }
+      else {
+        switch (i) {
+          case 0:
+            store.setImageName("", i);
+            break;
+          case 1:
+            store.setImageName("label image", i);
+            break;
+          case 2:
+            store.setImageName("macro image", i);
+            break;
+        }
+      }
       store.setImageDescription(comments[i], i);
 
       if (getDatestamp() != null) {


### PR DESCRIPTION
Backported from a private PR.

This updates ```AFIReader``` to more closely mirror ```SVSReader```, updates image names to use the same format as https://github.com/openmicroscopy/bioformats/pull/3094, and fixes exposure time and channel name metadata.

SVS tests should continue to pass with no configuration changes.  AFI files require updated configuration; the main things to check using any ```.afi``` from ```curated/afi/samples``` are:

* ```showinf -nopix file.afi``` and ```showinf -nopix -noflat file.afi``` show the same series counts and dimensions as ```showinf -nopix file_xyz.svs``` and ```showinf -nopix -noflat file_xyz.svs```
* ```showinf -nopix -omexml file.afi``` shows plausible exposure times - less than 1 second with this change, compared with hundreds of seconds with develop
* ```showinf -nopix -omexml file.afi``` shows channel names that correspond to the names of the grouped .svs files
* ```showinf -nopix -noflat file.afi``` shows image names that clearly indicate the label and macro series as in https://github.com/openmicroscopy/bioformats/pull/3094
* ```showinf -nopix file.afi``` shows 3 entries for each key in the original metadata table, one per channel

073ecff, 30434e2, and 1344477 add logic for handling pyramid resolutions and thumbnails with mismatched pixel types.  If there is a mismatch within resolutions of a single SVS, then anything not matching the full resolution image is removed.  If there is a mismatch between the whole pyramid in two SVS files (e.g. one SVS has all 16-bit images, and one has all 8-bit images), then the narrower pixels are expanded.  Often this indicates inconsistent post-processing, but I don't have a good example for testing as these cases are expected to be very rare in practice.  I could add ```WARN``` or ```ERROR``` level logging if that would help, and/or an option to turn off that logic.

This does require a minor release as memo files will be affected.  I don't have any other planned AFI/SVS changes though, so it's not blocking anything and can be medium/low priority for 5.9.0.