### PR TITLE
build: Never run upgrade checker when running unit tests

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -112,6 +112,7 @@ Type "ant -p" for a list of targets.
             <pathelement location="${test-classes.dir}"/>
             <pathelement location="${test.dir}"/>
           </classpath>
+          <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
           <xmlfileset file="${testng.xml}"/>
           <jvmarg value="-mx${testng.memory}"/>
         </testng>

--- a/components/bio-formats-plugins/build.xml
+++ b/components/bio-formats-plugins/build.xml
@@ -23,6 +23,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <classpath refid="test.classpath"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>
     </testng>

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -104,6 +104,9 @@
           <additionalClasspathElements>
             <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
           </additionalClasspathElements>
+          <systemPropertyVariables>
+            <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/components/bio-formats-tools/build.xml
+++ b/components/bio-formats-tools/build.xml
@@ -19,6 +19,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
       </classpath>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="${tests.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>
     </testng>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -105,6 +105,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/components/formats-api/build.xml
+++ b/components/formats-api/build.xml
@@ -23,6 +23,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
       </classpath>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>
     </testng>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -115,6 +115,9 @@
           <additionalClasspathElements>
               <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
           </additionalClasspathElements>
+          <systemPropertyVariables>
+            <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/components/formats-bsd/build.xml
+++ b/components/formats-bsd/build.xml
@@ -31,6 +31,7 @@ Type "ant -p" for a list of targets.
       </classpath>
       <sysproperty key="testng.runWriterTilingTests" value="${testng.runWriterTilingTests}"/>
       <sysproperty key="testng.runWriterSaveBytesTests" value="${testng.runWriterSaveBytesTests}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-Dlurawave.license=XXX"/>
     </testng>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -172,6 +172,7 @@
           <systemPropertyVariables>
             <testng.runWriterSaveBytesTests>2</testng.runWriterSaveBytesTests>
             <testng.runWriterTilingTests>2</testng.runWriterTilingTests>
+            <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -26,6 +26,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <classpath refid="test.classpath"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>
     </testng>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -207,6 +207,9 @@
               <additionalClasspathElements>
                 <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
               </additionalClasspathElements>
+              <systemPropertyVariables>
+                <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+              </systemPropertyVariables>
             </configuration>
           </execution>
           <execution>
@@ -225,6 +228,9 @@
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>org.openmicroscopy:ome-mdbtools</classpathDependencyExclude>
               </classpathDependencyExcludes>
+              <systemPropertyVariables>
+                <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+              </systemPropertyVariables>
             </configuration>
           </execution>
           <execution>
@@ -243,6 +249,9 @@
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>org.openmicroscopy:ome-poi</classpathDependencyExclude>
               </classpathDependencyExcludes>
+              <systemPropertyVariables>
+                <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+              </systemPropertyVariables>
             </configuration>
           </execution>
           <execution>
@@ -261,6 +270,9 @@
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>edu.ucar:netcdf</classpathDependencyExclude>
               </classpathDependencyExcludes>
+              <systemPropertyVariables>
+                <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+              </systemPropertyVariables>
             </configuration>
           </execution>
         </executions>

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -36,6 +36,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <classpath refid="test.classpath"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="testng.xml"/>
       <jvmarg value="-Dlogback.configurationFile=logback-target-test-runner.xml"/>
     </testng>
@@ -54,6 +55,7 @@ Type "ant -p" for a list of targets.
         <pathelement location="${classes.dir}"/>
       </classpath>
       <classpath refid="test.classpath"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <xmlfileset file="testng.xml"/>
       <jvmarg value="-Dlogback.configurationFile=logback-target-test-runner.xml"/>
     </testng>
@@ -83,6 +85,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.filename" value="${testng.filename}"/>
       <sysproperty key="testng.directory" value="${testng.directory}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -113,6 +116,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -142,6 +146,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -175,6 +180,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -206,6 +212,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -236,6 +243,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -266,6 +274,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -296,6 +305,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -324,6 +334,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
       <jvmarg value="-Duser.language=${user.language}"/>
       <jvmarg value="-Duser.country=${user.country}"/>
@@ -342,6 +353,7 @@ Type "ant -p" for a list of targets.
       <classpath refid="test.classpath"/>
       <classfileset file="${classes.dir}/loci/tests/testng/MetadataConfigurableTest.class"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
+      <sysproperty key="bioformats_can_do_upgrade_check" value="false"/>
       <jvmarg value="-mx${testng.memory}"/>
     </testng>
     <fail if="failedTest"/>


### PR DESCRIPTION
This results in unnecessary hits and biased statistics.  Add `bioformats_can_do_upgrade_check=false` to all test invocations.

The main culprits are the bio-formats-tools unit tests.  However, this PR disables them comprehensively to avoid any potential for future mis-reporting.

Testing: check CI builds are green.