### PR TITLE
ci: Only test ant build with JDK8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,9 +7,6 @@ environment:
   matrix:
     - java: 9
       build: maven
-    - java: 9
-      build: ant
-      ant_version: 1.10.1
     - java: 1.8
       build: maven
     - java: 1.8
@@ -17,9 +14,6 @@ environment:
       ant_version: 1.10.1
     - java: 1.7
       build: maven
-    - java: 1.7
-      build: ant
-      ant_version: 1.9.9
 
 cache:
   - '%AV_BF_M2% -> appveyor.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ env:
 
 matrix:
   fast_finish: true
+  exclude:
+  - jdk: oraclejdk9
+    env: BUILD=ant
+  - jdk: openjdk7
+    env: BUILD=ant
 
 before_install:
   - if [[ $BUILD == 'ant' ]]; then pip install --user flake8 Sphinx; fi


### PR DESCRIPTION
The last commit from https://github.com/openmicroscopy/bioformats/pull/3138 but for `east`.  This will speed up the CI wait times, particularly for appveyor by 15-20 minutes per run.

The test matrix size for travis and appveyor will reduce from 6 to 4.

Testing: check the builds are green and that the matrix size has decreased.