### PR TITLE
test-suite: Fixes from east

### DIFF
--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -512,6 +512,7 @@ public class Configuration {
       try {
         planeSize = DataTools.safeMultiply32(reader.getSizeX(),
           reader.getSizeY(), reader.getEffectiveSizeC(),
+          reader.getRGBChannelCount(),
           FormatTools.getBytesPerPixel(reader.getPixelType()));
         canOpenImages = planeSize > 0 && TestTools.canFitInMemory(planeSize);
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1979,7 +1979,7 @@ public class FormatReaderTest {
           continue;
         }
 
-        if (planeSize < 0 || !TestTools.canFitInMemory(planeSize)) {
+        if (planeSize <= 0 || !TestTools.canFitInMemory(planeSize)) {
           continue;
         }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1971,7 +1971,8 @@ public class FormatReaderTest {
         long planeSize = -1;
         try {
           planeSize = DataTools.safeMultiply32(reader.getSizeX(),
-            reader.getSizeY(), reader.getRGBChannelCount(),
+            reader.getSizeY(), reader.getEffectiveSizeC(),
+            reader.getRGBChannelCount(),
             FormatTools.getBytesPerPixel(reader.getPixelType()));
         }
         catch (IllegalArgumentException e) {


### PR DESCRIPTION
A few selected fixed from https://github.com/openmicroscopy/bioformats/pull/3145 so that the large images are tested the same as on `east`.