### PR TITLE
Backported TiffParser fixes and getIFDs deprecation

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/EPSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/EPSReader.java
@@ -233,7 +233,7 @@ public class EPSReader extends FormatReader {
 
       in = new RandomAccessInputStream(b);
       TiffParser tp = new TiffParser(in);
-      ifds = tp.getIFDs();
+      ifds = tp.getMainIFDs();
 
       IFD firstIFD = ifds.get(0);
       map = tp.getColorMap(firstIFD);

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -452,7 +452,7 @@ public class MicromanagerReader extends FormatReader {
       }
       try {
         TiffParser parser = new TiffParser(path);
-        int nIFDs = parser.getIFDs().size();
+        int nIFDs = parser.getMainIFDs().size();
         IFD firstIFD = parser.getFirstIFD();
         parser.fillInIFD(firstIFD);
 
@@ -484,7 +484,7 @@ public class MicromanagerReader extends FormatReader {
           }
         }
 
-        IFDList ifds = parser.getIFDs();
+        IFDList ifds = parser.getMainIFDs();
         for (int i=0; i<ifds.size(); i++) {
           if (!parseMMJSONTag) {
             break;

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -450,11 +450,11 @@ public class MinimalTiffReader extends FormatReader {
 
     IFDList allIFDs = null;
     if (!mergeSubIFDs) {
-      allIFDs = tiffParser.getIFDs();
+      allIFDs = tiffParser.getMainIFDs();
     }
     else {
       allIFDs = new IFDList();
-      for (IFD ifd : tiffParser.getIFDs()) {
+      for (IFD ifd : tiffParser.getMainIFDs()) {
         allIFDs.add(ifd);
         allIFDs.addAll(tiffParser.getSubIFDs(ifd));
       }

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -456,9 +456,7 @@ public class MinimalTiffReader extends FormatReader {
       allIFDs = new IFDList();
       for (IFD ifd : tiffParser.getIFDs()) {
         allIFDs.add(ifd);
-        for (IFD subifd : tiffParser.getSubIFDs(ifd)) {
-          allIFDs.add(subifd);
-        }
+        allIFDs.addAll(tiffParser.getSubIFDs(ifd));
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -387,7 +387,6 @@ public class MinimalTiffReader extends FormatReader {
       resolutionLevels = null;
       j2kCodecOptions = null;
       seriesToIFD = false;
-      mergeSubIFDs = false;
     }
   }
 

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -94,6 +94,8 @@ public class MinimalTiffReader extends FormatReader {
 
   protected boolean seriesToIFD = false;
 
+  protected boolean mergeSubIFDs = false;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -384,6 +386,7 @@ public class MinimalTiffReader extends FormatReader {
       resolutionLevels = null;
       j2kCodecOptions = null;
       seriesToIFD = false;
+      mergeSubIFDs = false;
     }
   }
 
@@ -445,7 +448,19 @@ public class MinimalTiffReader extends FormatReader {
 
     LOGGER.info("Reading IFDs");
 
-    IFDList allIFDs = tiffParser.getIFDs();
+    IFDList allIFDs = null;
+    if (!mergeSubIFDs) {
+      allIFDs = tiffParser.getIFDs();
+    }
+    else {
+      allIFDs = new IFDList();
+      for (IFD ifd : tiffParser.getIFDs()) {
+        allIFDs.add(ifd);
+        for (IFD subifd : tiffParser.getSubIFDs(ifd)) {
+          allIFDs.add(subifd);
+        }
+      }
+    }
 
     if (allIFDs == null || allIFDs.size() == 0) {
       throw new FormatException("No IFDs found");

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -94,6 +94,7 @@ public class MinimalTiffReader extends FormatReader {
 
   protected boolean seriesToIFD = false;
 
+  /** Merge SubIFDs into the main IFD list. */
   protected boolean mergeSubIFDs = false;
 
   /** Number of JPEG 2000 resolution levels. */

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -95,7 +95,7 @@ public class MinimalTiffReader extends FormatReader {
   protected boolean seriesToIFD = false;
 
   /** Merge SubIFDs into the main IFD list. */
-  protected boolean mergeSubIFDs = false;
+  protected transient boolean mergeSubIFDs = false;
 
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -210,7 +210,53 @@ public class TiffParser {
 
   // -- TiffParser methods - IFD parsing --
 
-  /** Returns all IFDs in the file.  */
+  /** Returns the main list of IFDs in the file.
+   *
+   * This does not include SUBIFDS.
+   */
+  public IFDList getMainIFDs() throws IOException {
+    if (ifdList != null) return ifdList;
+
+    long[] offsets = getIFDOffsets();
+    IFDList ifds = new IFDList();
+
+    for (long offset : offsets) {
+      IFD ifd = getIFD(offset);
+      if (ifd == null) continue;
+      if (ifd.containsKey(IFD.IMAGE_WIDTH)) {
+        ifds.add(ifd);
+      }
+    }
+    if (doCaching) {
+      ifdList = ifds;
+    }
+
+    return ifds;
+  }
+
+  /** Returns the SUBIFDS belonging to a given IFD. */
+  public IFDList getSubIFDs(IFD ifd) throws IOException {
+    IFDList list = new IFDList();
+    long[] offsets = null;
+    try {
+      fillInIFD(ifd);
+      offsets = ifd.getIFDLongArray(IFD.SUB_IFD);
+    } catch (FormatException e) {
+    }
+
+    if (offsets != null) {
+      for (long offset : offsets) {
+        list.add(getIFD(offset));
+      }
+    }
+
+    return list;
+  }
+
+  /** Returns all IFDs in the file, including SUBIFDS.
+   * @deprecated Use {@link #getMainIFDs()} and {@link #getSubIFDs(IFD)} instead.
+   */
+  @Deprecated
   public IFDList getIFDs() throws IOException {
     if (ifdList != null) return ifdList;
 
@@ -229,6 +275,14 @@ public class TiffParser {
         subOffsets = ifd.getIFDLongArray(IFD.SUB_IFD);
       }
       catch (FormatException e) { }
+      if (subOffsets != null) {
+        for (long subOffset : subOffsets) {
+          IFD sub = getIFD(subOffset);
+          if (sub != null) {
+            ifds.add(sub);
+          }
+        }
+      }
     }
     if (doCaching) ifdList = ifds;
 
@@ -237,7 +291,7 @@ public class TiffParser {
 
   /** Returns thumbnail IFDs. */
   public IFDList getThumbnailIFDs() throws IOException {
-    IFDList ifds = getIFDs();
+    IFDList ifds = getMainIFDs();
     IFDList thumbnails = new IFDList();
     for (IFD ifd : ifds) {
       Number subfile = (Number) ifd.getIFDValue(IFD.NEW_SUBFILE_TYPE);
@@ -251,7 +305,7 @@ public class TiffParser {
 
   /** Returns non-thumbnail IFDs. */
   public IFDList getNonThumbnailIFDs() throws IOException {
-    IFDList ifds = getIFDs();
+    IFDList ifds = getMainIFDs();
     IFDList nonThumbs = new IFDList();
     for (IFD ifd : ifds) {
       Number subfile = (Number) ifd.getIFDValue(IFD.NEW_SUBFILE_TYPE);
@@ -265,7 +319,7 @@ public class TiffParser {
 
   /** Returns EXIF IFDs. */
   public IFDList getExifIFDs() throws FormatException, IOException {
-    IFDList ifds = getIFDs();
+    IFDList ifds = getMainIFDs();
     IFDList exif = new IFDList();
     for (IFD ifd : ifds) {
       long offset = ifd.getIFDLongValue(IFD.EXIF, 0);
@@ -368,10 +422,10 @@ public class TiffParser {
     ifd.put(new Integer(IFD.BIG_TIFF), new Boolean(bigTiff));
 
     // read in directory entries for this IFD
-    LOGGER.trace("getIFDs: seeking IFD at {}", offset);
+    LOGGER.trace("getIFD: seeking IFD at {}", offset);
     in.seek(offset);
     long numEntries = bigTiff ? in.readLong() : in.readUnsignedShort();
-    LOGGER.trace("getIFDs: {} directory entries to read", numEntries);
+    LOGGER.trace("getIFD: {} directory entries to read", numEntries);
     if (numEntries == 0 || numEntries == 1) return ifd;
 
     int bytesPerEntry = bigTiff ?
@@ -405,7 +459,7 @@ public class TiffParser {
       if (count * bpe + pointer > inputLen) {
         int oldCount = count;
         count = (int) ((inputLen - pointer) / bpe);
-        LOGGER.trace("getIFDs: truncated {} array elements for tag {}",
+        LOGGER.trace("getIFD: truncated {} array elements for tag {}",
           (oldCount - count), tag);
         if (count < 0) count = oldCount;
       }
@@ -1283,23 +1337,4 @@ public class TiffParser {
 
     return new TiffIFDEntry(entryTag, entryType, valueCount, offset);
   }
-
-  public IFDList getSubIFDs(IFD ifd) throws IOException {
-    IFDList list = new IFDList();
-    long[] offsets = null;
-    try {
-      fillInIFD(ifd);
-      offsets = ifd.getIFDLongArray(IFD.SUB_IFD);
-    } catch (FormatException e) {
-    }
-
-    if (offsets != null) {
-      for (long offset : offsets) {
-        list.add(getIFD(offset));
-      }
-    }
-
-    return list;
-  }
-
 }

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -229,14 +229,6 @@ public class TiffParser {
         subOffsets = ifd.getIFDLongArray(IFD.SUB_IFD);
       }
       catch (FormatException e) { }
-      if (subOffsets != null) {
-        for (long subOffset : subOffsets) {
-          IFD sub = getIFD(subOffset);
-          if (sub != null) {
-            ifds.add(sub);
-          }
-        }
-      }
     }
     if (doCaching) ifdList = ifds;
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1284,4 +1284,22 @@ public class TiffParser {
     return new TiffIFDEntry(entryTag, entryType, valueCount, offset);
   }
 
+  public IFDList getSubIFDs(IFD ifd) throws IOException {
+    IFDList list = new IFDList();
+    long[] offsets = null;
+    try {
+      fillInIFD(ifd);
+      offsets = ifd.getIFDLongArray(IFD.SUB_IFD);
+    } catch (FormatException e) {
+    }
+
+    if (offsets != null) {
+      for (long offset : offsets) {
+        list.add(getIFD(offset));
+      }
+    }
+
+    return list;
+  }
+
 }

--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -410,7 +410,7 @@ public class APLReader extends FormatReader {
 
       parser[i] = new TiffParser(tiffFiles[i]);
       parser[i].setDoCaching(false);
-      ifds[i] = parser[i].getIFDs();
+      ifds[i] = parser[i].getMainIFDs();
 
       for (IFD ifd : ifds[i]) {
         parser[i].fillInIFD(ifd);

--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -638,7 +638,7 @@ public class CellSensReader extends FormatReader {
     }
 
     parser = new TiffParser(id);
-    ifds = parser.getIFDs();
+    ifds = parser.getMainIFDs();
 
     RandomAccessInputStream vsi = new RandomAccessInputStream(id);
     vsi.order(parser.getStream().isLittleEndian());

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -83,6 +83,7 @@ public class DNGReader extends BaseTiffReader {
       new String[] {"cr2", "crw", "jpg", "thm", "wav", "tif", "tiff"});
     suffixSufficient = false;
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
+    mergeSubIFDs = true;
   }
 
   // -- IFormatReader API methods --
@@ -338,8 +339,6 @@ public class DNGReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
-    mergeSubIFDs = true;
-
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -338,6 +338,8 @@ public class DNGReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    mergeSubIFDs = true;
+
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -601,7 +601,7 @@ public class FV1000Reader extends FormatReader {
         for (String previewName : previewNames) {
           RandomAccessInputStream preview = getFile(previewName);
           TiffParser tp = new TiffParser(preview);
-          ifds = tp.getIFDs();
+          ifds = tp.getMainIFDs();
           preview.close();
           tp = null;
           ms1.imageCount += ifds.size();
@@ -966,7 +966,7 @@ public class FV1000Reader extends FormatReader {
         }
         try {
           TiffParser tp = new TiffParser(plane);
-          IFDList ifd = tp.getIFDs();
+          IFDList ifd = tp.getMainIFDs();
           ifds.add(ifd);
         }
         finally {

--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1320,7 +1320,7 @@ public class FlexReader extends FormatReader {
               firstIFD.getStripOffsets().length == 1)
             {
               tp.setDoCaching(false);
-              file.ifds = tp.getIFDs();
+              file.ifds = tp.getMainIFDs();
               file.ifds.set(0, firstIFD);
               if (firstIFD.getStripOffsets().length == 1) {
                 // used to ensure that image offsets are read, not calculated

--- a/components/formats-gpl/src/loci/formats/in/GelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GelReader.java
@@ -139,7 +139,7 @@ public class GelReader extends BaseTiffReader {
   /* @see BaseTiffReader#initMetadata() */
   @Override
   protected void initMetadata() throws FormatException, IOException {
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
     if (ifds.size() > 1) {
       IFDList tmpIFDs = ifds;
       ifds = new IFDList();

--- a/components/formats-gpl/src/loci/formats/in/ImaconReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImaconReader.java
@@ -118,7 +118,7 @@ public class ImaconReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
 
     core.clear();
     for (int i=0; i<ifds.size(); i++) {

--- a/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/IonpathMIBITiffReader.java
@@ -102,7 +102,7 @@ public class IonpathMIBITiffReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
     int seriesIndex;
     String imageType = null;
 

--- a/components/formats-gpl/src/loci/formats/in/JPKReader.java
+++ b/components/formats-gpl/src/loci/formats/in/JPKReader.java
@@ -84,7 +84,7 @@ public class JPKReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
 
     // repopulate core metadata
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaReader.java
@@ -784,7 +784,7 @@ public class LeicaReader extends FormatReader {
 
       // open the TIFF file and look for the "Image Description" field
 
-      ifds = tp.getIFDs();
+      ifds = tp.getMainIFDs();
       if (ifds == null) throw new FormatException("No IFDs found");
       String descr = ifds.get(0).getComment();
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -307,7 +307,7 @@ public class LeicaSCNReader extends BaseTiffReader {
 
     int count = handler.count();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
 
     if (ifds.size() < count) {
       count = ifds.size();

--- a/components/formats-gpl/src/loci/formats/in/MRWReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRWReader.java
@@ -211,7 +211,7 @@ public class MRWReader extends FormatReader {
         in.read(b);
         RandomAccessInputStream ras = new RandomAccessInputStream(b);
         TiffParser tp = new TiffParser(ras);
-        IFDList ifds = tp.getIFDs();
+        IFDList ifds = tp.getMainIFDs();
 
         for (IFD ifd : ifds) {
           Integer[] keys = (Integer[]) ifd.keySet().toArray(new Integer[0]);

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -1048,7 +1048,7 @@ public class MetamorphReader extends BaseTiffReader {
               stream = new RandomAccessInputStream(file, 16);
               tp = new TiffParser(stream);
               tp.checkHeader();
-              IFDList f = tp.getIFDs();
+              IFDList f = tp.getMainIFDs();
               if (f.size() > 0) {
                 lastFile = fileIndex;
                 lastIFDs = f;

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -292,7 +292,7 @@ public class NDPIReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
 
     // fix the offsets for > 4 GB files
     RandomAccessInputStream stream = new RandomAccessInputStream(currentId);

--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -35,7 +35,6 @@ import loci.formats.FormatReader;
 import loci.formats.ChannelSeparator;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
-import loci.formats.FormatReader;
 import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
@@ -206,7 +205,7 @@ public class NDPISReader extends FormatReader {
       // populate channel names based on IFD entry
       try (RandomAccessInputStream in = new RandomAccessInputStream(ndpiFiles[c])) {
         TiffParser tp = new TiffParser(in);
-        ifd = tp.getIFDs().get(0);
+        ifd = tp.getMainIFDs().get(0);
       }
 
       String channelName = ifd.getIFDStringValue(TAG_CHANNEL);

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -437,6 +437,8 @@ public class NikonReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
+    mergeSubIFDs = true;
+
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -116,6 +116,7 @@ public class NikonReader extends BaseTiffReader {
     super("Nikon NEF", new String[] {"nef", "tif", "tiff"});
     suffixSufficient = false;
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
+    mergeSubIFDs = true;
   }
 
   // -- IFormatReader API methods --
@@ -437,8 +438,6 @@ public class NikonReader extends BaseTiffReader {
   /* @see loci.formats.FormatReader#initFile(String) */
   @Override
   protected void initFile(String id) throws FormatException, IOException {
-    mergeSubIFDs = true;
-
     super.initFile(id);
 
     original = ifds.get(0);

--- a/components/formats-gpl/src/loci/formats/in/SVSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SVSReader.java
@@ -250,7 +250,7 @@ public class SVSReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
 
     int seriesCount = ifds.size();
 

--- a/components/formats-gpl/src/loci/formats/in/TCSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TCSReader.java
@@ -274,7 +274,7 @@ public class TCSReader extends FormatReader {
     tiffParser = new TiffParser(in);
     tiffs = new ArrayList<String>();
 
-    IFDList ifds = tiffParser.getIFDs();
+    IFDList ifds = tiffParser.getMainIFDs();
     String date = ifds.get(0).getIFDStringValue(IFD.DATE_TIME);
     if (date != null) {
       datestamp = DateTools.getTime(date, "yyyy:MM:dd HH:mm:ss");
@@ -537,10 +537,10 @@ public class TCSReader extends FormatReader {
     RandomAccessInputStream s =
       new RandomAccessInputStream(current.getAbsolutePath(), 16);
     TiffParser p = new TiffParser(s);
-    IFD ifd = p.getIFDs().get(0);
+    IFD ifd = p.getMainIFDs().get(0);
     s.close();
 
-    int expectedIFDCount = p.getIFDs().size();
+    int expectedIFDCount = p.getMainIFDs().size();
     long width = ifd.getImageWidth();
     long height = ifd.getImageLength();
     int samples = ifd.getSamplesPerPixel();
@@ -554,9 +554,9 @@ public class TCSReader extends FormatReader {
       if (!tp.isValidHeader()) {
         continue;
       }
-      ifd = tp.getIFDs().get(0);
+      ifd = tp.getMainIFDs().get(0);
 
-      if (tp.getIFDs().size() != expectedIFDCount ||
+      if (tp.getMainIFDs().size() != expectedIFDCount ||
         ifd.getImageWidth() != width || ifd.getImageLength() != height ||
         ifd.getSamplesPerPixel() != samples)
       {
@@ -584,7 +584,7 @@ public class TCSReader extends FormatReader {
       for (String tiff : tiffs) {
         s = new RandomAccessInputStream(tiff, 16);
         TiffParser parser = new TiffParser(s);
-        ifd = parser.getIFDs().get(0);
+        ifd = parser.getMainIFDs().get(0);
         s.close();
 
         String date = ifd.getIFDStringValue(IFD.DATE_TIME);

--- a/components/formats-gpl/src/loci/formats/in/TrestleReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TrestleReader.java
@@ -211,7 +211,7 @@ public class TrestleReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
     for (IFD ifd : ifds) {
       tiffParser.fillInIFD(ifd);
     }

--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -195,7 +195,7 @@ public class VectraReader extends BaseTiffReader {
   protected void initStandardMetadata() throws FormatException, IOException {
     super.initStandardMetadata();
 
-    ifds = tiffParser.getIFDs();
+    ifds = tiffParser.getMainIFDs();
     thumbnailIFDs = null;
 
     for (IFD ifd : ifds) {

--- a/components/formats-gpl/utils/ExtractFlexMetadata.java
+++ b/components/formats-gpl/utils/ExtractFlexMetadata.java
@@ -50,7 +50,7 @@ public class ExtractFlexMetadata {
         String outId = (dot >= 0 ? id.substring(0, dot) : id) + ".xml";
         RandomAccessInputStream in = new RandomAccessInputStream(id);
         TiffParser parser = new TiffParser(in);
-        IFD firstIFD = parser.getIFDs().get(0);
+        IFD firstIFD = parser.getMainIFDs().get(0);
         String xml = firstIFD.getIFDTextValue(FlexReader.FLEX);
         in.close();
         FileWriter writer = new FileWriter(new File(outId));

--- a/components/formats-gpl/utils/TiffDumper.java
+++ b/components/formats-gpl/utils/TiffDumper.java
@@ -45,7 +45,7 @@ public class TiffDumper {
   public static void dumpIFDs(String path) throws IOException {
     RandomAccessInputStream in = new RandomAccessInputStream(path);
     TiffParser parser = new TiffParser(in);
-    IFDList ifdList = parser.getIFDs();
+    IFDList ifdList = parser.getMainIFDs();
     for (IFD ifd : ifdList) {
       for (Integer key : ifd.keySet()) {
         int k = key.intValue();

--- a/components/test-suite/src/loci/tests/testng/Configuration.java
+++ b/components/test-suite/src/loci/tests/testng/Configuration.java
@@ -512,6 +512,7 @@ public class Configuration {
       try {
         planeSize = DataTools.safeMultiply32(reader.getSizeX(),
           reader.getSizeY(), reader.getEffectiveSizeC(),
+          reader.getRGBChannelCount(),
           FormatTools.getBytesPerPixel(reader.getPixelType()));
         canOpenImages = planeSize > 0 && TestTools.canFitInMemory(planeSize);
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1979,7 +1979,7 @@ public class FormatReaderTest {
           continue;
         }
 
-        if (planeSize < 0 || !TestTools.canFitInMemory(planeSize)) {
+        if (planeSize <= 0 || !TestTools.canFitInMemory(planeSize)) {
           continue;
         }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1971,7 +1971,8 @@ public class FormatReaderTest {
         long planeSize = -1;
         try {
           planeSize = DataTools.safeMultiply32(reader.getSizeX(),
-            reader.getSizeY(), reader.getRGBChannelCount(),
+            reader.getSizeY(), reader.getEffectiveSizeC(),
+            reader.getRGBChannelCount(),
             FormatTools.getBytesPerPixel(reader.getPixelType()));
         }
         catch (IllegalArgumentException e) {

--- a/tools/test-build
+++ b/tools/test-build
@@ -22,13 +22,6 @@ antbuild()
 {
     (
       ant clean compile
-      ant clean compile-formats-api
-      ant clean compile-bio-formats-plugins
-      ant clean compile-formats-bsd
-      ant clean compile-formats-gpl
-      ant clean compile-bio-formats-tools
-      ant clean compile-tests
-      ant clean compile-turbojpeg
       ant clean utils
       # Do not clean here so that we can potentially archive the
       # java archives.


### PR DESCRIPTION
Selected commits from https://github.com/openmicroscopy/bioformats/pull/3145 to add `getMainIFDs` to replace and deprecate `getIFDs`.

`MinimalTiffReader.mergeSubIFDs` is marked `transient` to avoid breaking memos.

Testing: Should be tested by the full repo tests and CI.  May need additional checking for memo breakage.