### PR TITLE
Metamorph: override getDomains() to check if the current file has a plate

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -364,6 +364,7 @@ public class MetamorphReader extends BaseTiffReader {
       hasAbsoluteZ = false;
       hasAbsoluteZValid = false;
       stageLabels = null;
+      isHCS = false;
     }
   }
 
@@ -1207,14 +1208,12 @@ public class MetamorphReader extends BaseTiffReader {
       if (uic2tagEntry != null) {
         parseUIC2Tags(uic2tagEntry.getValueOffset());
       }
-      if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-        if (uic4tagEntry != null) {
-          parseUIC4Tags(uic4tagEntry.getValueOffset());
-        }
-        if (uic1tagEntry != null) {
-          parseUIC1Tags(uic1tagEntry.getValueOffset(),
-            uic1tagEntry.getValueCount());
-        }
+      if (uic4tagEntry != null) {
+        parseUIC4Tags(uic4tagEntry.getValueOffset());
+      }
+      if (uic1tagEntry != null) {
+        parseUIC1Tags(uic1tagEntry.getValueOffset(),
+          uic1tagEntry.getValueCount());
       }
       in.seek(uic4tagEntry.getValueOffset());
     }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -174,6 +174,14 @@ public class MetamorphReader extends BaseTiffReader {
 
   // -- IFormatReader API methods --
 
+  /* @see loci.formats.IFormatReader#getDomains() */
+  @Override
+  public String[] getDomains() {
+    FormatTools.assertId(currentId, true, 1);
+    return isHCS ? new String[] {FormatTools.HCS_DOMAIN} :
+      new String[] {FormatTools.LM_DOMAIN};
+  }
+
   /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
   @Override
   public boolean isThisType(String name, boolean open) {


### PR DESCRIPTION
Backported from a private PR.

To test, use ```data_repo/curated/metamorph/andressa/MCF-10A/Sparse/Collagen/120806_1_w1Filter_DAPI.TIF```.  First verify that ```showinf -nopix -omexml 120806_1_w1Filter_DAPI.TIF``` (with or without this PR) does not report a ```Plate```, i.e. this is not an HCS dataset.

Without this PR, test code such as:

```
ImageReader r = new ImageReader();
r.setId("/ome/data_repo/curated/metamorph/andressa/MCF-10A/Sparse/Collagen/120806_1_w1Filter_DAPI.TIF");
String[] domains = r.getDomains();
r.close();
for (String d : domains) {
  System.out.println("domain = " + d);
}
```
should indicate that this dataset is identified as having the HCS domain, even though it does not report HCS metadata.

With this PR, the same test should result in only the LM domain being reported, so that ```getDomains()``` is now consistent with the existence of a ```Plate``` in OME-XML.

The original use case for this was ensuring that Metamorph files imported via Insight could be assigned to a Project and Dataset; incorrectly reporting the HCS domain meant that imported images were always placed under ```Orphaned Images```.

Builds should be unaffected, and this should be safe for a patch release if necessary.
