### PR TITLE
ImageWriter: Get compression types from the writer in use

### DIFF
--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -96,12 +96,6 @@ public class ImageWriter implements IFormatWriter {
    */
   private String[] suffixes;
 
-  /**
-   * Compression types for all file format writers.
-   * Populated the first time getCompressionTypes() is called.
-   */
-  protected String[] compressionTypes;
-
   /** Name of current file. */
   protected String currentId;
 
@@ -366,19 +360,7 @@ public class ImageWriter implements IFormatWriter {
   /* @see IFormatWriter#getCompressionTypes() */
   @Override
   public String[] getCompressionTypes() {
-    if (compressionTypes == null) {
-      HashSet<String> set = new HashSet<String>();
-      for (int i=0; i<writers.length; i++) {
-        String[] s = writers[i].getCompressionTypes();
-        if (s != null) {
-          for (int j=0; j<s.length; j++) set.add(s[j]);
-        }
-      }
-      compressionTypes = new String[set.size()];
-      set.toArray(compressionTypes);
-      Arrays.sort(compressionTypes);
-    }
-    return compressionTypes;
+    return getWriter().getCompressionTypes();
   }
 
   /* @see IFormatWriter#getPixelTypes() */
@@ -402,19 +384,7 @@ public class ImageWriter implements IFormatWriter {
   /* @see IFormatWriter#setCompression(String) */
   @Override
   public void setCompression(String compress) throws FormatException {
-    boolean ok = false;
-    for (int i=0; i<writers.length; i++) {
-      String[] s = writers[i].getCompressionTypes();
-      if (s == null) continue;
-      for (int j=0; j<s.length; j++) {
-        if (s[j].equals(compress)) {
-          // valid compression type for this format
-          writers[i].setCompression(compress);
-          ok = true;
-        }
-      }
-    }
-    if (!ok) throw new FormatException("Invalid compression type: " + compress);
+    getWriter().setCompression(compress);
   }
 
   /* @see IFormatWriter#getCompression() */


### PR DESCRIPTION
See https://trello.com/c/O5LkXtx0/29-imagewriter-compression-behaviour

Testing: Try `bfconvert -compression zlib` with and without both this PR and https://github.com/openmicroscopy/bioformats/pull/3153

- without both PRs, zlib compression will be allowed, but won't be used
- with https://github.com/openmicroscopy/bioformats/pull/3153 zlib compression will be allowed and will be used
- with this PR but without https://github.com/openmicroscopy/bioformats/pull/3153 zlib compression will be disallowed (tests it fails correctly if a codec is not supported by the chosen writer, but is supported by another writer and ends up in the combined codec list)

The combined codec list is the cause of the problem, and I'm unsure why it's required.  We don't have the same behaviour for any other features like e.g. pixel types.