### PR TITLE
Do not unconditionally force the SCM revision to be fetched only once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,6 @@
             </execution>
           </executions>
           <configuration>
-            <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
             <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
           </configuration>
         </plugin>


### PR DESCRIPTION
Fixes https://github.com/ome/bio-formats-build/issues/21

When bioformats is built as part of a multi-module project https://github.com/ome/bio-formats-build, it becomes necessary to force the build number to be re-fetch for each module. Otherwise the build number from previous components e.g. `ome-common` is used.

This issue primarily affects development builds of Bio-Formats since release components should consume upstream artifacts. Also only the Bio-Formats API has
The performance overhead should be minimal especially as we decoupled a lot of components.

To test this PR:
- build Bio-Formats using https://github.com/ome/bio-formats-build
- look at the content of the  manifest using `unzip -q -c META-INF/MANIFEST.MF formats-gpl.jar`. Without this PR the SHA1 of `ome-common-java` should be stored in the manifest. With this PR the SHA1 of `bioformats` should be stored
- all builds should remain green

As a follow-up, all decoupled components could be reviewed to drop this behavior. However, this only affects development builds and Bio-Formats is the only one API providing an introspection of the build number/revision via `FormatTools`.
