### PR TITLE
Warn if passing metadata with dimensionOrder in bfsave

### DIFF
--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -5,7 +5,9 @@ function bfsave(varargin)
 %    specified by outputPath.
 %
 %    bfsave(I, outputPath, dimensionOrder) specifies the dimension order of
-%    the input matrix. Default valuse is XYZCT.
+%    the input matrix. This value will be ignored if an OME-XML metadata
+%    object is also passed to bfsave via the metadata key/value parameter.
+%    Default value is XYZCT.
 %
 %    bfsave(I, outputPath, 'Compression', compression) specifies the
 %    compression to use when writing the OME-TIFF file.

--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -73,6 +73,9 @@ if isempty(ip.Results.metadata)
         ip.Results.dimensionOrder);
 else
     metadata = ip.Results.metadata;
+    if ~ismember('dimensionOrder', ip.UsingDefaults)
+        warning('''dimensionOrders'' is ignored if passing ''metadata''');
+    end
 end
 
 % Create ImageWriter


### PR DESCRIPTION
Silent dropping of the dimensionOrder parameter stumped me for some time while trying to combine files.