### PR TITLE
ND2: prevent integer overflow when reading a tile from a large image

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -294,12 +294,15 @@ public class NativeND2Reader extends FormatReader {
       int rowLength = getSizeX() * pixel + scanlinePad * bpp;
       int destLength = w * pixel;
 
-      in.skipBytes(rowLength * y);
+      long skip = (long) rowLength * y;
+      in.seek(in.getFilePointer() + skip);
       byte[] pix = new byte[destLength * h];
+      long pre = (long) x * pixel;
+      long post = (long) pixel * (getSizeX() - w - x) + (scanlinePad * bpp);
       for (int row=0; row<h; row++) {
-        in.skipBytes(x * pixel);
+        in.seek(in.getFilePointer() + pre);
         in.read(pix, row * destLength, destLength);
-        in.skipBytes(pixel * (getSizeX() - w - x) + scanlinePad * bpp);
+        in.seek(in.getFilePointer() + post);
       }
 
       pix = ImageTools.splitChannels(pix, lastChannel, getEffectiveSizeC(),


### PR DESCRIPTION
Backported from a private PR.

The original use case was a 12589 x 48981 uint16 .nd2 file.  Reading tiles from approximately the bottom half of the image resulted in an integer overflow when calculating the number of bytes to skip before reading.  This changes all of the relevant ```skipBytes``` calls (which only takes an ```int``` ) to ```seek``` calls, and uses ```long``` multiplication as needed to prevent overflows.

Discussed with @sbesson yesterday, and agreed that a test file would not be necessary given the limited scope of this change (i.e. code review and passing builds are sufficient).  Also /cc @mtbc for review as suggested by @sbesson.