### PR TITLE
Fix Metamorph RGB series channel count

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -679,6 +679,9 @@ public class MetamorphReader extends BaseTiffReader {
       ms0.sizeC = cc;
       ms0.sizeT = tc;
       ms0.imageCount = getSizeZ() * getSizeC() * getSizeT();
+      if (isRGB()) {
+        ms0.sizeC *= 3;
+      }
       ms0.dimensionOrder = "XYZCT";
 
       if (stks != null && stks.length > 1) {
@@ -1003,8 +1006,8 @@ public class MetamorphReader extends BaseTiffReader {
           exposureTimes.add(exposureTime);
         }
       }
-      else if (exposureTimes.size() == 1 && exposureTimes.size() < getSizeC()) {
-        for (int c=1; c<getSizeC(); c++) {
+      else if (exposureTimes.size() == 1 && exposureTimes.size() < getEffectiveSizeC()) {
+        for (int c=1; c<getEffectiveSizeC(); c++) {
           MetamorphHandler channelHandler = new MetamorphHandler();
 
           String channelComment = getComment(i, c);


### PR DESCRIPTION
In ND files referencing RGB images, sizeC was getting set to 1 rather than 3.
(The individual STK/TIFF files are properly handled). This change multiplies
the sizeC by 3 for RGB images, and replaces a later use of sizeC with
effectiveSizeC.

The specific failure I was encountering was that the pixel buffer would be too small in calls to openBytes, by a factor of 3. `showinf` for example crashes on such images. I uploaded an example failing image to the Glencoe ftp server as `jmuhlich_metamorph_rgb`. Note that I manually edited the .nd file down from an enormous 450-series slide scan to just a single series. With this patch, this image is handled correctly.