### PR TITLE
Add .scan extension to MetamorphReader

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -153,7 +153,7 @@ loci.formats.in.LeicaReader           # lei, tif
 loci.formats.in.NikonReader           # nef, tif
 loci.formats.in.FluoviewReader        # tif
 loci.formats.in.PrairieReader         # xml, cfg, tif
-loci.formats.in.MetamorphReader       # stk, tif, nd
+loci.formats.in.MetamorphReader       # stk, tif, nd, scan
 loci.formats.in.MicromanagerReader    # txt, tif
 loci.formats.in.ImprovisionTiffReader # tif
 loci.formats.in.MetamorphTiffReader   # tif

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -96,6 +96,7 @@ public class MetamorphReader extends BaseTiffReader {
   public static final String LONG_DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
 
   public static final String[] ND_SUFFIX = {"nd", "scan"};
+  public static final String[] PARENT_INDEX_SUFFIX = {"nd", "scan", "htd"};
   public static final String[] STK_SUFFIX = {"stk", "tif", "tiff"};
 
   public static final Pattern WELL_COORDS = Pattern.compile(
@@ -181,7 +182,7 @@ public class MetamorphReader extends BaseTiffReader {
     if (!location.exists()) {
         return false;
     }
-    if (checkSuffix(name, "nd")) return true;
+    if (checkSuffix(name, ND_SUFFIX)) return true;
     if (open) {
       location = location.getAbsoluteFile();
       Location parent = location.getParentFile();
@@ -190,17 +191,13 @@ public class MetamorphReader extends BaseTiffReader {
 
       while (baseName.indexOf('_') >= 0) {
         baseName = baseName.substring(0, baseName.lastIndexOf("_"));
-        if (checkSuffix(name, suffixes) &&
-          (new Location(parent, baseName + ".nd").exists() ||
-          new Location(parent, baseName + ".ND").exists()))
-        {
-          return true;
-        }
-        if (checkSuffix(name, suffixes) &&
-          (new Location(parent, baseName + ".htd").exists() ||
-          new Location(parent, baseName + ".HTD").exists()))
-        {
-          return false;
+        if (checkSuffix(name, suffixes)) {
+          for (String ext : PARENT_INDEX_SUFFIX) {
+            if ((new Location(parent, baseName + "." + ext)).exists() ||
+                (new Location(parent, baseName + "." + ext.toUpperCase())).exists()) {
+              return true;
+            }
+          }
         }
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -95,7 +95,7 @@ public class MetamorphReader extends BaseTiffReader {
   public static final String SHORT_DATE_FORMAT = "yyyyMMdd HH:mm:ss";
   public static final String LONG_DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
 
-  public static final String[] ND_SUFFIX = {"nd"};
+  public static final String[] ND_SUFFIX = {"nd", "scan"};
   public static final String[] STK_SUFFIX = {"stk", "tif", "tiff"};
 
   public static final Pattern WELL_COORDS = Pattern.compile(
@@ -164,12 +164,12 @@ public class MetamorphReader extends BaseTiffReader {
 
   /** Constructs a new Metamorph reader. */
   public MetamorphReader() {
-    super("Metamorph STK", new String[] {"stk", "nd", "tif", "tiff"});
+    super("Metamorph STK", new String[] {"stk", "nd", "scan", "tif", "tiff"});
     domains = new String[] {FormatTools.LM_DOMAIN, FormatTools.HCS_DOMAIN};
     hasCompanionFiles = true;
     suffixSufficient = false;
     datasetDescription = "One or more .stk or .tif/.tiff files plus an " +
-      "optional .nd file";
+      "optional .nd or .scan file";
   }
 
   // -- IFormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -192,13 +192,13 @@ public class MetamorphReader extends BaseTiffReader {
         baseName = baseName.substring(0, baseName.lastIndexOf("_"));
         if (checkSuffix(name, suffixes)) {
           for (String ext : ND_SUFFIX) {
-            if ((new Location(parent, baseName + "." + ext)).exists() ||
-                (new Location(parent, baseName + "." + ext.toUpperCase())).exists()) {
+            if (new Location(parent, baseName + "." + ext).exists() ||
+                new Location(parent, baseName + "." + ext.toUpperCase()).exists()) {
               return true;
             }
           }
-          if ((new Location(parent, baseName + ".htd")).exists() ||
-              (new Location(parent, baseName + ".HTD")).exists()) {
+          if (new Location(parent, baseName + ".htd").exists() ||
+              new Location(parent, baseName + ".HTD").exists()) {
             return false;
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -96,7 +96,6 @@ public class MetamorphReader extends BaseTiffReader {
   public static final String LONG_DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
 
   public static final String[] ND_SUFFIX = {"nd", "scan"};
-  public static final String[] PARENT_INDEX_SUFFIX = {"nd", "scan", "htd"};
   public static final String[] STK_SUFFIX = {"stk", "tif", "tiff"};
 
   public static final Pattern WELL_COORDS = Pattern.compile(
@@ -192,11 +191,15 @@ public class MetamorphReader extends BaseTiffReader {
       while (baseName.indexOf('_') >= 0) {
         baseName = baseName.substring(0, baseName.lastIndexOf("_"));
         if (checkSuffix(name, suffixes)) {
-          for (String ext : PARENT_INDEX_SUFFIX) {
+          for (String ext : ND_SUFFIX) {
             if ((new Location(parent, baseName + "." + ext)).exists() ||
                 (new Location(parent, baseName + "." + ext.toUpperCase())).exists()) {
               return true;
             }
+          }
+          if ((new Location(parent, baseName + ".htd")).exists() ||
+              (new Location(parent, baseName + ".HTD")).exists()) {
+            return false;
           }
         }
       }


### PR DESCRIPTION
The .scan extension seems equivalent to .nd by visual inspection. This is
reinforced by this Molecular Devices help page:

http://mdc.custhelp.com/app/answers/detail/a_id/19368/~/supported-file-formats