### PR TITLE
Plugins exporter: Reorder the dimensions

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -568,9 +568,9 @@ public class Exporter {
                 String ext = outfile.substring(dot);
 
                 int nextFile = 0;
-                for (int z=0; z<(splitZ ? sizeZ : 1); z++) {
-                    for (int c=0; c<(splitC ? sizeC : 1); c++) {
-                        for (int t=0; t<(splitT ? sizeT : 1); t++) {
+                for (int t=0; t<(splitT ? sizeT : 1); t++) {
+                    for (int z=0; z<(splitZ ? sizeZ : 1); z++) {
+                        for (int c=0; c<(splitC ? sizeC : 1); c++) {
                             int index = FormatTools.getIndex(ORDER, sizeZ, sizeC, sizeT, sizeZ*sizeC*sizeT, z, c, t);
                             String pattern = base + (splitZ ? "_Z%z" : "") + (splitC ? "_C%c" : "") + (splitT ? "_T%t" : "") + ext;
                             outputFiles[nextFile++] = FormatTools.getFilename(0, index, store, pattern, padded);


### PR DESCRIPTION
Issue raised on the ImageJ mailing list https://list.nih.gov/cgi-bin/wa.exe?A1=ind1806&L=IMAGEJ#6

When splitting planes on export the filenames incorrectly label the Z, T and C indexes.

This appears to be because the output filenames are stored in order t - c - z due to the looping at: https://github.com/openmicroscopy/bioformats/blob/develop/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java#L576

The hardcoded dim order for the exporter at https://github.com/openmicroscopy/bioformats/blob/develop/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java#L761 is XYCZT


To test:
- Follow the instructions from the original mailing list post
- Ensure that once exported with split planes that the labels on the images match the filenames
- Ensure that all builds and tests remain green