### PR TITLE
GelReader: Don't allow overflow when reading unsigned integer values

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GelReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GelReader.java
@@ -121,7 +121,7 @@ public class GelReader extends BaseTiffReader {
       int originalBytes = ifd.getBitsPerSample()[0] / 8;
 
       for (int i=0; i<tmp.length/4; i++) {
-        long value = DataTools.bytesToShort(tmp, i*originalBytes,
+        long value = DataTools.bytesToInt(tmp, i*originalBytes,
           originalBytes, isLittleEndian());
         long square = value * value;
         float pixel = square * scale;


### PR DESCRIPTION
[Trello](https://trello.com/c/WeajJ80u/242-gel-incorrect-pixel-data)

The use of DataTools.bytesToShort was causing values to wrap around when reading unsigned values which were not representable in a signed short.  Use bytesToInt to avoid this problem.

Testing: Try reading the GEL file from https://www.openmicroscopy.org/qa2/qa/feedback/21519/ with and without this patch.  It should display properly with this patch applied.

Note: may require the GEL configuration test data regenerating for images which were previously being read incorrectly.