### PR TITLE
Build updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,9 +7,6 @@ environment:
   matrix:
     - java: 9
       build: maven
-    - java: 9
-      build: ant
-      ant_version: 1.10.1
     - java: 1.8
       build: maven
     - java: 1.8
@@ -17,9 +14,6 @@ environment:
       ant_version: 1.10.1
     - java: 1.7
       build: maven
-    - java: 1.7
-      build: ant
-      ant_version: 1.9.9
 
 cache:
   - '%AV_BF_M2% -> appveyor.yml'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,11 @@ environment:
 
 # Note that only Oracle JDK is provided.
   matrix:
+    - java: 9
+      build: maven
+    - java: 9
+      build: ant
+      ant_version: 1.10.1
     - java: 1.8
       build: maven
     - java: 1.8
@@ -30,6 +35,7 @@ init:
   - refreshenv
   - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
   - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
+  - 'if [%java%] == [9] set "JAVA_HOME=C:\Program Files\Java\jdk9"'
   - PATH=%JAVA_HOME%\bin;%PATH%
   - 'if [%build%] == [maven] set "MAVEN_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'
   - 'if [%build%] == [ant] set "ANT_OPTS=-Dmaven.repo.local=%AV_BF_M2%"'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .settings
 .DS_Store
+.idea
 artifacts
 build
 components/*/utils/*.class

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .classpath
+.idea
 .project
 .settings
 .DS_Store
@@ -15,3 +16,5 @@ testng.css
 tools/*.jar
 *.log
 *.xpr
+*.class
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ env:
 
 matrix:
   fast_finish: true
+  exclude:
+  - jdk: oraclejdk9
+    env: BUILD=ant
+  - jdk: openjdk7
+    env: BUILD=ant
 
 before_install:
   - if [[ $BUILD == 'ant' ]]; then pip install --user flake8 Sphinx; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ sudo: false
 cache:
   directories:
   - $HOME/.m2
+  - downloads
 
 addons:
   apt_packages:
     - git
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
   - openjdk7
 

--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -96,6 +96,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <suiteXmlFiles>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -79,14 +79,14 @@
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>xalan</groupId>
       <artifactId>serializer</artifactId>
-      <version>2.7.2</version>
+      <version>${xalan.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
-      <version>2.7.2</version>
+      <version>${xalan.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -104,6 +104,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -69,6 +69,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <appendAssemblyId>false</appendAssemblyId>

--- a/components/bundles/loci_tools/pom.xml
+++ b/components/bundles/loci_tools/pom.xml
@@ -64,6 +64,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <appendAssemblyId>false</appendAssemblyId>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -133,51 +133,6 @@
         </configuration>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
-                    <versionRange>[1.2.1,)</versionRange>
-                    <goals>
-                      <goal>exec</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                    </execute>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                	<pluginExecutionFilter>
-                		<groupId>org.codehaus.mojo</groupId>
-                		<artifactId>
-                			build-helper-maven-plugin
-                		</artifactId>
-                		<versionRange>[1.4,)</versionRange>
-                		<goals>
-                			<goal>add-source</goal>
-                		</goals>
-                	</pluginExecutionFilter>
-                	<action>
-                		<ignore></ignore>
-                	</action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <developers>
@@ -227,4 +182,60 @@
       </properties>
     </developer>
   </developers>
+
+  <profiles>
+    <profile>
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <configuration>
+              <lifecycleMappingMetadata>
+                <pluginExecutions>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>exec-maven-plugin</artifactId>
+                      <versionRange>[1.2.1,)</versionRange>
+                      <goals>
+                        <goal>exec</goal>
+                      </goals>
+                    </pluginExecutionFilter>
+                    <action>
+                      <execute>
+                        <runOnIncremental>false</runOnIncremental>
+                      </execute>
+                    </action>
+                  </pluginExecution>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>
+                        build-helper-maven-plugin
+                      </artifactId>
+                      <versionRange>[1.4,)</versionRange>
+                      <goals>
+                        <goal>add-source</goal>
+                      </goals>
+                    </pluginExecutionFilter>
+                    <action>
+                      <ignore></ignore>
+                    </action>
+                  </pluginExecution>
+                </pluginExecutions>
+              </lifecycleMappingMetadata>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -58,14 +58,14 @@
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>xalan</groupId>
       <artifactId>serializer</artifactId>
-      <version>2.7.2</version>
+      <version>${xalan.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
-      <version>2.7.2</version>
+      <version>${xalan.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -110,6 +110,10 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <additionalClasspathElements>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -203,7 +203,7 @@
                     <pluginExecutionFilter>
                       <groupId>org.codehaus.mojo</groupId>
                       <artifactId>exec-maven-plugin</artifactId>
-                      <versionRange>[1.2.1,)</versionRange>
+                      <versionRange>[1.6.0,)</versionRange>
                       <goals>
                         <goal>exec</goal>
                       </goals>
@@ -220,7 +220,7 @@
                       <artifactId>
                         build-helper-maven-plugin
                       </artifactId>
-                      <versionRange>[1.4,)</versionRange>
+                      <versionRange>[3.0.0,)</versionRange>
                       <goals>
                         <goal>add-source</goal>
                       </goals>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -160,6 +160,10 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <suiteXmlFiles>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -127,6 +127,13 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>${testng.version}</version>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -189,51 +189,6 @@
         </configuration>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
-                    <versionRange>[1.2.1,)</versionRange>
-                    <goals>
-                      <goal>exec</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                    </execute>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                	<pluginExecutionFilter>
-                		<groupId>org.codehaus.mojo</groupId>
-                		<artifactId>
-                			build-helper-maven-plugin
-                		</artifactId>
-                		<versionRange>[1.4,)</versionRange>
-                		<goals>
-                			<goal>add-source</goal>
-                		</goals>
-                	</pluginExecutionFilter>
-                	<action>
-                		<ignore></ignore>
-                	</action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <developers>
@@ -283,4 +238,60 @@
       </properties>
     </developer>
   </developers>
+
+  <profiles>
+    <profile>
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <configuration>
+              <lifecycleMappingMetadata>
+                <pluginExecutions>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>exec-maven-plugin</artifactId>
+                      <versionRange>[1.2.1,)</versionRange>
+                      <goals>
+                        <goal>exec</goal>
+                      </goals>
+                    </pluginExecutionFilter>
+                    <action>
+                      <execute>
+                        <runOnIncremental>false</runOnIncremental>
+                      </execute>
+                    </action>
+                  </pluginExecution>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>
+                        build-helper-maven-plugin
+                      </artifactId>
+                      <versionRange>[1.4,)</versionRange>
+                      <goals>
+                        <goal>add-source</goal>
+                      </goals>
+                    </pluginExecutionFilter>
+                    <action>
+                      <ignore></ignore>
+                    </action>
+                  </pluginExecution>
+                </pluginExecutions>
+              </lifecycleMappingMetadata>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -259,7 +259,7 @@
                     <pluginExecutionFilter>
                       <groupId>org.codehaus.mojo</groupId>
                       <artifactId>exec-maven-plugin</artifactId>
-                      <versionRange>[1.2.1,)</versionRange>
+                      <versionRange>[1.6.0,)</versionRange>
                       <goals>
                         <goal>exec</goal>
                       </goals>
@@ -276,7 +276,7 @@
                       <artifactId>
                         build-helper-maven-plugin
                       </artifactId>
-                      <versionRange>[1.4,)</versionRange>
+                      <versionRange>[3.0.0,)</versionRange>
                       <goals>
                         <goal>add-source</goal>
                       </goals>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -115,14 +115,14 @@
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>xalan</groupId>
       <artifactId>serializer</artifactId>
-      <version>2.7.2</version>
+      <version>${xalan.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <!-- NB: We want this, despite warning from dependency:analyze. -->
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
-      <version>2.7.2</version>
+      <version>${xalan.version}</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -143,6 +143,13 @@
     <!-- NB: dependency:analyze has false warning about xml-apis:xml-apis. -->
 
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>${testng.version}</version>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -181,6 +181,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -97,6 +97,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/pom.xml
+++ b/pom.xml
@@ -168,17 +168,17 @@
       <plugins>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.0.0</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.5</version>
+          <version>3.0.0</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.6.1</version>
           <!-- Require the Java 7 platform. -->
           <configuration>
             <source>1.7</source>
@@ -188,22 +188,22 @@
 
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>3.0.1</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.1</version>
+          <version>2.8.2</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>2.5.2</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.0.2</version>
           <!-- Always add classpath to JAR manifests. -->
           <configuration>
             <skipIfEmpty>true</skipIfEmpty>
@@ -238,7 +238,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <!-- NB: The same version declaration and configuration block also
                appears in the <reporting> section, and must be kept in sync. -->
-          <version>2.9.1</version>
+          <version>2.10.4</version>
           <configuration>
             <javadocDirectory>${project.basedir}/src</javadocDirectory>
             <maxmemory>1024m</maxmemory>
@@ -258,12 +258,12 @@
 
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.5</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.4.2</version>
+          <version>2.5.3</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
@@ -275,17 +275,17 @@
 
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.0.2</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.6</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>3.0.1</version>
           <!-- Build source artifact in addition to main artifact. -->
           <executions>
             <execution>
@@ -298,7 +298,7 @@
 
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.16</version>
+          <version>2.20</version>
           <!-- Make sure that:
                A) unit tests run with sufficient RAM allocated;
                B) unit tests do not pop a Java dock icon on OS X;
@@ -323,7 +323,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>1.2</version>
+          <version>1.4</version>
           <!-- Record SCM revision in manifest. -->
           <executions>
             <execution>
@@ -345,7 +345,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.2.1</version>
+          <version>1.6.0</version>
         </plugin>
 
         <!-- License Maven plugin -
@@ -354,7 +354,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>1.6</version>
+          <version>1.13</version>
           <configuration>
             <projectName>${project.description}</projectName>
             <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
@@ -375,7 +375,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.1</version>
+          <version>2.4</version>
         </plugin>
 
         <!-- Eclipse-specific configuration
@@ -497,7 +497,7 @@
   </reporting>
 
   <prerequisites>
-    <maven>2.2.1</maven>
+    <maven>3.0.5</maven>
   </prerequisites>
 
   <organization>
@@ -585,7 +585,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>1.8</version>
+            <version>3.0.0</version>
             <configuration>
               <debug>${invoker.debug}</debug>
               <showErrors>true</showErrors>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <ome-jai.version>0.1.0</ome-jai.version>
     <ome-codecs.version>0.2.0</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
+    <xalan.version>2.7.2</xalan.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
     </testResources>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+
       <!-- Create -sources.jar when building. -->
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
@@ -170,6 +175,31 @@
 
     <pluginManagement>
       <plugins>
+        <!-- Enforce minimum maven version -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>1.4.1</version>
+          <executions>
+            <execution>
+              <id>enforce-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>[3.0.5,)</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>[1.7,)</version>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>3.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
     <jxrlib.version>0.2.1</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 
+    <!-- Maven plugin versions -->
+    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -237,9 +240,7 @@
 
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <!-- NB: The same version declaration and configuration block also
-               appears in the <reporting> section, and must be kept in sync. -->
-          <version>2.10.4</version>
+          <version>${maven-javadoc-plugin.version}</version>
           <configuration>
             <javadocDirectory>${project.basedir}/src</javadocDirectory>
             <maxmemory>1024m</maxmemory>
@@ -477,7 +478,7 @@
              "search[es] the same groupId/artifactId in the
              build.pluginManagement.plugins section", this claim
              unfortunately does not seem to reflect reality. -->
-        <version>2.9.1</version>
+        <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <javadocDirectory>${project.basedir}/src</javadocDirectory>
           <maxmemory>1024m</maxmemory>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <xalan.version>2.7.2</xalan.version>
 
     <!-- Maven plugin versions -->
-    <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -222,7 +222,7 @@
 
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.1.0</version>
         </plugin>
 
         <plugin>
@@ -312,7 +312,7 @@
 
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.6</version>
+          <version>3.7</version>
         </plugin>
 
         <plugin>
@@ -386,7 +386,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>1.14</version>
+          <version>1.15</version>
           <configuration>
             <projectName>${project.description}</projectName>
             <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
@@ -407,7 +407,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.5</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -536,7 +536,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <configuration>
               <debug>${invoker.debug}</debug>
               <showErrors>true</showErrors>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <xalan.version>2.7.2</xalan.version>
 
     <!-- Maven plugin versions -->
-    <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -202,7 +202,7 @@
 
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
 
         <plugin>
@@ -212,7 +212,7 @@
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.7.0</version>
           <!-- Require the Java 7 platform. -->
           <configuration>
             <source>1.7</source>
@@ -222,7 +222,7 @@
 
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.0.2</version>
         </plugin>
 
         <plugin>
@@ -330,7 +330,7 @@
 
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.20.1</version>
           <!-- Make sure that:
                A) unit tests run with sufficient RAM allocated;
                B) unit tests do not pop a Java dock icon on OS X;
@@ -386,7 +386,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>1.13</version>
+          <version>1.14</version>
           <configuration>
             <projectName>${project.description}</projectName>
             <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>3.0.0-M1</version>
           <executions>
             <execution>
               <id>enforce-versions</id>

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
 
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.5</version>
+          <version>3.5.1</version>
         </plugin>
 
         <plugin>
@@ -330,7 +330,7 @@
 
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.21.0</version>
           <!-- Make sure that:
                A) unit tests run with sufficient RAM allocated;
                B) unit tests do not pop a Java dock icon on OS X;

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.codehaus.gmaven</groupId>
                         <artifactId>gmaven-plugin</artifactId>
-                        <versionRange>[1.4,)</versionRange>
+                        <versionRange>[2.0.6,)</versionRange>
                         <goals>
                           <goal>execute</goal>
                         </goals>
@@ -611,7 +611,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>buildnumber-maven-plugin</artifactId>
-                        <versionRange>[1.0,)</versionRange>
+                        <versionRange>[1.4,)</versionRange>
                         <goals>
                           <goal>create</goal>
                         </goals>
@@ -627,7 +627,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
-                        <versionRange>[2.0,)</versionRange>
+                        <versionRange>[3.0.2,)</versionRange>
                         <goals>
                           <goal>jar</goal>
                         </goals>
@@ -643,7 +643,7 @@
                       <pluginExecutionFilter>
                         <groupId>net.imagej</groupId>
                         <artifactId>imagej-maven-plugin</artifactId>
-                        <versionRange>[0.1.0,)</versionRange>
+                        <versionRange>[0.6.0,)</versionRange>
                         <goals>
                           <goal>set-rootdir</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <date>${maven.build.timestamp}</date>
     <year>2017</year>
     <project.rootdir>${basedir}</project.rootdir>
-    <imagej1.version>1.48s</imagej1.version>
+    <imagej1.version>1.51r</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.1.1</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -413,40 +413,6 @@
     </pluginManagement>
   </build>
 
-  <reporting>
-    <plugins>
-      <!-- Generate javadocs as part of site generation. -->
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <!-- NB: The following version declaration and configuration block
-             are fully replicated from the pluginManagement section. This
-             is necessary because many versions of maven-site-plugin
-             (including 3.3) do not respect the pluginManagement values.
-             See: http://jira.codehaus.org/browse/MSITE-443
-             While the maven-site-plugin documentation states that it
-             "search[es] the same groupId/artifactId in the
-             build.pluginManagement.plugins section", this claim
-             unfortunately does not seem to reflect reality. -->
-        <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <javadocDirectory>${project.basedir}/src</javadocDirectory>
-          <maxmemory>1024m</maxmemory>
-          <!-- Workaround for javadoc bug when classes in the default
-               package access classes from non-default packages. See:
-               http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5101868 -->
-          <use>false</use>
-          <links>
-            <!-- Java 7 -->
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
-
-            <!-- ImageJ1 -->
-            <link>http://jenkins.imagej.net/job/ImageJ1-javadoc/javadoc/</link>
-          </links>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <prerequisites>
     <maven>3.0.5</maven>
   </prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -409,87 +409,6 @@
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.4</version>
         </plugin>
-
-        <!-- Eclipse-specific configuration
-
-             With a recent version of m2e, Eclipse's Maven binding, it is no
-             longer enough to configure plugins; they will be ignored by
-             default. But we really want the buildnumber and the jar plugin to
-             do their job. So now we have to add lifecycle mappings in addition
-             to configuring the plugins.
-
-             Let's hope that m2e remains the only IDE Maven binding that
-             requires such a lot of additional work just to get the same result
-             as plain Maven would produce out of the box. -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>gmaven-plugin</artifactId>
-                    <versionRange>[1.4,)</versionRange>
-                    <goals>
-                      <goal>execute</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>buildnumber-maven-plugin</artifactId>
-                    <versionRange>[1.0,)</versionRange>
-                    <goals>
-                      <goal>create</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>true</runOnIncremental>
-                      <runOnConfiguration>true</runOnConfiguration>
-                    </execute>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <versionRange>[2.0,)</versionRange>
-                    <goals>
-                      <goal>jar</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>true</runOnIncremental>
-                      <runOnConfiguration>true</runOnConfiguration>
-                    </execute>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>net.imagej</groupId>
-                    <artifactId>imagej-maven-plugin</artifactId>
-                    <versionRange>[0.1.0,)</versionRange>
-                    <goals>
-                      <goal>set-rootdir</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -643,6 +562,102 @@
             </executions>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- Eclipse-specific configuration
+
+                 With a recent version of m2e, Eclipse's Maven
+                 binding, it is no longer enough to configure plugins;
+                 they will be ignored by default. But we really want
+                 the buildnumber and the jar plugin to do their
+                 job. So now we have to add lifecycle mappings in
+                 addition to configuring the plugins.
+
+                 Let's hope that m2e remains the only IDE Maven
+                 binding that requires such a lot of additional work
+                 just to get the same result as plain Maven would
+                 produce out of the box. -->
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>gmaven-plugin</artifactId>
+                        <versionRange>[1.4,)</versionRange>
+                        <goals>
+                          <goal>execute</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>buildnumber-maven-plugin</artifactId>
+                        <versionRange>[1.0,)</versionRange>
+                        <goals>
+                          <goal>create</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute>
+                          <runOnIncremental>true</runOnIncremental>
+                          <runOnConfiguration>true</runOnConfiguration>
+                        </execute>
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <versionRange>[2.0,)</versionRange>
+                        <goals>
+                          <goal>jar</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute>
+                          <runOnIncremental>true</runOnIncremental>
+                          <runOnConfiguration>true</runOnConfiguration>
+                        </execute>
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>net.imagej</groupId>
+                        <artifactId>imagej-maven-plugin</artifactId>
+                        <versionRange>[0.1.0,)</versionRange>
+                        <goals>
+                          <goal>set-rootdir</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
[Trello card](https://trello.com/c/Y5MCXFTs/38-backport-needed-maven-fixes-from-east)

Backport of all build-related changes from east for 5.9.0.

- Maven plugin updates
- pom improvements
- ci updates
- ignore IntelliJ files

This allows building and testing with Java 9 and 10, which is useful for development on contemporary systems, e.g. Ubuntu 18.10, where bioformats develop is currently not buildable by default.

Testing: Check CI builds are green.