### PR TITLE
OIR - Prevent infinite loop

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -616,7 +616,7 @@ public class OIRReader extends FormatReader {
       s.findString("<?xml");
       s.seek(s.getFilePointer() - 9);
       int length = s.readInt();
-      if (length < 0 || length + s.getFilePointer() > s.length()) {
+      if (length <= 0 || length + s.getFilePointer() > s.length()) {
         break;
       }
       long fp = s.getFilePointer();


### PR DESCRIPTION
This is a follow up to a thread on the forums: https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8522&sid=c0ae5e3d8131cd28aaf123a570cd3ca6

From debugging the file is caught in a while loop at https://github.com/dgault/bioformats/blob/47d5e46ed52f13c1388f7315545bebe684bdcc0e/components/formats-gpl/src/loci/formats/in/OIRReader.java#L615

Each iteration of the loop the file pointer remains unchanged and the length read at https://github.com/dgault/bioformats/blob/47d5e46ed52f13c1388f7315545bebe684bdcc0e/components/formats-gpl/src/loci/formats/in/OIRReader.java#L618 is 0

To test:
- Ensure that all builds and tests remain green
- Without the PR test using QA-21538 and see that importing the file results in an infinite loop
- With the PR reproduce the above test and ensure that the image opens and displays correctly