### PR TITLE
Update the ImageJ API link for Javadoc crosslinks

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -251,7 +251,7 @@ your FindBugs installation's lib directory. E.g.:
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-      <link href="http://rsbweb.nih.gov/ij/developer/api/"/>
+      <link href="https://imagej.nih.gov/ij/developer/api/"/>
       <link href="http://www.ssec.wisc.edu/visad-docs/javadoc/"/>
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
       <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -31,7 +31,7 @@ Type "ant -p" for a list of targets.
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-      <link href="http://rsbweb.nih.gov/ij/developer/api/"/>
+      <link href="https://imagej.nih.gov/ij/developer/api/"/>
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
       <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->
     </javadoc>


### PR DESCRIPTION
http://rsbweb.nih.gov/ij/developer/api/ is now redirecting to https://imagej.nih.gov/ij/developer/api/.

The daily Bio-Formats CI job has been unstable recently failing on the first link. Trying to switch to the redirected HTTPS link to see if it helps stabilizing things on our side. /cc @dgault 