### PR TITLE
Leica LIF: only prioritize C in dimension order if channels are RGB

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -2159,7 +2159,7 @@ public class LIFReader extends FormatReader {
     Arrays.sort(bytes);
     ms.dimensionOrder = "XY";
     if (getRGBChannelCount() == 1 || getRGBChannelCount() == getSizeC()) {
-      if (getSizeC() > 1 && getSizeT() > 1) {
+      if (getRGBChannelCount() > 1) {
         ms.dimensionOrder += 'C';
       }
       for (Long nBytes : bytes) {


### PR DESCRIPTION
See https://trello.com/c/Zp2rgbqf/246-leica-lif-dimension-problems

To test, use ```data_repo/curated/leica-lif/pascal/test.lif```.  Without this change, verify that the dimension order (```XYCZT```) is incorrect by comparing what LAS X shows against each channel as opened in ImageJ.
I would expect C=0, Z=0, T=0 and C=1, Z=0, T=0 in ImageJ to be from the same channel according to LAS X.

With this change, the same comparison should show that C=0 and C=1 are now distinct channels.  The dimension order should now be reported as ```XYZCT```.  Builds should remain green, and this should be safe for a patch release if needed.