### PR TITLE
Fix download URLs in bf.bat and bf.sh

### DIFF
--- a/tools/bf.bat
+++ b/tools/bf.bat
@@ -59,7 +59,7 @@ if exist "%BF_JAR_DIR%\bioformats_package.jar" (
   echo Required JAR libraries not found. Please download:
   echo   bioformats_package.jar
   echo from:
-  echo   http://downloads.openmicroscopy.org/latest/bio-formats5.1
+  echo   https://downloads.openmicroscopy.org/latest/bio-formats/artifacts/
   echo and place in the same directory as the command line tools.
   goto end
 )

--- a/tools/bf.sh
+++ b/tools/bf.sh
@@ -69,7 +69,7 @@ else
     echo "Required JAR libraries not found. Please download:"
     echo "  bioformats_package.jar"
     echo "from:"
-    echo "  http://downloads.openmicroscopy.org/latest/bio-formats5.1"
+    echo "  https://downloads.openmicroscopy.org/latest/bio-formats/artifacts/"
     echo "and place in the same directory as the command line tools."
     exit 2
   fi


### PR DESCRIPTION
See https://trello.com/c/gcxA7ZMJ/514-tools-downloads-link-falls-out-of-date

The new URLs remove an explicit version number reference, and should currently point to the 5.8.2 download directory.

This shouldn't affect builds or behavior other than changing what is printed when using ```showinf``` or ```bfconvert``` cannot find valid Bio-Formats jars.  Definitely not urgent, and should be safe for a patch release.