### PR TITLE
Correcting image pixel metadata parsing for LEOReader

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LEOReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LEOReader.java
@@ -96,23 +96,23 @@ public class LEOReader extends BaseTiffReader {
       for (int line=36; line<lines.length; line++) {
         if (lines[line].equals("AP_IMAGE_PIXEL_SIZE")) {
           // pixel size is stored in nm, converted now to micrometers
-          double xSize = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" nm","e+03"));
+          double xSize = Double.parseDouble(lines[++line].split("\\s+=\\s+")[1].replace(" nm","e-03"));
         }
         else if (lines[line].equals("AP_WD")) {
           //working distance stored in mm, converting now to micrometers
-          double workingDistance = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" mm","e-03"));
+          double workingDistance = Double.parseDouble(lines[++line].split("\\s+=\\s+")[1].replace(" mm","e+03"));
         }
         else if (lines[line].equals("AP_ACTUALCURRENT")) {
-          double filament = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" A",""));
+          double filament = Double.parseDouble(lines[++line].split("\\s+=\\s+")[1].replace(" A",""));
         }
         else if (lines[line].equals("AP_ACTUALKV")) {
-          double eht = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" kV","e+03").replace(" V",""));
+          double eht = Double.parseDouble(lines[++line].split("\\s+=\\s+")[1].replace(" kV","e+03").replace(" V",""));
         }
         else if (lines[line].equals("AP_TIME")) {
-          date += lines[line++].split(" :")[1];
+          date += lines[++line].split(" :")[1];
         }
         else if (lines[line].equals("AP_DATE")) {
-          date += " " + lines[line++].split(" :")[1];
+          date += " " + lines[++line].split(" :")[1];
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/LEOReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LEOReader.java
@@ -55,6 +55,8 @@ public class LEOReader extends BaseTiffReader {
   // -- Fields --
 
   private double xSize;
+  private double filament;
+  private double eht;
   private String date;
   private double workingDistance;
 

--- a/components/formats-gpl/src/loci/formats/in/LEOReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LEOReader.java
@@ -88,23 +88,29 @@ public class LEOReader extends BaseTiffReader {
 
     String tag = ifds.get(0).getIFDTextValue(LEO_TAG);
     String[] lines = tag.split("\n");
-   
+    date = "";
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-      for (int row=36; row<lines.length; row++) {
-        if (lines[row].equals("AP_IMAGE_PIXEL_SIZE")) {
+      for (int line=36; line<lines.length; line++) {
+        if (lines[line].equals("AP_IMAGE_PIXEL_SIZE")) {
           // pixel size is stored in nm, converted now to micrometers
-          double xSize = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" nm","e+03"));
+          double xSize = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" nm","e+03"));
         }
         else if (lines[line].equals("AP_WD")) {
           //working distance stored in mm, converting now to micrometers
-          double workingDistance = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" mm","e-03"));
+          double workingDistance = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" mm","e-03"));
         }
         else if (lines[line].equals("AP_ACTUALCURRENT")) {
-          double filament = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" A",""));
+          double filament = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" A",""));
         }
         else if (lines[line].equals("AP_ACTUALKV")) {
-          double eht = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" kV","e+03").replace(" V",""));
+          double eht = Double.parseDouble(lines[line++].split("\\s+=\\s+")[1].replace(" kV","e+03").replace(" V",""));
+        }
+        else if (lines[line].equals("AP_TIME")) {
+          date += lines[line++].split(" :")[1];
+        }
+        else if (lines[line].equals("AP_DATE")) {
+          date += " " + lines[line++].split(" :")[1];
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/LEOReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LEOReader.java
@@ -88,25 +88,26 @@ public class LEOReader extends BaseTiffReader {
 
     String tag = ifds.get(0).getIFDTextValue(LEO_TAG);
     String[] lines = tag.split("\n");
-
-    date = "";
-
-    for (int line=10; line<lines.length; line++) {
-      if (lines[line].equals("clock")) {
-        date += lines[++line];
-      }
-      else if (lines[line].equals("date")) {
-        date += " " + lines[++line];
-      }
-    }
+   
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
-      // physical sizes stored in meters
-      xSize = Double.parseDouble(lines[3]) * 1000000;
+      for (int row=36; row<lines.length; row++) {
+        if (lines[row].equals("AP_IMAGE_PIXEL_SIZE")) {
+          // pixel size is stored in nm, converted now to micrometers
+          double xSize = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" nm","e+03"));
+        }
+        else if (lines[line].equals("AP_WD")) {
+          //working distance stored in mm, converting now to micrometers
+          double workingDistance = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" mm","e-03"));
+        }
+        else if (lines[line].equals("AP_ACTUALCURRENT")) {
+          double filament = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" A",""));
+        }
+        else if (lines[line].equals("AP_ACTUALKV")) {
+          double eht = Double.parseDouble(lines[row+ 1].split("\\s+=\\s+")[1].replace(" kV","e+03").replace(" V",""));
+        }
+      }
 
-      double eht = Double.parseDouble(lines[6]);
-      double filament = Double.parseDouble(lines[7]);
-      workingDistance = Double.parseDouble(lines[9]);
       addGlobalMeta("EHT", eht);
       addGlobalMeta("Filament", filament);
       addGlobalMeta("Working Distance", workingDistance);


### PR DESCRIPTION
Attempting to correct the issue highlighted here: https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8535

Currently my testing has this compiling and running fine as an ImageJ plugin, though something goes wrong, as the actual metadata values in ImageJ end up as defaults without the parsed values. Probably has something to do with assigning the variables correctly, as I'm unsure I've done that right.

Any guidance on how to troubleshoot from here would be appreciated.