### PR TITLE
Micro-Manager: warn if the dataset was acquired with >1.4.22

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -1098,6 +1098,9 @@ public class MicromanagerReader extends FormatReader {
    * which file/INI table the key and value came from.
    */
   private void handleKeyValue(String key, String value) {
+    if (key == null || value == null) {
+      return;
+    }
     addSeriesMeta(key, value);
 
     if (key.equals("MicroManagerVersion")) {


### PR DESCRIPTION
See https://trello.com/c/p8Jr7Hub/31-micromanager-v2-error-message

To test, use one of the *_metadata.txt files in ```curated/micromanager/qa-17040```.  Without this PR, ```showinf -nopix``` should not show any warnings during initialization.  The Micro-Manager version should be present in the original metadata table, and should be 2.0.x.  With this PR, the same test should show a warning indicating that the dataset is not officially supported.  The original metadata table should be the same as without this PR.

Datasets acquired with older versions of Micro-Manager should be unaffected; this can be checked with any of the datasets in ```curated/micromanager/public/```.

I wouldn't expect this to affect memo files, in which case it should be safe for a patch release.