### PR TITLE
Allow .fake files to represent a pyramid

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -97,6 +97,7 @@ import ome.units.UNITS;
  *  <li>showinf 'SPW&amp;screens=2&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=1&amp;plateAcqs=1.fake'</li>
  *  <li>showinf 'Plate&amp;screens=0&amp;plates=1&amp;plateRows=3&amp;plateCols=3&amp;fields=8&amp;plateAcqs=5.fake'</li>
  *  <li>showinf 'regions&amp;points=10&amp;ellipses=5&amp;rectangles=10.fake'</li>
+ *  <li>showinf 'pyramid&amp;sizeX=10000&amp;sizeY=10000&amp;resolutions=5&amp;resolutionScale=2.fake' -noflat -resolution 4</li>
  * </ul></p>
  */
 public class FakeReader extends FormatReader {


### PR DESCRIPTION
See https://trello.com/c/hvjosNYD/18-fake-resolutions

The ```resolutions``` key defines the total number of resolutions, so must be a positive integer.  By default, it is 1.  The ```resolutionScale``` key defines how ```SizeX``` and ```SizeY``` are calculated for each resolution; the sizes are divided by ```resolutionScale``` for each successively smaller resolution.  It must be greater than 1, and is 2 by default.

To test, try ```showinf``` with a few pyramids as indicated in the Javadoc.  Verify that unit tests continue to pass and that the new ```testPyramid*``` tests are being run.