### PR TITLE
OIR: prevent current file from being overridden if it has the .oir extension

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -310,9 +310,21 @@ public class OIRReader extends FormatReader {
           catch (NumberFormatException e) {
           }
         }
-        else if (file.startsWith(prefix) && checkSuffix(file, "oir")) {
-          current = new Location(parent, file);
-          currentId = current.getAbsolutePath();
+      }
+
+      // tried to initialize using one of the companion files
+      // reset the current file to the main .oir file
+      // current file should not be overridden if a file with .oir extension
+      // was originally passed to setId
+      if (extraFiles.contains(current.getAbsolutePath())) {
+        for (String file : fileList) {
+          // the prefix case needs to match, but the case of ".oir" doesn't matter
+          // this should mean that xyz_00001 matches xyz.oir but not xyz_test.oir
+          if (file.startsWith(prefix) && file.equalsIgnoreCase(prefix + ".oir")) {
+            current = new Location(parent, file);
+            currentId = current.getAbsolutePath();
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
See https://trello.com/c/VzvQbYBf/14-incorrect-handling-of-similarly-named-oir-files

To test, use the files from QA 21577.  Without this PR, ```showinf -nopix R13L-S2-5_X20_ZOOM1_Z.oir``` should show that ```R13L-S2-5_X20_ZOOM1_Z_CONTROL.oir``` is in the used file list (despite being a separate dataset).  With this PR, ```showinf -nopix``` on either file should show only the selected file in the used file list.

Builds should remain green, and memo files should be unaffected so this should be safe for a patch release.  There is a workaround, though, so could certainly be deferred until after 5.9.1 if needed.