### PR TITLE
Initial pyramid OME-TIFF writer

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -108,6 +108,7 @@ public final class ImageConverter {
   private int saveTileWidth = 0, saveTileHeight = 0;
   private boolean validate = false;
   private boolean zeroPadding = false;
+  private boolean flat = true;
 
   private IFormatReader reader;
   private MinMaxCalculator minMax;
@@ -149,6 +150,7 @@ public final class ImageConverter {
         else if (args[i].equals("-novalid")) validate = false;
         else if (args[i].equals("-validate")) validate = true;
         else if (args[i].equals("-padded")) zeroPadding = true;
+        else if (args[i].equals("-noflat")) flat = false;
         else if (args[i].equals("-option")) {
           options.set(args[++i], args[++i]);
         }
@@ -226,11 +228,11 @@ public final class ImageConverter {
     String[] s = {
       "To convert a file between formats, run:",
       "  bfconvert [-debug] [-stitch] [-separate] [-merge] [-expand]",
-      "    [-bigtiff] [-compression codec] [-series series] [-map id]",
-      "    [-range start end] [-crop x,y,w,h] [-channel channel] [-z Z]",
-      "    [-timepoint timepoint] [-nogroup] [-nolookup] [-autoscale]",
-      "    [-version] [-no-upgrade] [-padded] [-option key value]",
-      "    in_file out_file",
+      "    [-bigtiff] [-compression codec] [-series series] [-noflat]",
+      "    [-map id] [-range start end] [-crop x,y,w,h]",
+      "    [-channel channel] [-z Z] [-timepoint timepoint] [-nogroup]",
+      "    [-nolookup] [-autoscale] [-version] [-no-upgrade] [-padded]",
+      "    [-option key value] in_file out_file",
       "",
       "    -version: print the library version and exit",
       " -no-upgrade: do not perform the upgrade check",
@@ -242,6 +244,7 @@ public final class ImageConverter {
       "    -bigtiff: force BigTIFF files to be written",
       "-compression: specify the codec to use when saving images",
       "     -series: specify which image series to convert",
+      "     -noflat: do not flatten subresolutions",
       "        -map: specify file on disk to which name should be mapped",
       "      -range: specify range of planes to convert (inclusive)",
       "    -nogroup: force multi-file datasets to be read as individual" +
@@ -369,6 +372,7 @@ public final class ImageConverter {
     reader.setGroupFiles(group);
     reader.setMetadataFiltered(true);
     reader.setOriginalMetadataPopulated(true);
+    reader.setFlattenedResolutions(flat);
     OMEXMLService service = null;
     try {
       ServiceFactory factory = new ServiceFactory();

--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -122,8 +122,8 @@ public abstract class FormatWriter extends FormatHandler
   @Override
   public void saveBytes(int no, byte[] buf) throws FormatException, IOException
   {
-    int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
-    int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
+    int width = getSizeX();
+    int height = getSizeY();
     saveBytes(no, buf, 0, 0, width, height);
   }
 
@@ -140,8 +140,8 @@ public abstract class FormatWriter extends FormatHandler
   public void savePlane(int no, Object plane)
     throws FormatException, IOException
   {
-    int width = metadataRetrieve.getPixelsSizeX(getSeries()).getValue();
-    int height = metadataRetrieve.getPixelsSizeY(getSeries()).getValue();
+    int width = getSizeX();
+    int height = getSizeY();
     savePlane(no, plane, 0, 0, width, height);
   }
 
@@ -300,35 +300,29 @@ public abstract class FormatWriter extends FormatHandler
   /* @see IFormatWriter#getTileSizeX() */
   @Override
   public int getTileSizeX() throws FormatException {
-    PositiveInteger width = metadataRetrieve.getPixelsSizeX(getSeries());
-    if (width == null) throw new FormatException("Pixels Size X must not be null when attempting to get tile size.");
-    return width.getValue();
+    return getSizeX();
   }
 
   /* @see IFormatWriter#setTileSizeX(int) */
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
-    PositiveInteger width = metadataRetrieve.getPixelsSizeX(getSeries());
-    if (width == null) throw new FormatException("Pixels Size X must not be null when attempting to set tile size.");
+    int width = getSizeX();
     if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
-    return width.getValue();
+    return width;
   }
 
   /* @see IFormatWriter#getTileSizeY() */
   @Override
   public int getTileSizeY() throws FormatException {
-    PositiveInteger height = metadataRetrieve.getPixelsSizeY(getSeries());
-    if (height == null) throw new FormatException("Pixels Size Y must not be null when attempting to get tile size.");
-    return height.getValue();
+    return getSizeY();
   }
 
   /* @see IFormatWriter#setTileSizeY(int) */
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
-    PositiveInteger height = metadataRetrieve.getPixelsSizeY(getSeries());
-    if (height == null) throw new FormatException("Pixels Size Y must not be null when attempting to set tile size.");
+    int height = getSizeY();
     if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
-    return height.getValue();
+    return height;
   }
 
   // -- IPyramidHandler API methods --
@@ -427,8 +421,8 @@ public abstract class FormatWriter extends FormatHandler
           "Plane index:%d must be < %d", no, planes));
     }
 
-    int sizeX = r.getPixelsSizeX(series).getValue().intValue();
-    int sizeY = r.getPixelsSizeY(series).getValue().intValue();
+    int sizeX = getSizeX();
+    int sizeY = getSizeY();
     if (x < 0) throw new FormatException(String.format("X:%d must be >= 0", x));
     if (y < 0) throw new FormatException(String.format("Y:%d must be >= 0", y));
     if (x >= sizeX) {
@@ -481,7 +475,7 @@ public abstract class FormatWriter extends FormatHandler
 
     if (interleaved) bpp *= samples;
 
-    int sizeX = r.getPixelsSizeX(series).getValue().intValue();
+    int sizeX = getSizeX();
 
     out.skipBytes(bpp * (y * sizeX + x));
   }
@@ -492,8 +486,8 @@ public abstract class FormatWriter extends FormatHandler
    */
   protected boolean isFullPlane(int x, int y, int w, int h) {
     MetadataRetrieve r = getMetadataRetrieve();
-    int sizeX = r.getPixelsSizeX(series).getValue().intValue();
-    int sizeY = r.getPixelsSizeY(series).getValue().intValue();
+    int sizeX = getSizeX();
+    int sizeY = getSizeY();
     return x == 0 && y == 0 && w == sizeX && h == sizeY;
   }
 
@@ -529,6 +523,25 @@ public abstract class FormatWriter extends FormatHandler
 
   protected RandomAccessOutputStream createOutputStream() throws IOException {
     return new RandomAccessOutputStream(currentId);
+  }
+
+  protected int getSizeX() {
+    MetadataRetrieve r = getMetadataRetrieve();
+    if (getResolution() == 0) {
+      return r.getPixelsSizeX(getSeries()).getValue().intValue();
+    }
+    return ((IPyramidStore) r).getResolutionSizeX(
+      getSeries(), getResolution()).getValue().intValue();
+  }
+
+  protected int getSizeY() {
+    MetadataRetrieve r = getMetadataRetrieve();
+    if (getResolution() == 0) {
+      return r.getPixelsSizeY(getSeries()).getValue().intValue();
+    }
+    return ((IPyramidStore) r).getResolutionSizeY(
+      getSeries(), getResolution()).getValue().intValue();
+
   }
 
 }

--- a/components/formats-api/src/loci/formats/IFormatReader.java
+++ b/components/formats-api/src/loci/formats/IFormatReader.java
@@ -42,7 +42,7 @@ import loci.formats.meta.MetadataStore;
 /**
  * Interface for all biological file format readers.
  */
-public interface IFormatReader extends IFormatHandler {
+public interface IFormatReader extends IFormatHandler, IPyramidHandler {
 
   // -- Constants --
 
@@ -580,28 +580,6 @@ public interface IFormatReader extends IFormatHandler {
    */
   @Deprecated
   void setCoreIndex(int no);
-
-  /**
-   * Return the number of resolutions for the current series.
-   *
-   * Resolutions are stored in descending order, so the largest resolution is
-   * first and the smallest resolution is last.
-   */
-  int getResolutionCount();
-
-  /**
-   * Set the resolution level.
-   *
-   * @see #getResolutionCount()
-   */
-  void setResolution(int resolution);
-
-  /**
-   * Get the current resolution level.
-   *
-   * @see #getResolutionCount()
-   */
-  int getResolution();
 
   /** Return whether or not resolution flattening is enabled. */
   boolean hasFlattenedResolutions();

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -42,7 +42,7 @@ import loci.formats.meta.MetadataRetrieve;
 /**
  * Interface for all biological file format writers.
  */
-public interface IFormatWriter extends IFormatHandler {
+public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
 
   /**
    * Saves the given image to the current series in the current file.

--- a/components/formats-api/src/loci/formats/IPyramidHandler.java
+++ b/components/formats-api/src/loci/formats/IPyramidHandler.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * Top-level reader and writer APIs
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats;
+
+/**
+ * Interface for defining image pyramids.
+ */
+public interface IPyramidHandler {
+
+  /**
+   * Return the number of resolutions for the current series.
+   *
+   * Resolutions are stored in descending order, so the largest resolution is
+   * first and the smallest resolution is last.
+   */
+  int getResolutionCount();
+
+  /**
+   * Set the resolution level.
+   *
+   * @see #getResolutionCount()
+   */
+  void setResolution(int resolution);
+
+  /**
+   * Get the current resolution level.
+   *
+   * @see #getResolutionCount()
+   */
+  int getResolution();
+
+}

--- a/components/formats-api/src/loci/formats/ImageWriter.java
+++ b/components/formats-api/src/loci/formats/ImageWriter.java
@@ -487,4 +487,24 @@ public class ImageWriter implements IFormatWriter {
     getWriter().close();
   }
 
+  // -- IPyramidHandler API methods --
+
+  /* @see IPyramidHandler#getResolutionCount() */
+  @Override
+  public int getResolutionCount() {
+    return getWriter().getResolutionCount();
+  }
+
+  /* @see IPyramidHandler#getResolution() */
+  @Override
+  public int getResolution() {
+    return getWriter().getResolution();
+  }
+
+  /* @see IPyramidHandler#setResolution(int) */
+  @Override
+  public void setResolution(int resolution) {
+    getWriter().setResolution(resolution);
+  }
+
 }

--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -157,6 +157,17 @@ public final class MetadataTools {
       store.setPixelsSignificantBits(
         new PositiveInteger(r.getBitsPerPixel()), i);
 
+      if (store instanceof IPyramidStore) {
+        for (int res=1; res<r.getResolutionCount(); res++) {
+          r.setResolution(res);
+          ((IPyramidStore) store).setResolutionSizeX(
+            new PositiveInteger(r.getSizeX()), i, res);
+          ((IPyramidStore) store).setResolutionSizeY(
+            new PositiveInteger(r.getSizeY()), i, res);
+        }
+        r.setResolution(0);
+      }
+
       try {
         OMEXMLService service =
           new ServiceFactory().getInstance(OMEXMLService.class);
@@ -265,11 +276,13 @@ public final class MetadataTools {
 
       if (store instanceof IPyramidStore) {
         for (int res=1; res<r.getResolutionCount(); res++) {
+          r.setResolution(res);
           ((IPyramidStore) store).setResolutionSizeX(
             new PositiveInteger(r.getSizeX()), i, res);
           ((IPyramidStore) store).setResolutionSizeY(
             new PositiveInteger(r.getSizeY()), i, res);
         }
+        r.setResolution(0);
       }
     }
     r.setSeries(oldSeries);

--- a/components/formats-api/src/loci/formats/MetadataTools.java
+++ b/components/formats-api/src/loci/formats/MetadataTools.java
@@ -42,6 +42,7 @@ import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
 import loci.formats.meta.IMetadata;
+import loci.formats.meta.IPyramidStore;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.ome.OMEXMLMetadata;
@@ -261,6 +262,15 @@ public final class MetadataTools {
       populatePixelsOnly(store, i, r.isLittleEndian(), r.getDimensionOrder(),
         pixelType, r.getSizeX(), r.getSizeY(), r.getSizeZ(), r.getSizeC(),
         r.getSizeT(), r.getRGBChannelCount());
+
+      if (store instanceof IPyramidStore) {
+        for (int res=1; res<r.getResolutionCount(); res++) {
+          ((IPyramidStore) store).setResolutionSizeX(
+            new PositiveInteger(r.getSizeX()), i, res);
+          ((IPyramidStore) store).setResolutionSizeY(
+            new PositiveInteger(r.getSizeY()), i, res);
+        }
+      }
     }
     r.setSeries(oldSeries);
   }

--- a/components/formats-api/src/loci/formats/WriterWrapper.java
+++ b/components/formats-api/src/loci/formats/WriterWrapper.java
@@ -382,6 +382,21 @@ public abstract class WriterWrapper implements IFormatWriter {
     writer.close();
   }
 
+  @Override
+  public int getResolutionCount() {
+    return writer.getResolutionCount();
+  }
+
+  @Override
+  public int getResolution() {
+    return writer.getResolution();
+  }
+
+  @Override
+  public void setResolution(int resolution) {
+    writer.setResolution(resolution);
+  }
+
   // -- Helper methods --
 
   private WriterWrapper duplicateRecurse(

--- a/components/formats-api/src/loci/formats/meta/IPyramidStore.java
+++ b/components/formats-api/src/loci/formats/meta/IPyramidStore.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * Top-level reader and writer APIs
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.meta;
+
+import ome.xml.model.primitives.PositiveInteger;
+
+/**
+ * Interface for defining pyramid resolutions.
+ */
+public interface IPyramidStore {
+
+  /**
+   * Define the image width in pixels of the given pyramid resolution.
+   * Both width and height must be defined for each desired resolution.
+   *
+   * @param sizeX the image width in pixels
+   * @param image the Image (series) index
+   * @param resolution the resolution index; expected to be greater than 0
+   *    as the largest resolution is defined by the Image itself.
+   *
+   * @see #setResolutionSizeY(PositiveInteger, int, int)
+   */
+  void setResolutionSizeX(PositiveInteger sizeX, int image, int resolution);
+
+  /**
+   * Define the image height in pixels of the given pyramid resolution.
+   * Both width and height must be defined for each desired resolution.
+   *
+   * @param sizeY the image height in pixels
+   * @param image the Image (series) index
+   * @param resolution the resolution index; expected to be greater than 0
+   *    as the largest resolution is defined by the Image itself.
+   *
+   * @see #setResolutionSizeX(PositiveInteger, int, int)
+   */
+  void setResolutionSizeY(PositiveInteger sizeY, int image, int resolution);
+
+  /**
+   * Retrieve the number of pyramid resolutions defined for the given Image.
+   *
+   * @param image the Image (series) index
+   * @return the number of valid pyramid resolutions, including the largest
+   *    resolution; expected to be positive if the Image index is valid.
+   */
+  int getResolutionCount(int image);
+
+  /**
+   * Retrieve the image width in pixels of the given pyramid resolution.
+   *
+   * @param image the Image (series) index
+   * @param resolution the resolution index; expected to be greater than 0
+   *    as the largest resolution is defined by the Image itself.
+   * @return the width in pixels, or null if either index is invalid
+   */
+  PositiveInteger getResolutionSizeX(int image, int resolution);
+
+  /**
+   * Retrieve the image height in pixels of the given pyramid resolution.
+   *
+   * @param image the Image (series) index
+   * @param resolution the resolution index; expected to be greater than 0
+   *    as the largest resolution is defined by the Image itself.
+   * @return the height in pixels, or null if either index is invalid
+   */
+  PositiveInteger getResolutionSizeY(int image, int resolution);
+
+}

--- a/components/formats-api/src/loci/formats/ome/OMEPyramidStore.java
+++ b/components/formats-api/src/loci/formats/ome/OMEPyramidStore.java
@@ -1,0 +1,183 @@
+/*
+ * #%L
+ * Top-level reader and writer APIs
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.ome;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import loci.formats.meta.IPyramidStore;
+import ome.xml.model.primitives.PositiveInteger;
+
+/**
+ * Extension of OMEXMLMetadataImpl that allows for pyramid resolution storage and retrieval.
+ */
+public class OMEPyramidStore extends OMEXMLMetadataImpl implements IPyramidStore {
+
+  private List<List<Resolution>> resolutions = new ArrayList<List<Resolution>>();
+
+  /* @see IPyramidStore#setResolutionSizeX(PositiveInteger, int, int) */
+  public void setResolutionSizeX(PositiveInteger sizeX, int image, int resolution) {
+    checkImageIndex(image);
+    Resolution r = lookupResolution(image, resolution, true);
+    r.x = sizeX;
+  }
+
+  /* @see IPyramidStore#setResolutionSizeY(PositiveInteger, int, int) */
+  public void setResolutionSizeY(PositiveInteger sizeY, int image, int resolution) {
+    checkImageIndex(image);
+    Resolution r = lookupResolution(image, resolution, true);
+    r.y = sizeY;
+  }
+
+  /* @see IPyramidStore#getResolutionCount(int) */
+  public int getResolutionCount(int image) {
+    checkImageIndex(image);
+    return resolutions.get(image).size();
+  }
+
+  /* @see IPyramidStore#getResolutionSizeX(int, int) */
+  public PositiveInteger getResolutionSizeX(int image, int resolution) {
+    checkResolutionIndex(image, resolution);
+    Resolution r = lookupResolution(image, resolution);
+    return r == null ? null : r.x;
+  }
+
+  /* @see IPyramidStore#getResolutionSizeY(int, int) */
+  public PositiveInteger getResolutionSizeY(int image, int resolution) {
+    checkResolutionIndex(image, resolution);
+    Resolution r = lookupResolution(image, resolution);
+    return r == null ? null : r.y;
+  }
+
+  // -- Helper methods --
+
+  /**
+   * Verify that the given index is non-negative and less than the Image count.
+   *
+   * @param image the index to check
+   * @throws IllegalArgumentException if the index is invalid
+   */
+  private void checkImageIndex(int image) {
+    if (image < 0 || image >= getImageCount()) {
+      throw new IllegalArgumentException("Invalid image index: " + image);
+    }
+  }
+
+  /**
+   * Verify that the given image and resolution indices are valid.
+   *
+   * @param image the Image index to check
+   * @param res the resolution index to check
+   * @throws IllegalArgumentException if either index is invalid
+   *
+   * @see #checkImageIndex(int)
+   */
+  private void checkResolutionIndex(int image, int res) {
+    checkImageIndex(image);
+    if (res == 0) {
+      throw new IllegalArgumentException("Use {get,set}PixelsSize{X,Y} " +
+        "to work with the largest resolution");
+    }
+    else if (res < 0 || res >= getResolutionCount(image)) {
+      throw new IllegalArgumentException(
+        "Invalid resolution index for image #" + image + ": " + res);
+    }
+  }
+
+  /**
+   * Find the Resolution object for the given indices.
+   *
+   * @param image the Image index
+   * @param res the resolution index
+   * @return the corresponding Resolution object, or null if one does not exist
+   * @see #lookupResolution(int, int, boolean)
+   */
+  private Resolution lookupResolution(int image, int res) {
+    return lookupResolution(image, res, false);
+  }
+
+  /**
+   * Find the Resolution object for the given indices.
+   * If 'insert' is true, then a Resolution will be created
+   * if one does not exist.
+   *
+   * @param image the Image index
+   * @param res the resolution index
+   * @param insert true if a Resolution should be created
+   * @return the corresponding Resolution object, or null if one
+   *    does not exist and 'insert' is false
+   */
+  private Resolution lookupResolution(int image, int res, boolean insert) {
+    if (image < 0 || image >= resolutions.size()) {
+      if (insert) {
+        insertResolution(new Resolution(), image, res);
+        return lookupResolution(image, res);
+      }
+      return null;
+    }
+    List<Resolution> currentResolutions = resolutions.get(image);
+    if (res < 0 || res >= currentResolutions.size()) {
+      if (insert) {
+        insertResolution(new Resolution(), image, res);
+        return lookupResolution(image, res);
+      }
+      return null;
+    }
+    return currentResolutions.get(res);
+  }
+
+  /**
+   * Store the given Resolution object at the given indices.
+   *
+   * @param r the Resolution object to store
+   * @param image the Image index
+   * @param res the resolution index
+   */
+  private void insertResolution(Resolution r, int image, int res) {
+    while (image >= resolutions.size()) {
+      resolutions.add(new ArrayList<Resolution>());
+    }
+    List<Resolution> currentResolutions = resolutions.get(image);
+    while (res > currentResolutions.size()) {
+      currentResolutions.add(new Resolution());
+    }
+    currentResolutions.add(r);
+  }
+
+  class Resolution {
+    public PositiveInteger x, y;
+    public int index;
+    public int parentImage = -1;
+  }
+
+}

--- a/components/formats-api/src/loci/formats/ome/OMEPyramidStore.java
+++ b/components/formats-api/src/loci/formats/ome/OMEPyramidStore.java
@@ -48,33 +48,37 @@ public class OMEPyramidStore extends OMEXMLMetadataImpl implements IPyramidStore
   public static final String NAMESPACE = "openmicroscopy.org/PyramidResolution";
 
   private List<List<Resolution>> resolutions = new ArrayList<List<Resolution>>();
+  private boolean written = false;
 
   @Override
   public String dumpXML() {
     // insert resolution data as an annotation
 
-    int annIndex = 0;
-    try {
-      annIndex = getMapAnnotationCount();
-    }
-    catch (NullPointerException e) {
-      // just means there are no other map annotations
-    }
-    for (int i=0; i<resolutions.size(); i++) {
-      List<MapPair> resAnnotation = new ArrayList<MapPair>();
-      for (int r=1; r<resolutions.get(i).size(); r++) {
-        resAnnotation.add(
-          new MapPair(String.valueOf(r), resolutions.get(i).get(r).toString()));
+    // TODO: doesn't allow for updating resolutions
+    if (!written) {
+      int annIndex = 0;
+      try {
+        annIndex = getMapAnnotationCount();
       }
-      String mapId = "Annotation:Resolution:" + i;
-      setMapAnnotationID(mapId, annIndex);
-      setMapAnnotationNamespace(NAMESPACE, annIndex);
-      setMapAnnotationValue(resAnnotation, annIndex);
-      annIndex++;
+      catch (NullPointerException e) {
+        // just means there are no other map annotations
+      }
+      for (int i=0; i<resolutions.size(); i++) {
+        List<MapPair> resAnnotation = new ArrayList<MapPair>();
+        for (int r=1; r<resolutions.get(i).size(); r++) {
+          resAnnotation.add(
+            new MapPair(String.valueOf(r), resolutions.get(i).get(r).toString()));
+        }
+        String mapId = "Annotation:Resolution:" + i;
+        setMapAnnotationID(mapId, annIndex);
+        setMapAnnotationNamespace(NAMESPACE, annIndex);
+        setMapAnnotationValue(resAnnotation, annIndex);
+          annIndex++;
+      }
+      written = true;
     }
 
-    String xml = super.dumpXML();
-    return xml;
+    return super.dumpXML();
   }
 
   @Override
@@ -105,6 +109,7 @@ public class OMEPyramidStore extends OMEXMLMetadataImpl implements IPyramidStore
         }
 
         resolutions.add(r);
+        written = true;
       }
     }
   }

--- a/components/formats-api/src/loci/formats/ome/OMEPyramidStore.java
+++ b/components/formats-api/src/loci/formats/ome/OMEPyramidStore.java
@@ -62,7 +62,7 @@ public class OMEPyramidStore extends OMEXMLMetadataImpl implements IPyramidStore
   /* @see IPyramidStore#getResolutionCount(int) */
   public int getResolutionCount(int image) {
     checkImageIndex(image);
-    return resolutions.get(image).size();
+    return image < resolutions.size() ? resolutions.get(image).size() : 1;
   }
 
   /* @see IPyramidStore#getResolutionSizeX(int, int) */

--- a/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
+++ b/components/formats-api/src/loci/formats/services/OMEXMLServiceImpl.java
@@ -60,8 +60,8 @@ import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 import loci.formats.meta.ModuloAnnotation;
 import loci.formats.meta.OriginalMetadataAnnotation;
+import loci.formats.ome.OMEPyramidStore;
 import loci.formats.ome.OMEXMLMetadata;
-import loci.formats.ome.OMEXMLMetadataImpl;
 
 import ome.units.quantity.Length;
 
@@ -372,7 +372,7 @@ public class OMEXMLServiceImpl extends AbstractService implements OMEXMLService
     OMEXMLMetadataRoot ome =
       xml == null ? null : createRoot(transformToLatestVersion(xml));
 
-    OMEXMLMetadata meta = new OMEXMLMetadataImpl();
+    OMEXMLMetadata meta = new OMEPyramidStore();
     if (ome != null) meta.setRoot(ome);
     return meta;
   }

--- a/components/formats-api/src/loci/formats/writers.txt
+++ b/components/formats-api/src/loci/formats/writers.txt
@@ -3,6 +3,7 @@
 # Please do not edit unless you know what you are doing.
 
 loci.formats.out.OMEXMLWriter  	# ome
+loci.formats.out.PyramidOMETiffWriter # ome.tif, ome.tiff
 loci.formats.out.OMETiffWriter  # ome.tif, ome.tiff
 loci.formats.out.TiffWriter     # tif, tiff
 loci.formats.out.JPEGWriter     # jpg, jpeg

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1257,6 +1257,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
   }
 
   private void addSubResolutions() throws IOException, FormatException {
+    boolean repopulateMetadata = false;
     for(int s = 0; s < core.size(); s++) {
       OMETiffCoreMetadata c0 = (OMETiffCoreMetadata) core.get(s, 0);
       int i = info[s][0].ifd;
@@ -1276,6 +1277,10 @@ public class OMETiffReader extends SubResolutionFormatReader {
       TiffParser p = new TiffParser(rs);
       IFDList subifds = p.getSubIFDs(ifd);
       c0.resolutionCount = subifds.size() + 1;
+
+      if (c0.resolutionCount > 1 && hasFlattenedResolutions()) {
+        repopulateMetadata = true;
+      }
 
       for (int si = 0; si < subifds.size(); si++) {
         IFD subifd = subifds.get(si);
@@ -1310,6 +1315,12 @@ public class OMETiffReader extends SubResolutionFormatReader {
       }
     }
     core.reorder();
+
+    // make sure the Image count matches the series count when
+    // the resolutions are flattened
+    if (repopulateMetadata) {
+      MetadataTools.populatePixels(metadataStore, this);
+    }
   }
 
   /** Extracts the OME-XML from the current {@link #metadataFile}. */

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -267,7 +267,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
   /* @see loci.formats.SubResolutionFormatReader#get8BitLookupTable() */
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
-    int series = getSeries();
     if (info[series][lastPlane] == null ||
       info[series][lastPlane].reader == null ||
       info[series][lastPlane].id == null)
@@ -281,7 +280,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
   /* @see loci.formats.SubResolutionFormatReader#get16BitLookupTable() */
   @Override
   public short[][] get16BitLookupTable() throws FormatException, IOException {
-    int series = getSeries();
     if (info[series][lastPlane] == null ||
       info[series][lastPlane].reader == null ||
       info[series][lastPlane].id == null)
@@ -316,7 +314,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
     throws FormatException, IOException
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
-    int series = getSeries();
     lastPlane = no;
     int i = info[series][no].ifd;
 
@@ -358,7 +355,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
     FormatTools.assertId(currentId, true, 1);
-    int series = getSeries();
     if (noPixels) return null;
     final List<String> usedFiles = new ArrayList<>();
     if (metadataFile != null) {
@@ -428,18 +424,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
   public int getOptimalTileHeight() {
     FormatTools.assertId(currentId, true, 1);
     return ((OMETiffCoreMetadata) currentCore()).tileHeight;
-  }
-
-  /* @see IFormatReader#getcoredataList() */
-  @Override
-  public List<CoreMetadata> getCoreMetadataList() {
-    FormatTools.assertId(currentId, true, 1);
-    if (flattenedResolutions) {
-      return core.getSeriesList();
-    }
-    else {
-      return core.getFlattenedList();
-    }
   }
 
   // -- Internal FormatReader API methods --
@@ -1273,14 +1257,6 @@ public class OMETiffReader extends SubResolutionFormatReader {
   }
 
   private void addSubResolutions() throws IOException, FormatException {
-    // If sub-resolutions are flattened, we simply ignore them.  This
-    // is because the MetadataStore contains only the Images present
-    // in the original OME-XML and adding additional ones afterward is
-    // rather difficult.  It also interacts badly with the reader
-    // wrappers.
-    if(flattenedResolutions) {
-      return;
-    }
     for(int s = 0; s < core.size(); s++) {
       OMETiffCoreMetadata c0 = (OMETiffCoreMetadata) core.get(s, 0);
       int i = info[s][0].ifd;
@@ -1299,6 +1275,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
         new RandomAccessInputStream(info[s][0].id, 16);
       TiffParser p = new TiffParser(rs);
       IFDList subifds = p.getSubIFDs(ifd);
+      c0.resolutionCount = subifds.size() + 1;
 
       for (int si = 0; si < subifds.size(); si++) {
         IFD subifd = subifds.get(si);

--- a/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
@@ -87,5 +87,17 @@ public class PyramidOMETiffWriter extends OMETiffWriter {
 
   // -- IFormatWriter API methods --
 
+  @Override
+  public void saveBytes(int no, byte[] buf, IFD ifd, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    if (getResolution() > 0) {
+      if (ifd == null) {
+        ifd = new IFD();
+      }
+      ifd.put(IFD.NEW_SUBFILE_TYPE, 1);
+    }
+    super.saveBytes(no, buf, ifd, x, y, w, h);
+  }
 
 }

--- a/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/PyramidOMETiffWriter.java
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.out;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import ome.xml.meta.OMEXMLMetadataRoot;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveInteger;
+
+import loci.common.Location;
+import loci.common.Constants;
+import loci.common.RandomAccessInputStream;
+import loci.common.RandomAccessOutputStream;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.meta.IPyramidStore;
+import loci.formats.meta.MetadataRetrieve;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.OMEXMLService;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.TiffSaver;
+import loci.formats.in.MetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
+
+/**
+ * PyramidOMETiffWriter is the file format writer for pyramid OME-TIFF files.
+ */
+public class PyramidOMETiffWriter extends OMETiffWriter {
+
+  // -- Constructor --
+
+  // -- IFormatHandler API methods --
+
+  /* @see IFormatHandler#isThisType(String) */
+  @Override
+  public boolean isThisType(String name) {
+    if (!super.isThisType(name)) {
+      return false;
+    }
+    MetadataRetrieve r = getMetadataRetrieve();
+    if (!(r instanceof IPyramidStore)) {
+      return false;
+    }
+    return ((IPyramidStore) r).getResolutionCount(0) > 1;
+  }
+
+  // -- IFormatWriter API methods --
+
+
+}

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -411,11 +411,13 @@ public class TiffWriter extends FormatWriter {
 
     int index = (no * getResolutionCount()) + getResolution();
     int currentSeries = getSeries();
+    int currentResolution = getResolution();
     for (int i=0; i<currentSeries; i++) {
       setSeries(i);
       index += (getPlaneCount() * getResolutionCount());
     }
     setSeries(currentSeries);
+    setResolution(currentResolution);
     return index;
   }
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -659,6 +659,22 @@ public class TiffSaver {
     writeIntValue(out, 0);
   }
 
+  public void overwriteIFDOffset(RandomAccessInputStream raf, long offset,
+    long nextPointer)
+    throws FormatException, IOException
+  {
+    if (raf == null) {
+      throw new FormatException("Input stream cannot be null");
+    }
+    int bytesPerEntry = bigTiff ?
+      TiffConstants.BIG_TIFF_BYTES_PER_ENTRY : TiffConstants.BYTES_PER_ENTRY;
+    raf.seek(offset);
+    long entries = bigTiff ? raf.readLong() : raf.readUnsignedShort();
+    long overwriteOffset = offset + bytesPerEntry * entries + (bigTiff ? 8 : 2);
+    out.seek(overwriteOffset);
+    writeIntValue(out, nextPointer);
+  }
+
   /**
    * Surgically overwrites an existing IFD value with the given one. This
    * method requires that the IFD directory entry already exist. It
@@ -779,7 +795,7 @@ public class TiffSaver {
         writeIntValue(out, newOffset);
         if (extraBuf.length() > 0) {
           out.seek(newOffset);
-          out.write(extraBuf.getByteBuffer(), 0, newCount);
+          out.write(extraBuf.getByteBuffer());
         }
         return;
       }

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -735,9 +735,11 @@ public class TiffSaver {
         ByteArrayHandle extraBuf = new ByteArrayHandle();
         RandomAccessOutputStream extraOut =
           new RandomAccessOutputStream(extraBuf);
+        ifdOut.order(little);
         extraOut.order(little);
         TiffSaver saver = new TiffSaver(ifdOut, ifdBuf);
-        saver.setLittleEndian(isLittleEndian());
+        saver.setLittleEndian(little);
+        saver.setBigTiff(bigTiff);
         saver.writeIFDValue(extraOut, entry.getValueOffset(), tag, value);
         ifdOut.close();
         saver.close();
@@ -752,7 +754,7 @@ public class TiffSaver {
         int newCount;
         long newOffset;
         if (bigTiff) {
-          newCount = ifdBuf.readInt();
+          newCount = (int) ifdBuf.readLong();
           newOffset = ifdBuf.readLong();
         }
         else {

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -295,7 +295,7 @@ public class TiffWriterTest {
       writer.setTileSizeY(tile_size);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Pixels Size Y must not be null when attempting to set tile size")) {
+      if (e.getMessage().contains("Size Y must not be null")) {
         thrown = true;
       }
     }
@@ -305,7 +305,7 @@ public class TiffWriterTest {
       writer.setTileSizeX(tile_size);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Pixels Size X must not be null when attempting to set tile size")) {
+      if (e.getMessage().contains("Size X must not be null")) {
         thrown = true;
       }
     }
@@ -315,7 +315,7 @@ public class TiffWriterTest {
       writer.getTileSizeX();
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Pixels Size X must not be null when attempting to get tile size")) {
+      if (e.getMessage().contains("Size X must not be null")) {
         thrown = true;
       }
     }
@@ -325,7 +325,7 @@ public class TiffWriterTest {
       writer.getTileSizeY();
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Pixels Size Y must not be null when attempting to get tile size")) {
+      if (e.getMessage().contains("Size Y must not be null")) {
         thrown = true;
       }
     }

--- a/components/formats-bsd/test/loci/formats/utests/tiff/PyramidTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/PyramidTest.java
@@ -1,0 +1,371 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.utests.tiff;
+
+import static org.testng.AssertJUnit.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import loci.formats.FormatException;
+import loci.formats.IFormatReader;
+import loci.formats.ImageReader;
+import loci.formats.MetadataTools;
+import loci.formats.meta.DummyMetadata;
+import loci.formats.meta.IMetadata;
+import loci.formats.meta.IPyramidStore;
+import loci.formats.out.PyramidOMETiffWriter;
+import loci.formats.tiff.IFD;
+
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.PositiveInteger;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Reads a set of pyramid resolutions (one per file) and converts to a single
+ * pyramid OME-TIFF.
+ */
+public class PyramidTest {
+
+  private static final int RESOLUTION_COUNT = 4;
+  private static final int EXTRA_WIDTH = 9;
+  private static final int EXTRA_HEIGHT = 3;
+  private static final int TILE_SIZE = 1;
+  private static final int SCALE = 2;
+
+  private File[] files = new File[9];
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    for (int i=0; i<files.length; i++) {
+      files[i] = File.createTempFile("PyramidTest", ".ome.tiff");
+    }
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    for (File f : files) {
+      f.delete();
+    }
+  }
+
+  @Test
+  public void testSinglePyramid() throws FormatException, IOException {
+    writePyramid(files[0].getAbsolutePath(), new int[] {8}, new int[] {8}, 1, 0, false, false);
+    IFormatReader reader = getReader(0);
+    try {
+      assertEquals(reader.getSeriesCount(), 1);
+      assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testSinglePyramidBigTiff() throws FormatException, IOException {
+    writePyramid(files[1].getAbsolutePath(), new int[] {8}, new int[] {8}, 1, 0, false, true);
+    IFormatReader reader = getReader(1);
+    try {
+      assertEquals(reader.getSeriesCount(), 1);
+      assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testSinglePyramidBigEndian() throws FormatException, IOException {
+    writePyramid(files[2].getAbsolutePath(), new int[] {8}, new int[] {8}, 1, 0, true, false);
+    IFormatReader reader = getReader(2);
+    try {
+      assertEquals(reader.getSeriesCount(), 1);
+      assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testSinglePyramidBigEndianBigTiff() throws FormatException, IOException {
+    writePyramid(files[3].getAbsolutePath(), new int[] {8}, new int[] {8}, 1, 0, true, true);
+    IFormatReader reader = getReader(3);
+    try {
+      assertEquals(reader.getSeriesCount(), 1);
+      assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testSinglePyramidWithExtra() throws FormatException, IOException {
+    writePyramid(files[4].getAbsolutePath(), new int[] {16}, new int[] {16}, 1, 2, false, true);
+    IFormatReader reader = getReader(4);
+    try {
+      assertEquals(reader.getSeriesCount(), 3);
+      assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+      assertEquals(reader.getSizeX(), 16);
+      assertEquals(reader.getSizeY(), 16);
+      reader.setSeries(1);
+      assertEquals(reader.getResolutionCount(), 1);
+      assertEquals(reader.getSizeX(), EXTRA_WIDTH);
+      assertEquals(reader.getSizeY(), EXTRA_HEIGHT);
+      reader.setSeries(2);
+      assertEquals(reader.getResolutionCount(), 1);
+      assertEquals(reader.getSizeX(), EXTRA_WIDTH);
+      assertEquals(reader.getSizeY(), EXTRA_HEIGHT);
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testSinglePyramidMultiplePlanes() throws FormatException, IOException {
+    writePyramid(files[5].getAbsolutePath(), new int[] {16}, new int[] {16}, 3, 0, false, true);
+    IFormatReader reader = getReader(5);
+    try {
+      assertEquals(reader.getSeriesCount(), 1);
+      assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+      assertEquals(reader.getSizeX(), 16);
+      assertEquals(reader.getSizeY(), 16);
+      for (int i=0; i<RESOLUTION_COUNT; i++) {
+        reader.setResolution(i);
+        assertEquals(reader.getSizeZ(), 3);
+      }
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testMultiplePyramids() throws FormatException, IOException {
+    int[] dims = new int[] {16, 10};
+    writePyramid(files[6].getAbsolutePath(), dims, dims, 1, 0, false, true);
+    IFormatReader reader = getReader(6);
+    try {
+      assertEquals(reader.getSeriesCount(), 2);
+      for (int s=0; s<reader.getSeriesCount(); s++) {
+        reader.setSeries(s);
+        assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+        assertEquals(reader.getSizeX(), dims[s]);
+        assertEquals(reader.getSizeY(), dims[s]);
+        assertEquals(reader.getSizeZ(), 1);
+      }
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testMultiplePyramidsExtra() throws FormatException, IOException {
+    int[] dims = new int[] {8, 10};
+    writePyramid(files[7].getAbsolutePath(), dims, dims, 1, 2, false, true);
+    IFormatReader reader = getReader(7);
+    try {
+      assertEquals(reader.getSeriesCount(), 4);
+      for (int s=0; s<reader.getSeriesCount(); s++) {
+        reader.setSeries(s);
+        if (s < dims.length) {
+          assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+          assertEquals(reader.getSizeX(), dims[s]);
+          assertEquals(reader.getSizeY(), dims[s]);
+        }
+        else {
+          assertEquals(reader.getResolutionCount(), 1);
+          assertEquals(reader.getSizeX(), EXTRA_WIDTH);
+          assertEquals(reader.getSizeY(), EXTRA_HEIGHT);
+        }
+        assertEquals(reader.getSizeZ(), 1);
+      }
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testMultiplePyramidsMultiplePlanes() throws FormatException, IOException {
+    int[] dims = new int[] {8, 10};
+    writePyramid(files[8].getAbsolutePath(), dims, dims, 2, 0, false, true);
+    IFormatReader reader = getReader(8);
+    try {
+      assertEquals(reader.getSeriesCount(), 2);
+      for (int s=0; s<reader.getSeriesCount(); s++) {
+        reader.setSeries(s);
+        assertEquals(reader.getResolutionCount(), RESOLUTION_COUNT);
+        assertEquals(reader.getSizeX(), dims[s]);
+        assertEquals(reader.getSizeY(), dims[s]);
+        assertEquals(reader.getSizeZ(), 2);
+      }
+      assertTrue(checkPixels(reader));
+    }
+    finally {
+      reader.close();
+    }
+  }
+
+  private IFormatReader getReader(int index) throws FormatException, IOException {
+    ImageReader reader = new ImageReader();
+    reader.setFlattenedResolutions(false);
+    reader.setId(files[index].getAbsolutePath());
+    return reader;
+  }
+
+  private boolean checkPixels(IFormatReader reader) throws FormatException, IOException {
+    int index = 1;
+    for (int s=0; s<reader.getSeriesCount(); s++) {
+      reader.setSeries(s);
+      for (int r=0; r<reader.getResolutionCount(); r++) {
+        reader.setResolution(r);
+
+        for (int p=0; p<reader.getImageCount(); p++) {
+          byte[] plane = reader.openBytes(p);
+          for (byte pixel : plane) {
+            if ((pixel & 0xff) != index) {
+              return false;
+            }
+          }
+          index++;
+        }
+      }
+    }
+    return true;
+  }
+
+  private void writePyramid(String file, int[] widths, int[] heights, int planes,
+    int extra, boolean bigEndian, boolean bigTiff)
+    throws FormatException, IOException
+   {
+    // read each input file's metadata to build an IPyramidStore
+    // that represents the full image pyramid
+    IMetadata meta = MetadataTools.createOMEXMLMetadata();
+
+    if (!(meta instanceof IPyramidStore)) {
+      throw new FormatException("MetadataStore is not an IPyramidStore; " +
+        "cannot write pyramid");
+    }
+
+    for (int p=0; p<widths.length; p++) {
+      populateImage(meta, p, widths[p], heights[p], planes, bigEndian);
+
+      for (int r=1; r<RESOLUTION_COUNT; r++) {
+        int scale = (int) Math.pow(SCALE, r);
+        ((IPyramidStore) meta).setResolutionSizeX(
+          new PositiveInteger(widths[p] / scale), p, r);
+        ((IPyramidStore) meta).setResolutionSizeY(
+          new PositiveInteger(heights[p] / scale), p, r);
+      }
+    }
+    for (int p=widths.length; p<widths.length+extra; p++) {
+      populateImage(meta, p, EXTRA_WIDTH, EXTRA_HEIGHT, planes, bigEndian);
+    }
+  
+    PyramidOMETiffWriter writer = new PyramidOMETiffWriter();
+    writer.setBigTiff(bigTiff);
+    writer.setWriteSequentially(true);
+    writer.setMetadataRetrieve(meta);
+    writer.setId(file);
+
+    int index = 1;
+    for (int p=0; p<widths.length; p++) {
+      writer.setSeries(p);
+      for (int r=0; r<RESOLUTION_COUNT; r++) {
+        writer.setResolution(r);
+
+        int scale = (int) Math.pow(SCALE, r);
+        int width = widths[p] / scale;
+        int height = heights[p] / scale;
+        for (int plane=0; plane<planes; plane++) {
+          byte[] tile = new byte[] {(byte) index++};
+          IFD ifd = new IFD();
+          ifd.put(IFD.TILE_WIDTH, TILE_SIZE);
+          ifd.put(IFD.TILE_LENGTH, TILE_SIZE);
+
+          for (int yy=0; yy<height; yy++) {
+            for (int xx=0; xx<width; xx++) {
+              writer.saveBytes(plane, tile, ifd, xx, yy, TILE_SIZE, TILE_SIZE);
+            }
+          }
+        }
+      }
+    }
+    for (int e=0; e<extra; e++) {
+      writer.setSeries(widths.length + e);
+      for (int plane=0; plane<planes; plane++) {
+        byte[] extraPlane = new byte[EXTRA_WIDTH * EXTRA_HEIGHT];
+        Arrays.fill(extraPlane, (byte) index++);
+        writer.saveBytes(plane, extraPlane);
+      }
+    }
+    writer.close();
+  }
+
+  /**
+   * Set metadata for writing a single Image/series.  Does not set subresolution data.
+   */
+  private void populateImage(IMetadata meta, int p, int width, int height, int planes, boolean bigEndian) {
+    meta.setImageID("Image:" + p, p);
+    meta.setPixelsID("Pixels:" + p, p);
+    meta.setPixelsDimensionOrder(DimensionOrder.XYZCT, p);
+    meta.setPixelsSizeX(new PositiveInteger(width), p);
+    meta.setPixelsSizeY(new PositiveInteger(height), p);
+    meta.setPixelsSizeZ(new PositiveInteger(planes), p);
+    meta.setPixelsSizeC(new PositiveInteger(1), p);
+    meta.setPixelsSizeT(new PositiveInteger(1), p);
+    meta.setPixelsType(PixelType.UINT8, p);
+    meta.setPixelsBigEndian(bigEndian, p);
+    meta.setChannelID("Channel:" + p + ":0", p, 0);
+    meta.setChannelSamplesPerPixel(new PositiveInteger(1), p, 0);
+  }
+
+}

--- a/components/formats-gpl/utils/MinimumPyramidWriter.java
+++ b/components/formats-gpl/utils/MinimumPyramidWriter.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import loci.common.services.ServiceFactory;
+import loci.formats.*;
+import loci.formats.ome.OMEPyramidStore;
+import loci.formats.services.OMEXMLService;
+
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.PositiveInteger;
+
+/**
+ * Demonstrates the minimum amount of metadata
+ * necessary to write out an image pyramid.
+ */
+public class MinimumPyramidWriter {
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 1) {
+      System.out.println("Please specify an output file name.");
+      System.exit(1);
+    }
+    String id = args[0];
+
+    // create a blank pyramid
+
+    int w = 4096, h = 4096, c = 1;
+    int resolutions = 6;
+    int pixelType = FormatTools.UINT16;
+    int bpp = FormatTools.getBytesPerPixel(pixelType);
+    byte[] img = new byte[w * h * c * bpp];
+
+    // fill with random data
+    for (int i=0; i<img.length; i++) img[i] = (byte) (256 * Math.random());
+
+    // create metadata object with minimum required metadata fields
+    System.out.println("Populating metadata...");
+
+    ServiceFactory factory = new ServiceFactory();
+    OMEXMLService service = factory.getInstance(OMEXMLService.class);
+    OMEPyramidStore meta = (OMEPyramidStore) service.createOMEXMLMetadata();
+
+    MetadataTools.populateMetadata(meta, 0, null, false, "XYZCT",
+      FormatTools.getPixelTypeString(pixelType), w, h, 1, c, 1, c);
+
+    for (int i=1; i<resolutions; i++) {
+      int scale = (int) Math.pow(2, i);
+      meta.setResolutionSizeX(new PositiveInteger(w / scale), 0, i);
+      meta.setResolutionSizeY(new PositiveInteger(h / scale), 0, i);
+    }
+
+    // write image plane to disk
+    System.out.println("Writing image to '" + id + "'...");
+    IFormatWriter writer = new ImageWriter();
+    writer.setMetadataRetrieve(meta);
+    writer.setId(id);
+    writer.saveBytes(0, img);
+    for (int i=1; i<resolutions; i++) {
+      // TODO
+    }
+    writer.close();
+
+    System.out.println("Done.");
+  }
+
+}

--- a/components/formats-gpl/utils/MinimumPyramidWriter.java
+++ b/components/formats-gpl/utils/MinimumPyramidWriter.java
@@ -23,6 +23,8 @@
  * #L%
  */
 
+import java.util.Arrays;
+
 import loci.common.services.ServiceFactory;
 import loci.formats.*;
 import loci.formats.ome.OMEPyramidStore;
@@ -79,7 +81,13 @@ public class MinimumPyramidWriter {
     writer.setId(id);
     writer.saveBytes(0, img);
     for (int i=1; i<resolutions; i++) {
-      // TODO
+      writer.setResolution(i);
+      int x = meta.getResolutionSizeX(0, i).getValue();
+      int y = meta.getResolutionSizeY(0, i).getValue();
+      byte[] downsample = new byte[x * y * bpp * c];
+      // don't use random data, so it's obvious that the correct resolution is read
+      Arrays.fill(downsample, (byte) i);
+      writer.saveBytes(0, downsample);
     }
     writer.close();
 

--- a/components/formats-gpl/utils/WritePyramid.java
+++ b/components/formats-gpl/utils/WritePyramid.java
@@ -1,0 +1,108 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import loci.formats.ImageReader;
+import loci.formats.MetadataTools;
+import loci.formats.meta.DummyMetadata;
+import loci.formats.meta.IMetadata;
+import loci.formats.meta.IPyramidStore;
+import loci.formats.out.PyramidOMETiffWriter;
+import loci.formats.tiff.IFD;
+
+import ome.xml.model.primitives.PositiveInteger;
+
+/**
+ * Reads a set of pyramid resolutions (one per file) and converts to a single
+ * pyramid OME-TIFF.
+ */
+public class WritePyramid {
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 2) {
+      System.out.println("Specify one input file per resolution in " +
+        "descending order and one output file");
+      return;
+    }
+    loci.common.DebugTools.enableLogging("INFO");
+
+    // read each input file's metadata to build an IPyramidStore
+    // that represents the full image pyramid
+    IMetadata meta = MetadataTools.createOMEXMLMetadata();
+    if (!(meta instanceof IPyramidStore)) {
+      System.out.println("MetadataStore is not an IPyramidStore; " +
+        "cannot write pyramid");
+      return;
+    }
+
+    ImageReader reader = new ImageReader();
+    reader.setMetadataStore(meta);
+    reader.setId(args[0]);
+    reader.close();
+    reader.setMetadataStore(new DummyMetadata());
+    for (int i=1; i<args.length-1; i++) {
+      reader.setId(args[i]);
+      int x = reader.getSizeX();
+      int y = reader.getSizeY();
+      reader.close();
+      ((IPyramidStore) meta).setResolutionSizeX(new PositiveInteger(x), 0, i);
+      ((IPyramidStore) meta).setResolutionSizeY(new PositiveInteger(y), 0, i);
+    }
+
+    // pass metadata to the writer so that a single file will be
+    // written containing the whole image pyramid
+    String output = args[args.length - 1];
+    PyramidOMETiffWriter writer = new PyramidOMETiffWriter();
+    writer.setWriteSequentially(true);
+    writer.setMetadataRetrieve(meta);
+    writer.setId(output);
+
+    // save image tiles with dimensions 256x256
+    // the largest resolution in a pyramid may be very large,
+    // so working with whole planes at once doesn't make sense
+    int tileSize = 256;
+    for (int i=0; i<args.length-1; i++) {
+      writer.setResolution(i);
+      reader.setId(args[i]);
+      writer.setInterleaved(reader.isInterleaved());
+
+      for (int plane=0; plane<reader.getImageCount(); plane++) {
+        IFD ifd = new IFD();
+        ifd.put(IFD.TILE_WIDTH, tileSize);
+        ifd.put(IFD.TILE_LENGTH, tileSize);
+        for (int yy=0; yy<reader.getSizeY(); yy+=tileSize) {
+          for (int xx=0; xx<reader.getSizeX(); xx+=tileSize) {
+            int realWidth = (int) Math.min(tileSize, reader.getSizeX() - xx);
+            int realHeight = (int) Math.min(tileSize, reader.getSizeY() - yy);
+            byte[] tile = reader.openBytes(plane, xx, yy, realWidth, realHeight);
+            writer.saveBytes(plane, tile, ifd, xx, yy, realWidth, realHeight);
+          }
+        }
+      }
+      reader.close();
+    }
+    writer.close();
+  }
+
+}


### PR DESCRIPTION
See https://trello.com/c/MRzY025E/2-java-writer-implementation

```loci.formats.out.PyramidOMETiffWriter``` is the new writer for pyramid OME-TIFFs.  It will be used whenever an OME-TIFF extension is specified and resolution metadata is supplied to the writer.  ```PyramidOMETiffWriter``` extends ```OMETiffWriter```; the only major differences are the addition of ```NEW_SUBFILE_TYPE``` and ```SUB_IFD``` tags during ```saveBytes```, and the ```SUB_IFD``` tag and IFD offset overwriting during ```close()```.  Note that when multiple planes per resolution are present, the assumption is that every plane in the resolution is written before switching resolutions (i.e. R0P0, R0P1, ... R0Pn, R1P0, R1P1, ...).  If the spec differs, this will need to be updated in the writer.

Stand-alone examples are ```components/formats-gpl/utils/MinimumPyramidWriter.java``` (writing a pyramid when the pixels/metadata are not supplied by a reader) and ```components/formats-gpl/utils/WritePyramid.java``` (writing a pyramid by reading a set of files, one per resolution).  Unit tests are in ```components/formats-bsd/src/loci/formats/utests/tiff/PyramidTest.java```.

When a source file is recognized as a pyramid, ```bfconvert -noflat input output.ome.tiff``` (using BigTIFF if needed) should result in an OME-TIFF that ```showinf -nopix -noflat``` recognizes as a pyramid.  Be aware that some formats with pyramids are not recognized as such on ```east``` (independent of this PR), so check ```showinf -nopix -noflat``` before trying a conversion (NDPI for example won't work, but SVS and Leica SCN should be OK).  ```showinf -nopix``` on the resulting output file will now show a series count matching the resolution count (plus any extra series), instead of just the full resolution(s).  This is consistent with how flattened resolutions are handled in other readers, and was the only real reader change necessary.

Testing pyramid writing exposed a few bugs in ```TiffSaver```, particularly when overwriting IFD values/offsets in BigTIFF files or when a tag value is not inlined and requires multiple bytes per array entry.

The main thing that needs discussion here is whether the API for supplying resolution metadata is what we actually want to support.  I picked an "extend MetadataStore" strategy partly to reduce the burden on the caller in the conversion case, but mostly just needed to get *something* in place to move on to the actual writer.  An alternative (as referenced on the Trello card) would be to have ```setSizeX``` and ```setSizeY``` in ```IFormatWriter``` and just remove the ```IPyramidStore```/```OMEPyramidStore```/```MetadataTools```/etc. changes here.  Either way, enforcement of resolution ordering needs to be added - it's a minor change, but was waiting for the spec PR to make sure I get it right.