### PR TITLE
AVI: skip RIFF chunks with FourCC != "AVI "

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/AVIReader.java
+++ b/components/formats-bsd/src/loci/formats/in/AVIReader.java
@@ -540,12 +540,17 @@ public class AVIReader extends FormatReader {
   }
 
   private void readChunk() throws FormatException, IOException {
+    long originalOffset = in.getFilePointer();
     readChunkHeader();
     CoreMetadata m = core.get(0);
 
-    if (type.equals("RIFF")) {
+    if (type.equals(AVI_MAGIC_STRING)) {
       if (!fcc.startsWith("AVI")) {
-        throw new FormatException("Sorry, AVI RIFF format not found.");
+        LOGGER.warn("Unrecognized chunk '{}' at offset {}", fcc, originalOffset);
+        if (in.getFilePointer() + size - 4 <= in.length()) {
+          in.skipBytes(size - 4);
+          return;
+        }
       }
     }
     else if (in.getFilePointer() == 12) {
@@ -565,7 +570,7 @@ public class AVIReader extends FormatReader {
 
     while ((in.length() - in.getFilePointer()) > 4) {
       listString = in.readString(4);
-      if (listString.equals("RIFF")) {
+      if (listString.equals(AVI_MAGIC_STRING)) {
         in.seek(in.getFilePointer() - 4);
         return;
       }


### PR DESCRIPTION
Backported from a private PR.  The original bug report indicated that AVI files acquired using software from Keyence (https://www.keyence.com/products/microscope/fluorescence-microscope/index.jsp?_ga=2.138499632.28338486.1533222430-676692882.1533222430) are unreadable due to an extra RIFF chunk at the end of the file which should be ignored.

To test, use ```data_repo/curated/avi/sample-avis/extra-chunk/HyperStack.avi```.  This is not real data, but simulates the extra RIFF chunk written by Keyence software (see the corresponding readme).

Without this PR, ```showinf -debug HyperStack.avi``` should throw the following:

```
loci.formats.FormatException: Sorry, AVI RIFF format not found.
	at loci.formats.in.AVIReader.readChunk(AVIReader.java:548) ~[bioformats_package.jar:5.9.1-SNAPSHOT]
	at loci.formats.in.AVIReader.initFile(AVIReader.java:322) ~[bioformats_package.jar:5.9.1-SNAPSHOT]
	at loci.formats.FormatReader.setId(FormatReader.java:1397) ~[bioformats_package.jar:5.9.1-SNAPSHOT]
	at loci.formats.ImageReader.setId(ImageReader.java:842) ~[bioformats_package.jar:5.9.1-SNAPSHOT]
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650) ~[bioformats_package.jar:5.9.1-SNAPSHOT]
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1034) [bioformats_package.jar:5.9.1-SNAPSHOT]
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1120) [bioformats_package.jar:5.9.1-SNAPSHOT]
```

With this PR, the same test should open images without throwing an exception; the dimensions and images should be identical to the existing ```data_repo/curated/avi/sample-avis/rgb-odd-width/HyperStack.avi```.

This should be safe for a patch release, but I definitely wouldn't expect it to be included in 5.9.1 so feel free to exclude as needed.