### PR TITLE
Type detection and physical size unit fixes for MRC

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -170,7 +170,7 @@ public class DeltavisionReader extends FormatReader {
     if(new TiffParser(stream).isValidHeader()) {
       return false;
     }
-    final int blockLen = 98;
+    final int blockLen = 212;
     if (!FormatTools.validStream(stream, blockLen, true)) return false;
     stream.seek(96);
     int magic = stream.readShort() & 0xffff;
@@ -179,6 +179,11 @@ public class DeltavisionReader extends FormatReader {
       return false;
     }
     stream.order(magic == (LITTLE_ENDIAN & 0xffff));
+    stream.seek(208);
+    boolean isMap = stream.readString(4).trim().equals("MAP");
+    if (isMap) {
+      return false;
+    }
     stream.seek(0);
     int x = stream.readInt();
     int y = stream.readInt();

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -36,6 +36,7 @@ import loci.formats.FormatTools;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import ome.units.quantity.Length;
+import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
@@ -299,8 +300,13 @@ public class MRCReader extends FormatReader {
 
     extHeaderSize = in.readInt();
 
+    in.skipBytes(8);
+
+    String extType = in.readString(4);
+    addGlobalMeta("Extended header type", extType);
+
     if (level != MetadataLevel.MINIMUM) {
-      in.skipBytes(64);
+      in.skipBytes(52);
 
       int idtype = in.readShort();
 
@@ -325,6 +331,8 @@ public class MRCReader extends FormatReader {
       for (int i=0; i<10; i++) {
         addGlobalMetaList("Label", in.readString(80));
       }
+
+      LOGGER.info("Skipping extended header of type '{}' and size {}", extType, extHeaderSize);
     }
 
     LOGGER.info("Populating metadata");
@@ -341,9 +349,15 @@ public class MRCReader extends FormatReader {
     MetadataTools.populatePixels(store, this);
 
     if (level != MetadataLevel.MINIMUM) {
-      Length sizeX = FormatTools.getPhysicalSizeX(xSize, UNITS.ANGSTROM);
-      Length sizeY = FormatTools.getPhysicalSizeY(ySize, UNITS.ANGSTROM);
-      Length sizeZ = FormatTools.getPhysicalSizeZ(zSize, UNITS.ANGSTROM);
+      // this is the unit specified by the MRC documentation
+      Unit sizeUnit = UNITS.ANGSTROM;
+      if (extType.equals("AGAR")) {
+        // FEI software typically writes physical sizes in micrometers
+        sizeUnit = UNITS.MICROM;
+      }
+      Length sizeX = FormatTools.getPhysicalSizeX(xSize, sizeUnit);
+      Length sizeY = FormatTools.getPhysicalSizeY(ySize, sizeUnit);
+      Length sizeZ = FormatTools.getPhysicalSizeZ(zSize, sizeUnit);
 
       if (sizeX != null) {
         store.setPixelsPhysicalSizeX(sizeX, 0);


### PR DESCRIPTION
Backported from a private PR.

To test, use ```data_repo/curated/mrc/samples/agar-exttype/golgi-modified-AGAR.mrc```.  As noted in the readme, this is a copy of ```data_repo/curated/mrc/samples/golgi.mrc``` with 10 bytes modified to illustrate the problem (since the original file written by FEI's EPU software cannot be shared).

Without this PR, ```showinf -nopix -omexml golgi-modified-AGAR.mrc``` should detect the file as being Deltavision and not MRC.  The ```DeltaT```, ```ExposureTime```, and physical size/position values in the OME-XML are highly improbable, which is good indication that the type detection is wrong.

With this PR, the same test should detect the file as MRC, with more reasonable physical sizes of 1um x 1um.  The extended header type (```AGAR```) and size (```0```) should be logged.

The extended header type is used to determine the physical size units, which seems valid based upon:

http://www.ccpem.ac.uk/mrc_format/mrc2014.php#note8
http://www.ccpem.ac.uk/downloads/EPU_user_manual_AppendixCfordistribution.pdf
http://blake.bcm.edu/eman2/doxygen_html/mrcio_8h_source.html#l00236

FEI software can apparently use the ```AGAR``` (old style) or ```FEI1``` (new style) extended type.  Only ```AGAR``` is handled, since we don't have an example of ```FEI1```.  Per the linked EMAN2 documentation, older MRC files generated by FEI software use micrometers for units instead of meters as noted in the specification.

Builds should remain green and memo files should not be affected.  This should be safe for a patch release, but certainly not 5.9.1.