### PR TITLE
Zeiss LSM: explicitly detect SIM data for use in coloring channels

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissLSMReader.java
@@ -197,6 +197,8 @@ public class ZeissLSMReader extends FormatReader {
     new HashMap<Integer, String>();
   private Color[] channelColor;
 
+  private transient boolean isSIM = false;
+
   // -- Constructor --
 
   /** Constructs a new Zeiss LSM reader. */
@@ -280,6 +282,7 @@ public class ZeissLSMReader extends FormatReader {
       acquiredDate.clear();
       channelNames = null;
       channelColor = null;
+      isSIM = false;
     }
   }
 
@@ -1082,6 +1085,11 @@ public class ZeissLSMReader extends FormatReader {
         }
       }
 
+      if (applicationTagOffset != 0) {
+        in.seek(applicationTagOffset);
+        parseApplicationTags();
+      }
+
       if (channelColorsOffset != 0) {
         in.seek(channelColorsOffset + 12);
         int colorsOffset = in.readInt();
@@ -1108,7 +1116,7 @@ public class ZeissLSMReader extends FormatReader {
             // previous channel (necessary for SIM data)
             // otherwise set the color to white, as this will display better
             if (red == 0 && green == 0 & blue == 0) {
-              if (i > 0) {
+              if (i > 0 && isSIM) {
                 red = channelColor[i - 1].getRed();
                 green = channelColor[i - 1].getGreen();
                 blue = channelColor[i - 1].getBlue();
@@ -1293,11 +1301,6 @@ public class ZeissLSMReader extends FormatReader {
         for (SubBlock block : nonAcquiredBlocks) {
           populateMetadataStore(block, store, series);
         }
-      }
-
-      if (applicationTagOffset != 0) {
-        in.seek(applicationTagOffset);
-        parseApplicationTags();
       }
     }
 
@@ -2253,6 +2256,10 @@ public class ZeissLSMReader extends FormatReader {
       }
 
       addGlobalMeta(entryName, data);
+
+      if (entryName.startsWith("SimOut") || entryName.startsWith("SimPar")) {
+        isSIM = true;
+      }
 
       if (in.getFilePointer() == fp + entrySize) {
         continue;


### PR DESCRIPTION
Expands upon https://github.com/openmicroscopy/bioformats/pull/2851.  Backported from a private PR.

To test, use the following files:

```
data_repo/curated/zeiss-czi/nottingham/incorrect-colors/SIM SpinalChord2ch SeqFrame modeLongerExpo_OutResaved.lsm
data_repo/curated/zeiss-lsm/aaron-ostrovsky/ChaMARCM-F000015_Seg002.lsm
data_repo/curated/zeiss-lsm/greg/ChaMARCM-F000374_Seg002.lsm
data_repo/curated/zeiss-lsm/markus/CDW_3.mdb/CDW_3.mdb
data_repo/curated/zeiss-lsm/martin/051215-Dundee/051215-j-tf.mdb
data_repo/curated/zeiss-lsm/martin/sample files.mdb/XYZ-ch0.lsm
data_repo/curated/zeiss-lsm/martin/sample files.mdb/sample files.mdb
```

Without this PR, ```showinf -nopix -omexml``` on each should show that none of the channels beyond the first are colored white.  With this PR, the same test should show no change for the first file; all other files have one white channel.  This corresponds to what is shown when opening the files in ZEN Black (screenshots in ```team/mlinkert/lsm-screenshots```).

Builds should remain green, and this should not affect memo files so should be safe for a patch release (definitely not urgent though).