### PR TITLE
Use imagej.net URL for ImageJ Javadoc

### DIFF
--- a/ant/java.xml
+++ b/ant/java.xml
@@ -251,10 +251,8 @@ your FindBugs installation's lib directory. E.g.:
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-      <link href="https://imagej.net/developer/api/"/>
-      <link href="http://www.ssec.wisc.edu/visad-docs/javadoc/"/>
-      <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
-      <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->
+      <link href="https://imagej.net/developer/api/"
+            offline="true" packagelistLoc="${root.dir}/ant/package-list"/>
     </javadoc>
   </target>
 

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -251,7 +251,7 @@ your FindBugs installation's lib directory. E.g.:
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-      <link href="https://imagej.nih.gov/ij/developer/api/"/>
+      <link href="https://imagej.net/developer/api/"/>
       <link href="http://www.ssec.wisc.edu/visad-docs/javadoc/"/>
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
       <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->

--- a/ant/package-list
+++ b/ant/package-list
@@ -1,0 +1,12 @@
+ij
+ij.gui
+ij.io
+ij.macro
+ij.measure
+ij.plugin
+ij.plugin.filter
+ij.plugin.frame
+ij.plugin.tool
+ij.process
+ij.text
+ij.util

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -31,7 +31,7 @@ Type "ant -p" for a list of targets.
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-      <link href="https://imagej.nih.gov/ij/developer/api/"/>
+      <link href="https://imagej.net/developer/api/"/>
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
       <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->
     </javadoc>

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -31,9 +31,8 @@ Type "ant -p" for a list of targets.
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
       <link href="http://docs.oracle.com/javase/7/docs/api/"/>
-      <link href="https://imagej.net/developer/api/"/>
-      <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
-      <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->
+      <link href="https://imagej.net/developer/api/"
+            offline="true" packagelistLoc="${root.dir}/ant/package-list"/>
     </javadoc>
     <zip destfile="${artifact.dir}/bio-formats-javadocs-${release.version}.zip">
       <zipfileset dir="${merged-docs.dir}" prefix="bio-formats-javadocs-${release.version}"/>


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/pull/3172#issuecomment-412448699

A previous switch to imagej.net had been conflating with other issues related to the CI environment. As  the connection to imagej.nih.gov seems to be frequently flaky in the morning, trying to switch again to imagej.net as the canonical location for the ImageJ API.