### PR TITLE
TIFF: split IFDs into separate series if the dimensions or pixel type mismatch

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -97,6 +97,12 @@ public class MinimalTiffReader extends FormatReader {
   /** Merge SubIFDs into the main IFD list. */
   protected transient boolean mergeSubIFDs = false;
 
+  /**
+   * Whether or not IFDs with different dimensions can be
+   * split into separate series.
+   */
+  protected transient boolean canSeparateSeries = true;
+
   /** Number of JPEG 2000 resolution levels. */
   private Integer resolutionLevels;
 
@@ -490,7 +496,7 @@ public class MinimalTiffReader extends FormatReader {
             (int) ifd.getImageLength() != y ||
             ifd.getPixelType() != type)
           {
-            separateSeries = true;
+            separateSeries = canSeparateSeries;
           }
         }
       }

--- a/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MinimalTiffReader.java
@@ -511,7 +511,9 @@ public class MinimalTiffReader extends FormatReader {
 
     if (separateSeries) {
       core.clear();
-      for (int i=0; i<ifds.size(); i++) {
+      ms0.imageCount = 1;
+      core.add(ms0);
+      for (int i=1; i<ifds.size(); i++) {
         core.add(new CoreMetadata());
         core.get(i).imageCount = 1;
       }
@@ -633,6 +635,9 @@ public class MinimalTiffReader extends FormatReader {
 
     // New core metadata now that we know how many sub-resolutions we have.
     if (resolutionLevels != null && subResolutionIFDs.size() > 0) {
+      ms0 = core.get(0);
+      core.clear();
+      core.add(ms0);
       IFDList ifds = subResolutionIFDs.get(0);
       int seriesCount = ifds.size() + 1;
       if (!hasFlattenedResolutions()) {
@@ -650,7 +655,7 @@ public class MinimalTiffReader extends FormatReader {
       }
 
       for (IFD ifd : ifds) {
-        CoreMetadata ms =  new CoreMetadata(this, 0);
+        CoreMetadata ms = new CoreMetadata(this, 0);
         core.add(ms);
         ms.sizeX = (int) ifd.getImageWidth();
         ms.sizeY = (int) ifd.getImageLength();

--- a/components/formats-gpl/src/loci/formats/in/DNGReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DNGReader.java
@@ -84,6 +84,7 @@ public class DNGReader extends BaseTiffReader {
     suffixSufficient = false;
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
     mergeSubIFDs = true;
+    canSeparateSeries = false;
   }
 
   // -- IFormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -78,6 +78,7 @@ public class NDPIReader extends BaseTiffReader {
   public NDPIReader() {
     super("Hamamatsu NDPI", new String[] {"ndpi"});
     domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
+    canSeparateSeries = false;
   }
 
   // -- IFormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/NikonReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NikonReader.java
@@ -117,6 +117,7 @@ public class NikonReader extends BaseTiffReader {
     suffixSufficient = false;
     domains = new String[] {FormatTools.GRAPHICS_DOMAIN};
     mergeSubIFDs = true;
+    canSeparateSeries = false;
   }
 
   // -- IFormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/SISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SISReader.java
@@ -74,6 +74,7 @@ public class SISReader extends BaseTiffReader {
     suffixSufficient = false;
     suffixNecessary = true;
     domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
+    canSeparateSeries = false;
   }
 
   // -- IFormatReader API methods --


### PR DESCRIPTION
Backported from a private PR.  See #3200.

To test, use the files in ```data_repo/curated/tiff/bgriffen``` (same as linked from #3200).  Without this PR, ```showinf``` on any file should throw an ```ArrayIndexOutOfBoundsException``` and ```SizeT``` should be 2.  With this PR, the same test should show 2 series each with ```SizeT``` of 1.  The image for each series should be readable without an exception.

```tiffinfo``` on each file will confirm that there are two IFDs, both of which have a subfile type of 0 (i.e. neither is flagged as a thumbnail).  There doesn't appear to be any other metadata in the files to indicate that the second image should be ignored, even though it's pretty clearly just a thumbnail.

It's possible that this may introduce some build failures, as impact is difficult to assess given how many readers rely upon ```MinimalTiffReader```.  This can certainly be excluded after a first test run to reduce noise.  Memo files shouldn't be affected, but this is arguably a breaking core metadata change.

https://trac.openmicroscopy.org/ome/ticket/13144 is related, but not completely covered by this PR.