### PR TITLE
Gatan: handle empty tag type 23

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -553,8 +553,13 @@ public class GatanReader extends FormatReader {
         parseTags(num, labelString.isEmpty() ? parent : labelString, indent + "  ");
         LOGGER.debug("{}}", indent);
       }
+      else if (type == 23) {
+        in.skipBytes(5);
+        i--;
+      }
       else {
         LOGGER.debug("{}{}: unknown type: {}", new Object[] {indent, i, type});
+        LOGGER.debug("  unknown type @ fp = {}", in.getFilePointer());
       }
 
       NumberFormat f = NumberFormat.getInstance(Locale.ENGLISH);


### PR DESCRIPTION
See https://trello.com/c/aNKCQ2Jf/520-gatan-dimensions-information-not-found

To test, use the .dm4 file in ```data_repo/curated/gatan/qa-21652```.  Without this change, ```showinf -debug``` should throw a ```FormatException``` as indicated on the card.  With this change, the same test should successfully initialize the file and read a single image.  The XYZCT dimensions and min/max values should match those of the .tif file in the same directory.

The images should also visually match, but it's probably easier to see when opening in ImageJ.  Note that the pixel types are different (float for .dm4, uint16 for .tif); that seems fine to me, but perhaps @mtbc can confirm if that is unexpected.

This should be safe for a patch release and should not introduce any build failures.