### PR TITLE
Components version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <ome-model.version>5.5.4</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
-    <ome-jai.version>0.1.0</ome-jai.version>
+    <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.2.2</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.1.1</logback.version>
-    <ome-stubs.version>5.3.0</ome-stubs.version>
+    <ome-stubs.version>5.3.2</ome-stubs.version>
     <lwf-stubs.version>${ome-stubs.version}</lwf-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
     <ome-metakit.version>5.3.2</ome-metakit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <ome-common.version>5.3.6</ome-common.version>
     <ome-model.version>5.6.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
-    <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
+    <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
     <ome-codecs.version>0.2.2</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <ome-stubs.version>5.3.0</ome-stubs.version>
     <lwf-stubs.version>${ome-stubs.version}</lwf-stubs.version>
     <mipav-stubs.version>${ome-stubs.version}</mipav-stubs.version>
-    <ome-metakit.version>5.3.0</ome-metakit.version>
+    <ome-metakit.version>5.3.2</ome-metakit.version>
     <metakit.version>${ome-metakit.version}</metakit.version>
     <slf4j.version>1.7.6</slf4j.version>
     <kryo.version>2.24.0</kryo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.6</ome-common.version>
     <ome-model.version>5.5.4</ome-model.version>
-    <ome-poi.version>5.3.1</ome-poi.version>
+    <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <ome-jai.version>0.1.0</ome-jai.version>
     <ome-codecs.version>0.2.0</ome-codecs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.6</ome-common.version>
-    <ome-model.version>5.5.4</ome-model.version>
+    <ome-model.version>5.6.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome-common.version>5.3.2</ome-common.version>
+    <ome-common.version>5.3.6</ome-common.version>
     <ome-model.version>5.5.4</ome-model.version>
     <ome-poi.version>5.3.1</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.0</ome-mdbtools.version>
     <ome-jai.version>0.1.0</ome-jai.version>
-    <ome-codecs.version>0.2.0</ome-codecs.version>
+    <ome-codecs.version>0.2.2</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 


### PR DESCRIPTION
See https://trello.com/c/jyKnyYF8/5-review-ome-components-dependencies

This PR does not provide any obvious bug fix but updates the version of the low-level OME components to consume releases made in the last 6 months. In particular, this should ensure the contract of the Bio-Formats dependencies declared in its POM matches what is currently shipped by distributions like Fiji.

|  Component   |  Milestones |  Summary
|--------------|-------------|----------
| ome-common   | [5.3.3](https://github.com/ome/ome-common-java/milestone/4?closed=1) [5.3.4](https://github.com/ome/ome-common-java/milestone/5?closed=1) [5.3.5](https://github.com/ome/ome-common-java/milestone/6?closed=1) [5.3.6](https://github.com/ome/ome-common-java/milestone/7?closed=1) | Build updates, Javadoc improvements
| ome-poi  | [5.3.2](https://github.com/ome/ome-poi/milestone/1?closed=1) [5.3.3](https://github.com/ome/ome-poi/milestone/4?closed=1) | Build updates
| ome-mdbtools  | [5.3.1](https://github.com/ome/ome-mdbtools/milestone/2?closed=1) [5.3.2](https://github.com/ome/ome-mdbtools/milestone/3?closed=1) | Build updates
| ome-jai  | [0.1.1](https://github.com/ome/ome-jai/milestone/2?closed=1) [0.1.2](https://github.com/ome/ome-jai/milestone/3?closed=1) [0.1.3](https://github.com/ome/ome-jai/milestone/4?closed=1) | Build updates
| ome-codecs  | [0.2.1](https://github.com/ome/ome-codecs/milestone/3?closed=1) [0.2.2](https://github.com/ome/ome-codecs/milestone/4?closed=1) | Build updates
| ome-stubs  | [5.3.1](https://github.com/ome/ome-stubs/milestone/2?closed=1) [5.3.2](https://github.com/ome/ome-stubs/milestone/3?closed=1) | Build updates
| ome-model  | [5.5.6](https://github.com/ome/ome-model/milestone/10?closed=1) [5.5.7](https://github.com/ome/ome-model/milestone/11?closed=1) [5.6.0](https://github.com/ome/ome-model/milestone/12?closed=1) [5.6.1](https://github.com/ome/ome-model/milestone/13?closed=1) [5.6.2](https://github.com/ome/ome-model/milestone/14?closed=1) [5.6.3](https://github.com/ome/ome-model/milestone/15?closed=1) | Build updates, documentation changes

In terms of testing, the primary thing is to check that all repository tests builds are still passing. This update should introduce no memo file regression and should be safe for the upcoming 5.9.2 patch release. In terms of CI, the tests against the `leo` samples folder where memo files have been generated with 5.9.0 should keep passing.