### PR TITLE
Fix configuration series table retrieval for pyramid detection

### DIFF
--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -243,6 +243,7 @@ Type "ant -p" for a list of targets.
       <sysproperty key="testng.configDirectory" value="${testng.configDirectory}"/>
       <sysproperty key="testng.cacheDirectory" value="${testng.cacheDirectory}"/>
       <sysproperty key="testng.configSuffix" value="${testng.configSuffix}"/>
+      <sysproperty key="testng.allow-missing" value="${testng.allow-missing}"/>
       <sysproperty key="testng.multiplier" value="${testng.multiplier}"/>
       <sysproperty key="lurawave.license" value="${lurawave.license}"/>
       <sysproperty key="testng.in-memory" value="${testng.in-memory}"/>

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -682,7 +682,9 @@ public class FormatReaderTest {
     String testName = "SeriesCount";
     if (!initFile()) result(testName, false, "initFile");
 
-    result(testName, reader.getSeriesCount() == config.getSeriesCount());
+    result(testName, reader.getSeriesCount() == config.getSeriesCount(),
+      "got " + reader.getSeriesCount() +
+      ", expected " + config.getSeriesCount());
   }
 
   @Test(groups = {"all", "fast", "automated"})
@@ -1921,6 +1923,11 @@ public class FormatReaderTest {
       resolutionReader.setMetadataFiltered(true);
       resolutionReader.setId(id);
 
+      if (resolutionReader.getSeriesCount() != config.getSeriesCount(false)) {
+        success = false;
+        msg = "incorrect unflattened series count";
+      }
+
       // check the MD5 of the first plane in each resolution
       for (int i=0; i<resolutionReader.getSeriesCount() && success; i++) {
         resolutionReader.setSeries(i);
@@ -2087,6 +2094,11 @@ public class FormatReaderTest {
       resolutionReader.setOriginalMetadataPopulated(false);
       resolutionReader.setMetadataFiltered(true);
       resolutionReader.setId(id);
+
+      if (resolutionReader.getSeriesCount() != config.getSeriesCount(false)) {
+        success = false;
+        msg = "incorrect unflattened series count";
+      }
 
       // check the MD5 of the first plane in each resolution
       for (int i=0; i<resolutionReader.getSeriesCount() && success; i++) {
@@ -2761,9 +2773,6 @@ public class FormatReaderTest {
         Location.setIdMap(idMap);
 
         reallyInMemory = TestTools.mapFile(id);
-      }
-      if(id.endsWith(".ome.tiff")) {
-        reader.setFlattenedResolutions(false);
       }
       reader.setId(id);
       // remove used files


### PR DESCRIPTION
See https://github.com/openmicroscopy/data_repo_config/pull/321 and https://trello.com/c/q5mPwXHU/37-review-broken-pyramid-readers

The series table names should match the unflattened series/resolution
indexes.  The table data (SizeX, SizeY, physical sizes, ...) corresponds
to the metadata from a reader with flattened resolutions.  This updates
Configuration to allow the flattened-ness to be specified when setting
the active series or getting the series count.  By default, flattened is
true.  The unflattened pixels tests now check that the unflattened
reader's series count matches the configuration's unflattened series
count.

All of this means that readers that correctly report pyramids will have
passing tests, and readers that do not correctly report pyramids will
fail testUnflattened*PixelsHashes.

Assuming no errors in the config PR above, I'd expect to see no test failures for SVS files, and 2 failures per dataset for NDPI files and anything else that should be a pyramid but isn't currently.