### PR TITLE
Pyramid reader fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -422,7 +422,8 @@ public class NDPIReader extends BaseTiffReader {
 
     for (int s=0; s<core.size(); s++) {
       for (int r = 0; r < core.size(s); r++) {
-        IFD ifd = ifds.get(getIFDIndex(core.flattenedIndex(s, r), 0));
+        int index = core.flattenedIndex(s, r);
+        IFD ifd = ifds.get(getIFDIndex(index, 0));
         PhotoInterp p = ifd.getPhotometricInterpretation();
         int samples = ifd.getSamplesPerPixel();
         CoreMetadata ms = core.get(s, r);
@@ -430,7 +431,7 @@ public class NDPIReader extends BaseTiffReader {
 
         ms.sizeX = (int) ifd.getImageWidth();
         ms.sizeY = (int) ifd.getImageLength();
-        ms.sizeZ = s < pyramidHeight ? sizeZ : 1;
+        ms.sizeZ = index < pyramidHeight ? sizeZ : 1;
         ms.sizeT = 1;
         ms.sizeC = ms.rgb ? samples : 1;
         ms.littleEndian = ifd.isLittleEndian();
@@ -443,7 +444,7 @@ public class NDPIReader extends BaseTiffReader {
           ms.sizeX > MAX_SIZE && ms.sizeY > MAX_SIZE;
         ms.falseColor = false;
         ms.dimensionOrder = "XYCZT";
-        ms.thumbnail = s != 0;
+        ms.thumbnail = index != 0;
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/NDPIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPIReader.java
@@ -408,15 +408,21 @@ public class NDPIReader extends BaseTiffReader {
     core.clear();
     for (int s=0; s<seriesCount; s++) {
       CoreMetadata ms = new CoreMetadata();
-      core.add(ms);
       if (s == 0) {
         ms.resolutionCount = pyramidHeight;
+        core.add(ms);
+      }
+      else if (s < pyramidHeight) {
+        core.add(0, ms);
+      }
+      else {
+        core.add(ms);
       }
     }
 
     for (int s=0; s<core.size(); s++) {
       for (int r = 0; r < core.size(s); r++) {
-        IFD ifd = ifds.get(getIFDIndex(s, 0));
+        IFD ifd = ifds.get(getIFDIndex(core.flattenedIndex(s, r), 0));
         PhotoInterp p = ifd.getPhotometricInterpretation();
         int samples = ifd.getSamplesPerPixel();
         CoreMetadata ms = core.get(s, r);

--- a/components/formats-gpl/src/loci/formats/in/TrestleReader.java
+++ b/components/formats-gpl/src/loci/formats/in/TrestleReader.java
@@ -142,7 +142,7 @@ public class TrestleReader extends BaseTiffReader {
   public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    if (core.size() == 1) {
+    if (core.size() == 1 && core.size(0) == 1) {
       return super.openBytes(no, buf, x, y, w, h);
     }
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
@@ -242,42 +242,48 @@ public class TrestleReader extends BaseTiffReader {
     for (int i=0; i<seriesCount; i++) {
       CoreMetadata c = new CoreMetadata();
 
-      if (i == 0 && !hasFlattenedResolutions()) {
+      if (i == 0) {
         c.resolutionCount = seriesCount;
+        core.add(c);
       }
-      core.add(c);
+      else {
+        core.add(0, c);
+      }
     }
 
     // repopulate core metadata
 
     for (int s=0; s<core.size(); s++) {
-      CoreMetadata ms = core.get(s, 0);
-      IFD ifd = ifds.get(s);
-      PhotoInterp p = ifd.getPhotometricInterpretation();
-      int samples = ifd.getSamplesPerPixel();
-      ms.rgb = samples > 1 || p == PhotoInterp.RGB;
+      for (int r=0; r<core.size(s); r++) {
+        CoreMetadata ms = core.get(s, r);
+        int index = core.flattenedIndex(s, r);
+        IFD ifd = ifds.get(index);
+        PhotoInterp p = ifd.getPhotometricInterpretation();
+        int samples = ifd.getSamplesPerPixel();
+        ms.rgb = samples > 1 || p == PhotoInterp.RGB;
 
-      long numTileRows = ifd.getTilesPerColumn() - 1;
-      long numTileCols = ifd.getTilesPerRow() - 1;
+        long numTileRows = ifd.getTilesPerColumn() - 1;
+        long numTileCols = ifd.getTilesPerRow() - 1;
 
-      int overlapX = overlaps[s * 2];
-      int overlapY = overlaps[s * 2 + 1];
+        int overlapX = overlaps[index * 2];
+        int overlapY = overlaps[index * 2 + 1];
 
-      ms.sizeX = (int) (ifd.getImageWidth() - (numTileCols * overlapX));
-      ms.sizeY = (int) (ifd.getImageLength() - (numTileRows * overlapY));
-      ms.sizeZ = 1;
-      ms.sizeT = 1;
-      ms.sizeC = ms.rgb ? samples : 1;
-      ms.littleEndian = ifd.isLittleEndian();
-      ms.indexed = p == PhotoInterp.RGB_PALETTE &&
-        (get8BitLookupTable() != null || get16BitLookupTable() != null);
-      ms.imageCount = 1;
-      ms.pixelType = ifd.getPixelType();
-      ms.metadataComplete = true;
-      ms.interleaved = false;
-      ms.falseColor = false;
-      ms.dimensionOrder = "XYCZT";
-      ms.thumbnail = s > 0;
+        ms.sizeX = (int) (ifd.getImageWidth() - (numTileCols * overlapX));
+        ms.sizeY = (int) (ifd.getImageLength() - (numTileRows * overlapY));
+        ms.sizeZ = 1;
+        ms.sizeT = 1;
+        ms.sizeC = ms.rgb ? samples : 1;
+        ms.littleEndian = ifd.isLittleEndian();
+        ms.indexed = p == PhotoInterp.RGB_PALETTE &&
+          (get8BitLookupTable() != null || get16BitLookupTable() != null);
+        ms.imageCount = 1;
+        ms.pixelType = ifd.getPixelType();
+        ms.metadataComplete = true;
+        ms.interleaved = false;
+        ms.falseColor = false;
+        ms.dimensionOrder = "XYCZT";
+        ms.thumbnail = s > 0 || r > 0;
+      }
     }
 
     // look for all of the other associated metadata files

--- a/components/formats-gpl/src/loci/formats/in/VectraReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VectraReader.java
@@ -229,13 +229,18 @@ public class VectraReader extends BaseTiffReader {
       if (s == 0) {
         ms.resolutionCount = pyramidDepth;
       }
-      core.add(ms);
+      if (s > 0 && s < pyramidDepth) {
+        core.add(0, ms);
+      }
+      else {
+        core.add(ms);
+      }
     }
 
     for (int s = 0; s < core.size(); s++) {
       for (int r = 0; r < core.size(s); r++) {
         CoreMetadata ms = core.get(s, r);
-        int index = getIFDIndex(s, 0);
+        int index = getIFDIndex(core.flattenedIndex(s, r), 0);
         IFD ifd = ifds.get(index);
         PhotoInterp p = ifd.getPhotometricInterpretation();
         int samples = ifd.getSamplesPerPixel();
@@ -257,7 +262,7 @@ public class VectraReader extends BaseTiffReader {
         ms.interleaved = false;
         ms.falseColor = false;
         ms.dimensionOrder = "XYCZT";
-        ms.thumbnail = s != 0;
+        ms.thumbnail = s != 0 || r > 0;
       }
     }
   }
@@ -403,7 +408,7 @@ public class VectraReader extends BaseTiffReader {
     if (name != null) {
       return name;
     }
-    return core.size() == ifds.size() - 1 ? "label" : "macro";
+    return core.flattenedSize() == ifds.size() - 1 ? "label" : "macro";
   }
 
   private String getIFDComment(int ifdIndex) {
@@ -457,7 +462,7 @@ public class VectraReader extends BaseTiffReader {
 
     }
     // optional extra macro or label image at the end of the IFD list
-    return ifds.size() - (core.size() - coreIndex);
+    return ifds.size() - (core.flattenedSize() - coreIndex);
   }
 
 }


### PR DESCRIPTION
See https://trello.com/c/q5mPwXHU/37-review-broken-pyramid-readers and https://github.com/openmicroscopy/bioformats/pull/3208.

This should fix how pyramids are reported for NDPI, NDPIS (indirectly), Vectra QPTIFF, and Trestle.  Most of the test failures introduced in https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-test-repo/205/ should be resolved.