### PR TITLE
Fix menu path in error message

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/Updater.java
+++ b/components/bio-formats-plugins/src/loci/plugins/Updater.java
@@ -63,7 +63,7 @@ public class Updater implements PlugIn {
   @Override
   public void run(String arg) {
     if (isFiji()) {
-      IJ.showMessage("Please use 'Help > Update Fiji' to update.");
+      IJ.showMessage("Please use 'Help > Update...' to update.");
       return;
     }
 


### PR DESCRIPTION
The Fiji updater was retired in 2016 (see https://github.com/fiji/Fiji_Updater/commit/a59f3e7d4d513b2d9f8777e81c510bfa51e9a010), and with it the 'Update Fiji' command was removed from Fiji. The replacement is the ImageJ updater at 'Help > Update...'