### PR TITLE
Restrict use case for TiffJAIReader in TiffDelegateReader

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/TiffDelegateReader.java
+++ b/components/formats-bsd/src/loci/formats/in/TiffDelegateReader.java
@@ -32,7 +32,13 @@
 
 package loci.formats.in;
 
+import java.io.IOException;
+import java.util.ArrayList;
+
+import loci.formats.CoreMetadata;
 import loci.formats.DelegateReader;
+import loci.formats.FormatException;
+import loci.formats.UnsupportedCompressionException;
 
 /**
  * TiffDelegateReader is a file format reader for TIFF files.
@@ -54,6 +60,41 @@ public class TiffDelegateReader extends DelegateReader {
     nativeReaderInitialized = false;
     legacyReaderInitialized = false;
     suffixNecessary = false;
+  }
+
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    if (!isLegacy()) {
+      try {
+        return nativeReader.openBytes(no, buf, x, y, w, h);
+      }
+      catch (UnsupportedCompressionException e) {
+        LOGGER.debug("Could not open plane with native reader", e);
+        if (!legacyReaderInitialized) {
+          legacyReader.setId(getCurrentFile());
+          legacyReaderInitialized = true;
+          nativeReader.close();
+          nativeReaderInitialized = false;
+        }
+        return legacyReader.openBytes(no, buf, x, y, w, h);
+      }
+    }
+    return super.openBytes(no, buf, x, y, w, h);
+  }
+
+  @Override
+  public void setId(String id) throws FormatException, IOException {
+    if (isLegacy()) {
+      super.setId(id);
+    }
+    nativeReader.setId(id);
+    nativeReaderInitialized = true;
+    currentId = nativeReader.getCurrentFile();
+    core = new ArrayList<CoreMetadata>(nativeReader.getCoreMetadataList());
+    metadata = nativeReader.getGlobalMetadata();
+    metadataStore = nativeReader.getMetadataStore();
   }
 
 }


### PR DESCRIPTION
See https://trello.com/c/tEwJO09D/263-misleading-jai-error-message-on-corrupt-tiff

```TiffJAIReader``` should now only be used if ```setLegacy(true)``` is explicitly called or ```openBytes``` throws an ```UnsupportedCompressionException```.  See also https://trac.openmicroscopy.org/ome/ticket/4090

To test, use a corrupt TIFF (e.g. ```/ome/team/mlinkert/corrupt.tiff```) and a TIFF with unsupported compression (e.g. ```data_repo/curated/tiff/public/libtiff/fax2d.tif```).  Without this PR, ```showinf -debug corrupt.tiff``` will throw an exception indicating that JAI is missing.  ```xxd corrupt.tiff``` will confirm that there are only 4 bytes in the file (TIFF endian marker and magic bytes), so there is no way it could be initialized by any TIFF reader.  ```showinf fax2d.tif``` will throw ```UnsupportedCompressionException``` with no indication that JAI could be used to read the file.

With this PR, ```showinf corrupt.tiff``` will throw an ```EOFException``` with no mention of JAI.  ```showinf fax2d.tif``` will throw an exception indicating that JAI is missing during ```openBytes```.  ```showinf -debug fax2d.tif``` will also log the original ```UnsupportedCompressionException```.

Builds should remain green; I would not expect this to affect memo files.  Definitely low priority, though, since this is less about fixing a bug and more about making it less irritating to identify corrupt TIFF issues.
 