### PR TITLE
DICOM file grouping fixes

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -275,7 +275,7 @@ public class DicomReader extends FormatReader {
 
     Integer[] keys = fileList.keySet().toArray(new Integer[0]);
     Arrays.sort(keys);
-    if (fileList.size() > 1) {
+    if (fileList.size() > 1 || fileList.get(keys[getSeries()]).size() > 1) {
       int fileNumber = 0;
       if (fileList.get(keys[getSeries()]).size() > 1) {
         fileNumber = no / imagesPerFile;
@@ -1395,8 +1395,14 @@ public class DicomReader extends FormatReader {
     }
     stream.close();
 
+    LOGGER.trace("  date = {}, originalDate = {}", date, originalDate);
+    LOGGER.trace("  time = {}, originalTime = {}", time, originalTime);
+    LOGGER.trace("  instance = {}, originalInstance = {}", instance, originalInstance);
+    LOGGER.trace("  checkSeries = {}", checkSeries);
+    LOGGER.trace("  fileSeries = {}, originalSeries = {}", fileSeries, originalSeries);
+
     if (date == null || time == null || instance == null ||
-      (checkSeries && fileSeries == originalSeries))
+      (checkSeries && fileSeries != originalSeries))
     {
       return;
     }
@@ -1412,6 +1418,9 @@ public class DicomReader extends FormatReader {
       timestamp = Integer.parseInt(originalTime);
     }
     catch (NumberFormatException e) { }
+
+    LOGGER.trace("  stamp = {}", stamp);
+    LOGGER.trace("  timestamp = {}", timestamp);
 
     if (date.equals(originalDate) && (Math.abs(stamp - timestamp) < 150)) {
       int position = Integer.parseInt(instance) - 1;

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -290,6 +290,9 @@ public class DicomReader extends FormatReader {
     int ec = isIndexed() ? 1 : getSizeC();
     int bpp = FormatTools.getBytesPerPixel(getPixelType());
     int bytes = getSizeX() * getSizeY() * bpp * ec;
+    if (in == null) {
+      in = new RandomAccessInputStream(currentId);
+    }
     in.seek(offsets[no]);
 
     if (isRLE) {

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -669,15 +669,7 @@ public class DicomReader extends FormatReader {
             if (fileList == null) {
               fileList = new HashMap<Integer, List<String>>();
             }
-            int seriesIndex = 0;
-            if (originalInstance != null) {
-              try {
-                seriesIndex = Integer.parseInt(originalInstance);
-              }
-              catch (NumberFormatException e) {
-                LOGGER.debug("Could not parse instance number: {}", originalInstance);
-              }
-            }
+            int seriesIndex = originalSeries;
             if (fileList.get(seriesIndex) == null) {
               fileList.put(seriesIndex, new ArrayList<String>());
             }
@@ -701,8 +693,9 @@ public class DicomReader extends FormatReader {
 
     if (id.endsWith("DICOMDIR")) {
       String parent = new Location(currentId).getAbsoluteFile().getParent();
+      Integer[] fileKeys = fileList.keySet().toArray(new Integer[0]);
+      Arrays.sort(fileKeys);
       for (int q=0; q<fileList.size(); q++) {
-        Integer[] fileKeys = fileList.keySet().toArray(new Integer[0]);
         for (int i=0; i<fileList.get(fileKeys[q]).size(); i++) {
           String file = fileList.get(fileKeys[q]).get(i);
           file = file.replace('\\', File.separatorChar);
@@ -717,7 +710,7 @@ public class DicomReader extends FormatReader {
         companionFiles.set(i, parent + File.separator + file);
       }
       companionFiles.add(new Location(currentId).getAbsolutePath());
-      initFile(fileList.get(0).get(0));
+      initFile(fileList.get(fileKeys[0]).get(0));
       return;
     }
 

--- a/components/formats-bsd/src/loci/formats/in/DicomReader.java
+++ b/components/formats-bsd/src/loci/formats/in/DicomReader.java
@@ -1418,8 +1418,8 @@ public class DicomReader extends FormatReader {
     LOGGER.trace("  instance = {}, originalInstance = {}", instance, originalInstance);
     LOGGER.trace("  checkSeries = {}", checkSeries);
     LOGGER.trace("  fileSeries = {}, originalSeries = {}", fileSeries, originalSeries);
-    LOGGER.debug("  currentX = {}, originalX = {}", currentX, originalX);
-    LOGGER.debug("  currentY = {}, originalY = {}", currentY, originalY);
+    LOGGER.trace("  currentX = {}, originalX = {}", currentX, originalX);
+    LOGGER.trace("  currentY = {}, originalY = {}", currentY, originalY);
 
     if (date == null || time == null || instance == null ||
       (checkSeries && fileSeries != originalSeries))


### PR DESCRIPTION
Backports 3 private PRs.  This improves file grouping and file-to-series mapping for multi-file datasets with and without a ```DICOMDIR``` file.

To test, use the following new datasets:

1. ```data_repo/curated/dicom/melissa/two-files-single-series``` (2 files)
2. ```data_repo/curated/dicom/melissa/two-files-two-series``` (2 files)
3. ```data_repo/curated/dicom/public/nema/Liver/DICOMDIR``` (```DICOMDIR``` + 183 files)

Datasets 1 and 2 are artificial datasets constructed as noted in the respective readmes.  Dataset 3 is directly copied from ftp://medical.nema.org/medical/dicom/DataSets/WG16/Philips/ClassicSingleFrame/Liver/

Without this PR, ```showinf -nopix 0.dcm``` for both datasets 1 and 2 should show 2 series and 3 used files (both datasets are grouped together, with one file omitted).  The first series has 1 Z section, and the second series has 2 Z sections.

Without this PR, ```showinf -nopix DICOMDIR``` for dataset 3 will show 80 series, each with a small but variable number of Z sections.

With this PR, ```showinf -nopix 0.dcm``` for dataset 1 should show 1 series with 2 Z sections and two used files (```two-files-single-series/0.dcm``` and ```two-files-single-series/1.dcm```).

```showinf -nopix 0.dcm``` for dataset 2 should show 2 series each with 1 Z section and varying SizeY.  There should be two used files (```two-files-two-series/0.dcm``` and ```two-files-two-series/1.dcm```).

```showinf -nopix DICOMDIR``` for dataset 3 should show 5 series, each with 18-50 Z sections.  The total number of planes across all series should be 173, which matches the number of (single plane) ```IM_*``` files.

Viewing datasets 1 and 2 in ImageJ should result in all images matching ```data_repo/curated/dicom/public/samples/CT-MONO2-16-chest.dcm``` (this is the base file from which the datasets were constructed).  Viewing dataset 3 in ImageJ should result in 5 clearly distinct Z stacks with no planes obviously out of order.

All builds should pass; there should be no failures or configuration changes for existing DICOM datasets.  I would expect memo files to be affected.
