### PR TITLE
Initial CV7000 reader

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -114,6 +114,7 @@ loci.formats.in.OperettaReader        # xml, tif, tiff
 loci.formats.in.InveonReader          # hdr, ct.img, cat, ...
 loci.formats.in.CellVoyagerReader     # xml, tif
 loci.formats.in.ColumbusReader        # xml, tif
+loci.formats.in.CV7000Reader          # wpi
 
 # standard PIC reader must go last (it accepts any PIC)
 loci.formats.in.BioRadReader          # pic

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -127,16 +127,14 @@ public class CV7000Reader extends FormatReader {
   /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
   @Override
   public String[] getUsedFiles(boolean noPixels) {
-    if (noPixels) {
-      HashSet<String> files = new HashSet<String>();
-      for (String file : allFiles) {
-        if (!checkSuffix(file, "tif")) {
-          files.add(file);
-        }
+    ArrayList<String> files = new ArrayList<String>();
+    files.add(new Location(currentId).getAbsolutePath());
+    for (String file : allFiles) {
+      if (!files.contains(file) && (!noPixels || !checkSuffix(file, "tif"))) {
+        files.add(file);
       }
-      return files.toArray(new String[files.size()]);
     }
-    return allFiles;
+    return files.toArray(new String[files.size()]);
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
@@ -145,7 +143,7 @@ public class CV7000Reader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
 
     HashSet<String> files = new HashSet<String>();
-    files.add(currentId);
+    files.add(new Location(currentId).getAbsolutePath());
     files.add(measurementPath);
     if (detailPath != null) {
       files.add(detailPath);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -150,7 +150,9 @@ public class CV7000Reader extends FormatReader {
     }
     if (!noPixels && channels != null) {
       for (Channel c : channels) {
-        if (c != null && c.correctionFile != null) {
+        if (c != null && c.correctionFile != null &&
+          new Location(c.correctionFile).exists())
+        {
           files.add(c.correctionFile);
         }
       }
@@ -253,6 +255,12 @@ public class CV7000Reader extends FormatReader {
       String xml = DataTools.readFile(settingsPath).trim();
       if (xml.length() > 0) {
         XMLTools.parseXML(xml, settingsHandler);
+      }
+    }
+
+    for (Channel ch : channels) {
+      if (ch.correctionFile != null) {
+        ch.correctionFile = new Location(parent, ch.correctionFile).getAbsolutePath();
       }
     }
 
@@ -430,12 +438,6 @@ public class CV7000Reader extends FormatReader {
             }
             Channel channel = null;
             for (Channel ch : channels) {
-              if (i == 0 && ch.correctionFile != null) {
-                if (new Location(ch.correctionFile).getParent() == null) {
-                  ch.correctionFile = new Location(parent, ch.correctionFile).getAbsolutePath();
-                }
-              }
-
               if (ch.index == p.channel) {
                 channel = ch;
                 break;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -1,0 +1,589 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2015 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import loci.common.DataTools;
+import loci.common.Location;
+import loci.common.RandomAccessInputStream;
+import loci.common.xml.BaseHandler;
+import loci.common.xml.XMLTools;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.meta.MetadataStore;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.TiffParser;
+
+import ome.units.UNITS;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveFloat;
+import ome.xml.model.primitives.PositiveInteger;
+
+import org.xml.sax.Attributes;
+
+/**
+ *
+ * @author Melissa Linkert melissa at glencoesoftware.com
+ */
+public class CV7000Reader extends FormatReader {
+
+  // -- Constants --
+
+  private static final String MEASUREMENT_FILE = "MeasurementData.mlf";
+  private static final String MEASUREMENT_DETAIL = "MeasurementDetail.mrf";
+  private static final String POST_PROCESS = "PostProcess.ppf";
+
+  // -- Fields --
+
+  private String[] allFiles;
+  private Location parent;
+  private MinimalTiffReader reader;
+  private String wppPath;
+  private String detailPath;
+  private String measurementPath;
+  private ArrayList<Plane> planeData;
+  private ArrayList<Channel> channels;
+  private int fields;
+  private int realRows, realCols;
+
+  // -- Constructor --
+
+  /** Constructs a new Yokogawa CV7000 reader. */
+  public CV7000Reader() {
+    super("Yokogawa CV7000", new String[] {"wpi"});
+    hasCompanionFiles = true;
+    domains = new String[] {FormatTools.HCS_DOMAIN};
+    datasetDescription = "Directory with XML files and one .tif/.tiff file per plane";
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#getRequiredDirectories(String[]) */
+  @Override
+  public int getRequiredDirectories(String[] files)
+    throws FormatException, IOException
+  {
+    return 1;
+  }
+
+  /* @see loci.formats.IFormatReader#isSingleFile(String) */
+  @Override
+  public boolean isSingleFile(String id) throws FormatException, IOException {
+    return false;
+  }
+
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  @Override
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
+  }
+
+  /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
+  @Override
+  public String[] getSeriesUsedFiles(boolean noPixels) {
+    FormatTools.assertId(currentId, true, 1);
+
+    ArrayList<String> files = new ArrayList<String>();
+    files.add(currentId);
+    files.add(measurementPath);
+    if (detailPath != null) {
+      files.add(detailPath);
+    }
+    if (wppPath != null) {
+      files.add(wppPath);
+    }
+    if (!noPixels && planeData != null) {
+      for (Plane p : planeData) {
+        if (p != null && p.file != null && !files.contains(p.file)) {
+          files.add(p.file);
+        }
+      }
+    }
+    if (!noPixels && channels != null) {
+      for (Channel c : channels) {
+        if (c != null && c.correctionFile != null) {
+          files.add(new Location(parent, c.correctionFile).getAbsolutePath());
+        }
+      }
+    }
+    for (String file : allFiles) {
+      String path = new Location(parent, file).getAbsolutePath();
+      if (!files.contains(path) && (!noPixels || !checkSuffix(path, "tif"))) {
+        files.add(path);
+      }
+    }
+    return files.toArray(new String[files.size()]);
+  }
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      if (reader != null) {
+        reader.close();
+      }
+      reader = null;
+      measurementPath = null;
+      detailPath = null;
+      wppPath = null;
+      planeData = null;
+      fields = 0;
+      realRows = 0;
+      realCols = 0;
+      channels = null;
+    }
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+
+    Plane p = lookupPlane(getSeries(), no);
+    if (p != null && p.file != null) {
+      reader.setId(p.file);
+      return reader.openBytes(0, buf, x, y, w, h);
+    }
+    return buf;
+  }
+
+  // -- Internal FormatReader API methods --
+
+  /* @see loci.formats.FormatReader#initFile(String) */
+  @Override
+  protected void initFile(String id) throws FormatException, IOException {
+    super.initFile(id);
+    WPIHandler plate = new WPIHandler();
+    XMLTools.parseXML(DataTools.readFile(id), plate);
+
+    parent = new Location(id).getAbsoluteFile().getParentFile();
+    allFiles = parent.list(true);
+    Location measurementData = new Location(parent, MEASUREMENT_FILE);
+
+    if (!measurementData.exists()) {
+      throw new FormatException("Missing " + MEASUREMENT_FILE + " file");
+    }
+
+    measurementPath = measurementData.getAbsolutePath();
+    MeasurementDataHandler measurementHandler = new MeasurementDataHandler(parent.getAbsolutePath());
+    XMLTools.parseXML(DataTools.readFile(measurementPath), measurementHandler);
+
+    planeData = measurementHandler.getPlanes();
+
+    Location measurementDetail = new Location(parent, MEASUREMENT_DETAIL);
+    if (!measurementDetail.exists()) {
+      LOGGER.warn("Missing " + MEASUREMENT_DETAIL + " file");
+    }
+    else {
+      channels = new ArrayList<Channel>();
+      detailPath = measurementDetail.getAbsolutePath();
+      MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
+      XMLTools.parseXML(DataTools.readFile(detailPath), detailHandler);
+      if (wppPath != null) {
+        wppPath = new Location(parent, wppPath).getAbsolutePath();
+      }
+    }
+
+    String firstFile = null;
+    int minSizeZ = Integer.MAX_VALUE, maxSizeZ = 0;
+    int minSizeC = Integer.MAX_VALUE, maxSizeC = 0;
+    int minSizeT = Integer.MAX_VALUE, maxSizeT = 0;
+    fields = 0;
+    int minRows = Integer.MAX_VALUE, maxRows = 0;
+    int minCols = Integer.MAX_VALUE, maxCols = 0;
+
+    for (Plane p : planeData) {
+      if (p != null) {
+        if (p.file != null && firstFile == null) {
+          firstFile = p.file;
+        }
+
+        if (p.timepoint > maxSizeT) {
+          maxSizeT = p.timepoint;
+        }
+        if (p.timepoint < minSizeT) {
+          minSizeT = p.timepoint;
+        }
+        if (p.z > maxSizeZ) {
+          maxSizeZ = p.z;
+        }
+        if (p.z < minSizeZ) {
+          minSizeZ = p.z;
+        }
+        if (p.channel > maxSizeC) {
+          maxSizeC = p.channel;
+        }
+        if (p.channel < minSizeC) {
+          minSizeC = p.channel;
+        }
+
+        if (p.field >= fields) {
+          fields = p.field + 1;
+        }
+        if (p.row > maxRows) {
+          maxRows = p.row;
+        }
+        if (p.row < minRows) {
+          minRows = p.row;
+        }
+        if (p.column > maxCols) {
+          maxCols = p.column;
+        }
+        if (p.column < minCols) {
+          minCols = p.column;
+        }
+      }
+    }
+
+    reader = new MinimalTiffReader();
+    reader.setId(firstFile);
+    core.clear();
+    core.add(reader.getCoreMetadataList().get(0));
+
+    core.get(0).dimensionOrder = "XYCZT";
+    core.get(0).sizeZ = (maxSizeZ - minSizeZ) + 1;
+    core.get(0).sizeT = (maxSizeT - minSizeT) + 1;
+    core.get(0).sizeC *= (maxSizeC - minSizeC) + 1;
+    core.get(0).imageCount = getSizeZ() * getSizeT() * (getSizeC() / reader.getSizeC());
+
+    realRows = maxRows - minRows + 1;
+    realCols = maxCols - minCols + 1;
+
+    for (int i=1; i<realRows * realCols * fields; i++) {
+      core.add(new CoreMetadata(core.get(0)));
+    }
+
+    int[] seriesLengths = new int[] {fields, realCols, realRows};
+    int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
+    for (Plane p : planeData) {
+      p.series = FormatTools.positionToRaster(seriesLengths,
+        new int[] {p.field, p.column - minCols, p.row - minRows});
+      p.no = FormatTools.positionToRaster(planeLengths,
+        new int[] {p.channel - minSizeC, p.z - minSizeZ, p.timepoint - minSizeT});
+    }
+
+    // populate the MetadataStore
+
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this, true);
+
+    store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
+    store.setPlateName(plate.getPlateName(), 0);
+    store.setPlateDescription(plate.getPlateDescription(), 0);
+    store.setPlateExternalIdentifier(plate.getPlateID(), 0);
+    store.setPlateRows(new PositiveInteger(plate.getPlateRows()), 0);
+    store.setPlateColumns(new PositiveInteger(plate.getPlateColumns()), 0);
+
+    String plateAcqID = MetadataTools.createLSID("PlateAcquisition", 0, 0);
+    store.setPlateAcquisitionID(plateAcqID, 0, 0);
+
+    PositiveInteger fieldCount = FormatTools.getMaxFieldCount(fields);
+    if (fieldCount != null) {
+      store.setPlateAcquisitionMaximumFieldCount(fieldCount, 0, 0);
+    }
+
+    int nextWell = 0;
+    int nextImage = 0;
+    for (int row=0; row<plate.getPlateRows(); row++) {
+      for (int col=0; col<plate.getPlateColumns(); col++) {
+        if (!isWellAcquired(row, col)) {
+          continue;
+        }
+        store.setWellID(MetadataTools.createLSID("Well", 0, nextWell), 0, nextWell);
+        store.setWellRow(new NonNegativeInteger(row), 0, nextWell);
+        store.setWellColumn(new NonNegativeInteger(col), 0, nextWell);
+
+        for (int field=0; field<fields; field++) {
+          String wellSampleID =
+            MetadataTools.createLSID("WellSample", 0, nextWell, field);
+          store.setWellSampleID(wellSampleID, 0, nextWell, field);
+          store.setWellSampleIndex(
+            new NonNegativeInteger(nextImage), 0, nextWell, field);
+          String imageID = MetadataTools.createLSID("Image", nextImage);
+          store.setImageID(imageID, nextImage);
+          store.setWellSampleImageRef(imageID, 0, nextWell, field);
+
+          String name = "Well " + ((char) ('A' + row)) + (col + 1) + ", Field " + (field + 1);
+          store.setImageName(name, nextImage);
+          store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, nextImage);
+          nextImage++;
+        }
+        nextWell++;
+      }
+    }
+
+    if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
+      store.setPlateName(plate.getPlateName(), 0);
+      store.setPlateDescription(plate.getPlateDescription(), 0);
+      store.setPlateExternalIdentifier(plate.getPlateID(), 0);
+
+      for (int i=0; i<getSeriesCount(); i++) {
+        if (channels != null) {
+          for (int c=0; c<getSizeC(); c++) {
+            Plane p = lookupPlane(i, c);
+            Channel channel = null;
+            for (Channel ch : channels) {
+              if (ch.index == p.channel) {
+                channel = ch;
+                break;
+              }
+            }
+            if (channel == null) {
+              continue;
+            }
+
+            if (c == 0) {
+              store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(channel.xSize), i);
+              store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(channel.xSize), i);
+            }
+            store.setChannelName("Channel #" + (channel.index + 1) + ", Camera #" + channel.cameraNumber, i, c);
+          }
+        }
+
+        for (int p=0; p<getImageCount(); p++) {
+          Plane plane = lookupPlane(i, p);
+          if (plane == null) {
+            continue;
+          }
+          store.setPlanePositionX(FormatTools.createLength(plane.xpos, UNITS.REFERENCEFRAME), i, p);
+          store.setPlanePositionY(FormatTools.createLength(plane.ypos, UNITS.REFERENCEFRAME), i, p);
+          store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.REFERENCEFRAME), i, p);
+        }
+      }
+
+    }
+  }
+
+  private boolean isWellAcquired(int row, int col) {
+    if (planeData != null) {
+      for (Plane p : planeData) {
+        if (p != null && p.file != null && p.row == row && p.column == col) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private Plane lookupPlane(int series, int no) {
+    for (Plane p : planeData) {
+      if (p != null && p.series == series && p.no == no) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  // -- Helper classes --
+
+  class WPIHandler extends BaseHandler {
+    private int plateRows;
+    private int plateColumns;
+    private String name;
+    private String plateID;
+    private String description;
+
+    public int getPlateRows() {
+      return plateRows;
+    }
+
+    public int getPlateColumns() {
+      return plateColumns;
+    }
+
+    public String getPlateName() {
+      return name;
+    }
+
+    public String getPlateID() {
+      return plateID;
+    }
+
+    public String getPlateDescription() {
+      return description;
+    }
+
+
+    @Override
+    public void characters(char[] ch, int start, int length) {
+
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      if (qName.equals("bts:WellPlate")) {
+        name = attributes.getValue("bts:Name");
+        plateID = attributes.getValue("bts:ProductID");
+        plateRows = Integer.parseInt(attributes.getValue("bts:Rows"));
+        plateColumns = Integer.parseInt(attributes.getValue("bts:Columns"));
+      }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) {
+
+    }
+
+  }
+
+  class MeasurementDataHandler extends BaseHandler {
+    private StringBuffer currentValue = new StringBuffer();
+    private ArrayList<Plane> planes = new ArrayList<Plane>();
+    private String parentDir;
+
+    public MeasurementDataHandler(String parentDir) {
+      super();
+      this.parentDir = parentDir;
+    }
+
+    public ArrayList<Plane> getPlanes() {
+      return planes;
+    }
+
+    // -- DefaultHandler API methods --
+
+    @Override
+    public void characters(char[] ch, int start, int length) {
+      String value = new String(ch, start, length);
+      currentValue.append(value);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      currentValue.setLength(0);
+
+      if (qName.equals("bts:MeasurementRecord")) {
+        Plane p = new Plane();
+        p.row = Integer.parseInt(attributes.getValue("bts:Row")) - 1;
+        p.column = Integer.parseInt(attributes.getValue("bts:Column")) - 1;
+        p.timepoint = Integer.parseInt(attributes.getValue("bts:TimePoint")) - 1;
+        p.field = Integer.parseInt(attributes.getValue("bts:FieldIndex")) - 1;
+        p.z = Integer.parseInt(attributes.getValue("bts:ZIndex")) - 1;
+        p.channel = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
+        p.xpos = Double.parseDouble(attributes.getValue("bts:X"));
+        p.ypos = Double.parseDouble(attributes.getValue("bts:Y"));
+        p.zpos = Double.parseDouble(attributes.getValue("bts:Z"));
+        p.timestamp = attributes.getValue("bts:Time");
+        planes.add(p);
+      }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) {
+      String value = currentValue.toString();
+      if (qName.equals("bts:MeasurementRecord")) {
+        planes.get(planes.size() - 1).file = new Location(parentDir, value).getAbsolutePath();
+      }
+    }
+
+  }
+
+  class MeasurementDetailHandler extends BaseHandler {
+    private StringBuffer currentValue = new StringBuffer();
+
+    // -- DefaultHandler API methods --
+
+    @Override
+    public void characters(char[] ch, int start, int length) {
+      String value = new String(ch, start, length);
+      currentValue.append(value);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      currentValue.setLength(0);
+
+      if (qName.equals("bts:MeasurementSamplePlate")) {
+        wppPath = attributes.getValue("bts:WellPlateProductFileName");
+      }
+      else if (qName.equals("bts:MeasurementChannel")) {
+        Channel c = new Channel();
+        c.index = Integer.parseInt(attributes.getValue("bts:Ch"));
+        c.xSize = Double.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
+        c.ySize = Double.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
+        c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
+        c.correctionFile = attributes.getValue("bts:ShadingCorrectionSource");
+        channels.add(c);
+      }
+      else if (qName.equals("bts:MeasurementDetail")) {
+        // bts:OperatorName
+        // bts:Title
+        // bts:BeginTime
+        // bts:EndTime
+        // bts:MeasurementSettingFileName
+        // bts:TargetSystem
+      }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) {
+      String value = currentValue.toString();
+    }
+
+  }
+
+  class Channel {
+    public int index;
+    public double xSize;
+    public double ySize;
+    public int cameraNumber;
+    public String correctionFile;
+  }
+
+  class Plane {
+    public String file;
+    public String timestamp;
+    public int row;
+    public int column;
+    public int timepoint;
+    public int field;
+    public int z;
+    public int channel;
+    public double xpos;
+    public double ypos;
+    public double zpos;
+    public int series;
+    public int no;
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -366,12 +366,14 @@ public class CV7000Reader extends FormatReader {
     int nextImage = 0;
     for (int row=0; row<plate.getPlateRows(); row++) {
       for (int col=0; col<plate.getPlateColumns(); col++) {
-        if (!isWellAcquired(row, col)) {
-          continue;
-        }
         store.setWellID(MetadataTools.createLSID("Well", 0, nextWell), 0, nextWell);
         store.setWellRow(new NonNegativeInteger(row), 0, nextWell);
         store.setWellColumn(new NonNegativeInteger(col), 0, nextWell);
+
+        if (!isWellAcquired(row, col)) {
+          nextWell++;
+          continue;
+        }
 
         for (int field=0; field<fields; field++) {
           String wellSampleID =

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -124,6 +124,21 @@ public class CV7000Reader extends FormatReader {
     return FormatTools.MUST_GROUP;
   }
 
+  /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
+  @Override
+  public String[] getUsedFiles(boolean noPixels) {
+    if (noPixels) {
+      HashSet<String> files = new HashSet<String>();
+      for (String file : allFiles) {
+        if (!checkSuffix(file, "tif")) {
+          files.add(file);
+        }
+      }
+      return files.toArray(new String[files.size()]);
+    }
+    return allFiles;
+  }
+
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
   @Override
   public String[] getSeriesUsedFiles(boolean noPixels) {
@@ -227,6 +242,7 @@ public class CV7000Reader extends FormatReader {
 
     parent = new Location(id).getAbsoluteFile().getParentFile();
     allFiles = parent.list(true);
+    Arrays.sort(allFiles);
     for (int i=0; i<allFiles.length; i++) {
       allFiles[i] = new Location(parent, allFiles[i]).getAbsolutePath();
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -49,6 +49,8 @@ import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 
 /**
@@ -58,6 +60,8 @@ import org.xml.sax.Attributes;
 public class CV7000Reader extends FormatReader {
 
   // -- Constants --
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CV7000Reader.class);
 
   private static final String MEASUREMENT_FILE = "MeasurementData.mlf";
   private static final String MEASUREMENT_DETAIL = "MeasurementDetail.mrf";
@@ -490,19 +494,25 @@ public class CV7000Reader extends FormatReader {
     {
       currentValue.setLength(0);
 
-      if (qName.equals("bts:MeasurementRecord")) {
-        Plane p = new Plane();
-        p.row = Integer.parseInt(attributes.getValue("bts:Row")) - 1;
-        p.column = Integer.parseInt(attributes.getValue("bts:Column")) - 1;
-        p.timepoint = Integer.parseInt(attributes.getValue("bts:TimePoint")) - 1;
-        p.field = Integer.parseInt(attributes.getValue("bts:FieldIndex")) - 1;
-        p.z = Integer.parseInt(attributes.getValue("bts:ZIndex")) - 1;
-        p.channel = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
-        p.xpos = Double.parseDouble(attributes.getValue("bts:X"));
-        p.ypos = Double.parseDouble(attributes.getValue("bts:Y"));
-        p.zpos = Double.parseDouble(attributes.getValue("bts:Z"));
-        p.timestamp = attributes.getValue("bts:Time");
-        planes.add(p);
+      try {
+        if (qName.equals("bts:MeasurementRecord")) {
+          Plane p = new Plane();
+          p.row = Integer.parseInt(attributes.getValue("bts:Row")) - 1;
+          p.column = Integer.parseInt(attributes.getValue("bts:Column")) - 1;
+          p.timepoint = Integer.parseInt(attributes.getValue("bts:TimePoint")) - 1;
+          p.field = Integer.parseInt(attributes.getValue("bts:FieldIndex")) - 1;
+          p.z = Integer.parseInt(attributes.getValue("bts:ZIndex")) - 1;
+          p.channel = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
+          p.xpos = Double.parseDouble(attributes.getValue("bts:X"));
+          p.ypos = Double.parseDouble(attributes.getValue("bts:Y"));
+          p.zpos = Double.parseDouble(attributes.getValue("bts:Z"));
+          p.timestamp = attributes.getValue("bts:Time");
+          planes.add(p);
+        }
+      }
+      catch (RuntimeException e) {
+        LOGGER.error("Error parsing attributes: {}", attributes);
+        throw e;
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -142,6 +142,9 @@ public class CV7000Reader extends FormatReader {
     }
     if (!noPixels && planeData != null) {
       for (int index : reversePlaneLookup[getSeries()]) {
+        if (index < 0) {
+          continue;
+        }
         Plane p = planeData.get(index);
         if (p != null && p.file != null) {
           files.add(p.file);
@@ -197,6 +200,7 @@ public class CV7000Reader extends FormatReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
+    Arrays.fill(buf, (byte) 0);
     Plane p = lookupPlane(getSeries(), no);
     LOGGER.trace("series = {}, no = {}, file = {}", series, no, p == null ? null : p.file);
     if (p != null && p.file != null) {
@@ -325,6 +329,10 @@ public class CV7000Reader extends FormatReader {
     int[] seriesLengths = new int[] {fields, realWells};
     int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
     reversePlaneLookup = new int[getSeriesCount()][getImageCount()];
+    for (int i=0; i<reversePlaneLookup.length; i++) {
+      // do this so that the index does not default to 0 for ERR planes
+      Arrays.fill(reversePlaneLookup[i], -1);
+    }
     for (int i=0; i<planeData.size(); i++) {
       Plane p = planeData.get(i);
       int wellIndex = Arrays.binarySearch(wells, p.row * plate.getPlateColumns() + p.column);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -289,7 +289,7 @@ public class CV7000Reader extends FormatReader {
     reader = new MinimalTiffReader();
     reader.setId(firstFile);
     core.clear();
-    core.add(reader.getCoreMetadataList().get(0));
+    core.add(new CoreMetadata(reader.getCoreMetadataList().get(0)));
 
     core.get(0).dimensionOrder = "XYCZT";
     core.get(0).sizeZ = (maxSizeZ - minSizeZ) + 1;
@@ -570,7 +570,7 @@ public class CV7000Reader extends FormatReader {
       }
       else if (qName.equals("bts:MeasurementChannel")) {
         Channel c = new Channel();
-        c.index = Integer.parseInt(attributes.getValue("bts:Ch"));
+        c.index = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
         c.xSize = Double.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
         c.ySize = Double.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -253,7 +253,10 @@ public class CV7000Reader extends FormatReader {
     if (settingsPath != null && new Location(settingsPath).exists()) {
       lightSources = new ArrayList<LightSource>();
       MeasurementSettingsHandler settingsHandler = new MeasurementSettingsHandler();
-      XMLTools.parseXML(DataTools.readFile(settingsPath), settingsHandler);
+      String xml = DataTools.readFile(settingsPath).trim();
+      if (xml.length() > 0) {
+        XMLTools.parseXML(xml, settingsHandler);
+      }
     }
 
     String firstFile = null;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -517,7 +517,7 @@ public class CV7000Reader extends FormatReader {
           Map<String, String> attributeMap = new HashMap<String, String>();
           for (int i = 0; i < attributes.getLength(); i++) {
             attributeMap.put(
-                attributes.getLocalName(i), attributes.getValue(i));
+                attributes.getQName(i), attributes.getValue(i));
           }
           LOGGER.error("Error parsing attributes: {}", attributeMap, e);
         }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -475,6 +475,7 @@ public class CV7000Reader extends FormatReader {
 
   class MeasurementDataHandler extends BaseHandler {
     private StringBuffer currentValue = new StringBuffer();
+    private String btsType;
     private ArrayList<Plane> planes = new ArrayList<Plane>();
     private String parentDir;
 
@@ -502,8 +503,8 @@ public class CV7000Reader extends FormatReader {
       currentValue.setLength(0);
 
       try {
-        if (qName.equals("bts:MeasurementRecord")
-            && attributes.getValue("bts:Type").equals("IMG")) {
+        btsType = attributes.getValue("bts:Type");
+        if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG")) {
           // When the instrument is recording an acquisition error the "type"
           // will be "ERR" so we can skip those.
           Plane p = new Plane();
@@ -536,7 +537,7 @@ public class CV7000Reader extends FormatReader {
     @Override
     public void endElement(String uri, String localName, String qName) {
       String value = currentValue.toString();
-      if (qName.equals("bts:MeasurementRecord")) {
+      if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG")) {
         planes.get(planes.size() - 1).file = new Location(parentDir, value).getAbsolutePath();
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -163,7 +163,7 @@ public class CV7000Reader extends FormatReader {
     }
     files.addAll(extraFiles);
     for (String file : allFiles) {
-      if (!checkSuffix(file, "tif")) {
+      if (!checkSuffix(file, "tif") && !(new Location(file).isDirectory())) {
         files.add(file);
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -486,7 +486,9 @@ public class CV7000Reader extends FormatReader {
               int index = -1;
               for (int ref=0; ref<channel.lightSourceRefs.size(); ref++) {
                 int lightSource = channel.lightSourceRefs.get(ref);
-                if (lightSources.get(lightSource).wavelength < channel.excitation) {
+                if ("Laser".equals(lightSources.get(lightSource).type) &&
+                  lightSources.get(lightSource).wavelength < channel.excitation)
+                {
                   index = lightSource;
                 }
               }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -372,6 +372,11 @@ public class CV7000Reader extends FormatReader {
         if (channels != null) {
           for (int c=0; c<getSizeC(); c++) {
             Plane p = lookupPlane(i, c);
+            if (p == null) {
+              // There was likely an error during acquisition for this
+              // particular plane.  Skip it.
+              continue;
+            }
             Channel channel = null;
             for (Channel ch : channels) {
               if (ch.index == p.channel) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -486,7 +486,7 @@ public class CV7000Reader extends FormatReader {
 
             if (c == 0) {
               store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(channel.xSize), i);
-              store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(channel.xSize), i);
+              store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(channel.ySize), i);
             }
 
             int objective = -1;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -667,9 +667,9 @@ public class CV7000Reader extends FormatReader {
           p.field = Integer.parseInt(attributes.getValue("bts:FieldIndex")) - 1;
           p.z = Integer.parseInt(attributes.getValue("bts:ZIndex")) - 1;
           p.channel = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
-          p.xpos = Double.parseDouble(attributes.getValue("bts:X"));
-          p.ypos = Double.parseDouble(attributes.getValue("bts:Y"));
-          p.zpos = Double.parseDouble(attributes.getValue("bts:Z"));
+          p.xpos = DataTools.parseDouble(attributes.getValue("bts:X"));
+          p.ypos = DataTools.parseDouble(attributes.getValue("bts:Y"));
+          p.zpos = DataTools.parseDouble(attributes.getValue("bts:Z"));
           p.timestamp = attributes.getValue("bts:Time");
           planes.add(p);
         }
@@ -718,8 +718,8 @@ public class CV7000Reader extends FormatReader {
       else if (qName.equals("bts:MeasurementChannel")) {
         Channel c = new Channel();
         c.index = Integer.parseInt(attributes.getValue("bts:Ch")) - 1;
-        c.xSize = Double.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
-        c.ySize = Double.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
+        c.xSize = DataTools.parseDouble(attributes.getValue("bts:HorizontalPixelDimension"));
+        c.ySize = DataTools.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
         c.correctionFile = attributes.getValue("bts:ShadingCorrectionSource");
         if (c.correctionFile != null && c.correctionFile.trim().length() == 0) {
@@ -761,20 +761,8 @@ public class CV7000Reader extends FormatReader {
         String wavelength = attributes.getValue("bts:WaveLength");
         String power = attributes.getValue("bts:Power");
 
-        if (wavelength != null) {
-          try {
-            l.wavelength = new Double(wavelength);
-          }
-          catch (NumberFormatException e) {
-          }
-        }
-        if (power != null) {
-          try {
-            l.power = new Double(power);
-          }
-          catch (NumberFormatException e) {
-          }
-        }
+        l.wavelength = DataTools.parseDouble(wavelength);
+        l.power = DataTools.parseDouble(power);
 
         lightSources.add(l);
       }
@@ -790,20 +778,10 @@ public class CV7000Reader extends FormatReader {
             currentChannel.binning = attributes.getValue("bts:Binning");
 
             String mag = attributes.getValue("bts:Magnification");
-            if (mag != null) {
-              try {
-                currentChannel.magnification = new Double(mag);
-              }
-              catch (NumberFormatException e) { }
-            }
+            currentChannel.magnification = DataTools.parseDouble(mag);
 
             String exposure = attributes.getValue("bts:ExposureTime");
-            if (exposure != null) {
-              try {
-                currentChannel.exposureTime = new Double(exposure);
-              }
-              catch (NumberFormatException e) { }
-            }
+            currentChannel.exposureTime = DataTools.parseDouble(exposure);
 
             String color = attributes.getValue("bts:Color");
             if (color != null) {
@@ -827,10 +805,7 @@ public class CV7000Reader extends FormatReader {
               if (acquisition.indexOf("/") > 0) {
                 acquisition = acquisition.replaceAll("BP", "");
                 String wave = acquisition.substring(0, acquisition.indexOf("/"));
-                try {
-                  currentChannel.excitation = new Double(wave);
-                }
-                catch (NumberFormatException e) { }
+                currentChannel.excitation = DataTools.parseDouble(wave);
               }
             }
           }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -389,8 +389,10 @@ public class CV7000Reader extends FormatReader {
             }
             Channel channel = null;
             for (Channel ch : channels) {
-              if (i == 0) {
-                ch.correctionFile = new Location(parent, ch.correctionFile).getAbsolutePath();
+              if (i == 0 && ch.correctionFile != null) {
+                if (new Location(ch.correctionFile).getParent() == null) {
+                  ch.correctionFile = new Location(parent, ch.correctionFile).getAbsolutePath();
+                }
               }
 
               if (ch.index == p.channel) {
@@ -550,7 +552,8 @@ public class CV7000Reader extends FormatReader {
     @Override
     public void endElement(String uri, String localName, String qName) {
       String value = currentValue.toString();
-      if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG")) {
+      if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG") &&
+        value.trim().length() > 0) {
         planes.get(planes.size() - 1).file = new Location(parentDir, value).getAbsolutePath();
       }
     }
@@ -567,6 +570,9 @@ public class CV7000Reader extends FormatReader {
     {
       if (qName.equals("bts:MeasurementSamplePlate")) {
         wppPath = attributes.getValue("bts:WellPlateProductFileName");
+        if (wppPath != null && wppPath.trim().length() == 0) {
+          wppPath = null;
+        }
       }
       else if (qName.equals("bts:MeasurementChannel")) {
         Channel c = new Channel();
@@ -575,6 +581,9 @@ public class CV7000Reader extends FormatReader {
         c.ySize = Double.parseDouble(attributes.getValue("bts:VerticalPixelDimension"));
         c.cameraNumber = Integer.parseInt(attributes.getValue("bts:CameraNumber"));
         c.correctionFile = attributes.getValue("bts:ShadingCorrectionSource");
+        if (c.correctionFile != null && c.correctionFile.trim().length() == 0) {
+          c.correctionFile = null;
+        }
         channels.add(c);
       }
       else if (qName.equals("bts:MeasurementDetail")) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -669,7 +669,10 @@ public class CV7000Reader extends FormatReader {
       String value = currentValue.toString();
       if (qName.equals("bts:MeasurementRecord") && btsType.equals("IMG") &&
         value.trim().length() > 0) {
-        planes.get(planes.size() - 1).file = new Location(parentDir, value).getAbsolutePath();
+        Location imgFile = new Location(parentDir, value);
+        if (imgFile.exists()) {
+          planes.get(planes.size() - 1).file = imgFile.getAbsolutePath();
+        }
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -222,10 +222,7 @@ public class CV7000Reader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
     WPIHandler plate = new WPIHandler();
-    String wpiXML = DataTools.readFile(id).trim();
-    if (wpiXML.endsWith(">>")) {
-      wpiXML = wpiXML.substring(0, wpiXML.length() - 1);
-    }
+    String wpiXML = readSanitizedXML(id);
     XMLTools.parseXML(wpiXML, plate);
 
     parent = new Location(id).getAbsoluteFile().getParentFile();
@@ -241,7 +238,7 @@ public class CV7000Reader extends FormatReader {
 
     measurementPath = measurementData.getAbsolutePath();
     MeasurementDataHandler measurementHandler = new MeasurementDataHandler(parent.getAbsolutePath());
-    XMLTools.parseXML(DataTools.readFile(measurementPath), measurementHandler);
+    XMLTools.parseXML(readSanitizedXML(measurementPath), measurementHandler);
 
     planeData = measurementHandler.getPlanes();
 
@@ -253,7 +250,7 @@ public class CV7000Reader extends FormatReader {
       channels = new ArrayList<Channel>();
       detailPath = measurementDetail.getAbsolutePath();
       MeasurementDetailHandler detailHandler = new MeasurementDetailHandler();
-      XMLTools.parseXML(DataTools.readFile(detailPath), detailHandler);
+      XMLTools.parseXML(readSanitizedXML(detailPath), detailHandler);
       if (wppPath != null) {
         wppPath = new Location(parent, wppPath).getAbsolutePath();
       }
@@ -265,7 +262,7 @@ public class CV7000Reader extends FormatReader {
     if (settingsPath != null && new Location(settingsPath).exists()) {
       lightSources = new ArrayList<LightSource>();
       MeasurementSettingsHandler settingsHandler = new MeasurementSettingsHandler();
-      String xml = DataTools.readFile(settingsPath).trim();
+      String xml = readSanitizedXML(settingsPath);
       if (xml.length() > 0) {
         XMLTools.parseXML(xml, settingsHandler);
       }
@@ -539,6 +536,14 @@ public class CV7000Reader extends FormatReader {
       }
 
     }
+  }
+
+  private String readSanitizedXML(String filename) throws IOException {
+    String xml = DataTools.readFile(filename).trim();
+    if (xml.endsWith(">>")) {
+      xml = xml.substring(0, xml.length() - 1);
+    }
+    return xml;
   }
 
   private boolean isWellAcquired(int row, int col) {

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -187,6 +187,7 @@ public class CV7000Reader extends FormatReader {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
     Plane p = lookupPlane(getSeries(), no);
+    LOGGER.trace("series = {}, no = {}, file = {}", series, no, p == null ? null : p.file);
     if (p != null && p.file != null) {
       reader.setId(p.file);
       return reader.openBytes(0, buf, x, y, w, h);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -497,7 +497,10 @@ public class CV7000Reader extends FormatReader {
       currentValue.setLength(0);
 
       try {
-        if (qName.equals("bts:MeasurementRecord")) {
+        if (qName.equals("bts:MeasurementRecord")
+            && attributes.getValue("bts:Type").equals("IMG")) {
+          // When the instrument is recording an acquisition error the "type"
+          // will be "ERR" so we can skip those.
           Plane p = new Plane();
           p.row = Integer.parseInt(attributes.getValue("bts:Row")) - 1;
           p.column = Integer.parseInt(attributes.getValue("bts:Column")) - 1;

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -28,6 +28,8 @@ package loci.formats.in;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import loci.common.DataTools;
 import loci.common.Location;
@@ -511,7 +513,14 @@ public class CV7000Reader extends FormatReader {
         }
       }
       catch (RuntimeException e) {
-        LOGGER.error("Error parsing attributes: {}", attributes);
+        if (LOGGER.isErrorEnabled()) {
+          Map<String, String> attributeMap = new HashMap<String, String>();
+          for (int i = 0; i < attributes.getLength(); i++) {
+            attributeMap.put(
+                attributes.getLocalName(i), attributes.getValue(i));
+          }
+          LOGGER.error("Error parsing attributes: {}", attributeMap, e);
+        }
         throw e;
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -541,7 +541,11 @@ public class CV7000Reader extends FormatReader {
     if (index < 0 || index >= planeData.size()) {
       return null;
     }
-    return planeData.get(index);
+    Plane p = planeData.get(index);
+    if (p.series != series || p.no != no) {
+      return null;
+    }
+    return p;
   }
 
   // -- Helper classes --

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -222,7 +222,11 @@ public class CV7000Reader extends FormatReader {
   protected void initFile(String id) throws FormatException, IOException {
     super.initFile(id);
     WPIHandler plate = new WPIHandler();
-    XMLTools.parseXML(DataTools.readFile(id), plate);
+    String wpiXML = DataTools.readFile(id).trim();
+    if (wpiXML.endsWith(">>")) {
+      wpiXML = wpiXML.substring(0, wpiXML.length() - 1);
+    }
+    XMLTools.parseXML(wpiXML, plate);
 
     parent = new Location(id).getAbsoluteFile().getParentFile();
     allFiles = parent.list(true);

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -47,6 +47,7 @@ import ome.units.UNITS;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
 
 import org.xml.sax.Attributes;
 
@@ -74,6 +75,7 @@ public class CV7000Reader extends FormatReader {
   private ArrayList<Channel> channels;
   private int fields;
   private int realRows, realCols;
+  private String startTime, endTime;
 
   // -- Constructor --
 
@@ -161,6 +163,8 @@ public class CV7000Reader extends FormatReader {
       realRows = 0;
       realCols = 0;
       channels = null;
+      startTime = null;
+      endTime = null;
     }
   }
 
@@ -316,6 +320,13 @@ public class CV7000Reader extends FormatReader {
       store.setPlateAcquisitionMaximumFieldCount(fieldCount, 0, 0);
     }
 
+    if (startTime != null) {
+      store.setPlateAcquisitionStartTime(new Timestamp(startTime), 0, 0);
+    }
+    if (endTime != null) {
+      store.setPlateAcquisitionEndTime(new Timestamp(endTime), 0, 0);
+    }
+
     int nextWell = 0;
     int nextImage = 0;
     for (int row=0; row<plate.getPlateRows(); row++) {
@@ -437,12 +448,6 @@ public class CV7000Reader extends FormatReader {
       return description;
     }
 
-
-    @Override
-    public void characters(char[] ch, int start, int length) {
-
-    }
-
     @Override
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
@@ -453,11 +458,6 @@ public class CV7000Reader extends FormatReader {
         plateRows = Integer.parseInt(attributes.getValue("bts:Rows"));
         plateColumns = Integer.parseInt(attributes.getValue("bts:Columns"));
       }
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) {
-
     }
 
   }
@@ -517,22 +517,13 @@ public class CV7000Reader extends FormatReader {
   }
 
   class MeasurementDetailHandler extends BaseHandler {
-    private StringBuffer currentValue = new StringBuffer();
 
     // -- DefaultHandler API methods --
-
-    @Override
-    public void characters(char[] ch, int start, int length) {
-      String value = new String(ch, start, length);
-      currentValue.append(value);
-    }
 
     @Override
     public void startElement(String uri, String localName, String qName,
       Attributes attributes)
     {
-      currentValue.setLength(0);
-
       if (qName.equals("bts:MeasurementSamplePlate")) {
         wppPath = attributes.getValue("bts:WellPlateProductFileName");
       }
@@ -546,18 +537,9 @@ public class CV7000Reader extends FormatReader {
         channels.add(c);
       }
       else if (qName.equals("bts:MeasurementDetail")) {
-        // bts:OperatorName
-        // bts:Title
-        // bts:BeginTime
-        // bts:EndTime
-        // bts:MeasurementSettingFileName
-        // bts:TargetSystem
+        startTime = attributes.getValue("bts:BeginTime");
+        endTime = attributes.getValue("bts:EndTime");
       }
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) {
-      String value = currentValue.toString();
     }
 
   }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1738,6 +1738,11 @@ public class FormatReaderTest {
             continue;
           }
 
+          // CV7000 datasets can only be reliably detected with the .wpi file
+          if (reader.getFormat().equals("Yokogawa CV7000")) {
+            continue;
+          }
+
           r.setId(base[i]);
 
           String[] comp = r.getUsedFiles();
@@ -2408,6 +2413,13 @@ public class FormatReaderTest {
             // ignore companion files for Leica LIF
             if (!used[i].toLowerCase().endsWith(".lif") &&
               r instanceof LIFReader)
+            {
+              continue;
+            }
+
+            // ignore anything other than .wpi for CV7000
+            if (!used[i].toLowerCase().endsWith(".wpi") &&
+              r instanceof CV7000Reader)
             {
               continue;
             }


### PR DESCRIPTION
Backported from a bunch of private PRs.  See https://trello.com/c/b0nFSUzZ/238-cv7000

To test, use 3 plates in ```/uod/idr/repos/curated/cv7000/glencoe/```.  For each, the ```.wpi``` file is the one to initialize (this is the main metadata file).  The ```DW 0001``` plate has 370 wells - standard 16x24 with D07, E12, H14, H21, I14, I24, J09, J18, K18, L17, L18, M02, P10, and P20 missing.  ```DW 0002``` is a single row (22 wells, H13 and H14 missing) and ```DW 0003``` is a single column (16 wells).  All three are single field, single T, single Z, and 4 channels (```DAPI, 488, 594, mitotracker```).  There are many more plates that cover a wider range of dimensions which could be transferred to ```data_repo```, but this requires coordination due to https://trello.com/c/AJf3bdxa/83-the-slow-death-of-ome-datarepo

For each, confirm that ```showinf -nopix -omexml``` shows dimensions that match the description above.  It should be possible to open each series (well), either via ```showinf``` or ImageJ.  The images are 16 bit, and not particularly biologically interesting (all were acquired specifically for testing).

Memo files will be impacted; may conflict with #3219 and/or #3151.