### PR TITLE
Bump ome-codecs version to 0.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>
-    <ome-codecs.version>0.2.2</ome-codecs.version>
+    <ome-codecs.version>0.2.3</ome-codecs.version>
     <jxrlib.version>0.2.1</jxrlib.version>
     <xalan.version>2.7.2</xalan.version>
 


### PR DESCRIPTION
The main change in this version is the Huffman table fix for images with multiple components (see https://github.com/ome/ome-codecs/pull/8)

Testing:
- Travis/Appveyor should pass and retrieve the latest version of the component
- CI tests should remain green including especially the `quicktime` filesets