### PR TITLE
Micromanager: better handling of very large *metadata.txt files

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -708,6 +708,15 @@ public class MicromanagerReader extends FormatReader {
     p.voltage = new Vector<Double>();
 
     RandomAccessInputStream s = new RandomAccessInputStream(jsonData);
+
+    if (s.length() > Integer.MAX_VALUE) {
+      LOGGER.warn(jsonData + " exceeds 2GB; metadata parsing is likely to fail");
+    }
+    else if (s.length() > 100 * 1024 * 1024) {
+      LOGGER.warn(jsonData + " is larger than 100MB and may require additional memory to parse. " +
+        "A minimum of 1024MB is suggested.");
+    }
+
     byte[] b = new byte[(int) s.length()];
     s.readFully(b);
     s.close();


### PR DESCRIPTION
Backported from a private PR.  Originally part of the same PR as https://github.com/ome/ome-common-java/pull/24 (prior to repo split).

Original use case was larger (~7000 plane) datasets acquired using the diSPIM plugin (https://micro-manager.org/wiki/ASIdiSPIM_Plugin).  I wasn't able to find a way to run a diSPIM acquisition without a connected instrument, so the closest test data is a 5000 T x 5 Z x 2 C multi-D acquisition with the relevant ```SPIMmode``` key added manually.

Complete dataset yet to be uploaded, so not ready for final testing.  Once uploaded, ```showinf -nopix 1.4-large-acq-take-2_1_MMStack_Pos0_metadata.txt``` without this PR or https://github.com/ome/ome-common-java/pull/24 will require ```BF_MAX_MEM``` to be at least 1200 MB.  With a build including both PRs, only 900 MB should be required.  As ```1.4-large-acq-take-2_1_MMStack_Pos0_metadata.txt``` is 195 MB, a warning should be logged indicating that the file may require additional memory.

Tests should continue to pass with existing Micromanager data; memo files will be affected.