### PR TITLE
CZI original metadata reduction

### DIFF
--- a/components/formats-api/src/loci/formats/CoreMetadata.java
+++ b/components/formats-api/src/loci/formats/CoreMetadata.java
@@ -168,7 +168,8 @@ public class CoreMetadata implements Cloneable {
     indexed = r.isIndexed();
     falseColor = r.isFalseColor();
     metadataComplete = r.isMetadataComplete();
-    seriesMetadata = r.getSeriesMetadata();
+    seriesMetadata = new Hashtable<String, Object>();
+    seriesMetadata.putAll(r.getSeriesMetadata());
     thumbnail = r.isThumbnailSeries();
     resolutionCount = r.getResolutionCount();
     moduloZ = r.getModuloZ();
@@ -197,7 +198,8 @@ public class CoreMetadata implements Cloneable {
     indexed = c.indexed;
     falseColor = c.falseColor;
     metadataComplete = c.metadataComplete;
-    seriesMetadata = c.seriesMetadata;
+    seriesMetadata = new Hashtable<String, Object>();
+    seriesMetadata.putAll(c.seriesMetadata);
     thumbnail = c.thumbnail;
     resolutionCount = c.resolutionCount;
     moduloZ = new Modulo(c.moduloZ);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1186,7 +1186,13 @@ public class ZeissCZIReader extends FormatReader {
             int seriesId = p.coreIndex + 1;
             //add padding to make sure the original metadata table is organized properly in ImageJ
             String sIndex = String.format("Positions|Series %0" + nameWidth + "d|", seriesId);
-            addSeriesMetaList(sIndex, dimension.start);
+            if (maxResolution == 0) {
+              addSeriesMetaList(sIndex, dimension.start);
+            }
+            else {
+              // don't store the start value for every tile in a pyramid
+              addSeriesMeta(sIndex, dimension.start);
+            }
             break;
         }
       }


### PR DESCRIPTION
Backported from a private PR.

To test, use any pyramid .czi file, e.g. ```curated/zeiss-czi/zeiss/jpeg-xr/a)BF-1scene-nozstack-compression85%.czi```.  Without this PR, examine the original metadata for series 0 with ```showinf -nopix```.  There should be hundreds of keys such as ```Positions|Series 03| #041: 0```, one per tile in each pyramid resolution.  All values for a given series should be equal, and the table for a single series contains the keys for every series.

With this PR, the same test should show a single key in the series original metadata table; nothing else should change.

74d5dac fixes a bug in ```CoreMetadata``` that causes the original metadata tables to be the same for every series.  21f4525 follows on from https://github.com/openmicroscopy/bioformats/pull/2600#issuecomment-252793637 and only sets a single position value in the original metadata table when reading a pyramid file.  Together the two commits should shrink the size of the combined original metadata tables, which reduces ```setId``` time particularly when a non-```DummyMetadata``` is used (e.g. OMERO import).

Memo files should be unaffected and tests should continue to pass.  
