### PR TITLE
bfsave: do not use ImageWriter.getCompressionTypes() for input check

### DIFF
--- a/components/formats-gpl/matlab/bfsave.m
+++ b/components/formats-gpl/matlab/bfsave.m
@@ -87,6 +87,12 @@ end
 writer.setWriteSequentially(true);
 writer.setMetadataRetrieve(metadata);
 if ~isempty(ip.Results.Compression)
+    compressionTypes = getCompressionTypes(writer);
+    if ~ismember(ip.Results.Compression, compressionTypes)
+        e = MException('bfsave:unsupportedCompression', ...
+            'Unsupported compression: %s.', ip.Results.Compression);
+        throw(e);
+    end
     writer.setCompression(ip.Results.Compression);
 end
 if ip.Results.BigTiff


### PR DESCRIPTION
This PR updates the MATLAB `bfsave` utility to improve the handling of compression types. The initial implementation was relying `ImageWriter.getCompressionTypes()` which behavior is modified by #3154.

## Changes

This PR updates the `bfsave` logic to:

- construct a concrete writer using `ImageWriter.getWriter(outputPath)` similarly to e.g. `bfconvert`
- use the API of the concrete writer to access compression types or writer-specific properties

## Testing

-  MATLAB tests running at https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-merge-matlab/ should be passing
- Using MATLAB or GNUOctave, a couple of scenarios can be tested

  * `bfsave(zeros(100,100,'uint8'), '/tmp/out.ome.tiff')` should create an OME-TIFF
  * `bfsave(zeros(100,100,'uint8'), '/tmp/out.ome.xml')` should create an OME-XML 
  * `bfsave(zeros(100,100,'uint8'), '/tmp/out.tiff')` should pass and create a TIFF 
  * `bfsave(zeros(100,100,'uint8'), '/tmp/out.tiff', 'Compression', 'JPEG')` should  create a TIFF using JPEG for compression
  * `bfsave(zeros(100,100,'uint8'), '/tmp/out.ome.xml', 'Compression', 'JPEG')` should fail with an unsupported compression type exception