### PR TITLE
Bruker: parse dimensions from d3proc file when available

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BrukerReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BrukerReader.java
@@ -316,16 +316,19 @@ public class BrukerReader extends FormatReader {
 
       parseLines(lines);
 
-      String procData = DataTools.readFile(procFiles.get(series));
-      lines = procData.split("\n");
-
-      parseLines(lines);
+      boolean parsedProcFile = false;
+      if (series < procFiles.size()) {
+        String procData = DataTools.readFile(procFiles.get(series));
+        lines = procData.split("\n");
+        parseLines(lines);
+        parsedProcFile = true;
+      }
 
       ms.pixelType =
         FormatTools.pixelTypeFromBytes(bits / 8, signed, isFloat);
 
       // reset the dimensions if the d3proc data does not match the pixel file size
-      if (getSizeZ() * getSizeT() != nr * ni && (ni > 1 || nr > 1 || ns > 1)) {
+      if (parsedProcFile && getSizeZ() * getSizeT() != nr * ni && (ni > 1 || nr > 1 || ns > 1)) {
         ni = 1;
         nr = 1;
         ns = 1;


### PR DESCRIPTION
Backported from private PRs.  This allows dimensions to be parsed from the optional (but usually present) ```d3proc``` file.  In case of a mismatch between the ```d3proc``` and the ```acqp```, the ```d3proc``` is preferred.  See also http://imaging.mrc-cbu.cam.ac.uk/imaging/FormatBruker

An artificial test dataset is in ```curated/bruker/samples/dimension-mismatch/```.  This is the result of copying the dataset in ```curated/bruker/wis/RA_060110.051/1/``` and modifying line 30 of ```acqp``` to be ```##$NR=5``` (instead of ```##$NR=1```).

Without this PR, ```showinf -nopix curated/bruker/samples/dimension-mismatch/1/acqp``` should show 3 Z sections and 5 timepoints, each of which is 128x128 and 16 bit.  The pixels file is ```curated/bruker/samples/dimension-mismatch/1/pdata/1/2dseq```, which is only large enough to contain 3 128x128x2 planes.

With this PR, the same ```showinf -nopix``` test should show 3 Z sections and 1 timepoint; the total number of pixel bytes should exactly match the size of the ```2dseq``` file.  The dimensions and images should also exactly match those of the first series in the original ```curated/bruker/wis/RA_060110.051/1/``` dataset.

I would expect builds to continue passing, but this will affect memo files.