### PR TITLE
TiffSaver: Only setLength of output file once

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -989,8 +989,21 @@ public class TiffSaver {
     //      * tileCount is 2
 
     int tileCount = isTiled ? tilesPerRow * tilesPerColumn : 1;
+
+    long stripStartPos = out.length();
+    long totalStripSize = 0;
     for (int i=0; i<strips.length; i++) {
-      out.seek(out.length());
+      totalStripSize += strips[i].length;
+    }
+    // sets the output file size without having to allocate for each strip iteration
+    out.seek(stripStartPos + totalStripSize);
+    // return to original position
+    out.seek(stripStartPos);
+
+    long stripOffset = 0;
+    for (int i=0; i<strips.length; i++) {
+      out.seek(stripStartPos + stripOffset);
+      stripOffset += strips[i].length;
       int index = interleaved ? i : (i / nChannels) * nChannels;
       int c = interleaved ? 0 : i % nChannels;
       int thisOffset = firstOffset + index + (c * tileCount);


### PR DESCRIPTION
This is in relation to trying to address performance issues, see https://trello.com/c/OimiHAQY/39-ome-common-profile-tiff-writing and https://github.com/ome/ome-common-java/pull/15

As shown in https://github.com/ome/ome-common-java/pull/15 the problem lies in the repeated calling of setLength on RandomAccessFile.

The issue originally thought to be a Windows issue looks like it may be related to Java versions with RandomAccessFile.setLength being much slower on Java 10 (see https://stackoverflow.com/questions/50450317/randomaccessfile-setlength-much-slower-on-java-10-centos for some info)

In Java 8 setLength does:
```
[pid 49027] ftruncate(23, 53248)        = 0
[pid 49027] lseek(23, 0, SEEK_SET)      = 0
[pid 49027] lseek(23, 0, SEEK_CUR)      = 0
```

While in Java 10 it introduces the much slower fallocate (to fix a bug):
```
[pid   444] fstat(8, {st_mode=S_IFREG|0664, st_size=126976, ...}) = 0
[pid   444] fallocate(8, 0, 0, 131072)  = 0
[pid   444] lseek(8, 0, SEEK_SET)       = 0
[pid   444] lseek(8, 0, SEEK_CUR)       = 0
```
This is particularly problematic for us as the profiling shows we make a large number of calls to setLength. Essentially every time we write a strip we are calling it to increase the length of the output file.

Buffering in NIOFileHandle will help improve this, but as TiffSaver knows the length of data it is writing it might make more sense to make a single call to allocate the length upfront. In this case it is being forced by seeking to length which in turn calls setLength.