### PR TITLE
Leica SCN: improvements for Versa datasets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -452,7 +452,17 @@ public class LeicaSCNReader extends BaseTiffReader {
           store.setPlanePositionY(offsetY, pos, q);
         }
 
-        store.setImageName(i.name + " (R" + subresolution + ")", pos);
+        if (hasFlattenedResolutions()) {
+          store.setImageName(i.name + " (R" + subresolution + ")", pos);
+        }
+        else {
+          if (ms.resolutionCount > 1) {
+            store.setImageName("", pos);
+          }
+          else {
+            store.setImageName(i.name, pos);
+          }
+        }
         store.setImageDescription("Collection " + c.name, pos);
 
         if (i.creationDate != null) {

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -84,6 +84,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     suffixNecessary = false;
     suffixSufficient = false;
     canSeparateSeries = false;
+    noSubresolutions = true;
   }
 
   // -- IFormatReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -238,7 +238,12 @@ public class LeicaSCNReader extends BaseTiffReader {
   @Override
   protected void initTiffParser() {
     super.initTiffParser();
-    tiffParser.setYCbCrCorrection(false);
+    // older .scn files require color correction
+    // newer files from Versa systems do not
+    if (handler != null) {
+      Image i = handler.imageMap.get(0);
+      tiffParser.setYCbCrCorrection(!"versa".equalsIgnoreCase(i.devModel));
+    }
   }
 
   protected void initCoreMetadata(int series, int resolution) throws FormatException, IOException {
@@ -329,6 +334,8 @@ public class LeicaSCNReader extends BaseTiffReader {
         throw new FormatException("Failed to parse XML", se);
       }
     }
+    initTiffParser();
+    tiffParser.setDoCaching(true);
 
     int count = handler.count();
 

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -234,6 +234,12 @@ public class LeicaSCNReader extends BaseTiffReader {
 
   // -- Internal BaseTiffReader API methods --
 
+  @Override
+  protected void initTiffParser() {
+    super.initTiffParser();
+    tiffParser.setYCbCrCorrection(false);
+  }
+
   protected void initCoreMetadata(int series, int resolution) throws FormatException, IOException {
     int pos = core.flattenedIndex(series, resolution);
     ImageCollection c = handler.collection;

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -307,7 +307,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     ms.littleEndian = ifd.isLittleEndian();
     ms.indexed = pi == PhotoInterp.RGB_PALETTE &&
       (get8BitLookupTable() != null || get16BitLookupTable() != null);
-    ms.imageCount = getSizeZ() * (ms.rgb ? 1 : getSizeC());
+    ms.imageCount = ms.sizeZ * (ms.rgb ? 1 : ms.sizeC);
     ms.pixelType = ifd.getPixelType();
     ms.metadataComplete = true;
     ms.interleaved = false;

--- a/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaSCNReader.java
@@ -327,6 +327,7 @@ public class LeicaSCNReader extends BaseTiffReader {
     handler = new LeicaSCNHandler();
     if (imageDescription != null) {
       try {
+        LOGGER.trace("Image description XML = {}", imageDescription);
         // parse the XML description
         XMLTools.parseXML(imageDescription, handler);
       }
@@ -456,7 +457,12 @@ public class LeicaSCNReader extends BaseTiffReader {
           store.setImageName(i.name + " (R" + subresolution + ")", pos);
         }
         else {
-          if (ms.resolutionCount > 1) {
+          if (pos == 0) {
+            // assume first image (usually a pyramid) is the macro image
+            // the value of i.name will not reliably identify a macro
+            store.setImageName("macro", pos);
+          }
+          else if (ms.resolutionCount > 1) {
             store.setImageName("", pos);
           }
           else {


### PR DESCRIPTION
Backported from recent private PR.  Coincidentally addresses at least part of #2811.

To test, use the file from QA 17671.  Without this PR, ```showinf -nopix -noflat``` should show 2 pyramids and no extra images.  ```showinf``` on any of the images should result in a weird pinkish image as documented in #2811.

With this PR, ```showinf -nopix -noflat``` should show 2 pyramids and an extra label image in series 2.  ```showinf``` on any of the images should show normal looking slide images with a white instead of pink background.  Leica/Aperio ImageScope can be used to verify that the images are valid.  Note that the slides are rotated 90 degrees from how they are presented in ImageScope; I don't see any obvious rotation metadata, so the reader doesn't deviate from the X and Y dimensions stored in the file.

Tests on all other SCN files should continue to pass.