### PR TITLE
ChannelSeparator: copy all channel metadata instead of just names

### DIFF
--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -321,7 +321,7 @@ public class ChannelSeparator extends ReaderWrapper {
             pixelsPopulated = true;
           }
           for (int i=1; i<rgbChannels; i++) {
-            MetadataConverter.convertChannelMetadata(retrieve, s, cIndex,
+            MetadataConverter.convertChannels(retrieve, s, cIndex,
               store, s, cIndex + i, false);
           }
         }

--- a/components/formats-bsd/src/loci/formats/ChannelSeparator.java
+++ b/components/formats-bsd/src/loci/formats/ChannelSeparator.java
@@ -38,6 +38,8 @@ import loci.common.DataTools;
 import loci.formats.meta.MetadataRetrieve;
 import loci.formats.meta.MetadataStore;
 
+import ome.xml.meta.MetadataConverter;
+
 /**
  * Logic to automatically separate the channels in a file.
  */
@@ -310,19 +312,17 @@ public class ChannelSeparator extends ReaderWrapper {
           continue;
         }
         for (int c=0; c<reader.getEffectiveSizeC(); c++) {
-          if (c * rgbChannels >= retrieve.getChannelCount(s)) {
+          int cIndex = c * rgbChannels;
+          if (cIndex >= retrieve.getChannelCount(s)) {
             break;
-          }
-          String originalChannelName = retrieve.getChannelName(s, c * rgbChannels);
-          if (originalChannelName == null) {
-            continue;
           }
           if (!pixelsPopulated) {
             MetadataTools.populatePixelsOnly(store, this);
             pixelsPopulated = true;
           }
           for (int i=1; i<rgbChannels; i++) {
-            store.setChannelName(originalChannelName, s, c * rgbChannels + i);
+            MetadataConverter.convertChannelMetadata(retrieve, s, cIndex,
+              store, s, cIndex + i, false);
           }
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>5.3.6</ome-common.version>
-    <ome-model.version>5.6.3</ome-model.version>
+    <ome-model.version>6.0.0-m1</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>
     <ome-jai.version>0.1.3</ome-jai.version>


### PR DESCRIPTION
Backported from unmerged private PR.  Uses https://github.com/ome/ome-model/pull/88.

To test, use a file with RGB data and more OME-XML Channel metadata than just a name.  I used ```curated/zeiss-czi/silke/White_574.czi```, but brightfield datasets in most of the WSI formats would work too.  Without this change, ```showinf -nopix -noflat -omexml -separate``` should show one ```Channel``` per original RGB component.  The names of all ```Channel```s in an ```Image``` should be the same, but only the first will have things like wavelengths, detector references, etc.

With this PR, ```showinf -nopix -noflat -omexml -separate``` should show that all ```Channel```s in an ```Image``` are identical apart from the ID.

This could impact OMERO imports, so it probably makes sense to also test a few imports of RGB data to make sure that nothing goes wrong.  I would expect builds to remain green, and I don't think this will affect memo files. 