### PR TITLE
OperettaReader: also populate WellSample positions if the metadata exists

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -619,7 +619,7 @@ public class OperettaReader extends FormatReader {
         else if ("PositionY".equals(currentName)) {
           // position stored in meters
           final double meters = Double.parseDouble(value);
-          activePlane.positionY = new Length(meters, UNITS.METRE);
+          activePlane.positionY = new Length(-meters, UNITS.METRE);
         }
         else if ("AbsPositionZ".equals(currentName)) {
           // position stored in meters

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -413,7 +413,7 @@ public class OperettaReader extends FormatReader {
           if (planes[imageIndex][0] != null && planes[imageIndex][0].absoluteTime != null) {
             store.setImageAcquisitionDate(planes[imageIndex][0].absoluteTime, imageIndex);
             store.setWellSamplePositionX(planes[imageIndex][0].positionX, 0, well, field);
-            store.setWellSamplePositionX(planes[imageIndex][0].positionY, 0, well, field);
+            store.setWellSamplePositionY(planes[imageIndex][0].positionY, 0, well, field);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -412,6 +412,8 @@ public class OperettaReader extends FormatReader {
 
           if (planes[imageIndex][0] != null && planes[imageIndex][0].absoluteTime != null) {
             store.setImageAcquisitionDate(planes[imageIndex][0].absoluteTime, imageIndex);
+            store.setWellSamplePositionX(planes[imageIndex][0].positionX, 0, well, field);
+            store.setWellSamplePositionX(planes[imageIndex][0].positionY, 0, well, field);
           }
         }
       }


### PR DESCRIPTION
See https://trello.com/c/WrSJs57r/197-improve-operetta-harmony-metadata#comment-5bbf50de8977243c9f33da8d

Currently this metadata is stored at the individual plane level. Similarly to other HCS reader, we are storing the X and Y positions of the first plane at the well sample level as well if this information exists.

This PR should not cause regression in the automated tests. The outcome of the population can be tested:
- either by looking at the OME-XML when reading a sample Operetta plate and verifying the `WellSample` elements have their positions populated
- or by importing a sample plate into an OMERO server with this PR and checking a grid is displayed in the Web client using the relative positions of the individual well samples.