### PR TITLE
Speed up TiffSaver.writeImage with bulk array writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tools/*.jar
 *.xpr
 *.class
 *.iml
+.*.swp

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -328,43 +328,74 @@ public class TiffSaver {
         stripOut[strip] = new DataOutputStream(stripBuf[strip]);
       }
       int[] bps = ifd.getBitsPerSample();
-      int off;
+      boolean channelsAllSameSize = true;
+      for (int c = 0; c < nChannels; c++)
+        if (bps[c] != bytesPerPixel * 8)
+          channelsAllSameSize = false;
 
       // write pixel strips to output buffers
-      int effectiveStrips = !interleaved ? nStrips / nChannels : nStrips;
-      if (effectiveStrips == 1 && copyDirectly) {
-        stripOut[0].write(buf);
-      }
-      else {
-        for (int strip = 0; strip < effectiveStrips; strip++) {
-          int xOffset = (strip % tilesPerRow) * tileWidth;
-          int yOffset = (strip / tilesPerRow) * tileHeight;
-          for (int row=0; row<tileHeight; row++) {
-            for (int col=0; col<tileWidth; col++) {
-              int ndx = ((row+yOffset) * w + col + xOffset) * bytesPerPixel;
-              for (int c=0; c<nChannels; c++) {
-                for (int n=0; n<bps[c]/8; n++) {
-                  if (interleaved) {
-                    off = ndx * nChannels + c * bytesPerPixel + n;
-                    if (row >= h || col >= w) {
-                      stripOut[strip].writeByte(0);
-                    } else if (off < buf.length) {
-                      stripOut[strip].writeByte(buf[off]);
+      // Check for the sane cases
+      if (ifd.getImageWidth() == w && ifd.getTileWidth() == w && channelsAllSameSize) {
+        // If the input, output, and tile widths are all the same,
+        // and the input bytesPerPixel (which is actually bytes per sample)
+        // matches the bits per channel for all channels,
+        // then the input can be directly copied to the output in appropriate size strips.
+        // Any interleaving of channels will be the same for input and output.
+        if (buf.length % stripSize == 0) {
+          for (int strip = 0; strip < nStrips; strip++) {
+            stripOut[strip].write(buf, strip * stripSize, stripSize);
+          }
+        } else {
+          for (int strip = 0; strip < nStrips - 1; strip++) {
+            stripOut[strip].write(buf, strip * stripSize, stripSize);
+          }
+          // Sigh.  Need to pad the last strip.
+          int pos = (nStrips - 1) * stripSize;
+          int len = buf.length - pos;
+          stripOut[nStrips - 1].write(buf, pos, len);
+          for (int n = len; n < stripSize; n++) {
+            stripOut[nStrips - 1].writeByte(0);
+          }
+        }
+      } else {
+        int effectiveStrips = !interleaved ? nStrips / nChannels : nStrips;
+        if (effectiveStrips == 1 && copyDirectly) {
+          stripOut[0].write(buf);
+        }
+        else {
+          for (int strip = 0; strip < effectiveStrips; strip++) {
+            // This is broken; the tilesPerRow is based on output image size and tile size,
+            // but the xOffset and yOffset are used to compute offsets into the input image buffer.
+            // This is only sane if the input image width and the output image width are the same.
+            int xOffset = (strip % tilesPerRow) * tileWidth;
+            int yOffset = (strip / tilesPerRow) * tileHeight;
+            for (int row=0; row<tileHeight; row++) {
+              for (int col=0; col<tileWidth; col++) {
+                int ndx = ((row+yOffset) * w + col + xOffset) * bytesPerPixel;
+                for (int c=0; c<nChannels; c++) {
+                  for (int n=0; n<bps[c]/8; n++) {
+                    if (interleaved) {
+                      int off = ndx * nChannels + c * bytesPerPixel + n;
+                      if (row >= h || col >= w) {
+                        stripOut[strip].writeByte(0);
+                      } else if (off < buf.length) {
+                        stripOut[strip].writeByte(buf[off]);
+                      }
+                      else {
+                        stripOut[strip].writeByte(0);
+                      }
                     }
                     else {
-                      stripOut[strip].writeByte(0);
-                    }
-                  }
-                  else {
-                    off = c * blockSize + ndx + n;
-                    int realStrip = (c * (nStrips / nChannels)) + strip;
-                    if (row >= h || col >= w) {
-                      stripOut[realStrip].writeByte(0);
-                    } else if (off < buf.length) {
-                      stripOut[realStrip].writeByte(buf[off]);
-                    }
-                    else {
-                      stripOut[realStrip].writeByte(0);
+                      int off = c * blockSize + ndx + n;
+                      int realStrip = (c * (nStrips / nChannels)) + strip;
+                      if (row >= h || col >= w) {
+                        stripOut[realStrip].writeByte(0);
+                      } else if (off < buf.length) {
+                        stripOut[realStrip].writeByte(buf[off]);
+                      }
+                      else {
+                        stripOut[realStrip].writeByte(0);
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
The writeImage method in TiffSaver does a byte-by-byte copy from the input buffer to the strip buffers, often in non-sequential order (because of interleaving).  I replace this with bulk array copies if the buffers are determined to be of equivalent widths and bit depths.

This work was motivated by the desire to speed up image format conversions for image files in excess of 50GB. In conjunction with additional changes in ome-codecs and ome-common-java, I have achieved a geometric to linear time asymptotic improvement, plus another ~30% speed improvement of just the linear time cost. The patch for ome-codecs and ome-common-java have already been submitted.

Separately, I am in the process of re-working writeIFD to consolidate buffering and file writes, but that isn't fully baked, yet.  Additional pull requests may be forthcoming when the baking is done.