### PR TITLE
buildFiles IOException when listing remote files

### DIFF
--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -34,6 +34,7 @@ package loci.formats;
 
 import java.io.File;
 import java.math.BigInteger;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -204,7 +205,14 @@ public class FilePattern {
 
     // build file listing
     List<String> fileList = new ArrayList<String>();
-    buildFiles("", num, fileList);
+    try {
+      buildFiles("", num, fileList);
+    }
+    catch (IOException e) {
+      msg = "Error whilst listing files.";
+      return;
+    }
+
     files = fileList.toArray(new String[0]);
 
     if (files.length == 0) {
@@ -755,7 +763,7 @@ public class FilePattern {
   // -- Helper methods --
 
   // recursive method for building the list of matching filenames
-  private void buildFiles(String prefix, int ndx, List<String> fileList) {
+  private void buildFiles(String prefix, int ndx, List<String> fileList) throws IOException {
     if (blocks.length == 0) {
       // regex pattern
 
@@ -831,7 +839,7 @@ public class FilePattern {
     }
   }
 
-  private String[] getAllFiles(String dir) {
+  private String[] getAllFiles(String dir) throws IOException {
     ArrayList<String> files = new ArrayList<String>();
 
     Location root = new Location(dir);

--- a/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/FakeReaderTest.java
@@ -170,7 +170,7 @@ public class FakeReaderTest {
   }
 
   /** Recursively set delete-on-exit for a directory tree. */
-  private void deleteTemporaryDirectoryOnExit(Location directoryRoot) {
+  private void deleteTemporaryDirectoryOnExit(Location directoryRoot) throws Exception {
     directoryRoot.deleteOnExit();
     Location[] children = directoryRoot.listFiles();
     if (children != null) {

--- a/components/formats-gpl/src/loci/formats/in/APLReader.java
+++ b/components/formats-gpl/src/loci/formats/in/APLReader.java
@@ -117,8 +117,15 @@ public class APLReader extends FormatReader {
 
     if (getSeries() < xmlFiles.length) {
       Location xmlFile = new Location(xmlFiles[getSeries()]);
-      if (xmlFile.exists() && !xmlFile.isDirectory()) {
-        files.add(xmlFiles[getSeries()]);
+      if (xmlFile.exists()) {
+        try {
+          if (!xmlFile.isDirectory()) {
+            files.add(xmlFiles[getSeries()]);
+          }
+        }
+        catch (IOException e) {
+          files.add(xmlFiles[getSeries()]);
+        }
       }
     }
     if (!noPixels && getSeries() < tiffFiles.length &&

--- a/components/formats-gpl/src/loci/formats/in/BDReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDReader.java
@@ -116,7 +116,13 @@ public class BDReader extends FormatReader {
     
     Location location = new Location(name);
     String id = location.getAbsolutePath();
-    boolean dirCheck = location.isDirectory();
+    boolean dirCheck;
+    try {
+      dirCheck = location.isDirectory();
+    }
+    catch (IOException e) {
+      dirCheck = false;
+    }
     if (dirCheck) return false;
     if (name.endsWith(EXPERIMENT_FILE)) return true;
     if (!open) return false;
@@ -712,7 +718,7 @@ public class BDReader extends FormatReader {
     }
   }
 
-  private String[][] getTiffs() {
+  private String[][] getTiffs() throws IOException {
     final List<List<String>> files = new ArrayList<List<String>>();
 
     Pattern p = Pattern.compile(".* - n\\d\\d\\d\\d\\d\\d\\.tif");

--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -232,6 +232,7 @@ public class FV1000Reader extends FormatReader {
         checkSuffix(oif.getAbsolutePath(), "oif") && !checkSuffix(name, "bmp");
     }
     catch (IndexOutOfBoundsException e) { }
+    catch (IOException e) { }
     catch (NullPointerException e) { }
     catch (FormatException e) { }
     return false;

--- a/components/formats-gpl/src/loci/formats/in/L2DReader.java
+++ b/components/formats-gpl/src/loci/formats/in/L2DReader.java
@@ -376,7 +376,7 @@ public class L2DReader extends FormatReader {
    * Recursively add all of the files in the given directory to the
    * used file list.
    */
-  private void addDirectory(String path, int series) {
+  private void addDirectory(String path, int series) throws IOException {
     Location dir = new Location(path);
     String[] files = dir.list();
     if (files == null) return;

--- a/components/test-suite/src/loci/tests/testng/FormatWriterTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatWriterTestFactory.java
@@ -26,6 +26,7 @@
 package loci.tests.testng;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +48,7 @@ public class FormatWriterTestFactory {
   // -- TestNG factory methods --
 
   @Factory
-  public Object[] createInstances() {
+  public Object[] createInstances() throws IOException {
     List files = new ArrayList();
 
     // parse explicit filename, if any

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -195,6 +195,7 @@ public class TestTools {
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig)
+    throws IOException
   {
     getFiles(root, files, config, toplevelConfig, null);
   }
@@ -202,6 +203,7 @@ public class TestTools {
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig, String[] subdirs)
+    throws IOException
   {
     getFiles(root, files, config, toplevelConfig, subdirs, "");
   }
@@ -251,7 +253,7 @@ public class TestTools {
   /** Recursively generate a list of files to test. */
   public static void getFiles(String root, List files,
     final ConfigurationTree config, String toplevelConfig, String[] subdirs,
-    String configFileSuffix)
+    String configFileSuffix) throws IOException
   {
     Location f = new Location(root);
     String[] subs = f.list();
@@ -366,25 +368,23 @@ public class TestTools {
     String[] files = root.list();
     for (String file : files) {
       Location check = new Location(root, file);
-      if (check.isDirectory()) {
-        parseConfigFiles(check.getAbsolutePath(), config);
-      }
-      else if (isConfigFile(check, "")) {
-        try {
+      try {
+        if (check.isDirectory()) {
+          parseConfigFiles(check.getAbsolutePath(), config);
+        } else if (isConfigFile(check, "")) {
           config.parseConfigFile(check.getAbsolutePath());
         }
-        catch (IOException e) {
-          LOGGER.warn("Failed to parse config {}", check, e);
-        }
+      }
+      catch (IOException e) {
+        LOGGER.warn("Failed to parse config {}", check, e);
       }
     }
   }
 
   /** Determines if the given file should be ignored by the test suite. */
   public static boolean isIgnoredFile(String file, ConfigurationTree config) {
-    if (file.indexOf(File.separator + ".") >= 0) return true; // hidden file
-
     try {
+      if (file.indexOf(File.separator + ".") >= 0) return true; // hidden file
       Configuration c = config.get(file);
       if (c == null) return false;
       if (!c.doTest()) return true;

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome-common.version>5.3.6</ome-common.version>
+    <ome-common.version>6.0.0-SNAPSHOT</ome-common.version>
     <ome-model.version>5.6.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>


### PR DESCRIPTION
Proposed changes in loci.common.Location to support remote files may result in IOExceptions
- See https://github.com/ome/ome-common-java/pull/33