### PR TITLE
Add link to reader-guide documentation

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -1,6 +1,7 @@
 # This document is a configuration file identifying all file format readers
 # available to Bio-Formats, and the order in which they should be used.
-# Please do not edit unless you know what you are doing (see reader-guide.txt).
+# Please do not edit unless you know what you are doing, see
+# https://docs.openmicroscopy.org/latest/bio-formats/developers/reader-guide.html
 
 loci.formats.in.FilePatternReader     # pattern
 


### PR DESCRIPTION
`readers.txt` says
> Please do not edit unless you know what you are doing (see reader-guide.txt).

It's not clear where `reader-guide.txt` is. My best guess is https://docs.openmicroscopy.org/latest/bio-formats/developers/reader-guide.html but that still doesn't explain how readers.txt works. Is there another document?