### PR TITLE
URL Pattern Reader

### DIFF
--- a/components/formats-api/src/loci/formats/WrappedReader.java
+++ b/components/formats-api/src/loci/formats/WrappedReader.java
@@ -1,0 +1,461 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats;
+
+import loci.formats.meta.MetadataStore;
+
+import java.io.IOException;
+import java.util.Hashtable;
+import java.util.List;
+
+/**
+ * Helper class for readers which wrap other readers.
+ *
+ * getHelper() must return a valid object once the constructor has completed unless the reader is
+ * closed. returning null will cause strange errors.
+ */
+public abstract class WrappedReader extends FormatReader {
+
+  // -- Constructor --
+
+  /**
+   * Constructs a new wrapped reader with the given name and suffixes.
+   */
+  protected WrappedReader(String format, String[] suffixes) {
+    super(format, suffixes);
+  }
+
+  /** Get the helper class that reads images */
+  protected abstract ReaderWrapper getHelper();
+
+  // -- IFormatReader methods --
+
+  @Override
+  public void reopenFile() throws IOException {
+    getHelper().reopenFile();
+  }
+
+  @Override
+  public int getImageCount() {
+    return getHelper().getImageCount();
+  }
+
+  @Override
+  public boolean isRGB() {
+    return getHelper().isRGB();
+  }
+
+  @Override
+  public int getSizeX() {
+    return getHelper().getSizeX();
+  }
+
+  @Override
+  public int getSizeY() {
+    return getHelper().getSizeY();
+  }
+
+  @Override
+  public int getSizeZ() {
+    return getHelper().getSizeZ();
+  }
+
+  @Override
+  public int getSizeC() {
+    return getHelper().getSizeC();
+  }
+
+  @Override
+  public int getSizeT() {
+    return getHelper().getSizeT();
+  }
+
+  @Override
+  public int getPixelType() {
+    return getHelper().getPixelType();
+  }
+
+  @Override
+  public int getBitsPerPixel() {
+    return getHelper().getBitsPerPixel();
+  }
+
+  @Override
+  public int getEffectiveSizeC() {
+    return getHelper().getEffectiveSizeC();
+  }
+
+  @Override
+  public int getRGBChannelCount() {
+    return getHelper().getRGBChannelCount();
+  }
+
+  @Override
+  public boolean isIndexed() {
+    return getHelper().isIndexed();
+  }
+
+  @Override
+  public boolean isFalseColor() {
+    return getHelper().isFalseColor();
+  }
+
+  @Override
+  public byte[][] get8BitLookupTable() throws FormatException, IOException {
+    return getHelper().get8BitLookupTable();
+  }
+
+  @Override
+  public short[][] get16BitLookupTable() throws FormatException, IOException {
+    return getHelper().get16BitLookupTable();
+  }
+
+  @Override
+  public Modulo getModuloZ() {
+    return getHelper().getModuloZ();
+  }
+
+  @Override
+  public Modulo getModuloC() {
+    return getHelper().getModuloC();
+  }
+
+  @Override
+  public Modulo getModuloT() {
+    return getHelper().getModuloT();
+  }
+
+  @Override
+  public int getThumbSizeX() {
+    return getHelper().getThumbSizeX();
+  }
+
+  @Override
+  public int getThumbSizeY() {
+    return getHelper().getThumbSizeY();
+  }
+
+  @Override
+  public boolean isLittleEndian() {
+    return getHelper().isLittleEndian();
+  }
+
+  @Override
+  public String getDimensionOrder() {
+    return getHelper().getDimensionOrder();
+  }
+
+  @Override
+  public boolean isOrderCertain() {
+    return getHelper().isOrderCertain();
+  }
+
+  @Override
+  public boolean isThumbnailSeries() {
+    return getHelper().isThumbnailSeries();
+  }
+
+  @Override
+  public boolean isInterleaved() {
+    return getHelper().isInterleaved();
+  }
+
+  @Override
+  public boolean isInterleaved(int subC) {
+    return getHelper().isInterleaved(subC);
+  }
+
+  @Override
+  public byte[] openBytes(int no) throws FormatException, IOException {
+    return getHelper().openBytes(no);
+  }
+
+  @Override
+  public byte[] openBytes(int no, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    return getHelper().openBytes(no, x, y, w, h);
+  }
+
+  @Override
+  public byte[] openBytes(int no, byte[] buf)
+    throws FormatException, IOException
+  {
+    return getHelper().openBytes(no, buf);
+  }
+
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    return getHelper().openBytes(no, buf, x, y, w, h);
+  }
+
+  @Override
+  public Object openPlane(int no, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    return getHelper().openPlane(no, x, y, w, h);
+  }
+
+  @Override
+  public byte[] openThumbBytes(int no) throws FormatException, IOException {
+    return getHelper().openThumbBytes(no);
+  }
+
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    ReaderWrapper helper = getHelper();
+    if (helper != null) {
+      helper.close(fileOnly);
+    }
+  }
+
+  @Override
+  public int getSeriesCount() {
+    return getHelper().getSeriesCount();
+  }
+
+  @Override
+  public void setSeries(int no) {
+    getHelper().setSeries(no);
+  }
+
+  @Override
+  public int getSeries() {
+    return getHelper().getSeries();
+  }
+
+  @Override
+  public void setGroupFiles(boolean group) {
+    getHelper().setGroupFiles(group);
+  }
+
+  @Override
+  public boolean isGroupFiles() {
+    return getHelper().isGroupFiles();
+  }
+
+  @Override
+  public boolean isMetadataComplete() {
+    return getHelper().isMetadataComplete();
+  }
+
+  @Override
+  public void setNormalized(boolean normalize) {
+    getHelper().setNormalized(normalize);
+  }
+
+  @Override
+  public boolean isNormalized() { return getHelper().isNormalized(); }
+
+  @Override
+  public void setOriginalMetadataPopulated(boolean populate) {
+    getHelper().setOriginalMetadataPopulated(populate);
+  }
+
+  @Override
+  public boolean isOriginalMetadataPopulated() {
+    return getHelper().isOriginalMetadataPopulated();
+  }
+
+  @Override
+  public String[] getSeriesUsedFiles(boolean noPixels) {
+    return getHelper().getSeriesUsedFiles(noPixels);
+  }
+
+  @Override
+  public String[] getUsedFiles(boolean noPixels) {
+    return getHelper().getUsedFiles(noPixels);
+  }
+
+  @Override
+  public int getIndex(int z, int c, int t) {
+    return getHelper().getIndex(z, c, t);
+  }
+
+  @Override
+  public int[] getZCTCoords(int index) {
+    return getHelper().getZCTCoords(index);
+  }
+
+  @Override
+  public Object getMetadataValue(String field) {
+    return getHelper().getMetadataValue(field);
+  }
+
+  @Override
+  public Object getSeriesMetadataValue(String field) {
+    return getHelper().getSeriesMetadataValue(field);
+  }
+
+  @Override
+  public Hashtable<String, Object> getGlobalMetadata() {
+    return getHelper().getGlobalMetadata();
+  }
+
+  @Override
+  public Hashtable<String, Object> getSeriesMetadata() {
+    return getHelper().getSeriesMetadata();
+  }
+
+  @Override
+  public List<CoreMetadata> getCoreMetadataList() {
+    return getHelper().getCoreMetadataList();
+  }
+
+  @Override
+  public void setMetadataFiltered(boolean filter) {
+    getHelper().setMetadataFiltered(filter);
+  }
+
+  @Override
+  public boolean isMetadataFiltered() { return getHelper().isMetadataFiltered(); }
+
+  @Override
+  public void setMetadataStore(MetadataStore store) {
+    getHelper().setMetadataStore(store);
+  }
+
+  @Override
+  public MetadataStore getMetadataStore() {
+    return getHelper().getMetadataStore();
+  }
+
+  @Override
+  public Object getMetadataStoreRoot() {
+    return getHelper().getMetadataStoreRoot();
+  }
+
+  @Override
+  public IFormatReader[] getUnderlyingReaders() {
+    return new IFormatReader[] {getHelper()};
+  }
+
+  @Override
+  public boolean isSingleFile(String id) throws FormatException, IOException {
+    return getHelper().isSingleFile(id);
+  }
+
+  @Override
+  public String getDatasetStructureDescription() {
+    return getHelper().getDatasetStructureDescription();
+  }
+
+  @Override
+  public boolean hasCompanionFiles() {
+    return getHelper().hasCompanionFiles();
+  }
+
+  @Override
+  public String[] getPossibleDomains(String id)
+    throws FormatException, IOException
+  {
+    return getHelper().getPossibleDomains(id);
+  }
+
+  @Override
+  public String[] getDomains() {
+    return getHelper().getDomains();
+  }
+
+  @Override
+  public int getOptimalTileWidth() {
+    return getHelper().getOptimalTileWidth();
+  }
+
+  @Override
+  public int getOptimalTileHeight() {
+    return getHelper().getOptimalTileHeight();
+  }
+
+  @Override
+  public int getCoreIndex() {
+    return getHelper().getCoreIndex();
+  }
+
+  @Override
+  public void setCoreIndex(int no) {
+    getHelper().setCoreIndex(no);
+  }
+
+  @Override
+  public int seriesToCoreIndex(int series) {
+    return getHelper().seriesToCoreIndex(series);
+  }
+
+  @Override
+  public int coreIndexToSeries(int index) {
+    return getHelper().coreIndexToSeries(index);
+  }
+
+  @Override
+  public int getResolutionCount() {
+    return getHelper().getResolutionCount();
+  }
+
+  @Override
+  public void setResolution(int no) {
+    getHelper().setResolution(no);
+  }
+
+  @Override
+  public int getResolution() {
+    return getHelper().getResolution();
+  }
+
+  @Override
+  public boolean hasFlattenedResolutions() {
+    return getHelper().hasFlattenedResolutions();
+  }
+
+  @Override
+  public void setFlattenedResolutions(boolean flattened) {
+    getHelper().setFlattenedResolutions(flattened);
+  }
+
+  // -- IFormatHandler API methods --
+
+  @Override
+  public Class<?> getNativeDataType() {
+    return getHelper().getNativeDataType();
+  }
+
+  @Override
+  public void close() throws IOException {
+    ReaderWrapper helper = getHelper();
+    if (helper != null) {
+      helper.close();
+    }
+  }
+}

--- a/components/formats-api/src/loci/formats/WrappedReader.java
+++ b/components/formats-api/src/loci/formats/WrappedReader.java
@@ -32,11 +32,14 @@
 
 package loci.formats;
 
+import loci.formats.in.MetadataLevel;
+import loci.formats.in.MetadataOptions;
 import loci.formats.meta.MetadataStore;
 
 import java.io.IOException;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class for readers which wrap other readers.
@@ -57,6 +60,23 @@ public abstract class WrappedReader extends FormatReader {
 
   /** Get the helper class that reads images */
   protected abstract ReaderWrapper getHelper();
+
+  // -- IMetadataConfigurable methods --
+
+  @Override
+  public Set<MetadataLevel> getSupportedMetadataLevels() {
+    return getHelper().getSupportedMetadataLevels();
+  }
+
+  @Override
+  public void setMetadataOptions(MetadataOptions options) {
+    getHelper().setMetadataOptions(options);
+  }
+
+  @Override
+  public MetadataOptions getMetadataOptions() {
+    return getHelper().getMetadataOptions();
+  }
 
   // -- IFormatReader methods --
 

--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -3,6 +3,7 @@
 # Please do not edit unless you know what you are doing (see reader-guide.txt).
 
 loci.formats.in.FilePatternReader     # pattern
+loci.formats.in.URLPatternReader      # urlpattern
 
 # readers for compressed/archive files
 loci.formats.in.ZipReader             # zip

--- a/components/formats-bsd/src/loci/formats/FilePattern.java
+++ b/components/formats-bsd/src/loci/formats/FilePattern.java
@@ -614,6 +614,9 @@ public class FilePattern {
     Location file = new Location(base).getAbsoluteFile();
     Location parent = file.getParentFile();
     String[] list = parent.list(true);
+    if (list == null) {
+      list = new String[0];
+    }
     return findSeriesPatterns(base, parent.getAbsolutePath(), list);
   }
 

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -35,7 +35,6 @@ package loci.formats.in;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
 
 import loci.common.DataTools;
@@ -44,126 +43,46 @@ import loci.formats.ClassList;
 import loci.formats.CoreMetadata;
 import loci.formats.FileStitcher;
 import loci.formats.FormatException;
-import loci.formats.FormatReader;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
-import loci.formats.Modulo;
-import loci.formats.meta.MetadataStore;
+import loci.formats.ReaderWrapper;
+import loci.formats.WrappedReader;
 
 /**
  *
  */
-public class FilePatternReader extends FormatReader {
+public class FilePatternReader extends WrappedReader {
 
   // -- Fields --
-
-  /** Helper class that reads images */
-  protected FileStitcher helper;
+  private FileStitcher helper;
 
   // -- Constructor --
 
   /** Constructs a new pattern reader. */
   public FilePatternReader() {
-    this("File pattern", new String[] {"pattern"}, true);
-  }
+    super("File pattern", new String[] {"pattern"});
 
-  /**
-   * Constructs a new pattern reader
-   * @param useDefaultClasses If true initialise with a default list of readers
-   */
-  protected FilePatternReader(String format, String[] suffixes, boolean useDefaultClasses) {
-    super(format, suffixes);
-    if (useDefaultClasses) {
-      ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
-      Class<? extends IFormatReader>[] classArray = classes.getClasses();
-      ClassList<IFormatReader> newClasses = new ClassList<IFormatReader>(IFormatReader.class);
-      for (Class<? extends IFormatReader> c : classArray) {
-        if (!c.equals(FilePatternReader.class)) {
-          newClasses.addClass(c);
-        }
+    ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
+    Class<? extends IFormatReader>[] classArray = classes.getClasses();
+    ClassList<IFormatReader> newClasses =
+      new ClassList<IFormatReader>(IFormatReader.class);
+    for (Class<? extends IFormatReader> c : classArray) {
+      if(!WrappedReader.class.isAssignableFrom(c)) {
+        newClasses.addClass(c);
       }
-      initHelper(newClasses);
     }
+    helper = new FileStitcher(new ImageReader(newClasses));
+
     suffixSufficient = true;
-    //suffixNecessary defaults to true
   }
 
-  /** Initialise the helper with a list of readers */
-  protected void initHelper(ClassList<IFormatReader> newClasses) {
-    helper = new FileStitcher(new ImageReader(newClasses));
+  // -- WrappedReader methods --
+
+  protected ReaderWrapper getHelper() {
+    return helper;
   }
 
   // -- IFormatReader methods --
-
-  @Override
-  public void reopenFile() throws IOException {
-    helper.reopenFile();
-  }
-
-  @Override
-  public int getImageCount() {
-    return helper.getImageCount();
-  }
-
-  @Override
-  public boolean isRGB() {
-    return helper.isRGB();
-  }
-
-  @Override
-  public int getSizeX() {
-    return helper.getSizeX();
-  }
-
-  @Override
-  public int getSizeY() {
-    return helper.getSizeY();
-  }
-
-  @Override
-  public int getSizeZ() {
-    return helper.getSizeZ();
-  }
-
-  @Override
-  public int getSizeC() {
-    return helper.getSizeC();
-  }
-
-  @Override
-  public int getSizeT() {
-    return helper.getSizeT();
-  }
-
-  @Override
-  public int getPixelType() {
-    return helper.getPixelType();
-  }
-
-  @Override
-  public int getBitsPerPixel() {
-    return helper.getBitsPerPixel();
-  }
-
-  @Override
-  public int getEffectiveSizeC() {
-    return helper.getEffectiveSizeC();
-  }
-
-  @Override
-  public int getRGBChannelCount() {
-    return helper.getRGBChannelCount();
-  }
-
-  @Override
-  public boolean isIndexed() {
-    return helper.isIndexed();
-  }
-
-  @Override
-  public boolean isFalseColor() {
-    return helper.isFalseColor();
-  }
 
   @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
@@ -179,152 +98,6 @@ public class FilePatternReader extends FormatReader {
       return null;
     }
     return helper.get16BitLookupTable();
-  }
-
-  @Override
-  public Modulo getModuloZ() {
-    return helper.getModuloZ();
-  }
-
-  @Override
-  public Modulo getModuloC() {
-    return helper.getModuloC();
-  }
-
-  @Override
-  public Modulo getModuloT() {
-    return helper.getModuloT();
-  }
-
-  @Override
-  public int getThumbSizeX() {
-    return helper.getThumbSizeX();
-  }
-
-  @Override
-  public int getThumbSizeY() {
-    return helper.getThumbSizeY();
-  }
-
-  @Override
-  public boolean isLittleEndian() {
-    return helper.isLittleEndian();
-  }
-
-  @Override
-  public String getDimensionOrder() {
-    return helper.getDimensionOrder();
-  }
-
-  @Override
-  public boolean isOrderCertain() {
-    return helper.isOrderCertain();
-  }
-
-  @Override
-  public boolean isThumbnailSeries() {
-    return helper.isThumbnailSeries();
-  }
-
-  @Override
-  public boolean isInterleaved() {
-    return helper.isInterleaved();
-  }
-
-  @Override
-  public boolean isInterleaved(int subC) {
-    return helper.isInterleaved(subC);
-  }
-
-  @Override
-  public byte[] openBytes(int no) throws FormatException, IOException {
-    return helper.openBytes(no);
-  }
-
-  @Override
-  public byte[] openBytes(int no, int x, int y, int w, int h)
-    throws FormatException, IOException
-  {
-    return helper.openBytes(no, x, y, w, h);
-  }
-
-  @Override
-  public byte[] openBytes(int no, byte[] buf)
-    throws FormatException, IOException
-  {
-    return helper.openBytes(no, buf);
-  }
-
-  @Override
-  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
-    throws FormatException, IOException
-  {
-    return helper.openBytes(no, buf, x, y, w, h);
-  }
-
-  @Override
-  public Object openPlane(int no, int x, int y, int w, int h)
-    throws FormatException, IOException
-  {
-    return helper.openPlane(no, x, y, w, h);
-  }
-
-  @Override
-  public byte[] openThumbBytes(int no) throws FormatException, IOException {
-    return helper.openThumbBytes(no);
-  }
-
-  @Override
-  public void close(boolean fileOnly) throws IOException {
-    helper.close(fileOnly);
-  }
-
-  @Override
-  public int getSeriesCount() {
-    return helper.getSeriesCount();
-  }
-
-  @Override
-  public void setSeries(int no) {
-    helper.setSeries(no);
-  }
-
-  @Override
-  public int getSeries() {
-    return helper.getSeries();
-  }
-
-  @Override
-  public void setGroupFiles(boolean group) {
-    helper.setGroupFiles(group);
-  }
-
-  @Override
-  public boolean isGroupFiles() {
-    return helper.isGroupFiles();
-  }
-
-  @Override
-  public boolean isMetadataComplete() {
-    return helper.isMetadataComplete();
-  }
-
-  @Override
-  public void setNormalized(boolean normalize) {
-    helper.setNormalized(normalize);
-  }
-
-  @Override
-  public boolean isNormalized() { return helper.isNormalized(); }
-
-  @Override
-  public void setOriginalMetadataPopulated(boolean populate) {
-    helper.setOriginalMetadataPopulated(populate);
-  }
-
-  @Override
-  public boolean isOriginalMetadataPopulated() {
-    return helper.isOriginalMetadataPopulated();
   }
 
   @Override
@@ -352,36 +125,6 @@ public class FilePatternReader extends FormatReader {
   }
 
   @Override
-  public int getIndex(int z, int c, int t) {
-    return helper.getIndex(z, c, t);
-  }
-
-  @Override
-  public int[] getZCTCoords(int index) {
-    return helper.getZCTCoords(index);
-  }
-
-  @Override
-  public Object getMetadataValue(String field) {
-    return helper.getMetadataValue(field);
-  }
-
-  @Override
-  public Object getSeriesMetadataValue(String field) {
-    return helper.getSeriesMetadataValue(field);
-  }
-
-  @Override
-  public Hashtable<String, Object> getGlobalMetadata() {
-    return helper.getGlobalMetadata();
-  }
-
-  @Override
-  public Hashtable<String, Object> getSeriesMetadata() {
-    return helper.getSeriesMetadata();
-  }
-
-  @Override
   public List<CoreMetadata> getCoreMetadataList() {
     // Only used for determining the object type.
     List<CoreMetadata> oldcore = helper.getCoreMetadataList();
@@ -397,127 +140,13 @@ public class FilePatternReader extends FormatReader {
   }
 
   @Override
-  public void setMetadataFiltered(boolean filter) {
-    helper.setMetadataFiltered(filter);
-  }
-
-  @Override
-  public boolean isMetadataFiltered() { return helper.isMetadataFiltered(); }
-
-  @Override
-  public void setMetadataStore(MetadataStore store) {
-    helper.setMetadataStore(store);
-  }
-
-  @Override
-  public MetadataStore getMetadataStore() {
-    return helper.getMetadataStore();
-  }
-
-  @Override
-  public Object getMetadataStoreRoot() {
-    return helper.getMetadataStoreRoot();
-  }
-
-  @Override
-  public IFormatReader[] getUnderlyingReaders() {
-    return new IFormatReader[] {helper};
-  }
-
-  @Override
   public boolean isSingleFile(String id) throws FormatException, IOException {
     return false;
   }
 
   @Override
-  public String getDatasetStructureDescription() {
-    return helper.getDatasetStructureDescription();
-  }
-
-  @Override
   public boolean hasCompanionFiles() {
     return true;
-  }
-
-  @Override
-  public String[] getPossibleDomains(String id)
-    throws FormatException, IOException
-  {
-    return helper.getPossibleDomains(id);
-  }
-
-  @Override
-  public String[] getDomains() {
-    return helper.getDomains();
-  }
-
-  @Override
-  public int getOptimalTileWidth() {
-    return helper.getOptimalTileWidth();
-  }
-
-  @Override
-  public int getOptimalTileHeight() {
-    return helper.getOptimalTileHeight();
-  }
-
-  @Override
-  public int getCoreIndex() {
-    return helper.getCoreIndex();
-  }
-
-  @Override
-  public void setCoreIndex(int no) {
-    helper.setCoreIndex(no);
-  }
-
-  @Override
-  public int seriesToCoreIndex(int series) {
-    return helper.seriesToCoreIndex(series);
-  }
-
-  @Override
-  public int coreIndexToSeries(int index) {
-    return helper.coreIndexToSeries(index);
-  }
-
-  @Override
-  public int getResolutionCount() {
-    return helper.getResolutionCount();
-  }
-
-  @Override
-  public void setResolution(int no) {
-    helper.setResolution(no);
-  }
-
-  @Override
-  public int getResolution() {
-    return helper.getResolution();
-  }
-
-  @Override
-  public boolean hasFlattenedResolutions() {
-    return helper.hasFlattenedResolutions();
-  }
-
-  @Override
-  public void setFlattenedResolutions(boolean flattened) {
-    helper.setFlattenedResolutions(flattened);
-  }
-
-  // -- IFormatHandler API methods --
-
-  @Override
-  public Class<?> getNativeDataType() {
-    return helper.getNativeDataType();
-  }
-
-  @Override
-  public void close() throws IOException {
-    if (helper != null) {
-      helper.close();
-    }
   }
 
   // -- Internal FormatReader methods --

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -63,20 +63,33 @@ public class FilePatternReader extends FormatReader {
 
   /** Constructs a new pattern reader. */
   public FilePatternReader() {
-    super("File pattern", new String[] {"pattern"});
+    this("File pattern", new String[] {"pattern"}, true);
+  }
 
-    ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
-    Class<? extends IFormatReader>[] classArray = classes.getClasses();
-    ClassList<IFormatReader> newClasses =
-      new ClassList<IFormatReader>(IFormatReader.class);
-    for (Class<? extends IFormatReader> c : classArray) {
-      if (!c.equals(FilePatternReader.class)) {
-        newClasses.addClass(c);
+  /**
+   * Constructs a new pattern reader
+   * @param useDefaultClasses If true initialise with a default list of readers
+   */
+  protected FilePatternReader(String format, String[] suffixes, boolean useDefaultClasses) {
+    super(format, suffixes);
+    if (useDefaultClasses) {
+      ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
+      Class<? extends IFormatReader>[] classArray = classes.getClasses();
+      ClassList<IFormatReader> newClasses = new ClassList<IFormatReader>(IFormatReader.class);
+      for (Class<? extends IFormatReader> c : classArray) {
+        if (!c.equals(FilePatternReader.class)) {
+          newClasses.addClass(c);
+        }
       }
+      initHelper(newClasses);
     }
-    helper = new FileStitcher(new ImageReader(newClasses));
-
     suffixSufficient = true;
+    //suffixNecessary defaults to true
+  }
+
+  /** Initialise the helper with a list of readers */
+  protected void initHelper(ClassList<IFormatReader> newClasses) {
+    helper = new FileStitcher(new ImageReader(newClasses));
   }
 
   // -- IFormatReader methods --

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -57,7 +57,8 @@ public class FilePatternReader extends FormatReader {
 
   // -- Fields --
 
-  private FileStitcher helper;
+  /** Helper class that reads images */
+  protected FileStitcher helper;
 
   // -- Constructor --
 

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -48,7 +48,6 @@ import loci.formats.FormatReader;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.Modulo;
-import loci.formats.ReaderWrapper;
 import loci.formats.meta.MetadataStore;
 
 /**
@@ -59,7 +58,7 @@ public class FilePatternReader extends FormatReader {
   // -- Fields --
 
   /** Helper class that reads images */
-  protected ReaderWrapper helper;
+  protected FileStitcher helper;
 
   // -- Constructor --
 
@@ -537,11 +536,10 @@ public class FilePatternReader extends FormatReader {
       pattern = dir + File.separator + pattern;
     }
 
-    FileStitcher stitcher = (FileStitcher)helper;
-    stitcher.setUsingPatternIds(true);
-    stitcher.setCanChangePattern(false);
-    stitcher.setId(pattern);
-    core = stitcher.getCoreMetadataList();
+    helper.setUsingPatternIds(true);
+    helper.setCanChangePattern(false);
+    helper.setId(pattern);
+    core = helper.getCoreMetadataList();
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FilePatternReader.java
@@ -48,6 +48,7 @@ import loci.formats.FormatReader;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
 import loci.formats.Modulo;
+import loci.formats.ReaderWrapper;
 import loci.formats.meta.MetadataStore;
 
 /**
@@ -58,7 +59,7 @@ public class FilePatternReader extends FormatReader {
   // -- Fields --
 
   /** Helper class that reads images */
-  protected FileStitcher helper;
+  protected ReaderWrapper helper;
 
   // -- Constructor --
 
@@ -536,10 +537,11 @@ public class FilePatternReader extends FormatReader {
       pattern = dir + File.separator + pattern;
     }
 
-    helper.setUsingPatternIds(true);
-    helper.setCanChangePattern(false);
-    helper.setId(pattern);
-    core = helper.getCoreMetadataList();
+    FileStitcher stitcher = (FileStitcher)helper;
+    stitcher.setUsingPatternIds(true);
+    stitcher.setCanChangePattern(false);
+    stitcher.setId(pattern);
+    core = stitcher.getCoreMetadataList();
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import loci.formats.ClassList;
+import loci.formats.IFormatReader;
+import loci.formats.ImageReader;
+
+/**
+ * A Pattern reader designed for use with opaque remote resources that should not be permanently fetched
+ * The urlpattern file represents all images in the fileset, individual files are not available to clients
+ */
+public class URLPatternReader extends FilePatternReader {
+
+  // -- Constructor --
+
+  /** Constructs a new pattern reader. */
+  public URLPatternReader() {
+    super("URL File pattern", new String[]{"urlpattern"}, false);
+    ClassList<IFormatReader> classes = ImageReader.getDefaultReaderClasses();
+    Class<? extends IFormatReader>[] classArray = classes.getClasses();
+    ClassList<IFormatReader> newClasses = new ClassList<IFormatReader>(IFormatReader.class);
+    for (Class<? extends IFormatReader> c : classArray) {
+      if (!c.equals(FilePatternReader.class) && !c.equals(URLPatternReader.class)) {
+        newClasses.addClass(c);
+      }
+    }
+    initHelper(newClasses);
+  }
+
+  // -- IFormatReader methods --
+
+  @Override
+  public String[] getUsedFiles(boolean noPixels) {
+    return new String[] {currentId};
+  }
+
+}

--- a/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
@@ -38,6 +38,7 @@ import loci.formats.ClassList;
 import loci.formats.FormatException;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
+import loci.formats.ReaderWrapper;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
@@ -66,6 +67,17 @@ public class URLPatternReader extends FilePatternReader {
       }
     }
     initHelper(newClasses);
+  }
+
+  /** Initialise the helper with a list of readers */
+  @Override
+  protected void initHelper(ClassList<IFormatReader> newClasses) {
+    class RemoteReader extends ReaderWrapper {
+      public RemoteReader(IFormatReader r) {
+        super(r);
+      }
+    };
+    helper = new RemoteReader(new ImageReader(newClasses));
   }
 
   // -- IFormatReader methods --
@@ -107,8 +119,6 @@ public class URLPatternReader extends FilePatternReader {
       initHelper(readerClasses);
     }
 
-    helper.setUsingPatternIds(true);
-    helper.setCanChangePattern(false);
     helper.setId(pattern);
     core = helper.getCoreMetadataList();
   }

--- a/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
@@ -38,7 +38,6 @@ import loci.formats.ClassList;
 import loci.formats.FormatException;
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
-import loci.formats.ReaderWrapper;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
@@ -67,17 +66,6 @@ public class URLPatternReader extends FilePatternReader {
       }
     }
     initHelper(newClasses);
-  }
-
-  /** Initialise the helper with a list of readers */
-  @Override
-  protected void initHelper(ClassList<IFormatReader> newClasses) {
-    class RemoteReader extends ReaderWrapper {
-      public RemoteReader(IFormatReader r) {
-        super(r);
-      }
-    };
-    helper = new RemoteReader(new ImageReader(newClasses));
   }
 
   // -- IFormatReader methods --
@@ -119,6 +107,8 @@ public class URLPatternReader extends FilePatternReader {
       initHelper(readerClasses);
     }
 
+    helper.setUsingPatternIds(true);
+    helper.setCanChangePattern(false);
     helper.setId(pattern);
     core = helper.getCoreMetadataList();
   }

--- a/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
+++ b/components/formats-bsd/src/loci/formats/in/URLPatternReader.java
@@ -48,7 +48,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -83,6 +85,7 @@ public class URLPatternReader extends WrappedReader {
 
   // These fields need to be set in the helper, but this can only be done
   // after we've opened the urlpattern file and obtained the list of readers
+  private MetadataOptions delayedOptions = null;
   private Boolean delayedGroup = null;
   private Boolean delayedNormalize = null;
   private Boolean delayedPopulate = null;
@@ -128,6 +131,9 @@ public class URLPatternReader extends WrappedReader {
     }
     helper = new RemoteReader(new ImageReader(newClasses));
 
+    if (delayedOptions != null) {
+      helper.setMetadataOptions(delayedOptions);
+    }
     if (delayedGroup != null) {
       helper.setGroupFiles(delayedGroup);
     }
@@ -154,6 +160,27 @@ public class URLPatternReader extends WrappedReader {
   protected ReaderWrapper getHelper() {
     FormatTools.assertId(currentId, true, 1);
     return helper;
+  }
+
+  // -- IMetadataConfigurable methods --
+
+  // This getter may be called before setId, which means the helper doesn't exist.
+  // We can't call super().super().getSupportedMetadataLevels()
+  @Override
+  public Set<MetadataLevel> getSupportedMetadataLevels() {
+    Set<MetadataLevel> supportedLevels = new HashSet<MetadataLevel>();
+    supportedLevels.add(MetadataLevel.ALL);
+    supportedLevels.add(MetadataLevel.NO_OVERLAYS);
+    supportedLevels.add(MetadataLevel.MINIMUM);
+    return supportedLevels;
+  }
+
+  // Delayed IMetadataConfigurable methods
+
+  @Override
+  public void setMetadataOptions(MetadataOptions options) {
+    FormatTools.assertId(currentId, false, 1);
+    delayedOptions = options;
   }
 
   // Delayed FormatReader methods


### PR DESCRIPTION
This is a version of FilePatternReader intended for importing remote files into OMERO as links. OMERO should only see this file, it should not see anything listed inside the `.urlpattern` file.