### PR TITLE
Switch to Oracle JDK 11 as Oracle discontinued JDK 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - git
 
 jdk:
-  - oraclejdk10
+  - oraclejdk11
   - oraclejdk8
   - openjdk7
 


### PR DESCRIPTION
See https://changelog.travis-ci.com/stop-a-job-early-if-a-deprecated-jdk-is-configured-76612

Primarily opened against Bio-Formats however as reported recently, all Java components tested by Travis are currently affected by this issue and will need to be patched (see https://github.com/search?utf8=%E2%9C%93&q=user%3Aome+user%3Aopenmicroscopy+oraclejdk10&type=Code).

We have effectively a few options to keep pre-testing compilation on newer Java versions, switch to `openjdk10`, upgrade to `oraclejdk11` or upgrade to `openjdk11`.
Part of this choice might involve considerations about the new policy of Oracle to support shipping free JDK binaries 6 months post-release.