### PR TITLE
Micromanager: switch to DataTools.parseDouble for double parsing

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -611,21 +611,21 @@ public class MicromanagerReader extends FormatReader {
       if (key.equals("XPositionUm")) {
         try {
           Position p = positions.get(getCoreIndex());
-          p.positions[i][0] = new Double(value);
+          p.positions[i][0] = DataTools.parseDouble(value);
         }
         catch (NumberFormatException e) { }
       }
       else if (key.equals("YPositionUm")) {
         try {
           Position p = positions.get(getCoreIndex());
-          p.positions[i][1] = new Double(value);
+          p.positions[i][1] = DataTools.parseDouble(value);
         }
         catch (NumberFormatException e) { }
       }
       else if (key.equals("ZPositionUm")) {
         try {
           Position p = positions.get(getCoreIndex());
-          p.positions[i][2] = new Double(value);
+          p.positions[i][2] = DataTools.parseDouble(value);
         }
         catch (NumberFormatException e) { }
       }
@@ -786,10 +786,10 @@ public class MicromanagerReader extends FormatReader {
           }
         }
         else if (key.equals("PixelSize_um")) {
-          p.pixelSize = new Double(value);
+          p.pixelSize = DataTools.parseDouble(value);
         }
         else if (key.equals("z-step_um")) {
-          p.sliceThickness = new Double(value);
+          p.sliceThickness = DataTools.parseDouble(value);
         }
         else if (key.equals("Time")) {
           p.time = value;
@@ -902,19 +902,25 @@ public class MicromanagerReader extends FormatReader {
             p.detectorModel = value;
           }
           else if (key.equals(p.cameraRef + "-Gain")) {
-            p.gain = (int) Double.parseDouble(value);
+            Double gain = DataTools.parseDouble(value);
+            if (gain != null) {
+              p.gain = gain.intValue();
+            }
           }
           else if (key.equals(p.cameraRef + "-Name")) {
             p.detectorManufacturer = value;
           }
           else if (key.equals(p.cameraRef + "-Temperature")) {
-            p.temperature = Double.parseDouble(value);
+            Double temperature = DataTools.parseDouble(value);
+            if (temperature != null) {
+              p.temperature = temperature;
+            }
           }
           else if (key.equals(p.cameraRef + "-CCDMode")) {
             p.cameraMode = value;
           }
           else if (key.startsWith("DAC-") && key.endsWith("-Volts")) {
-            p.voltage.add(new Double(value));
+            p.voltage.add(DataTools.parseDouble(value));
           }
           else if (key.equals("PositionName") && !value.equals("null")) {
             p.name = value;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -609,25 +609,16 @@ public class MicromanagerReader extends FormatReader {
     for (int i=plane; i<plane+nPlanes; i++) {
       addSeriesMeta(String.format("Plane #%0" + digits + "d %s", i, key), value);
       if (key.equals("XPositionUm")) {
-        try {
-          Position p = positions.get(getCoreIndex());
-          p.positions[i][0] = DataTools.parseDouble(value);
-        }
-        catch (NumberFormatException e) { }
+        Position p = positions.get(getCoreIndex());
+        p.positions[i][0] = DataTools.parseDouble(value);
       }
       else if (key.equals("YPositionUm")) {
-        try {
-          Position p = positions.get(getCoreIndex());
-          p.positions[i][1] = DataTools.parseDouble(value);
-        }
-        catch (NumberFormatException e) { }
+        Position p = positions.get(getCoreIndex());
+        p.positions[i][1] = DataTools.parseDouble(value);
       }
       else if (key.equals("ZPositionUm")) {
-        try {
-          Position p = positions.get(getCoreIndex());
-          p.positions[i][2] = DataTools.parseDouble(value);
-        }
-        catch (NumberFormatException e) { }
+        Position p = positions.get(getCoreIndex());
+        p.positions[i][2] = DataTools.parseDouble(value);
       }
     }
   }


### PR DESCRIPTION
Backported from a private PR.

This automatically prevents ```NumberFormatException```s for invalid double values and handles the case when the decimal separator in the file doesn't match the current locale's decimal separator.

To test, use ```curated/micromanager/pr-3253```, which was copied from ```curated/micromanager/qa-4984/```, but with ```0.5,``` replaced by ```"0,5",``` in ```metadata.txt```.  Without this PR, ```showinf -nopix -omexml metadata.txt``` will throw:

```
Exception in thread "main" java.lang.NumberFormatException: For input string: "0,5"
	at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
	at sun.misc.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.lang.Double.parseDouble(Double.java:538)
	at java.lang.Double.<init>(Double.java:608)
	at loci.formats.in.MicromanagerReader.parsePosition(MicromanagerReader.java:789)
	at loci.formats.in.MicromanagerReader.parsePosition(MicromanagerReader.java:469)
	at loci.formats.in.MicromanagerReader.initFile(MicromanagerReader.java:311)
	at loci.formats.FormatReader.setId(FormatReader.java:1395)
	at loci.formats.ImageReader.setId(ImageReader.java:842)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1034)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1120)
```

With this PR, the same test should successfully initialize the file and display OME-XML with ```PhysicalSizeX``` and ```PhysicalSizeY``` set to ```0.5```.

Builds and memo files should not be impacted.