### PR TITLE
Correct example with colormap in MATLAB

### DIFF
--- a/docs/sphinx/developers/examples/bftest.m
+++ b/docs/sphinx/developers/examples/bftest.m
@@ -43,12 +43,12 @@ series1_label3 = series1{3, 2};
 
 %Displaying images
 % displaying-images-start
-series1_colorMaps = data{1, 3};
+series1_colorMap = data{1, 3}{1, 1};
 figure('Name', series1_label1);
-if (isempty(series1_colorMaps{1}))
+if isempty(series1_colorMap)
   colormap(gray);
 else
-  colormap(series1_colorMaps{1}(1,:));
+  colormap(series1_colorMap);
 end
 imagesc(series1_plane1);
 % displaying-images-end


### PR DESCRIPTION
The colormap is stored in `data{idx_series, 3}{idx_series, idx_plane}` as an `n-by-3` array. Previous version just took the first row of the colormap, making everything the same colour.

Also easier to get the colormap once.