### PR TITLE
Update OperettaReader to include Harmony improvements

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -413,7 +413,7 @@ public class OperettaReader extends FormatReader {
           if (planes[imageIndex][0] != null && planes[imageIndex][0].absoluteTime != null) {
             store.setImageAcquisitionDate(planes[imageIndex][0].absoluteTime, imageIndex);
             store.setWellSamplePositionX(planes[imageIndex][0].positionX, 0, well, field);
-            store.setWellSamplePositionX(planes[imageIndex][0].positionY, 0, well, field);
+            store.setWellSamplePositionY(planes[imageIndex][0].positionY, 0, well, field);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -412,6 +412,8 @@ public class OperettaReader extends FormatReader {
 
           if (planes[imageIndex][0] != null && planes[imageIndex][0].absoluteTime != null) {
             store.setImageAcquisitionDate(planes[imageIndex][0].absoluteTime, imageIndex);
+            store.setWellSamplePositionX(planes[imageIndex][0].positionX, 0, well, field);
+            store.setWellSamplePositionX(planes[imageIndex][0].positionY, 0, well, field);
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -768,9 +768,9 @@ public class OperettaReader extends FormatReader {
         else if ("OrientationMatrix".equals(currentName)) {
           // 3x3 matrix that indicates how to interpret plane position values
           String[] values = value.replaceAll("[\\[\\]]", "").split(",");
-          boolean invertX = Integer.parseInt(values[0]) < 0;
-          boolean invertY = Integer.parseInt(values[4]) < 0;
-          boolean invertZ = Integer.parseInt(values[8]) < 0;
+          boolean invertX = DataTools.parseDouble(values[0]) < 0;
+          boolean invertY = DataTools.parseDouble(values[4]) < 0;
+          boolean invertZ = DataTools.parseDouble(values[8]) < 0;
           if (invertX) {
             xPositionMeters = xPositionMeters == null ? -1 : -xPositionMeters;
           }

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -167,7 +167,9 @@ public class OperettaReader extends FormatReader {
     if (!noPixels) {
       for (Plane[] well : planes) {
         for (Plane p : well) {
-          if (p != null && p.filename != null) {
+          if (p != null && p.filename != null &&
+            new Location(p.filename).exists())
+          {
             files.add(p.filename);
           }
         }
@@ -268,7 +270,13 @@ public class OperettaReader extends FormatReader {
         Arrays.sort(companionFolders);
         for (String folder : companionFolders) {
           LOGGER.trace("Found folder {}", folder);
-          if (!f.equals("Images") || !checkSuffix(folder, "tiff")) {
+          // the current file's parent directory will usually be "Images",
+          // but may have been renamed especially if there are no
+          // analysis results
+          if ((!f.equals("Images") &&
+            !f.equals(currentFile.getParentFile().getName())) ||
+            !checkSuffix(folder, "tiff"))
+          {
             String metadataFile = new Location(path, folder).getAbsolutePath();
             if (!metadataFile.equals(currentFile.getAbsolutePath())) {
               metadataFiles.add(metadataFile);

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -766,21 +766,33 @@ public class OperettaReader extends FormatReader {
           activePlane.channelType = value;
         }
         else if ("OrientationMatrix".equals(currentName)) {
-          // 3x3 matrix that indicates how to interpret plane position values
-          String[] values = value.replaceAll("[\\[\\]]", "").split(",");
-          boolean invertX = DataTools.parseDouble(values[0]) < 0;
-          boolean invertY = DataTools.parseDouble(values[4]) < 0;
-          boolean invertZ = DataTools.parseDouble(values[8]) < 0;
-          if (invertX) {
-            xPositionMeters = xPositionMeters == null ? -1 : -xPositionMeters;
+          // matrix that indicates how to interpret plane position values
+          String[] rows = value.split("]");
+          Double[][] matrix = new Double[rows.length][];
+          for (int i=0; i<rows.length; i++) {
+            rows[i] = rows[i].replaceAll("\\[", "").replaceAll(",", " ");
+            String[] values = rows[i].trim().split(" ");
+            matrix[i] = new Double[values.length];
+            for (int j=0; j<matrix[i].length; j++) {
+              matrix[i][j] = DataTools.parseDouble(values[j]);
+            }
           }
-          if (invertY) {
-            yPositionMeters = yPositionMeters == null ? -1 : -yPositionMeters;
+          if (matrix.length > 2 && matrix[0].length > 0 &&
+            matrix[1].length > 1 && matrix[2].length > 2)
+          {
+            boolean invertX = matrix[0][0] != null && matrix[0][0] < 0;
+            boolean invertY = matrix[1][1] != null && matrix[1][1] < 0;
+            boolean invertZ = matrix[2][2] != null && matrix[2][2] < 0;
+            if (invertX) {
+              xPositionMeters = xPositionMeters == null ? -1 : -xPositionMeters;
+            }
+            if (invertY) {
+              yPositionMeters = yPositionMeters == null ? -1 : -yPositionMeters;
+            }
+            if (invertZ) {
+              zPositionMeters = zPositionMeters == null ? -1 : -zPositionMeters;
+            }
           }
-          if (invertZ) {
-            zPositionMeters = zPositionMeters == null ? -1 : -zPositionMeters;
-          }
-
         }
       }
 

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1646,6 +1646,12 @@ public class FormatReaderTest {
             }
           }
 
+          // extra metadata files in Harmony/Operetta datasets
+          // cannot be used for type detection
+          if (reader.getFormat().equals("PerkinElmer Operetta")) {
+            continue;
+          }
+
           // Volocity datasets can only be detected with the .mvd2 file
           if (file.toLowerCase().endsWith(".mvd2") &&
             !base[i].toLowerCase().endsWith(".mvd2"))
@@ -2435,6 +2441,11 @@ public class FormatReaderTest {
 
             // Inveon only reliably detected from header file
             if (!result && r instanceof InveonReader) {
+              continue;
+            }
+
+            // Operetta only reliably detects from Index.*.xml
+            if (!result && r instanceof OperettaReader) {
               continue;
             }
 


### PR DESCRIPTION
Replaces https://github.com/openmicroscopy/bioformats/pull/3241 and includes the first two commits from https://github.com/openmicroscopy/bioformats/pull/3244.

All of the relevant differences from ```HarmonyReader``` are ported to ```OperettaReader``` in d8dc80d.  40cd547 and 8e8bb0e parses the ```OrientationMatrix``` tag, as noted in https://github.com/openmicroscopy/bioformats/pull/3244#issuecomment-432676269

Excluding for now since this will conflict with #3244. I can also close this and open a PR against https://github.com/sbesson/bioformats/tree/operetta_wellsampleposition, or we can close #3244 in favor of this (whichever is easier for review and IDR testing).