### PR TITLE
Data test updates

### DIFF
--- a/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
+++ b/components/test-suite/src/loci/tests/testng/ConfigurationTree.java
@@ -151,6 +151,9 @@ public class ConfigurationTree {
    *  Relocate a path from an base directory into a target directory
    */
   public String relocate(String path, String oldRoot, String newRoot) {
+    if (!path.startsWith(oldRoot)) {
+      return path;
+    }
     String subPath = path.substring((int) Math.min(
       oldRoot.length() + 1, path.length()));
     if (subPath.length() == 0) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -32,7 +32,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -1618,10 +1620,20 @@ public class FormatReaderTest {
     String msg = null;
     try {
       String[] base = reader.getUsedFiles();
+
+      // make sure that there are no duplicate files in the list
+
+      HashSet<String> uniqueFiles = new HashSet<String>();
+      Collections.addAll(uniqueFiles, base);
+      if (uniqueFiles.size() < base.length) {
+        success = false;
+        msg = "Used files list contains duplicates";
+      }
+
       if (base.length == 1) {
         if (!base[0].equals(file)) success = false;
       }
-      else {
+      else if (success) {
         Arrays.sort(base);
         IFormatReader r =
           /*config.noStitching() ? new ImageReader() :*/ new FileStitcher();

--- a/components/test-suite/test/loci/tests/testng/ConfigurationTreeTest.java
+++ b/components/test-suite/test/loci/tests/testng/ConfigurationTreeTest.java
@@ -25,39 +25,42 @@
 
 package loci.tests.testng;
 
+import java.nio.file.Paths;
+
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 
 public class ConfigurationTreeTest {
 
-  ConfigurationTree configTree = new ConfigurationTree("/data", "/config");
+  ConfigurationTree configTree =
+    new ConfigurationTree(path("/data"), path("/config"));
 
   @DataProvider(name = "configList")
   public Object[][] createConfigList() {
     return new Object[][]{
-      {"/config", "/data"},
-      {"/config/", "/data"},
-      {"/config/test", "/data/test"},
-      {"/config/test/test2/test3/", "/data/test/test2/test3"},
-      {"/data", "/data"},
-      {"/data/test", "/data/test"},
-      {"/data2", "/data2"},
-      {"/data2/test", "/data2/test"},
+      {path("/config"), path("/data")},
+      {path("/config/"), path("/data")},
+      {path("/config/test"), path("/data/test")},
+      {path("/config/test/test2/test3/"), path("/data/test/test2/test3")},
+      {path("/data"), path("/data")},
+      {path("/data/test"), path("/data/test")},
+      {path("/data2"), path("/data2")},
+      {path("/data2/test"), path("/data2/test")},
     };
   }
 
   @DataProvider(name = "rootList")
   public Object[][] createRootList() {
     return new Object[][]{
-      {"/data", "/config"},
-      {"/data/", "/config"},
-      {"/data/test", "/config/test"},
-      {"/data/test/test2/test3/", "/config/test/test2/test3"},
-      {"/config", "/config"},
-      {"/config/test", "/config/test"},
-      {"/config2", "/config2"},
-      {"/config2/test", "/config2/test"},
+      {path("/data"), path("/config")},
+      {path("/data/"), path("/config")},
+      {path("/data/test"), path("/config/test")},
+      {path("/data/test/test2/test3/"), path("/config/test/test2/test3")},
+      {path("/config"), path("/config")},
+      {path("/config/test"), path("/config/test")},
+      {path("/config2"), path("/config2")},
+      {path("/config2/test"), path("/config2/test")},
     };
   }
 
@@ -69,5 +72,15 @@ public class ConfigurationTreeTest {
   @Test(dataProvider = "rootList")
   public void testRelocateToConfig(String path, String expected) {
     assertEquals(configTree.relocateToConfig(path), expected);
+  }
+
+  /**
+   * Turn the specified path into a system-specific absolute path.
+   * On UNIX-based systems, this should return the original path.
+   * On Windows systems, the drive letter of the working directory
+   * will be prepended.
+   */
+  private String path(String path) {
+    return Paths.get(path).toAbsolutePath().toString();
   }
 }

--- a/components/test-suite/test/loci/tests/testng/ConfigurationTreeTest.java
+++ b/components/test-suite/test/loci/tests/testng/ConfigurationTreeTest.java
@@ -40,6 +40,10 @@ public class ConfigurationTreeTest {
       {"/config/", "/data"},
       {"/config/test", "/data/test"},
       {"/config/test/test2/test3/", "/data/test/test2/test3"},
+      {"/data", "/data"},
+      {"/data/test", "/data/test"},
+      {"/data2", "/data2"},
+      {"/data2/test", "/data2/test"},
     };
   }
 
@@ -50,6 +54,10 @@ public class ConfigurationTreeTest {
       {"/data/", "/config"},
       {"/data/test", "/config/test"},
       {"/data/test/test2/test3/", "/config/test/test2/test3"},
+      {"/config", "/config"},
+      {"/config/test", "/config/test"},
+      {"/config2", "/config2"},
+      {"/config2/test", "/config2/test"},
     };
   }
 

--- a/components/test-suite/test/loci/tests/testng/ConfigurationTreeTest.java
+++ b/components/test-suite/test/loci/tests/testng/ConfigurationTreeTest.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * OME Bio-Formats manual and automated test suite.
+ * %%
+ * Copyright (C) 2006 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.tests.testng;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class ConfigurationTreeTest {
+
+  ConfigurationTree configTree = new ConfigurationTree("/data", "/config");
+
+  @DataProvider(name = "configList")
+  public Object[][] createConfigList() {
+    return new Object[][]{
+      {"/config", "/data"},
+      {"/config/", "/data"},
+      {"/config/test", "/data/test"},
+      {"/config/test/test2/test3/", "/data/test/test2/test3"},
+    };
+  }
+
+  @DataProvider(name = "rootList")
+  public Object[][] createRootList() {
+    return new Object[][]{
+      {"/data", "/config"},
+      {"/data/", "/config"},
+      {"/data/test", "/config/test"},
+      {"/data/test/test2/test3/", "/config/test/test2/test3"},
+    };
+  }
+
+  @Test(dataProvider = "configList")
+  public void testRelocateToRoot(String path, String expected) {
+    assertEquals(configTree.relocateToRoot(path), expected);
+  }
+
+  @Test(dataProvider = "rootList")
+  public void testRelocateToConfig(String path, String expected) {
+    assertEquals(configTree.relocateToConfig(path), expected);
+  }
+}


### PR DESCRIPTION
Fixes recent test issues noted in https://trello.com/c/9MJdfI8N/48-add-test-for-duplicate-used-files, https://trello.com/c/0MB0a98B/66-fix-test-config-to-correctly-generate-new-pyramid-configurations, and https://github.com/openmicroscopy/data_repo_config/pull/331

93a830f should make ```test-config``` work as expected with pyramid files in all formats.  To test, run ```test-config``` and then ```test-automated``` on a directory containing pyramid files in any format (I used a local copy of ```curated/svs/alexandra```) and verify that the tests fail.  Remove the generated ```.bioformats``` file(s), then run the same commands again and verify that the tests pass.

0019a42 and 9286409 from @sbesson add unit tests for ```ConfigurationTree.relocate*``` and e869843 fixes ```ConfigurationTree```, which should prevent the weird test failures that occurred when running ```test-automated``` when ```.bioformats``` files were present in the ```testng.directory```.  ```cd components/test-suite && mvn``` with just 0019a42 and 9286409 should result in 2 test failures.  The same test with the whole PR should result in no test failures.

09d3252 updates ```testSaneUsedFiles``` to fail if there are any duplicate entries in the used files list.