### PR TITLE
Fixes for writing TIFF files in memory

### DIFF
--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -307,6 +307,7 @@ public class TiffWriter extends FormatWriter {
         initialized[series][no] = true;
 
         RandomAccessInputStream tmp = createInputStream();
+        tmp.order(littleEndian);
         if (tmp.length() == 0) {
           synchronized (this) {
             // write TIFF header

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -345,7 +345,12 @@ public class TiffParser {
       in.seek(offset);
       offsets.add(offset);
       int nEntries = bigTiff ? (int) in.readLong() : in.readUnsignedShort();
-      in.skipBytes(nEntries * bytesPerEntry);
+      int entryBytes = nEntries * bytesPerEntry;
+      if (in.getFilePointer() + entryBytes + (bigTiff ? 8 : 4) > in.length()) {
+        // this can easily happen when writing multiple planes to a file
+        break;
+      }
+      in.skipBytes(entryBytes);
       offset = getNextOffset(offset);
     }
 

--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -424,7 +424,7 @@ public class TiffSaver {
 
     RandomAccessInputStream in = null;
     try {
-      if (!sequentialWrite) {   
+      if (!sequentialWrite) {
         if (filename != null) {
           in = new RandomAccessInputStream(filename);
         }
@@ -443,6 +443,11 @@ public class TiffSaver {
           LOGGER.debug("Reading IFD from {} in non-sequential write.",
               ifdOffsets[no]);
           ifd = parser.getIFD(ifdOffsets[no]);
+        }
+        else if (no > 0 && no - 1 < ifdOffsets.length) {
+          ifd = parser.getIFD(ifdOffsets[no - 1]);
+          long next = parser.getNextOffset(ifdOffsets[no - 1]);
+          out.seek(next);
         }
       }
       else if (isTiled) {

--- a/components/formats-bsd/test/loci/formats/utests/out/WriterUtilities.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/WriterUtilities.java
@@ -98,8 +98,14 @@ public final class WriterUtilities {
 
     return metadata;
   }
-  
-  public static Plane writeImage(File file, int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels, 
+
+  public static Plane writeImage(File file, int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels,
+      int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
+    return writeImage(file.getAbsolutePath(), tileSize, littleEndian, interleaved, rgbChannels,
+      seriesCount, sizeT, compression, pixelType, bigTiff);
+  }
+
+  public static Plane writeImage(String file, int tileSize, boolean littleEndian, boolean interleaved, int rgbChannels,
       int seriesCount, int sizeT, String compression, int pixelType, boolean bigTiff) throws Exception {
     TiffWriter writer = new TiffWriter();
     String pixelTypeString = FormatTools.getPixelTypeString(pixelType);
@@ -111,7 +117,7 @@ public final class WriterUtilities {
       writer.setTileSizeX(tileSize);
       writer.setTileSizeY(tileSize);
     }
-    writer.setId(file.getAbsolutePath());
+    writer.setId(file);
 
     int bytes = FormatTools.getBytesPerPixel(pixelType);
     byte[] plane = getPlane(PLANE_WIDTH, PLANE_HEIGHT, bytes * rgbChannels);


### PR DESCRIPTION
Backported from a private PR.

b65d8c5 adds a unit test that will save TIFFs in memory with various combinations of endianness, compression, and dimensions.  The test setup is identical to the existing test for writing TIFFs to disk.
With b65d8c5 alone, ```ant test``` or ```mvn``` in ```components/formats-bsd``` should fail.

0c14653 fixes all test failures.  The change to ```TiffWriter``` resolves an issue with writing a single little endian plane; the remaining changes are required for writing multiple planes in memory.  With both commits, ```ant test``` or ```mvn``` in ```components/formats-bsd``` should pass.

Note that only a subset of the tests are run by default; setting ```testng.runWriterSaveBytesTests``` to 100 will run everything.  I did do this locally and all tests passed, but it might not be a bad idea to double-check during review. 
