### PR TITLE
OME-TIFF: rework how missing planes in TiffData are handled

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1321,6 +1321,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
         }
         core.add(s, c);
       }
+      rs.close();
     }
     core.reorder();
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1004,14 +1004,27 @@ public class OMETiffReader extends SubResolutionFormatReader {
       OMETiffCoreMetadata m = (OMETiffCoreMetadata) core.get(s, 0);
       info[s] = planes;
       try {
-        RandomAccessInputStream testFile = new RandomAccessInputStream(info[s][0].id, 16);
+        RandomAccessInputStream testFile = null;
+        if (info[s][0].id != null) {
+          testFile = new RandomAccessInputStream(info[s][0].id, 16);
+        }
+        if (info[s][0].reader == null) {
+          info[s][0].reader = new MinimalTiffReader();
+        }
         String firstFile = info[s][0].id;
-        if (!info[s][0].reader.isThisType(testFile)) {
+        if (firstFile == null ||
+          (testFile != null && !info[s][0].reader.isThisType(testFile)))
+        {
           LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);
           info[s][0].id = currentId;
           info[s][0].exists = false;
+          if (info[s][0].ifd < 0) {
+            info[s][0].ifd = 0;
+          }
         }
-        testFile.close();
+        if (testFile != null) {
+          testFile.close();
+        }
         for (int plane=1; plane<info[s].length; plane++) {
           if (info[s][plane].id == null || info[s][plane].reader == null) {
             continue;

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1003,8 +1003,8 @@ public class OMETiffReader extends SubResolutionFormatReader {
       // populate core metadata
       OMETiffCoreMetadata m = (OMETiffCoreMetadata) core.get(s, 0);
       info[s] = planes;
+      RandomAccessInputStream testFile = null;
       try {
-        RandomAccessInputStream testFile = null;
         if (info[s][0].id != null) {
           testFile = new RandomAccessInputStream(info[s][0].id, 16);
         }
@@ -1139,6 +1139,11 @@ public class OMETiffReader extends SubResolutionFormatReader {
       }
       catch (NullPointerException exc) {
         throw new FormatException("Incomplete Pixels metadata", exc);
+      }
+      finally {
+        if (testFile != null) {
+          testFile.close();
+        }
       }
     }
 

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -980,7 +980,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
       }
       // only use the current file's IFD count if this is a single file set
       // otherwise, we risk pulling in IFDs from a different Image
-      if (validPlanes < num && files.size() == 1) {
+      if (validPlanes < num && files.size() <= 1) {
         LOGGER.warn("Using TiffReader to determine the number of planes.");
         TiffReader r = new TiffReader();
         r.setId(currentId);

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -937,7 +937,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
           planes[no].ifd = ifd + q;
           planes[no].certain = true;
           planes[no].exists = exists;
-          LOGGER.debug("      Plane[{}]: file={}, IFD={}",
+          LOGGER.trace("      Plane[{}]: file={}, IFD={}",
             new Object[] {no, planes[no].id, planes[no].ifd});
         }
         if (numPlanes == null) {
@@ -948,7 +948,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
             planes[no].id = filename;
             planes[no].ifd = planes[no - 1].ifd + 1;
             planes[no].exists = exists;
-            LOGGER.debug("      Plane[{}]: FILLED", no);
+            LOGGER.trace("      Plane[{}]: FILLED", no);
           }
         }
         else {
@@ -958,7 +958,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
             planes[no].reader = null;
             planes[no].id = null;
             planes[no].ifd = -1;
-            LOGGER.debug("      Plane[{}]: CLEARED", no);
+            LOGGER.trace("      Plane[{}]: CLEARED", no);
           }
         }
         LOGGER.debug("    }");


### PR DESCRIPTION
Backported from a private PR.

Without this PR, if any plane was not covered by a ```TiffData```, then all ```TiffData``` information was thrown out and the plane count for the current ```Image``` was reset to the IFD count of the current file.  That's not unreasonable for single file datasets, but when multiple files are present this can be problematic.  ece2e8d describes the original use case as MicroManager-acquired data, where the datasets may contain multiple files that are split at 4GB so a single file does not neatly map to a single ```Image```, Z section, timepoint, etc.

A simpler example that demonstrates the problem is in ```curated/ome-tiff/samples/missing-planes```.  This was generated via ```bfconvert -option ometiff.companion test.companion.ome test&sizeZ=10.fake test-Z&z.ome.tiff```; the ```TiffData``` corresponding to ```test-Z5.ome.tiff``` (and ```test-Z5.ome.tiff``` itself) were then removed by hand.

Without this PR, ```showinf test-Z0.ome.tiff``` should result in a single plane.  With this PR, the same test should result in 10 planes, with Z=5 blank.

I would expect all tests to continue to pass without config changes.