### PR TITLE
Upgrade ome-common to 6.0.0-m1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome-common.version>5.3.6</ome-common.version>
+    <ome-common.version>6.0.0-m1</ome-common.version>
     <ome-model.version>5.6.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>


### PR DESCRIPTION
This allows us to make use of the changes in 5.3.7 and 6.0.0-m1:

 https://github.com/ome/ome-common-java/milestone/8?closed=1
https://github.com/ome/ome-common-java/pull/34
https://github.com/ome/ome-common-java/pull/35
https://github.com/ome/ome-common-java/pull/22
https://github.com/ome/ome-common-java/pull/27
https://github.com/ome/ome-common-java/pull/29

Especially relevant for continuing work on:

https://trello.com/c/spl6WleR/74-ome-tiff-pyramid-testing-phase-ii
https://trello.com/c/OimiHAQY/39-ome-common-profile-tiff-writing
https://trello.com/c/Fig1abYV/239-lif-parsedouble-exception