### PR TITLE
ImageConverter: usage extension

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/GenerateCache.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/GenerateCache.java
@@ -81,8 +81,6 @@ public class GenerateCache {
   }
 
   public static void main(String[] args) {
-    CommandLineTools.runUpgradeCheck(args);
-
     if (args.length < 2) {
       System.out.println("Usage:");
       System.out.println(
@@ -91,6 +89,8 @@ public class GenerateCache {
       System.out.println("If '-list' is specified, then 'fileOrDir' is a text file with one file per line.");
       return;
     }
+
+    CommandLineTools.runUpgradeCheck(args);
 
     boolean fileList = args.length >= 3 && args[0].equals("-list");
     String input = args[args.length - 2];

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -222,7 +222,7 @@ public final class ImageConverter {
   }
 
   /* Create a table of the extensions per output file format */
-  private String listExtensions() {
+  private static String listExtensions() {
       IFormatWriter[] writers = new ImageWriter().getWriters();
       String[] suffixes;
       StringBuilder sb = new StringBuilder();
@@ -239,7 +239,7 @@ public final class ImageConverter {
   }
 
   /* Create a table of the compression tables per output file format */
-  private String listCompressions() {
+  private static String listCompressions() {
       IFormatWriter[] writers = new ImageWriter().getWriters();
       String[] compressionTypes;
       StringBuilder sb = new StringBuilder();

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -233,7 +233,7 @@ public final class ImageConverter {
         for (int j=1; j<suffixes.length; j++) {
             sb.append(", ." + suffixes[j]);
         }
-        sb.append("\n");
+        sb.append('\n');
       }
       return sb.toString();
   }
@@ -251,7 +251,7 @@ public final class ImageConverter {
           for (int j=1; j<compressionTypes.length; j++) {
               sb.append(", " + compressionTypes[j]);
           }
-          sb.append("\n");
+          sb.append('\n');
         }
       }
       return sb.toString();
@@ -302,12 +302,10 @@ public final class ImageConverter {
       "for the conversion. The list of available formats and extensions is:",
       "",
       listExtensions(),
-      "",
       "Some file formats offer multiple compression schemes that can be set",
       "using the -compression option. The list of available compressions is:",
       "",
       listCompressions(),
-      "",
       "If any of the following patterns are present in out_file, they will",
       "be replaced with the indicated metadata value from the input file.",
       "",

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -339,7 +339,7 @@ public final class ImageConverter {
       "",
       "Each file would have a single image plane."
     };
-    for (int i=0; i<s.length; i++) LOGGER.info(s[i]);
+    for (int i=0; i<s.length; i++) System.out.println(s[i]);
   }
 
   // -- Utility methods --

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -36,7 +36,10 @@ import java.awt.image.IndexColorModel;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.HashMap;
+import java.util.TreeMap;
+import java.util.SortedMap;
 
 import loci.common.Constants;
 import loci.common.DataTools;
@@ -221,40 +224,40 @@ public final class ImageConverter {
     return true;
   }
 
-  /* Create a table of the extensions per output file format */
-  private static String listExtensions() {
-      IFormatWriter[] writers = new ImageWriter().getWriters();
-      String[] suffixes;
-      StringBuilder sb = new StringBuilder();
-      for (int i=0; i<writers.length; i++) {
-        sb.append(" * "  + writers[i].getFormat() + ": ");
-        suffixes = writers[i].getSuffixes();
-        sb.append("." + suffixes[0]);
-        for (int j=1; j<suffixes.length; j++) {
-            sb.append(", ." + suffixes[j]);
-        }
-        sb.append('\n');
-      }
-      return sb.toString();
+  /* Return a sorted map of the available extensions per writer */
+  private static SortedMap<String,String> getExtensions() {
+    IFormatWriter[] writers = new ImageWriter().getWriters();
+    SortedMap<String, String> extensions = new TreeMap<String, String>();
+    for (int i=0; i<writers.length; i++) {
+      extensions.put(writers[i].getFormat(),
+        String.join(", ", writers[i].getSuffixes()));
+    }
+    return extensions;
   }
 
-  /* Create a table of the compression tables per output file format */
-  private static String listCompressions() {
-      IFormatWriter[] writers = new ImageWriter().getWriters();
-      String[] compressionTypes;
-      StringBuilder sb = new StringBuilder();
-      for (int i=0; i<writers.length; i++) {
-        compressionTypes = writers[i].getCompressionTypes();
-        if (compressionTypes != null) {
-          sb.append(" * "  + writers[i].getFormat() + ": ");
-          sb.append(compressionTypes[0]);
-          for (int j=1; j<compressionTypes.length; j++) {
-              sb.append(", " + compressionTypes[j]);
-          }
-          sb.append('\n');
-        }
+  /* Return a sorted map of the available compressions per writer */
+  private static SortedMap<String,String> getCompressions() {
+    IFormatWriter[] writers = new ImageWriter().getWriters();
+    SortedMap<String, String> compressions = new TreeMap<String, String>();
+    for (int i=0; i<writers.length; i++) {
+      String[] compressionTypes = writers[i].getCompressionTypes();
+      if (compressionTypes != null) {
+        compressions.put(writers[i].getFormat(),
+          String.join(", ", compressionTypes));
       }
-      return sb.toString();
+    }
+    return compressions;
+  }
+
+  /* Formats a sorted map into a string for the utility usage */
+  private static String printList(SortedMap<String,String> map) {
+    StringBuilder sb = new StringBuilder();
+    Iterator it = map.entrySet().iterator();
+    while (it.hasNext()) {
+      SortedMap.Entry pair = (SortedMap.Entry) it.next();
+      sb.append(" * " + pair.getKey() + ": " + pair.getValue() + '\n');
+    }
+    return sb.toString();
   }
 
   /**
@@ -301,11 +304,11 @@ public final class ImageConverter {
       "The extension of the output file specifies the file format to use",
       "for the conversion. The list of available formats and extensions is:",
       "",
-      listExtensions(),
+      printList(getExtensions()),
       "Some file formats offer multiple compression schemes that can be set",
       "using the -compression option. The list of available compressions is:",
       "",
-      listCompressions(),
+      printList(getCompressions()),
       "If any of the following patterns are present in out_file, they will",
       "be replaced with the indicated metadata value from the input file.",
       "",

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -225,36 +225,36 @@ public final class ImageConverter {
   private String listExtensions() {
       IFormatWriter[] writers = new ImageWriter().getWriters();
       String[] suffixes;
-      String s = "";
+      StringBuilder sb = new StringBuilder();
       for (int i=0; i<writers.length; i++) {
-        s += " * "  + writers[i].getFormat() + ": ";
+        sb.append(" * "  + writers[i].getFormat() + ": ");
         suffixes = writers[i].getSuffixes();
-        s += "." + suffixes[0];
+        sb.append("." + suffixes[0]);
         for (int j=1; j<suffixes.length; j++) {
-            s += ", ." + suffixes[j];
+            sb.append(", ." + suffixes[j]);
         }
-        s += "\n";
+        sb.append("\n");
       }
-      return s;
+      return sb.toString();
   }
 
   /* Create a table of the compression tables per output file format */
   private String listCompressions() {
       IFormatWriter[] writers = new ImageWriter().getWriters();
       String[] compressionTypes;
-      String s = "";
+      StringBuilder sb = new StringBuilder();
       for (int i=0; i<writers.length; i++) {
         compressionTypes = writers[i].getCompressionTypes();
         if (compressionTypes != null) {
-          s += " * "  + writers[i].getFormat() + ": ";
-          s += compressionTypes[0];
+          sb.append(" * "  + writers[i].getFormat() + ": ");
+          sb.append(compressionTypes[0]);
           for (int j=1; j<compressionTypes.length; j++) {
-              s += ", " + compressionTypes[j];
+              sb.append(", " + compressionTypes[j]);
           }
-          s += "\n";
+          sb.append("\n");
         }
       }
-      return s;
+      return sb.toString();
   }
 
   /**

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -362,12 +362,12 @@ public final class ImageConverter {
       return true;
     }
 
-    CommandLineTools.runUpgradeCheck(args);
-
     if (in == null || out == null) {
       printUsage();
       return false;
     }
+
+    CommandLineTools.runUpgradeCheck(args);
 
     if (new Location(out).exists()) {
       if (overwrite == null) {

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -32,6 +32,8 @@
 
 package loci.formats.tools;
 
+import com.google.common.base.Joiner;
+
 import java.awt.image.IndexColorModel;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -230,7 +232,7 @@ public final class ImageConverter {
     SortedMap<String, String> extensions = new TreeMap<String, String>();
     for (int i=0; i<writers.length; i++) {
       extensions.put(writers[i].getFormat(),
-        String.join(", ", writers[i].getSuffixes()));
+        '.' + Joiner.on(", .").join(writers[i].getSuffixes()));
     }
     return extensions;
   }
@@ -243,7 +245,7 @@ public final class ImageConverter {
       String[] compressionTypes = writers[i].getCompressionTypes();
       if (compressionTypes != null) {
         compressions.put(writers[i].getFormat(),
-          String.join(", ", compressionTypes));
+          Joiner.on(", ").join(compressionTypes));
       }
     }
     return compressions;

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -221,6 +221,42 @@ public final class ImageConverter {
     return true;
   }
 
+  /* Create a table of the extensions per output file format */
+  private String listExtensions() {
+      IFormatWriter[] writers = new ImageWriter().getWriters();
+      String[] suffixes;
+      String s = "";
+      for (int i=0; i<writers.length; i++) {
+        s += " * "  + writers[i].getFormat() + ": ";
+        suffixes = writers[i].getSuffixes();
+        s += "." + suffixes[0];
+        for (int j=1; j<suffixes.length; j++) {
+            s += ", ." + suffixes[j];
+        }
+        s += "\n";
+      }
+      return s;
+  }
+
+  /* Create a table of the compression tables per output file format */
+  private String listCompressions() {
+      IFormatWriter[] writers = new ImageWriter().getWriters();
+      String[] compressionTypes;
+      String s = "";
+      for (int i=0; i<writers.length; i++) {
+        compressionTypes = writers[i].getCompressionTypes();
+        if (compressionTypes != null) {
+          s += " * "  + writers[i].getFormat() + ": ";
+          s += compressionTypes[0];
+          for (int j=1; j<compressionTypes.length; j++) {
+              s += ", " + compressionTypes[j];
+          }
+          s += "\n";
+        }
+      }
+      return s;
+  }
+
   /**
    * Output usage information, using log4j.
    */
@@ -261,6 +297,16 @@ public final class ImageConverter {
       "  -timepoint: only convert the specified timepoint (indexed from 0)",
       "     -padded: filename indexes for series, z, c and t will be zero padded",
       "     -option: add the specified key/value pair to the options list",
+      "",
+      "The extension of the output file specifies the file format to use",
+      "for the conversion. The list of available formats and extensions is:",
+      "",
+      listExtensions(),
+      "",
+      "Some file formats offer multiple compression schemes that can be set",
+      "using the -compression option. The list of available compressions is:",
+      "",
+      listCompressions(),
       "",
       "If any of the following patterns are present in out_file, they will",
       "be replaced with the indicated metadata value from the input file.",

--- a/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageInfo.java
@@ -347,7 +347,7 @@ public class ImageInfo {
       "* = may result in loss of precision",
       ""
     };
-    for (int i=0; i<s.length; i++) LOGGER.info(s[i]);
+    for (int i=0; i<s.length; i++) System.out.println(s[i]);
   }
 
   public void setReader(IFormatReader reader) {
@@ -1016,7 +1016,6 @@ public class ImageInfo {
       CommandLineTools.printVersion();
       return true;
     }
-    CommandLineTools.runUpgradeCheck(args);
 
     createReader();
 
@@ -1024,6 +1023,8 @@ public class ImageInfo {
       printUsage();
       return false;
     }
+
+    CommandLineTools.runUpgradeCheck(args);
 
     mapLocation();
     configureReaderPreInit();

--- a/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/TiffComment.java
@@ -52,8 +52,6 @@ import loci.formats.tiff.TiffSaver;
 public class TiffComment {
 
   public static void main(String[] args) throws FormatException, IOException {
-    CommandLineTools.runUpgradeCheck(args);
-
     if (args.length == 0) {
       System.out.println("Usage:");
       System.out.println(
@@ -74,6 +72,8 @@ public class TiffComment {
       System.out.println("    terminate reading from stdin.");
       return;
     }
+
+    CommandLineTools.runUpgradeCheck(args);
 
     // parse flags
     boolean edit = false;


### PR DESCRIPTION
See https://trello.com/c/ko5vYYZ7/35-bfconvert-help-review

This PR primarily reviews the usage of `bfconvert` to list the available list of extension/formats as well as compression schemes for relevant file formats.

Additionally, the upgrade check is skipped if the usage is displayed e.g. when calling `bfconvert` without argument and the utility usage is printed directly to to the stdout independently of the logger level (see https://trello.com/c/FHWeDznP/53-cli-systemout-vs-logging). Similar changes are applied to the other utility classes (`showinf`, `gen-cache`, `tiffcomment`)