### PR TITLE
maven: Allow ome-model groupId to be settable via a property

### DIFF
--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -34,7 +34,7 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>ome-xml</artifactId>
       <version>${ome-model.version}</version>
     </dependency>

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -34,7 +34,7 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>ome-xml</artifactId>
       <version>${ome-model.version}</version>
     </dependency>

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>ome-xml</artifactId>
       <version>${ome-model.version}</version>
     </dependency>

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -34,12 +34,12 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>ome-xml</artifactId>
       <version>${ome-model.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>specification</artifactId>
       <version>${ome-model.version}</version>
     </dependency>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -34,7 +34,7 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>ome-xml</artifactId>
       <version>${ome-model.version}</version>
     </dependency>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -34,7 +34,7 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
+      <groupId>${ome-model.group}</groupId>
       <artifactId>ome-xml</artifactId>
       <version>${ome-model.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
     <ome-common.version>6.0.0-m1</ome-common.version>
+    <ome-model.group>org.openmicroscopy</ome-model.group>
     <ome-model.version>5.6.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>


### PR DESCRIPTION
We currently use properties to allow component versions to be overridden for testing or other purposes.  This PR extends this to the `groupId` property for the ome-model jars.  These properties:

- `ome-model.version`
- `ome-model.group`

may be set on the command-line for both Maven and Ant builds to allow the use of ome-model jars other than the default.  The default behaviour remains unchanged.

Examples of group usage:

```
ant -Dome-model.version=5.6.2 -Dome-model.group=org.openmicroscopy clean jars tools test
mvn -Dome-model.version=5.6.2 -Dome-model.group=org.openmicroscopy
ant -Dome-model.version=5.7.1 -Dome-model.group=net.codelibre clean jars tools test
mvn -Dome-model.version=5.7.1 -Dome-model.group=net.codelibre
```

My intention is to use this with the CI jobs such as [this one](https://gitlab.com/codelibre/ome-model/pipelines/36767884), to ensure there is complete API and behaviour compatibility with the model and bio-formats in an automated fashion.  Being able to set these properties on the fly will make it possible to test directly against current `develop` rather than having to maintain and keep up to date a custom branch for the purpose.

Thanks for your consideration,
Roger