### PR TITLE
close resources 

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -489,9 +489,8 @@ public class MicromanagerReader extends FormatReader {
         plane++;
         continue;
       }
-      TiffParser parser = null;
-      try {
-        parser = new TiffParser(path);
+      try (RandomAccessInputStream in = new RandomAccessInputStream(path)) {
+        TiffParser parser = new TiffParser(in);
         int nIFDs = parser.getMainIFDs().size();
         IFD firstIFD = parser.getFirstIFD();
         parser.fillInIFD(firstIFD);
@@ -599,10 +598,6 @@ public class MicromanagerReader extends FormatReader {
       }
       catch (IOException e) {
         LOGGER.debug("Failed to read metadata from " + path, e);
-      } finally {
-        if (parser != null) {
-          parser.getStream().close();
-        }
       }
     }
   }
@@ -715,8 +710,11 @@ public class MicromanagerReader extends FormatReader {
     }
 
     byte[] b = new byte[(int) s.length()];
-    s.readFully(b);
-    s.close();
+    try {
+      s.readFully(b);
+    } finally {
+      s.close();
+    }
 
     int[] slice = new int[3];
     start = 0;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -489,8 +489,9 @@ public class MicromanagerReader extends FormatReader {
         plane++;
         continue;
       }
+      TiffParser parser = null;
       try {
-        TiffParser parser = new TiffParser(path);
+        parser = new TiffParser(path);
         int nIFDs = parser.getMainIFDs().size();
         IFD firstIFD = parser.getFirstIFD();
         parser.fillInIFD(firstIFD);
@@ -595,10 +596,13 @@ public class MicromanagerReader extends FormatReader {
           }
         }
         plane += ifds.size();
-        parser.getStream().close();
       }
       catch (IOException e) {
         LOGGER.debug("Failed to read metadata from " + path, e);
+      } finally {
+        if (parser != null) {
+          parser.getStream().close();
+        }
       }
     }
   }

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -1266,10 +1266,12 @@ public class OMETiffReader extends SubResolutionFormatReader {
         continue;
       }
       IFD ifd = ifdList.get(i);
-      RandomAccessInputStream rs =
-        new RandomAccessInputStream(info[s][0].id, 16);
-      TiffParser p = new TiffParser(rs);
-      IFDList subifds = p.getSubIFDs(ifd);
+      IFDList subifds = null;
+      try (RandomAccessInputStream rs =
+        new RandomAccessInputStream(info[s][0].id, 16)) {
+        TiffParser p = new TiffParser(rs);
+        subifds = p.getSubIFDs(ifd);
+      }
       c0.resolutionCount = subifds.size() + 1;
 
       if (c0.resolutionCount > 1 && hasFlattenedResolutions()) {
@@ -1325,7 +1327,7 @@ public class OMETiffReader extends SubResolutionFormatReader {
         checkSuffix(metadataFile, "ome.tf8") ||
         checkSuffix(metadataFile, "ome.btf")) {
       // metadata file is an OME-TIFF file; extract OME-XML comment
-      try (RandomAccessInputStream in = new RandomAccessInputStream(metadataFile)){
+      try (RandomAccessInputStream in = new RandomAccessInputStream(metadataFile)) {
         TiffParser parser = new TiffParser(in);
         return parser.getComment();
       }
@@ -1336,13 +1338,9 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
   private static IFD getFirstIFD(String fname) throws IOException {
     IFD firstIFD = null;
-    RandomAccessInputStream ras = new RandomAccessInputStream(fname, 16);
-    try {
+    try (RandomAccessInputStream ras = new RandomAccessInputStream(fname, 16)) {
       TiffParser tp = new TiffParser(ras);
       firstIFD = tp.getFirstIFD();
-    }
-    finally {
-      ras.close();
     }
     return firstIFD;
   }

--- a/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMETiffReader.java
@@ -993,14 +993,15 @@ public class OMETiffReader extends SubResolutionFormatReader {
       OMETiffCoreMetadata m = (OMETiffCoreMetadata) core.get(s, 0);
       info[s] = planes;
       try {
-        RandomAccessInputStream testFile = new RandomAccessInputStream(info[s][0].id, 16);
         String firstFile = info[s][0].id;
-        if (!info[s][0].reader.isThisType(testFile)) {
-          LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);
-          info[s][0].id = currentId;
-          info[s][0].exists = false;
+        try (RandomAccessInputStream testFile = new RandomAccessInputStream(info[s][0].id, 16)) {
+          if (!info[s][0].reader.isThisType(testFile)) {
+            LOGGER.warn("{} is not a valid OME-TIFF", info[s][0].id);
+            info[s][0].id = currentId;
+            info[s][0].exists = false;
+          }
         }
-        testFile.close();
+        
         for (int plane=1; plane<info[s].length; plane++) {
           if (info[s][plane].id.equals(firstFile)) {
             // don't repeat slow type checking if the files are the same
@@ -1011,13 +1012,13 @@ public class OMETiffReader extends SubResolutionFormatReader {
 
             continue;
           }
-          testFile = new RandomAccessInputStream(info[s][plane].id, 16);
-          if (!info[s][plane].reader.isThisType(testFile)) {
-            LOGGER.warn("{} is not a valid OME-TIFF", info[s][plane].id);
-            info[s][plane].id = info[s][0].id;
-            info[s][plane].exists = false;
+          try (RandomAccessInputStream testFile = new RandomAccessInputStream(info[s][plane].id, 16)) {
+            if (!info[s][plane].reader.isThisType(testFile)) {
+              LOGGER.warn("{} is not a valid OME-TIFF", info[s][plane].id);
+              info[s][plane].id = info[s][0].id;
+              info[s][plane].exists = false;
+            }
           }
-          testFile.close();
         }
 
         info[s][0].reader.setId(info[s][0].id);

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -204,7 +204,6 @@ public class TiffWriter extends FormatWriter {
   public void saveBytes(int no, byte[] buf, IFD ifd)
     throws IOException, FormatException
   {
-    MetadataRetrieve r = getMetadataRetrieve();
     int w = getSizeX();
     int h = getSizeY();
     saveBytes(no, buf, ifd, 0, 0, w, h);

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -454,19 +454,13 @@ public class TiffWriter extends FormatWriter {
   {
     IFD ifd = new IFD();
     if (!sequential) {
-      TiffParser parser = new TiffParser(currentId);
-      try {
+      try (RandomAccessInputStream in = new RandomAccessInputStream(currentId)) {
+        TiffParser parser = new TiffParser(in);
         long[] ifdOffsets = parser.getIFDOffsets();
         if (no < ifdOffsets.length) {
           ifd = parser.getIFD(ifdOffsets[no]);
         }
         saveBytes(no, buf, ifd, x, y, w, h);
-      }
-      finally {
-        RandomAccessInputStream tiffParserStream = parser.getStream();
-        if (tiffParserStream != null) {
-          tiffParserStream.close();
-        }
       }
     }
     else {

--- a/components/formats-gpl/src/loci/formats/in/SEQReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SEQReader.java
@@ -147,9 +147,11 @@ public class SEQReader extends BaseTiffReader {
     int[] lengths = new int[] {getSizeZ(), getEffectiveSizeC(), core.size(), getSizeT()};
     int index = FormatTools.positionToRaster(lengths, coords);
 
-    TiffParser p = new TiffParser(files[index]);
-    IFD ifd = p.getFirstIFD();
-    p.getSamples(ifd, buf, x, y, w, h);
+    try (RandomAccessInputStream in = new RandomAccessInputStream(files[index])) {
+      TiffParser p = new TiffParser(in);
+      IFD ifd = p.getFirstIFD();
+      p.getSamples(ifd, buf, x, y, w, h);
+    }
     return buf;
   }
 


### PR DESCRIPTION
Review classes using ``TiffSaver(String)`` constructor and make sure the stream is closed
Tests should remain green
See https://trello.com/c/NEWizoBO/90-tiffparser-leaking-resource