### PR TITLE
CV7000: fix channel indexing when the stored indexes do not match the count per field

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -289,41 +289,47 @@ public class CV7000Reader extends FormatReader {
     }
 
     String firstFile = null;
-    int minSizeZ = Integer.MAX_VALUE, maxSizeZ = 0;
-    int minSizeC = Integer.MAX_VALUE, maxSizeC = 0;
-    int minSizeT = Integer.MAX_VALUE, maxSizeT = 0;
+    HashMap<Integer, MinMax> minMax = new HashMap<Integer, MinMax>();
+
     fields = 0;
     HashSet<Integer> uniqueWells = new HashSet<Integer>();
 
     for (Plane p : planeData) {
       if (p != null) {
+        int wellIndex = p.row * plate.getPlateColumns() + p.column;
+        if (!minMax.containsKey(wellIndex)) {
+          minMax.put(wellIndex, new MinMax());
+        }
+        MinMax m = minMax.get(wellIndex);
+
         if (p.file != null && firstFile == null) {
           firstFile = p.file;
         }
 
-        if (p.timepoint > maxSizeT) {
-          maxSizeT = p.timepoint;
+        if (p.timepoint > m.maxT) {
+          m.maxT = p.timepoint;
         }
-        if (p.timepoint < minSizeT) {
-          minSizeT = p.timepoint;
+        if (p.timepoint < m.minT) {
+          m.minT = p.timepoint;
         }
-        if (p.z > maxSizeZ) {
-          maxSizeZ = p.z;
+        if (p.z > m.maxZ) {
+          m.maxZ = p.z;
         }
-        if (p.z < minSizeZ) {
-          minSizeZ = p.z;
+        if (p.z < m.minZ) {
+          m.minZ = p.z;
         }
-        if (p.channelIndex > maxSizeC) {
-          maxSizeC = p.channelIndex;
+        if (p.channelIndex > m.maxC) {
+          m.maxC = p.channelIndex;
         }
-        if (p.channelIndex < minSizeC) {
-          minSizeC = p.channelIndex;
+        if (p.channelIndex < m.minC) {
+          m.minC = p.channelIndex;
         }
 
         if (p.field >= fields) {
           fields = p.field + 1;
         }
-        uniqueWells.add(p.row * plate.getPlateColumns() + p.column);
+
+        uniqueWells.add(wellIndex);
       }
     }
 
@@ -333,34 +339,47 @@ public class CV7000Reader extends FormatReader {
     core.add(new CoreMetadata(reader.getCoreMetadataList().get(0)));
 
     core.get(0).dimensionOrder = "XYCZT";
-    core.get(0).sizeZ = (maxSizeZ - minSizeZ) + 1;
-    core.get(0).sizeT = (maxSizeT - minSizeT) + 1;
-    core.get(0).sizeC *= (maxSizeC - minSizeC) + 1;
-    core.get(0).imageCount = getSizeZ() * getSizeT() * (getSizeC() / reader.getSizeC());
 
     int realWells = uniqueWells.size();
     Integer[] wells = uniqueWells.toArray(new Integer[realWells]);
     Arrays.sort(wells);
+    reversePlaneLookup = new int[realWells * fields][];
 
-    for (int i=1; i<realWells * fields; i++) {
-      core.add(new CoreMetadata(core.get(0)));
+    for (int i=0; i<realWells * fields; i++) {
+      if (i > 0) {
+        core.add(new CoreMetadata(core.get(0)));
+      }
+
+      int wellIndex = wells[i / fields];
+      MinMax m = minMax.get(wellIndex);
+      core.get(i).sizeZ = (m.maxZ - m.minZ) + 1;
+      core.get(i).sizeT = (m.maxT - m.minT) + 1;
+      core.get(i).sizeC = reader.getSizeC() * ((m.maxC - m.minC) + 1);
+      core.get(i).imageCount = core.get(i).sizeZ * core.get(i).sizeT *
+        (core.get(i).sizeC / reader.getSizeC());
+      reversePlaneLookup[i] = new int[core.get(i).imageCount];
+      Arrays.fill(reversePlaneLookup[i], -1);
     }
 
     int[] seriesLengths = new int[] {fields, realWells};
     int[] planeLengths = new int[] {getSizeC(), getSizeZ(), getSizeT()};
-    reversePlaneLookup = new int[getSeriesCount()][getImageCount()];
-    for (int i=0; i<reversePlaneLookup.length; i++) {
-      // do this so that the index does not default to 0 for ERR planes
-      Arrays.fill(reversePlaneLookup[i], -1);
-    }
+
+
     extraFiles = new ArrayList<String>();
     for (int i=0; i<planeData.size(); i++) {
       Plane p = planeData.get(i);
-      int wellIndex = Arrays.binarySearch(wells, p.row * plate.getPlateColumns() + p.column);
+      int wellNumber = p.row * plate.getPlateColumns() + p.column;
+      int wellIndex = Arrays.binarySearch(wells, wellNumber);
       p.series = FormatTools.positionToRaster(seriesLengths,
         new int[] {p.field, wellIndex});
+      MinMax m = minMax.get(wellNumber);
+
+      planeLengths[0] = core.get(p.series).sizeC / reader.getSizeC();
+      planeLengths[1] = core.get(p.series).sizeZ;
+      planeLengths[2] = core.get(p.series).sizeT;
+
       p.no = FormatTools.positionToRaster(planeLengths,
-        new int[] {p.channelIndex - minSizeC, p.z - minSizeZ, p.timepoint - minSizeT});
+        new int[] {p.channelIndex - m.minC, p.z - m.minZ, p.timepoint - m.minT});
       if (reversePlaneLookup[p.series][p.no] < 0) {
         reversePlaneLookup[p.series][p.no] = i;
       }
@@ -424,6 +443,8 @@ public class CV7000Reader extends FormatReader {
           store.setImageName(name, nextImage);
           store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, nextImage);
 
+          setSeries(nextImage);
+
           // find the first valid plane to set WellSample positions
           int no = 0;
           Plane p = lookupPlane(nextImage, no);
@@ -444,6 +465,7 @@ public class CV7000Reader extends FormatReader {
         nextWell++;
       }
     }
+    setSeries(0);
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       store.setPlateName(plate.getPlateName(), 0);
@@ -481,6 +503,7 @@ public class CV7000Reader extends FormatReader {
       }
 
       for (int i=0; i<getSeriesCount(); i++) {
+        setSeries(i);
         if (channels != null) {
           for (int c=0; c<getSizeC(); c++) {
             Plane p = lookupPlane(i, c);
@@ -564,7 +587,7 @@ public class CV7000Reader extends FormatReader {
           store.setPlanePositionZ(FormatTools.createLength(plane.zpos, UNITS.REFERENCEFRAME), i, p);
         }
       }
-
+      setSeries(0);
     }
   }
 
@@ -904,6 +927,15 @@ public class CV7000Reader extends FormatReader {
     public double zpos;
     public int series;
     public int no;
+  }
+
+  class MinMax {
+    public int minZ = Integer.MAX_VALUE;
+    public int maxZ = 0;
+    public int minC = Integer.MAX_VALUE;
+    public int maxC = 0;
+    public int minT = Integer.MAX_VALUE;
+    public int maxT = 0;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/CV7000Reader.java
@@ -423,6 +423,22 @@ public class CV7000Reader extends FormatReader {
           String name = "Well " + ((char) ('A' + row)) + (col + 1) + ", Field " + (field + 1);
           store.setImageName(name, nextImage);
           store.setPlateAcquisitionWellSampleRef(wellSampleID, 0, 0, nextImage);
+
+          // find the first valid plane to set WellSample positions
+          int no = 0;
+          Plane p = lookupPlane(nextImage, no);
+          while (p == null && no < getImageCount()) {
+            p = lookupPlane(nextImage, no++);
+          }
+          if (p != null) {
+            store.setWellSamplePositionX(
+              FormatTools.createLength(p.xpos, UNITS.REFERENCEFRAME),
+              0, nextWell, field);
+            store.setWellSamplePositionY(
+              FormatTools.createLength(p.ypos, UNITS.REFERENCEFRAME),
+              0, nextWell, field);
+          }
+
           nextImage++;
         }
         nextWell++;


### PR DESCRIPTION
An arbitrary number of channels can be defined in the ```MeasurementDetail.mrf``` file, and only a subset may be referenced by each field.  This changes how channel counting and indexing is done to look
at the total number of unique channels in a field, instead of the total number of unique channels across all fields/wells.

See https://trello.com/c/b0nFSUzZ/49-cv7000

To test, use the ```Test-plate-1.wpi``` referenced on the card (configuration PR forthcoming).  Without this change, ```showinf -nopix Test-plate-1.wpi``` should show 10 channels.  This is because 10 channels are defined in the corresponding ```MeasurementDetail.mrf```, and the specific subset used varies by field.

With this change, the same test should show 5 channels in each series, which matches the number of unique channel identifiers in each field (and the acquisition description supplied in the ```*.md``` file).  Viewing a subset of the series should show that the channels are not mixed up (ImageJ may be easier for this since the images are 16 bit).  ```showinf -omexml -nopix``` should also show that ```WellSample.PositionX``` and ```WellSample.PositionY``` are populated, as noted in https://github.com/openmicroscopy/bioformats/pull/3224#discussion_r224841439

Memo files may be affected due to the addition of ```channelIndex``` in the ```Plane``` inner class.