### PR TITLE
ImageJ exporter: skip grayscale LUTs and allow non-gray LUTs to be omitted

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -46,12 +46,14 @@ import ij.process.ImageProcessor;
 import ij.process.LUT;
 import ij.process.ShortProcessor;
 
+import java.awt.Checkbox;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Vector;
 
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -324,6 +326,10 @@ public class Exporter {
             // this preserves backwards compatibility with existing macros,
             // so that non-default lookup tables do not suddenly disappear
             multiFile.addCheckbox("Do_not_save_lookup_tables", false);
+
+            // only allow LUTs to be turned off via macro for now
+            Vector checkboxes = multiFile.getCheckboxes();
+            ((Checkbox) checkboxes.get(checkboxes.size() - 1)).setVisible(false);
             multiFile.showDialog();
 
             splitZ = multiFile.getNextBoolean();


### PR DESCRIPTION
See https://trello.com/c/Qk6NBnPs/92-imagej-ome-tiff-writing-performance

cb82e22 fixes the immediate issue by omitting lookup table saving for any plane that has a default grayscale lookup table.  6e57191 adds an option to always omit lookup tables, which is ```false``` by default.

To test, run this macro:
```
run("Mitosis (26MB, 5D stack)");
// resulting file should be 35 MB
run("Bio-Formats Exporter", "save=macro-no-lut-no-save.ome.tiff do_not_save_lookup_tables compression=Uncompressed");

// resulting file should be 35 MB
// not disabling LUTs doesn't matter here since every plane has the default grayscale LUT
run("Bio-Formats Exporter", "save=macro-no-lut-save.ome.tiff compression=Uncompressed");

// explicitly change the LUT for every plane
run("Thallium");
// resulting file should be 35 MB since LUT saving is explicitly disabled
run("Bio-Formats Exporter", "save=macro-thallium-no-save.ome.tiff do_not_save_lookup_tables compression=Uncompressed");

// resulting file should be 226 MB (LUTs are preserved)
// should be backwards compatible with old macros when a non-default LUT is present
run("Bio-Formats Exporter", "save=macro-thallium-save.ome.tiff compression=Uncompressed");
close();
```

and verify that the resulting file sizes match expected sizes in the comments and that write times are generally faster except in the very last case.  That said, I'm not sure that I'm 100% sold on 6e57191 (is it too complicated for users to understand? should the default behavior be different?), so happy to revert, rework or split into a separate PR if anyone has strong feelings.

I didn't do anything here with respect to more efficiently storing duplicate LUTs in a TIFF as discussed in https://openmicroscopy.slack.com/archives/C0K5EED3R/p1543417107942200, but that could be a follow-up PR (it is just a little trickier, and may conflict with other TIFF-focused PRs).