### PR TITLE
Update default tile size to 0

### DIFF
--- a/components/formats-api/src/loci/formats/FormatWriter.java
+++ b/components/formats-api/src/loci/formats/FormatWriter.java
@@ -304,28 +304,28 @@ public abstract class FormatWriter extends FormatHandler
   /* @see IFormatWriter#getTileSizeX() */
   @Override
   public int getTileSizeX() throws FormatException {
-    return getSizeX();
+    return 0;
   }
 
   /* @see IFormatWriter#setTileSizeX(int) */
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
     int width = getSizeX();
-    if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
+    if (tileSize < 0) throw new FormatException("Tile size must be >= 0. Setting a tile size of 0 will disable tiling");
     return width;
   }
 
   /* @see IFormatWriter#getTileSizeY() */
   @Override
   public int getTileSizeY() throws FormatException {
-    return getSizeY();
+    return 0;
   }
 
   /* @see IFormatWriter#setTileSizeY(int) */
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
     int height = getSizeY();
-    if (tileSize <= 0) throw new FormatException("Tile size must be > 0.");
+    if (tileSize < 0) throw new FormatException("Tile size must be >= 0. Setting a tile size of 0 will disable tiling");
     return height;
   }
 

--- a/components/formats-api/src/loci/formats/IFormatWriter.java
+++ b/components/formats-api/src/loci/formats/IFormatWriter.java
@@ -204,7 +204,7 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
 
   /**
    * Retrieves the current tile width
-   * Defaults to full image width if not supported
+   * Defaults to 0 if not supported
    * @return The current tile width being used
    * @throws FormatException Image metadata including Pixels Size X must be set prior to calling getTileSizeX()
    */
@@ -212,16 +212,16 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
 
   /**
    * Will attempt to set the tile width to the desired value and return the actual value which will be used
-   * @param tileSize The tile width you wish to use
+   * @param tileSize The tile width you wish to use. Setting to 0 will disable tiling
    * @return The tile width which will actually be used, this may differ from the value requested.
    *         If the requested value is not supported the writer will return and use the closest appropriate value.
-   * @throws FormatException Tile size must be greater than 0 and less than the image width
+   * @throws FormatException Tile size must be greater than or equal to 0 and less than the image width
    */
   int setTileSizeX(int tileSize) throws FormatException;
 
   /**
    * Retrieves the current tile height
-   * Defaults to full image height if not supported
+   * Defaults to 0 if not supported
    * @return The current tile height being used
    * @throws FormatException Image metadata including Pixels Size Y must be set prior to calling getTileSizeY()
    */
@@ -229,10 +229,10 @@ public interface IFormatWriter extends IFormatHandler, IPyramidHandler {
 
   /**
    * Will attempt to set the tile height to the desired value and return the actual value which will be used
-   * @param tileSize The tile height you wish to use
+   * @param tileSize The tile height you wish to use. Setting to 0 will disable tiling
    * @return The tile height which will actually be used, this may differ from the value requested.
    *         If the requested value is not supported the writer will return and use the closest appropriate value.
-   * @throws FormatException Tile size must be greater than 0 and less than the image height
+   * @throws FormatException Tile size must be greater than or equal to 0 and less than the image height
    */
   int setTileSizeY(int tileSize) throws FormatException;
 

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -538,7 +538,10 @@ public class TiffWriter extends FormatWriter {
   @Override
   public int setTileSizeX(int tileSize) throws FormatException {
     tileSizeX = super.setTileSizeX(tileSize);
-    if (tileSize < TILE_GRANULARITY) {
+    if (tileSize == 0) {
+      tileSizeX = 0;
+    }
+    else if (tileSize < TILE_GRANULARITY) {
       tileSizeX = TILE_GRANULARITY;
     }
     else {
@@ -558,7 +561,10 @@ public class TiffWriter extends FormatWriter {
   @Override
   public int setTileSizeY(int tileSize) throws FormatException {
     tileSizeY = super.setTileSizeY(tileSize);
-    if (tileSize < TILE_GRANULARITY) {
+    if (tileSize == 0) {
+      tileSizeY = 0;
+    }
+    else if (tileSize < TILE_GRANULARITY) {
       tileSizeY = TILE_GRANULARITY;
     }
     else {

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -228,7 +228,7 @@ public class TiffWriter extends FormatWriter {
     int imageHeight = getSizeY();
     int currentTileSizeX = getTileSizeX();
     int currentTileSizeY = getTileSizeY();
-    if (currentTileSizeX != imageWidth || currentTileSizeY != imageHeight) {
+    if (currentTileSizeX > 0 || currentTileSizeY > 0) {
       ifd.put(new Integer(IFD.TILE_WIDTH), new Long(currentTileSizeX));
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(currentTileSizeY));
     }

--- a/components/formats-bsd/src/loci/formats/out/TiffWriter.java
+++ b/components/formats-bsd/src/loci/formats/out/TiffWriter.java
@@ -224,15 +224,14 @@ public class TiffWriter extends FormatWriter {
     int type = FormatTools.pixelTypeFromString(
         retrieve.getPixelsType(series).toString());
     int index = no;
-    int imageWidth = getSizeX();
-    int imageHeight = getSizeY();
     int currentTileSizeX = getTileSizeX();
     int currentTileSizeY = getTileSizeY();
-    if (currentTileSizeX > 0 || currentTileSizeY > 0) {
+    boolean usingTiling = currentTileSizeX > 0 && currentTileSizeY > 0;
+    if (usingTiling) {
       ifd.put(new Integer(IFD.TILE_WIDTH), new Long(currentTileSizeX));
       ifd.put(new Integer(IFD.TILE_LENGTH), new Long(currentTileSizeY));
     }
-    if (currentTileSizeX < w || currentTileSizeY < h) {
+    if (usingTiling && (currentTileSizeX < w || currentTileSizeY < h)) {
       int numTilesX = (w + (x % currentTileSizeX) + currentTileSizeX - 1) / currentTileSizeX;
       int numTilesY = (h + (y % currentTileSizeY) + currentTileSizeY - 1) / currentTileSizeY;
       for (int yTileIndex = 0; yTileIndex < numTilesY; yTileIndex++) {

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -220,7 +220,7 @@ public class TiffWriterTest {
   @Test
   public void testGetTileSizeX() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
-    assertEquals(WriterUtilities.SIZE_X, writer.getTileSizeX());
+    assertEquals(WriterUtilities.SIZE_X, 0);
     writer.close();
     writer = new TiffWriter();
     metadata.setPixelsSizeX(new PositiveInteger(100), 0);
@@ -255,7 +255,7 @@ public class TiffWriterTest {
   @Test
   public void testGetTileSizeY() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
-    assertEquals(WriterUtilities.SIZE_Y, writer.getTileSizeY());
+    assertEquals(WriterUtilities.SIZE_Y, 0);
     writer.close();
     writer = new TiffWriter();
     metadata.setPixelsSizeY(new PositiveInteger(100), 0);
@@ -305,21 +305,17 @@ public class TiffWriterTest {
       writer.setTileSizeX(tile_size);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Size X must not be null")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
     thrown = false;
     try {
       writer.getTileSizeX();
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Size X must not be null")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
     thrown = false;
     try {
       writer.getTileSizeY();

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -336,21 +336,17 @@ public class TiffWriterTest {
       writer.setTileSizeX(0);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Tile size must be > 0")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
     thrown = false;
     try {
       writer.setTileSizeY(0);
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Tile size must be > 0")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
     thrown = false;
     try {
       writer.setTileSizeX(WriterUtilities.SIZE_X);

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -111,8 +111,8 @@ public class TiffWriterTest {
 
   @BeforeClass
   public void readProperty() throws Exception {
-    percentageOfTilingTests = 10;//WriterUtilities.getPropValue("testng.runWriterTilingTests");
-    percentageOfSaveBytesTests = 10;//WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
+    percentageOfTilingTests = WriterUtilities.getPropValue("testng.runWriterTilingTests");
+    percentageOfSaveBytesTests = WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
   }
 
   @BeforeMethod

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -220,12 +220,12 @@ public class TiffWriterTest {
   @Test
   public void testGetTileSizeX() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
-    assertEquals(WriterUtilities.SIZE_X, 0);
+    assertEquals(0, writer.getTileSizeX());
     writer.close();
     writer = new TiffWriter();
     metadata.setPixelsSizeX(new PositiveInteger(100), 0);
     writer.setMetadataRetrieve(metadata);
-    assertEquals(100, writer.getTileSizeX());
+    assertEquals(0, writer.getTileSizeX());
   }
 
   @Test
@@ -255,12 +255,12 @@ public class TiffWriterTest {
   @Test
   public void testGetTileSizeY() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
-    assertEquals(WriterUtilities.SIZE_Y, 0);
+    assertEquals(0, writer.getTileSizeX());
     writer.close();
     writer = new TiffWriter();
     metadata.setPixelsSizeY(new PositiveInteger(100), 0);
     writer.setMetadataRetrieve(metadata);
-    assertEquals(100, writer.getTileSizeY());
+    assertEquals(0, writer.getTileSizeY());
   }
 
   @Test
@@ -305,9 +305,11 @@ public class TiffWriterTest {
       writer.setTileSizeX(tile_size);
     }
     catch(FormatException e) {
-      thrown = true;
+      if (e.getMessage().contains("Size X must not be null")) {
+        thrown = true;
+      }
     }
-    assert(!thrown);
+    assert(thrown);
     thrown = false;
     try {
       writer.getTileSizeX();
@@ -321,11 +323,9 @@ public class TiffWriterTest {
       writer.getTileSizeY();
     }
     catch(FormatException e) {
-      if (e.getMessage().contains("Size Y must not be null")) {
-        thrown = true;
-      }
+      thrown = true;
     }
-    assert(thrown);
+    assert(!thrown);
     writer.setMetadataRetrieve(metadata);
     thrown = false;
     try {

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -255,7 +255,7 @@ public class TiffWriterTest {
   @Test
   public void testGetTileSizeY() throws IOException, FormatException {
     writer.setMetadataRetrieve(metadata);
-    assertEquals(0, writer.getTileSizeX());
+    assertEquals(0, writer.getTileSizeY());
     writer.close();
     writer = new TiffWriter();
     metadata.setPixelsSizeY(new PositiveInteger(100), 0);

--- a/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/TiffWriterTest.java
@@ -86,7 +86,7 @@ public class TiffWriterTest {
       return new Object[][] {{0, false, false, 0, 0, 0, null, 0, false}};
     }
 
-    int[] tileSizes = {1, 32, 43, 64};
+    int[] tileSizes = {1, 32, 43, 64, WriterUtilities.PLANE_WIDTH};
     int[] channelCounts = {1, 3};
     int[] seriesCounts = {1, 5};
     int[] timeCounts = {1};
@@ -100,7 +100,7 @@ public class TiffWriterTest {
     if (percentageOfSaveBytesTests == 0) {
       return new Object[][] {{0, false, false, 0, 0, 0, null, 0, false}};
     }
-    int[] tileSizes = {WriterUtilities.PLANE_WIDTH};
+    int[] tileSizes = {0};
     int[] channelCounts = {1, 3};
     int[] seriesCounts = {1};
     int[] timeCounts = {1, 5};
@@ -111,8 +111,8 @@ public class TiffWriterTest {
 
   @BeforeClass
   public void readProperty() throws Exception {
-    percentageOfTilingTests = WriterUtilities.getPropValue("testng.runWriterTilingTests");
-    percentageOfSaveBytesTests = WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
+    percentageOfTilingTests = 10;//WriterUtilities.getPropValue("testng.runWriterTilingTests");
+    percentageOfSaveBytesTests = 10;//WriterUtilities.getPropValue("testng.runWriterSaveBytesTests");
   }
 
   @BeforeMethod

--- a/components/formats-bsd/test/loci/formats/utests/out/WriterUtilities.java
+++ b/components/formats-bsd/test/loci/formats/utests/out/WriterUtilities.java
@@ -107,7 +107,7 @@ public final class WriterUtilities {
     writer.setCompression(compression);
     writer.setInterleaved(interleaved);
     writer.setBigTiff(bigTiff);
-    if (tileSize != PLANE_WIDTH) {
+    if (tileSize != 0) {
       writer.setTileSizeX(tileSize);
       writer.setTileSizeY(tileSize);
     }


### PR DESCRIPTION
This PR is in response to https://trello.com/c/U9gw1uKc/89-tiling-api-tile-size-image-size

The request was to allow the full image size to be a valid tile size.

Without this PR:
- By default tileSizeX is the image width and tileSizeY is the image height
- These default tile sizes indicate that tiling is not being used
- A tileSize of 0 is invalid and throws an exception

With this PR:
- The default tile sizes are now 0
- A tileSizeX of the image width and tileSizeY of the height are valid sizes and tiling will be used
- A tileSize of 0 is valid and indicates that tiling is not being used

I don't believe there is any need to update the tiling developers page at https://github.com/ome/bio-formats-documentation/blob/9bc5d24a4b3a328f36ca8fd4b668bdc731cffa7e/sphinx/developers/tiling.rst