### PR TITLE
MicroManager: Store channel colors consistent with metadata

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -55,6 +55,7 @@ import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
 import loci.formats.tiff.IFDList;
 import loci.formats.tiff.TiffParser;
+import ome.xml.model.primitives.Color;
 import ome.xml.model.primitives.Timestamp;
 
 import org.xml.sax.Attributes;
@@ -370,6 +371,9 @@ public class MicromanagerReader extends FormatReader {
 
         for (int c=0; c<p.channels.length; c++) {
           store.setChannelName(p.channels[c], i, c);
+        }
+        for (int c=0; c<p.channelColors.length; c++) {
+          store.setChannelColor(Color.valueOf(p.channelColors[c]), i, c);
         }
 
         Length sizeX = FormatTools.getPhysicalSizeX(p.pixelSize);
@@ -750,7 +754,6 @@ public class MicromanagerReader extends FormatReader {
         if (value.length() == 0) {
           continue;
         }
-        value = value.substring(0, value.length() - 1);
         value = value.replaceAll("\"", "");
         if (value.endsWith(",")) value = value.substring(0, value.length() - 1);
         handleKeyValue(key, value);
@@ -761,6 +764,12 @@ public class MicromanagerReader extends FormatReader {
           p.channels = value.split(",");
           for (int q=0; q<p.channels.length; q++) {
             p.channels[q] = p.channels[q].replaceAll("\"", "").trim();
+          }
+        }
+        else if (key.equals("ChColors")) {
+          p.channelColors = value.split(",");
+          for (int q=0; q<p.channelColors.length; q++) {
+            p.channelColors[q] = p.channelColors[q].trim();
           }
         }
         else if (key.equals("Frames")) {
@@ -1215,6 +1224,7 @@ public class MicromanagerReader extends FormatReader {
     public transient String name;
 
     public String[] channels;
+    public String[] channelColors;
 
     public String comment, time;
     public Time exposureTime;

--- a/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
+++ b/components/formats-bsd/src/loci/formats/in/MicromanagerReader.java
@@ -372,8 +372,10 @@ public class MicromanagerReader extends FormatReader {
         for (int c=0; c<p.channels.length; c++) {
           store.setChannelName(p.channels[c], i, c);
         }
-        for (int c=0; c<p.channelColors.length; c++) {
-          store.setChannelColor(Color.valueOf(p.channelColors[c]), i, c);
+        if (p.channelColors != null) {
+          for (int c=0; c<p.channelColors.length; c++) {
+            store.setChannelColor(Color.valueOf(p.channelColors[c]), i, c);
+          }
         }
 
         Length sizeX = FormatTools.getPhysicalSizeX(p.pixelSize);


### PR DESCRIPTION
This issue was raised in forum thread https://www.openmicroscopy.org/community/viewtopic.php?f=13&t=8641&p=20331#p20331

A sample file is available in QA-27124

The thread covers 2 issues:
- The values stored in the metadata when exported from MicroManager differ from those expected. This will need resolution for the MicroManager team
- When opening the OME-TIFF the colors are read from the OME-XML and display correctly based on the stored values. When opening via the metadata file the MicroManagerReader is used and the colors are not stored resulting in different behaviour.

This PR covers the second scenario and should result in the same colors being populated and displayed when opening via either the ome.tiff or the metadata file.

Note the change to remove line 753 was due to it unnecessarily removing an extra character. I am unsure if this will have any unforeseen knock on effect on other metadata being parsed.

To test:
- Without this PR using QA-27124, open with Bio-Formats using the ome.tiff file and then the metadata file. Verify that when opening the ome.tiff that one of the channels appears as Magenta. The metadata file when opened will not have the magenta coloring. 
- Without this PR using QA-27124, use `showinf -omexml -nopix` and verify that with the ome.tiff the channels have color properties populated. With the metadata file the channels will have no color associated with them in the OME-XML
- With the PR rerun the above tests and verify that both files display the same with the Magenta color, and that the OME-XML for both contains color properties for the channels
- Ensure builds and tests are green