### PR TITLE
Bump ome-common to 6.0.0-m2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,6 @@ matrix:
   exclude:
   - jdk: oraclejdk11
     env: BUILD=ant
-  - jdk: openjdk7
-    env: BUILD=ant
-
-before_install:
-  - if [[ $BUILD == 'ant' ]]; then pip install --user flake8 Sphinx; fi
 
 script:
   - ./tools/test-build $BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
 jdk:
   - oraclejdk11
   - oraclejdk8
-  - openjdk7
 
 env:
   - BUILD=maven

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ addons:
     - git
 
 jdk:
+  - openjdk11
   - oraclejdk11
+  - openjdk8
   - oraclejdk8
 
 env:
@@ -28,6 +30,12 @@ matrix:
   exclude:
   - jdk: oraclejdk11
     env: BUILD=ant
+  - jdk: openjdk11
+    env: BUILD=ant
+  - jdk: oraclejdk8
+    env: BUILD=ant
+  - jdk: openjdk8
+    env: BUILD=maven
 
 script:
   - ./tools/test-build $BUILD

--- a/ant/global.xml
+++ b/ant/global.xml
@@ -14,17 +14,8 @@ Type "ant -p" for a list of targets.
 
   <!-- Convenient JDK version properties -->
 
-  <available property="jdk1.7+" classname="java.util.Objects"/>
-  <available property="jdk1.8+" classname="java.util.stream.IntStream"/>
-
   <target name="javadoc-properties">
-    <if>
-      <isset property="jdk1.8+"/>
-      <then>
-        <property name="javadoc.doclint" value="-Xdoclint:none"/>
-      </then>
-    </if>
-    <property name="javadoc.doclint" value=""/>
+    <property name="javadoc.doclint" value="-Xdoclint:none"/>
   </target>
 
   <!-- Convenient platform properties -->

--- a/ant/java.xml
+++ b/ant/java.xml
@@ -229,7 +229,7 @@ your FindBugs installation's lib directory. E.g.:
       <fileset dir="${utils.dir}" includes="**/*.class"/>
     </delete>
     <javac debug="true" includeantruntime="false" fork="true"
-      deprecation="true" source="1.7" target="1.7"
+      deprecation="true" source="1.8" target="1.8"
       encoding="UTF-8"
       srcdir="${utils.dir}" includes="**/*.java"
       classpath="${artifact.dir}/${component.jar}">
@@ -250,7 +250,7 @@ your FindBugs installation's lib directory. E.g.:
       <classpath refid="runtime.classpath"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
-      <link href="http://docs.oracle.com/javase/7/docs/api/"/>
+      <link href="http://docs.oracle.com/javase/8/docs/api/"/>
       <link href="https://imagej.nih.gov/ij/developer/api/"/>
       <link href="http://www.ssec.wisc.edu/visad-docs/javadoc/"/>
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->

--- a/components/bio-formats-plugins/build.properties
+++ b/components/bio-formats-plugins/build.properties
@@ -9,7 +9,7 @@
 component.name           = bio-formats_plugins
 component.jar            = bio-formats_plugins.jar
 component.version        = ${release.version}
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  =

--- a/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
+++ b/components/bio-formats-plugins/src/loci/plugins/util/LibraryChecker.java
@@ -106,9 +106,9 @@ public final class LibraryChecker {
 
   /** Checks for a new enough version of the Java Runtime Environment. */
   public static boolean checkJava() {
-    if (!IJ.isJava17()) {
+    if (!IJ.isJava18()) {
       IJ.error("Bio-Formats Plugins",
-        "Sorry, the Bio-Formats plugins require Java 1.7 or later.");
+        "Sorry, the Bio-Formats plugins require Java 1.8 or later.");
       return false;
     }
     return true;

--- a/components/bio-formats-tools/build.properties
+++ b/components/bio-formats-tools/build.properties
@@ -9,7 +9,7 @@
 component.name           = bio-formats-tools
 component.jar            = bio-formats-tools.jar
 component.version        = ${release.version}
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  =

--- a/components/bundles/bioformats_package/build.xml
+++ b/components/bundles/bioformats_package/build.xml
@@ -30,7 +30,7 @@ Type "ant -p" for a list of targets.
       <classpath refid="runtime.classpath"/>
       <doctitle><![CDATA[<h1>Bio-Formats</h1>]]></doctitle>
       <bottom><![CDATA[${copyright.begin} ${YEAR} ${copyright.end}]]></bottom>
-      <link href="http://docs.oracle.com/javase/7/docs/api/"/>
+      <link href="http://docs.oracle.com/javase/8/docs/api/"/>
       <link href="https://imagej.nih.gov/ij/developer/api/"/>
       <!--<link href="http://www.jdocs.com/formlayout/1.0.4/api/"/>-->
       <!--<link href="http://www.jdocs.com/looks/1.2.2/api/"/>-->

--- a/components/forks/turbojpeg/build.properties
+++ b/components/forks/turbojpeg/build.properties
@@ -9,7 +9,7 @@
 component.name           = turbojpeg
 component.jar            = turbojpeg.jar
 component.version        = 1.2.1
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  =

--- a/components/formats-api/build.properties
+++ b/components/formats-api/build.properties
@@ -9,7 +9,7 @@
 component.name           = formats-api
 component.jar            = formats-api.jar
 component.version        = ${release.version}
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  = 

--- a/components/formats-bsd/build.properties
+++ b/components/formats-bsd/build.properties
@@ -9,7 +9,7 @@
 component.name           = formats-bsd
 component.jar            = formats-bsd.jar
 component.version        = ${release.version}
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  = loci/formats/bio-formats-logo.png \

--- a/components/formats-gpl/build.properties
+++ b/components/formats-gpl/build.properties
@@ -9,7 +9,7 @@
 component.name           = formats-gpl
 component.jar            = formats-gpl.jar
 component.version        = ${release.version}
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  = loci/formats/bio-formats-logo.png \

--- a/components/test-suite/build.properties
+++ b/components/test-suite/build.properties
@@ -9,7 +9,7 @@
 component.name           = bio-formats-testing-framework
 component.jar            = bio-formats-testing-framework.jar
 component.version        = 1.0.0
-component.java-version   = 1.7
+component.java-version   = 1.8
 component.deprecation    = true
 
 component.resources-bin  =

--- a/config/BFSourceFormat.xml
+++ b/config/BFSourceFormat.xml
@@ -48,7 +48,7 @@
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
-<setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
@@ -164,7 +164,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
 <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
@@ -237,7 +237,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_member" value="insert"/>

--- a/pom.xml
+++ b/pom.xml
@@ -213,10 +213,10 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
-          <!-- Require the Java 7 platform. -->
+          <!-- Require the Java 8 platform. -->
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
 
@@ -279,8 +279,8 @@
                  http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5101868 -->
             <use>false</use>
             <links>
-              <!-- Java 7 -->
-              <link>http://docs.oracle.com/javase/7/docs/api/</link>
+              <!-- Java 8 -->
+              <link>http://docs.oracle.com/javase/8/docs/api/</link>
 
               <!-- ImageJ1 -->
               <link>http://jenkins.imagej.net/job/ImageJ1-javadoc/javadoc/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <kryo.version>2.24.0</kryo.version>
     <testng.version>6.8</testng.version>
     <guava.version>17.0</guava.version>
-    <ome-common.version>6.0.0-m1</ome-common.version>
+    <ome-common.version>6.0.0-m2</ome-common.version>
     <ome-model.version>5.6.3</ome-model.version>
     <ome-poi.version>5.3.3</ome-poi.version>
     <ome-mdbtools.version>5.3.2</ome-mdbtools.version>


### PR DESCRIPTION
See https://github.com/ome/ome-common-java/blob/v6.0.0-m2/NEWS.md#600-m2-2018-11-30 for the list of changes

Also disables `openjdk7` on Travis and switch to Java 8 as the minimum version.