### PR TITLE
Gatan DM3/DM4: adjust endianness and record byte count for long values

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -707,7 +707,10 @@ public class GatanReader extends FormatReader {
         return in.readByte();
       case UNKNOWN:
       case UNKNOWN2:
-        return in.readLong();
+        if (adjustEndianness) in.order(!in.isLittleEndian());
+        long l = in.readLong();
+        if (adjustEndianness) in.order(!in.isLittleEndian());
+        return l;
     }
     return 0;
   }
@@ -727,6 +730,9 @@ public class GatanReader extends FormatReader {
       case UBYTE:
       case CHAR:
         return 1;
+      case UNKNOWN:
+      case UNKNOWN2:
+        return 8;
     }
     return 0;
   }


### PR DESCRIPTION
Backported from private PR.  See https://trello.com/c/kTL4I4HP/282-gatan-dm4-missing-metadata

This change fixes reading of long and long array values. Endianness is now swapped as needed, consistent with how other multi-byte values are read. The width of long values is also now correctly defined, so that long array values are all read from the correct file offset.

To test, use the file from QA 21761.  ```showinf -nopix -debug``` without this change should show log messages during tag parsing similar to ```unknown type```.  The original metadata table should contain ~60 key/value pairs.

The same test with this change should not show any ```unknown type``` messages during tag parsing, and the original metadata table should be substantially larger (> 200 key/value pairs).

Not a high priority for the next milestone (or 6.0.0 in general).  I wouldn't expect this to cause any test failures or impact memo files, so would be safe for a patch release if needed. 