### PR TITLE
PyramidTiff: fix subresolution recording

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
+++ b/components/formats-gpl/src/loci/formats/in/PyramidTiffReader.java
@@ -61,6 +61,8 @@ public class PyramidTiffReader extends BaseTiffReader {
     suffixSufficient = false;
     suffixNecessary = false;
     equalStrips = true;
+    noSubresolutions = true;
+    canSeparateSeries = false;
   }
 
   // -- IFormatReader API methods --
@@ -126,9 +128,10 @@ public class PyramidTiffReader extends BaseTiffReader {
 
     // repopulate core metadata
     core.clear();
+    core.add();
     for (int s=0; s<seriesCount; s++) {
       CoreMetadata ms = new CoreMetadata();
-      core.add(ms);
+      core.add(0, ms);
 
       if (s == 0) {
         ms.resolutionCount = seriesCount;


### PR DESCRIPTION
See https://trello.com/c/2BwFsSmS/95-broken-pyramidtiffreader-reader

To test, use any of the files from ```/uod/idr/filesets/idr0053-faas-virtualnanoscopy/20181128-ftp```.  Without this change (on develop), ```showinf -nopix -noflat -omexml``` should show multiple series none of which have a subresolution.  With this change, the same test should show a single series with multiple subresolutions; the ```Image``` count in the resulting OME-XML should be 1.

One of the smaller files has been configured and copied to ```curated/pyramid-tiff/idr0053/MEFS_cryo.tif``` for automated testing.