### PR TITLE
Gatan: allow ROIs to be stored in DocumentObjectList groups

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/GatanReader.java
+++ b/components/formats-gpl/src/loci/formats/in/GatanReader.java
@@ -566,7 +566,10 @@ public class GatanReader extends FormatReader {
       if (value != null) {
         addGlobalMeta(labelString, value);
 
-        if (parent != null && parent.equals("AnnotationGroupList")) {
+        if (parent != null &&
+          (parent.equals("AnnotationGroupList") ||
+          parent.equals("DocumentObjectList")))
+        {
           // ROI found
           ROIShape shape = new ROIShape();
           if (labelString.equals("AnnotationType")) {


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/issues/3188 and QA 21647.

To test, use the file in ```curated/gatan/qa-21647/```.  Without this change, ```showinf -debug``` should throw an ```ArrayIndexOutOfBoundsException```.  With this change, ```showinf -normalize -omexml``` should correctly display the image and OME-XML.