### PR TITLE
ImageJ export: preserve physical size units

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
+++ b/components/bio-formats-plugins/src/loci/plugins/out/Exporter.java
@@ -505,10 +505,10 @@ public class Exporter {
 
             Calibration cal = imp.getCalibration();
 
-            store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(cal.pixelWidth), 0);
-            store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(cal.pixelHeight), 0);
-            store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(cal.pixelDepth), 0);
-            store.setPixelsTimeIncrement(new Time(new Double(cal.frameInterval), UNITS.SECOND), 0);
+            store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(cal.pixelWidth, cal.getXUnit()), 0);
+            store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(cal.pixelHeight, cal.getYUnit()), 0);
+            store.setPixelsPhysicalSizeZ(FormatTools.getPhysicalSizeZ(cal.pixelDepth, cal.getZUnit()), 0);
+            store.setPixelsTimeIncrement(FormatTools.getTime(new Double(cal.frameInterval), cal.getTimeUnit()), 0);
 
             if (imp.getImageStackSize() !=
                     imp.getNChannels() * imp.getNSlices() * imp.getNFrames())


### PR DESCRIPTION
See https://github.com/openmicroscopy/bioformats/issues/3127

Both the physical sizes and units are now taken from the ImagePlus' Calibration.  This should have no impact on the common case where physical sizes are unchanged after import, but should fix the case when units are changed after import.

To test, make sure that the original bug is fixed by running the macro in https://github.com/openmicroscopy/bioformats/issues/3127 with this change.  ```showinf -omexml``` on the resulting file should also confirm that the correct physical sizes are stored.  Also test with line 12 of the macro commented out (the first ```run("Properties..." ...```) and uncommented but with a unit that obviously cannot be mapped to an OME unit (I tried ```unit=december```).  Opening files using the Bio-Formats importer plugin and then exporting again should also continue to work as before.

Not sure if there are any other use cases to consider, or if/how this differs from the NPE-producing test mentioned in https://github.com/openmicroscopy/bioformats/issues/3127#issuecomment-382781009.
ImageJ allows the specified units to be free-form, so I do wonder if we should be doing any extra checking/logging in the case where a unit string cannot be mapped to real unit enum (as in the ```unit=december``` test above).