### PR TITLE
Fix tests to fail when a configured file throws UnknownFormatException

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTestFactory.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 
 import loci.common.DataTools;
 import loci.formats.FileStitcher;
+import loci.formats.UnknownFormatException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,7 +245,24 @@ public class FormatReaderTestFactory {
       String file = fileSet.iterator().next();
       try {
         reader.setId(file);
-      } catch (Exception e) {
+      }
+      catch (UnknownFormatException u) {
+        boolean validConfig = false;
+        try {
+          validConfig = FormatReaderTest.configTree.get(file) != null;
+        }
+        catch (IOException e) { }
+        if (validConfig) {
+          LOGGER.error("setId(\"{}\") failed", file, u);
+          failingIds.add(file);
+        }
+        else {
+          LOGGER.debug("Skipping file {} with unknown type", file);
+        }
+        fileSet.remove(file);
+        continue;
+      }
+      catch (Exception e) {
         LOGGER.error("setId(\"{}\") failed", file, e);
         failingIds.add(file);
         fileSet.remove(file);

--- a/components/test-suite/src/loci/tests/testng/TestTools.java
+++ b/components/test-suite/src/loci/tests/testng/TestTools.java
@@ -353,9 +353,9 @@ public class TestTools {
                !subsList.get(i).endsWith("test_setup.ini")) {
         if (typeTester.isThisType(subsList.get(i))) {
           LOGGER.debug("\tOK");
-          files.add(file.getAbsolutePath());
         }
         else LOGGER.debug("\tunknown type");
+        files.add(file.getAbsolutePath());
       }
       file = null;
     }


### PR DESCRIPTION
Prior to this change, any file for which ```isThisType``` did not return true in at least one reader would have been removed from the list of tests.  This meant that regressions affecting ```isThisType``` (especially on non-TIFF readers) were not necessarily detected.

I encountered this issue while in the process of backporting a private PR affecting ```MRCReader```, but it's fairly easy to test even with fake files.  To set up (without this change):

```
$ mkdir $TEST
$ touch $TEST/test.fake
$ ant -Dtestng.configDirectory=$TEST -Dtestng.directory=$TEST test-config
$ touch $TEST/unreadable-file.txt
$ ant -Dtestng.configDirectory=$TEST -Dtestng.directory=$TEST test-automated # this should pass
# now apply https://gist.github.com/melissalinkert/16afa151faa5f076b7f7ffce85597403 and rebuild
$ ant -Dtestng.configDirectory=$TEST -Dtestng.directory=$TEST test-automated # this should still pass, with 0 files tested
```

With this change and https://gist.github.com/melissalinkert/16afa151faa5f076b7f7ffce85597403:

```
$ ant -Dtestng.configDirectory=$TEST -Dtestng.directory=$TEST test-automated
```

should fail - only ```test.fake``` is tested, and ```setId``` fails with ```UnknownFormatException```.  With this change only (revert https://gist.github.com/melissalinkert/16afa151faa5f076b7f7ffce85597403):

```
$ ant -Dtestng.configDirectory=$TEST -Dtestng.directory=$TEST test-automated
```

should pass with only ```test.fake``` tested.  ```unreadable-file.txt``` is not tested because it throws ```UnknownFormatException``` and is not configured with ```test=true```, which means that we hopefully won't get additional false negatives from various extra text files that are scattered throughout the repo.

I'd hope that this wouldn't cause any additional test failures, but will keep an eye on tomorrow's build and note any changes here.
