### PR TITLE
MRC: fix endian detection in isThisType for old style headers

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -173,6 +173,7 @@ public class DeltavisionReader extends FormatReader {
     final int blockLen = 212;
     if (!FormatTools.validStream(stream, blockLen, true)) return false;
     stream.seek(96);
+    stream.order(true);
     int magic = stream.readShort() & 0xffff;
     boolean valid = magic == DV_MAGIC_BYTES_1 || magic == DV_MAGIC_BYTES_2;
     if (!valid) {
@@ -188,8 +189,12 @@ public class DeltavisionReader extends FormatReader {
     int x = stream.readInt();
     int y = stream.readInt();
     int count = stream.readInt();
+    // don't compare x * y * count to stream length,
+    // as that will reject any truncated files
+    // instead just check that at least one plane plus a header
+    // could be read
     return x > 0 && y > 0 && count > 0 &&
-      ((long) x * (long) y * (long) count < stream.length());
+      (HEADER_LENGTH + ((long) x * (long) y) <= stream.length());
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */

--- a/components/formats-gpl/src/loci/formats/in/MRCReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MRCReader.java
@@ -28,6 +28,7 @@ package loci.formats.in;
 import java.io.IOException;
 import java.math.BigInteger;
 
+import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -89,15 +90,21 @@ public class MRCReader extends FormatReader {
     stream.seek(0);
 
     int x = stream.readInt();
-    if (x <= 0 || x >= stream.length()) {
+    if ((x <= 0 || x >= stream.length()) &&
+      (DataTools.swap(x) <= 0 || DataTools.swap(x) >= stream.length()))
+    {
       return false;
     }
     int y = stream.readInt();
-    if (y <= 0 || y >= stream.length()) {
+    if ((y <= 0 || y >= stream.length()) &&
+      (DataTools.swap(y) <= 0 || DataTools.swap(y) >= stream.length()))
+    {
       return false;
     }
     int z = stream.readInt();
-    if (z <= 0 || z >= stream.length()) {
+    if ((z <= 0 || z >= stream.length()) &&
+      (DataTools.swap(z) <= 0 || DataTools.swap(z) >= stream.length()))
+    {
       return false;
     }
     return true;


### PR DESCRIPTION
4b771c5 backported from a private PR; 7cdaac0 added to fix test failures.   See the definition of offsets 196-216 in https://bio3d.colorado.edu/imod/doc/mrc_format.txt.  New style headers have an explicit endianness marker, but old style headers do not.

To test, use the file ```mrc/gh-3297/old-header/```, which was hand-created from an existing sample file (see the readme).  Without this change, ```showinf -nopix``` should throw ```UnknownFormatException```.  With this change, ```showinf -normalize``` should result in the file being detected as MRC, with sensible looking pixel data displayed.

While ```mrc/gh-3297/old-header``` has a little-endian example with an old style header, ```mrc/samples/golgi.mrc``` is a big-endian example with an old style header - so we do have to handle both cases.

This is the change that prompted #3296.  I would not expect any test failures, and this should be safe for a patch release if needed.