### PR TITLE
ND2: fix handling of duplicate and incomplete exposure time lists

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -847,7 +847,9 @@ public class ND2Handler extends BaseHandler {
       }
       // exposure times are often defined once in a PropertiesFast block,
       // and again in a PropertiesQuality block
-      else if (key.equals("Exposure") && "PropertiesQuality".equals(prevElement)) {
+      else if (key.equals("Exposure") &&
+        ("no_name".equals(prevElement) || "PropertiesQuality".equals(prevElement)))
+      {
         String[] s = value.trim().split(" ");
         Double time = DataTools.parseDouble(s[0]);
         if (time != null) {

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -845,7 +845,9 @@ public class ND2Handler extends BaseHandler {
         String temp = value.replaceAll("[\\D&&[^-.]]", "");
         temperature.add(DataTools.parseDouble(temp));
       }
-      else if (key.equals("Exposure")) {
+      // exposure times are often defined once in a PropertiesFast block,
+      // and again in a PropertiesQuality block
+      else if (key.equals("Exposure") && "PropertiesQuality".equals(prevElement)) {
         String[] s = value.trim().split(" ");
         Double time = DataTools.parseDouble(s[0]);
         if (time != null) {

--- a/components/formats-gpl/src/loci/formats/in/ND2Handler.java
+++ b/components/formats-gpl/src/loci/formats/in/ND2Handler.java
@@ -692,7 +692,7 @@ public class ND2Handler extends BaseHandler {
         if (magIndex + 1 < tokens.length) immersion = tokens[magIndex + 1];
       }
       else if (key.endsWith("dTimeMSec")) {
-        Long v = DataTools.parseLong(value);
+        Long v = DataTools.parseDouble(value).longValue();
         if (!ts.contains(v)) {
           ts.add(v);
           metadata.put("number of timepoints", ts.size());
@@ -848,7 +848,7 @@ public class ND2Handler extends BaseHandler {
       // exposure times are often defined once in a PropertiesFast block,
       // and again in a PropertiesQuality block
       else if (key.equals("Exposure") &&
-        ("no_name".equals(prevElement) || "PropertiesQuality".equals(prevElement)))
+        (prevElement == null || "no_name".equals(prevElement) || "PropertiesQuality".equals(prevElement)))
       {
         String[] s = value.trim().split(" ");
         Double time = DataTools.parseDouble(s[0]);
@@ -891,7 +891,7 @@ public class ND2Handler extends BaseHandler {
         exWave.add(new Double(v[0]));
       }
       else if (key.equals("Power")) {
-        power.add(DataTools.parseInteger(value));
+        power.add(DataTools.parseDouble(value).intValue());
       }
       else if (key.equals("CameraUniqueName")) {
         cameraModel = value;

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2119,10 +2119,16 @@ public class NativeND2Reader extends SubResolutionFormatReader {
     }
 
     // populate PlaneTiming and StagePosition data
-    if (handler != null && handler.getExposureTimes().size() > 0 &&
-      (exposureTime.size() == 0 || exposureTime.size() % getSizeC() != 0))
-    {
-      exposureTime = handler.getExposureTimes();
+    if (handler != null && handler.getExposureTimes().size() > 0) {
+      if (exposureTime.size() == 0 || handler.getExposureTimes().size() == 1 || exposureTime.size() % getSizeC() != 0) {
+        exposureTime = handler.getExposureTimes();
+        if (backupHandler != null && backupHandler.getExposureTimes().size() > exposureTime.size()) {
+          exposureTime = backupHandler.getExposureTimes();
+        }
+      }
+      else if (backupHandler == null || backupHandler.getExposureTimes().size() == 0) {
+        exposureTime = handler.getExposureTimes();
+      }
     }
     int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());
     for (int i=0; i<getSeriesCount(); i++) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2141,6 +2141,11 @@ public class NativeND2Reader extends SubResolutionFormatReader {
           if (exposureTime.size() >= getSizeC() && exposureTime.size() < getSizeC() * getSeriesCount()) {
             index = coords[1];
           }
+          else if (exposureTime.size() == 1) {
+            // if exposure times are the same for all channels,
+            // then sometimes only one value is stored
+            index = 0;
+          }
           if (exposureTime != null && index < exposureTime.size() && exposureTime.get(index) != null) {
             store.setPlaneExposureTime(new Time(exposureTime.get(index), UNITS.SECOND), i, n);
           }

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -2138,7 +2138,7 @@ public class NativeND2Reader extends SubResolutionFormatReader {
           }
 
           int index = i * getSizeC() + coords[1];
-          if (exposureTime.size() == getSizeC()) {
+          if (exposureTime.size() >= getSizeC() && exposureTime.size() < getSizeC() * getSeriesCount()) {
             index = coords[1];
           }
           if (exposureTime != null && index < exposureTime.size() && exposureTime.get(index) != null) {

--- a/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/NativeND2Reader.java
@@ -1974,7 +1974,9 @@ public class NativeND2Reader extends SubResolutionFormatReader {
           currentColor = (Integer) value;
         }
         else if (name.equals("dExposureTime")) {
-          exposureTime.add((Double) value);
+          if ((Double) value > 0) {
+            exposureTime.add(((Double) value) / 1000);
+          }
         }
         else if (name.equals("EmWavelength")) {
           Double wave = Double.parseDouble(value.toString());
@@ -2117,7 +2119,9 @@ public class NativeND2Reader extends SubResolutionFormatReader {
     }
 
     // populate PlaneTiming and StagePosition data
-    if (handler != null && handler.getExposureTimes().size() > 0) {
+    if (handler != null && handler.getExposureTimes().size() > 0 &&
+      (exposureTime.size() == 0 || exposureTime.size() % getSizeC() != 0))
+    {
       exposureTime = handler.getExposureTimes();
     }
     int zcPlanes = getImageCount() / ((split ? getSizeC() : 1) * getSizeT());


### PR DESCRIPTION
See https://trello.com/c/UnDryDi9/113-fix-exposure-times-for-control003nd2

https://github.com/openmicroscopy/data_repo_config/pull/353 updates the configuration for public QA 9507 to match the expected ground truth as recorded in https://github.com/openmicroscopy/bioformats/pull/3292#issuecomment-448717313

Exposure times are defined multiple times in multiple places.  This reduces the duplicates so that consecutive times correspond to consecutive channels, and handles the case when the exposure time list is larger than the ```SizeC``` for a single series, but smaller than the sum of ```SizeC``` for all series.

Not sure if this will cause any other test failures, but will keep an eye on tomorrow's build.  If there are additional test failures, it's possible that the configurations would need to change instead of this PR.