### PR TITLE
Zeiss CZI: handle invalid JPEG-XR tiles

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3709,7 +3709,13 @@ public class ZeissCZIReader extends FormatReader {
           options.height = directoryEntry.dimensionEntries[1].storedSize;
           options.maxBytes = options.width * options.height *
             getRGBChannelCount() * bytesPerPixel;
-          data = new JPEGXRCodec().decompress(data, options);
+          try {
+            data = new JPEGXRCodec().decompress(data, options);
+          }
+          catch (FormatException e) {
+            LOGGER.warn("Could not decompress block; some pixels may be 0", e);
+            data = new byte[options.maxBytes];
+          }
           break;
         case 104: // camera-specific packed pixels
           data = decode12BitCamera(data, options.maxBytes);

--- a/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
+++ b/components/formats-gpl/src/loci/formats/services/JPEGXRServiceImpl.java
@@ -50,9 +50,15 @@ public class JPEGXRServiceImpl extends AbstractService implements JPEGXRService 
    */
   public byte[] decompress(byte[] compressed) throws FormatException {
       LOGGER.trace("begin tile decode; compressed size = {}", compressed.length);
-      byte[] raw = Decode.decodeFirstFrame(compressed, 0, compressed.length);
-      LOGGER.trace("retrieved decompressed bytes size = {}", raw.length);
-      return raw;
+      try {
+        byte[] raw = Decode.decodeFirstFrame(compressed, 0, compressed.length);
+        LOGGER.trace("retrieved decompressed bytes size = {}", raw.length);
+        return raw;
+      }
+      // really only want to catch ome.jxrlib.FormatError, but that doesn't compile
+      catch (Exception e) {
+        throw new FormatException(e);
+      }
   }
 
 }


### PR DESCRIPTION
See QA 27169.

The code in the QA issue indicates that several tiles in the lower right corner of the largest image (the file contains a pyramid) cannot be read.  Checking the actual compressed bytes in each tile indicates that a JPEG-XR stream is present, but invalid.  One example is the tile whose upper left corner is (23216, 38012).  Opening the file in ZEN reliably produces this error the first time the mouse is moved over one of the affected tiles:

![zen-screenshot](https://user-images.githubusercontent.com/109998/50306085-3b4d4c00-045a-11e9-80a1-26ef759a4169.jpg)

Subsequent mouse-overs show pixel values of 0 for the last channel.

With this change, the test code in QA and reading affected tiles via ```showinf -crop``` should all work without an exception being thrown.  The wrapped ```ome.jxrlib.FormatError``` should be logged at ```WARN```, though, so it's clear that decodes were not successful.

The QA report mentions making the sample file public, but I have not yet done this as there is no contact information for the submitter.