### PR TITLE
Simplified bfGetPlane.m, avoids a data copy

### DIFF
--- a/components/formats-gpl/matlab/bfGetPlane.m
+++ b/components/formats-gpl/matlab/bfGetPlane.m
@@ -79,22 +79,13 @@ plane = r.openBytes(...
     ip.Results.iPlane - 1, ip.Results.x - 1, ip.Results.y - 1, ...
     ip.Results.width, ip.Results.height);
 
-% convert byte array to MATLAB image
-if sgn
-    % can get the data directly to a matrix
-    I = javaMethod('makeDataArray2D', 'loci.common.DataTools', plane, ...
-        bpp, fp, little, ip.Results.height);
-else
-    % get the data as a vector, either because makeDataArray2D
-    % is not available, or we need a vector for typecast
-    I = javaMethod('makeDataArray', 'loci.common.DataTools', plane, ...
-        bpp, fp, little);
-end
-
-% Java does not have explicitly unsigned data types;
-% hence, we must inform MATLAB when the data is unsigned
+% Convert byte array to MATLAB image
+I = javaMethod('makeDataArray2D', 'loci.common.DataTools', plane, ...
+    bpp, fp, little, ip.Results.height);
 if ~sgn
-    % NB: arr will always be a vector here
+    % Java does not have explicitly unsigned data types;
+    % hence, we must inform MATLAB when the data is unsigned
+    I = I(:);        % Need vector for typecast
     switch class(I)
         case 'int8'
             I = typecast(I, 'uint8');
@@ -105,10 +96,5 @@ if ~sgn
         case 'int64'
             I = typecast(I, 'uint64');
     end
-end
-
-if isvector(I)
-    % convert results from vector to matrix
-    shape = [ip.Results.width ip.Results.height];
-    I = reshape(I, shape)';
+    I = reshape(I, [ip.Results.height ip.Results.width]); % Convert back to matrix
 end


### PR DESCRIPTION
The original code contains a transpose operation `'` for unsigned integer images (i.e. most image files). This transpose incurs a data copy that is not necessary. This commit avoids this data copy by using the Java method `makeDataArray2D` also for unsigned int images, the resulting 2D array is reshaped to a vector to call `typecast`, and then reshaped back (reshaping does not copy data).