### PR TITLE
CellSens: fixes for tag parsing and single-file datasets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellSensReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellSensReader.java
@@ -406,6 +406,7 @@ public class CellSensReader extends FormatReader {
 
   private transient boolean expectETS = false;
   private transient int channelCount = 0;
+  private transient int zCount = 0;
 
   // -- Constructor --
 
@@ -609,6 +610,7 @@ public class CellSensReader extends FormatReader {
       expectETS = false;
       pyramids.clear();
       channelCount = 0;
+      zCount = 0;
     }
   }
 
@@ -701,8 +703,12 @@ public class CellSensReader extends FormatReader {
       if (ifds.size() > 1) {
         if (ifds.get(1).getSamplesPerPixel() == 1) {
           seriesCount = 2;
-          if (channelCount == 0) {
+          if (channelCount == 0 && zCount == 0) {
             channelCount = ifds.size() - 1;
+          }
+          else if (zCount > 0) {
+            zCount /= 2;
+            channelCount = (ifds.size() - 1) / zCount;
           }
         }
         else {
@@ -1819,6 +1825,9 @@ public class CellSensReader extends FormatReader {
             }
             if ("Channel Wavelength Value".equals(tagPrefix + tagName)) {
               channelCount++;
+            }
+            else if ("Z valueValue".equals(tagPrefix + tagName)) {
+              zCount++;
             }
           }
           storedValue = value;


### PR DESCRIPTION
Backported from a private PR.

c3161bc fixes a subtle bug in tag parsing that resulted in some metadata being missing or incorrect.  The ```cellsens/olivier/small-tiles/``` dataset should be the only one impacted by this change (see forthcoming configuration PR with screenshots).

The remaining two commits expand support for .vsi files that do not have associated .ets files.  Affected files are:

```
cellsens/samples/Channels/Composite.vsi
cellsens/samples/Count & Measure/Cell Multichannel-z-stack corr..vsi
cellsens/samples/Count & Measure/Cell Multichannel-z-stack.vsi
cellsens/samples/Fluorescence/Dako_CISH.vsi
cellsens/robert/Lung_Mite.vsi
```

In all cases, ```showinf``` should show that the first series is the same with or without this PR.  With this PR, all files should have at least one additional series, and should more closely match what is shown in Olympus' OlyVIA software (see screenshots on forthcoming configuration PR).

I wouldn't expect this to affect memo files, so probably safe to defer to a patch release if needed.