### PR TITLE
NDPISReader: handle variants where a constituent NDPI has no wavelength

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/NDPISReader.java
+++ b/components/formats-gpl/src/loci/formats/in/NDPISReader.java
@@ -212,10 +212,13 @@ public class NDPISReader extends FormatReader {
       Float wavelength = (Float) ifd.getIFDValue(TAG_EMISSION_WAVELENGTH);
 
       store.setChannelName(channelName, 0, c);
-      store.setChannelEmissionWavelength(new Length(wavelength, UNITS.NANOMETER), 0, c);
+      if (wavelength != null) {
+        store.setChannelEmissionWavelength(FormatTools.getEmissionWavelength(
+          (Double) wavelength.doubleValue()), 0, c);
+      }
 
       bandUsed[c] = 0;
-      if (ifd.getSamplesPerPixel() >= 3) {
+      if (ifd.getSamplesPerPixel() >= 3 && wavelength != null) {
         // define band used based on emission wavelength
         // wavelength = 0  Colour Image
         // 380 =< wavelength <= 490 Blue


### PR DESCRIPTION
Closes #3282 

Automated tests for Hamamatsu NDPI should remain green incl. the validation of wavelength for existing NDPIS datasets.
The new supplied dataset in #3282 should now open with Bio-Formats: two channels have no emission wavelength while the Cy5 and Trtc channels have an emission wavelength metadata.