### PR TITLE
TIFF: ignore FillOrder unless uncompressed or fax compressed

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -779,7 +779,9 @@ public class TiffParser {
 
     // reverse bits in each byte if FillOrder == 2
 
-    if (ifd.getIFDIntValue(IFD.FILL_ORDER) == 2) {
+    if (ifd.getIFDIntValue(IFD.FILL_ORDER) == 2 &&
+      compression.getCode() <= TiffCompression.GROUP_4_FAX.getCode())
+    {
       for (int i=0; i<tile.length; i++) {
         tile[i] = (byte) (Integer.reverse(tile[i]) >> 24);
       }


### PR DESCRIPTION
See:

https://trello.com/c/NFuiPd4s/45-large-tiff-0-pixel-value
https://trello.com/c/7pSOeMJF/46-big-tiff-breakage-in-571
https://trello.com/c/fKOcj8sd/47-tiff-incorrect-fillorder

and in particular rationale for this change in https://trello.com/c/fKOcj8sd/47-tiff-incorrect-fillorder#comment-5c1aca32a935af64b5348fb2

Test files are ```curated/tiff/darwinjob/SESSION4_Image2.tif```, ```curated/tiff/qa-20514/819_2.tif```, and ```/ome/team/mlinkert/tiff-fill-order/stephane-dallongeville/716_2.tif``` (not copied due to permissions issues).  All have large XY dimensions, and should be completely black without this PR.  With this PR, all should look like regular whole slide images with white backgrounds.