### PR TITLE
Olympus OIR: compare absolute file paths when reading pixels files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -614,7 +614,7 @@ public class OIRReader extends FormatReader {
     // seek past reference image blocks
     while (skipPixelBlock(file, s, false));
 
-    if (s.getFilePointer() == pixelStart && !file.endsWith(currentId)) {
+    if (s.getFilePointer() == pixelStart && !isCurrentFile(file)) {
       while (s.readInt() != 0xffffffff);
       s.skipBytes(4);
     }
@@ -639,7 +639,7 @@ public class OIRReader extends FormatReader {
       }
       LOGGER.trace("xml = {}", xml);
       if (((channels.size() == 0 || getSizeX() == 0 || getSizeY() == 0) &&
-        file.endsWith(currentId)) || xml.indexOf("lut:LUT") > 0)
+        isCurrentFile(file)) || xml.indexOf("lut:LUT") > 0)
       {
         parseXML(s, xml, fp);
       }
@@ -706,7 +706,7 @@ public class OIRReader extends FormatReader {
       long fp = s.getFilePointer();
       String xml = s.readString(xmlLength).trim();
       LOGGER.trace("xml = {}", xml);
-      if (file.endsWith(currentId) || xml.indexOf("lut:LUT") > 0) {
+      if (isCurrentFile(file) || xml.indexOf("lut:LUT") > 0) {
         parseXML(s, xml, fp);
       }
     }
@@ -1429,6 +1429,11 @@ public class OIRReader extends FormatReader {
       return 0;
     }
     return Integer.parseInt(uid.substring(index + 1));
+  }
+
+  private boolean isCurrentFile(String file) {
+    String currentPath = new Location(currentId).getAbsolutePath();
+    return currentPath.equals(new Location(file).getAbsolutePath());
   }
 
   // -- Helper classes --


### PR DESCRIPTION
Backported from private PR; opening to check test impact, but not expecting this to be included in 6.0.0 (can exclude after one test run if needed).

This ensures that the file path is normalized, so that the file
separators will be the same across all files.  This prevents weird
problems on Windows where passing ```/path/to/file.oir``` throws an
exception but ```\path\to\file.oir``` is fine.

Without this PR and any single-file .oir on Windows:

```
PS E:\tmp>./showinf ./file.oir
```

should throw an exception but ```./showinf .\file.oir``` should successfully read all planes.

With this change, both tests should successfully read all planes.

The incorrect behavior is more immediately obvious in Git Bash, since tab-completing the file name uses ```/```, while tab-completing in PowerShell replaces ```/``` with ```\```.  The exception above can be reproduced in PowerShell, though, just take care to type/paste the file name with ```/``` separators and don't touch the tab key.

Memo files and non-Windows behavior should be unaffected; this should be fine for a patch release.