### PR TITLE
MSR: Add null pointer check for "xyz-Table Z Resolution"

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ImspectorReader.java
@@ -414,12 +414,15 @@ public class ImspectorReader extends FormatReader {
           catch (NumberFormatException e) { }
         }
         else if (key.equals("xyz-Table Z Resolution")) {
-          int z = DataTools.parseDouble(value).intValue();
-          if (z == 1 && getSizeZ() > 1) {
-            originalT = getSizeT();
-            originalZ = getSizeZ();
-            m.sizeT *= getSizeZ();
-            m.sizeZ = 1;
+          Double doubleValue = DataTools.parseDouble(value);
+          if (doubleValue != null) {
+            int z = doubleValue.intValue();
+            if (z == 1 && getSizeZ() > 1) {
+              originalT = getSizeT();
+              originalZ = getSizeZ();
+              m.sizeT *= getSizeZ();
+              m.sizeZ = 1;
+            }
           }
         }
         else if (key.equals("Time Time Resolution")) {


### PR DESCRIPTION
This was reported in http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2019-February/004320.html and can be tested using QA-27309

With the QA file the value of "xyz-Table Z Resolution" is "false", which throws a NullPointerException when parsing the value. This PR adds a check for the null pointer and ignores the value.

To test, use QA-27309, with this PR included the file should open and display without any exception being thrown.