### PR TITLE
TIFF: clear buffer before returning when tile byte count or offset is invalid

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -34,6 +34,7 @@ package loci.formats.tiff;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
@@ -769,6 +770,9 @@ public class TiffParser {
 
     if (buf == null) buf = new byte[size];
     if (stripByteCounts[countIndex] == 0 || stripOffset >= in.length()) {
+      // make sure that the buffer is cleared before returning
+      // the caller may be reusing the same buffer for multiple calls to getTile
+      Arrays.fill(buf, (byte) 0);
       return buf;
     }
     byte[] tile = new byte[(int) stripByteCounts[countIndex]];


### PR DESCRIPTION
Backported from a private PR.

This ensures that any TIFF tile with an invalid offset or byte count of 0 will have pixel values set to 0.  Without this change, the tile would have been filled with data from the previously read tile, so the pixel values would have varied depending upon the order in which the tiles were retrieved.

To test, use ```curated/svs/alexandra/UMD001_ORO.svs```.  Compare the images shown by these two commands with and without this PR:

```
$ showinf UMD001_ORO.svs -crop 0,10500,512,541 # bottom 541 pixels
$ showinf UMD001_ORO.svs -crop 0,11040,512,1 # bottom 1 pixel
```

The second command should always show pixel values of 0.  The first command without this PR will show that the bottom row of pixels are not 0; with this PR they should all be 0.

See also http://trac.openmicroscopy.org/ome/ticket/2367.

I would expect this to be safe for a patch release, but am not sure if or how badly this will fail tests.  A configuration PR may be needed depending upon the status of builds in the morning.