### PR TITLE
Add test for HCS metadata

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -614,10 +614,10 @@ public class ScanrReader extends FormatReader {
       store.setPlateAcquisitionMaximumFieldCount(fieldCount, 0, 0);
     }
 
+    int index = 0;
     for (int i=0; i<getSeriesCount(); i++) {
       int field = i % nFields;
       int well = i / nFields;
-      int index = well;
       while (wellNumbers.get(index) == null && index < wellNumbers.size()) {
         index++;
       }
@@ -646,6 +646,7 @@ public class ScanrReader extends FormatReader {
       store.setImageName(name, i);
 
       store.setPlateAcquisitionWellSampleRef(wellSample, 0, 0, i);
+      index++;
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -646,7 +646,9 @@ public class ScanrReader extends FormatReader {
       store.setImageName(name, i);
 
       store.setPlateAcquisitionWellSampleRef(wellSample, 0, 0, i);
-      index++;
+      if (field == nFields - 1) {
+        index++;
+      }
     }
 
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1388,6 +1388,89 @@ public class FormatReaderTest {
     result(testName, true);
   }
 
+  @Test(groups = {"all", "fast", "automated"})
+  public void testHCSMetadata() {
+    if (config == null) throw new SkipException("No config tree");
+    String testName = "HCS";
+    if (!initFile()) result(testName, false, "initFile");
+    IMetadata retrieve = (IMetadata) reader.getMetadataStore();
+
+    for (int s=0; s<reader.getSeriesCount(); s++) {
+      config.setSeries(s);
+      String failureSuffix = " incorrect for series " + s;
+
+      int plate = config.getPlate();
+      if (plate >= retrieve.getPlateCount()) {
+        result(testName, false, "Plate index" + failureSuffix);
+      }
+      else if (plate < 0) {
+        if (retrieve.getPlateCount() > 0) {
+          result(testName, false, "Plate index" + failureSuffix);
+        }
+        continue;
+      }
+      boolean foundWell = false;
+      for (int w=0; w<retrieve.getWellCount(plate); w++) {
+        int row = config.getWellRow();
+        int col = config.getWellColumn();
+        if (row == retrieve.getWellRow(plate, w).getNumberValue().intValue() &&
+          col == retrieve.getWellColumn(plate, w).getNumberValue().intValue())
+        {
+          foundWell = true;
+
+          int wellSample = config.getWellSample();
+          String image = retrieve.getImageID(s);
+          if (wellSample >= retrieve.getWellSampleCount(plate, w) ||
+            wellSample < 0 ||
+            !image.equals(retrieve.getWellSampleImageRef(plate, w, wellSample)))
+          {
+            result(testName, false, "WellSample index" + failureSuffix);
+          }
+
+          Length positionX = retrieve.getWellSamplePositionX(plate, w, wellSample);
+          Length positionY = retrieve.getWellSamplePositionY(plate, w, wellSample);
+          Length configX = config.getWellSamplePositionX();
+          Length configY = config.getWellSamplePositionY();
+          if (positionX != null || configX != null) {
+            if (positionX == null || !positionX.equals(configX)) {
+              result(testName, false, "WellSample position X" + failureSuffix);
+            }
+          }
+          if (positionY != null || configY != null) {
+            if (positionY == null || !positionY.equals(configY)) {
+              result(testName, false, "WellSample position Y" + failureSuffix);
+            }
+          }
+
+          int plateAcq = config.getPlateAcquisition();
+          if (plateAcq >= retrieve.getPlateAcquisitionCount(plate) ||
+            (plateAcq < 0 && retrieve.getPlateAcquisitionCount(plate) > 0))
+          {
+            result(testName, false, "PlateAcquisition index" + failureSuffix);
+          }
+          String wellSampleID = retrieve.getWellSampleID(plate, w, wellSample);
+          boolean foundWellSampleRef = false;
+          for (int wsRef=0; wsRef<retrieve.getWellSampleRefCount(plate, plateAcq); wsRef++) {
+            String wellSampleRef = retrieve.getPlateAcquisitionWellSampleRef(
+              plate, plateAcq, wsRef);
+            if (wellSampleID.equals(wellSampleRef)) {
+              foundWellSampleRef = true;
+              break;
+            }
+          }
+          if (!foundWellSampleRef) {
+            result(testName, false, "PlateAcquisition missing WellSampleRef" + failureSuffix);
+          }
+        }
+      }
+      if (!foundWell) {
+        result(testName, false, "Well indexes" + failureSuffix);
+      }
+    }
+
+    result(testName, true);
+  }
+
   @Test(groups = {"all", "xml", "automated"})
   public void testEqualOMEXML() {
     if (config == null) throw new SkipException("No config tree");

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1443,23 +1443,25 @@ public class FormatReaderTest {
           }
 
           int plateAcq = config.getPlateAcquisition();
-          if (plateAcq >= retrieve.getPlateAcquisitionCount(plate) ||
-            (plateAcq < 0 && retrieve.getPlateAcquisitionCount(plate) > 0))
+          int plateAcqCount = retrieve.getPlateAcquisitionCount(plate);
+          if (plateAcq >= plateAcqCount || (plateAcq < 0 && plateAcqCount > 0))
           {
             result(testName, false, "PlateAcquisition index" + failureSuffix);
           }
-          String wellSampleID = retrieve.getWellSampleID(plate, w, wellSample);
-          boolean foundWellSampleRef = false;
-          for (int wsRef=0; wsRef<retrieve.getWellSampleRefCount(plate, plateAcq); wsRef++) {
-            String wellSampleRef = retrieve.getPlateAcquisitionWellSampleRef(
-              plate, plateAcq, wsRef);
-            if (wellSampleID.equals(wellSampleRef)) {
-              foundWellSampleRef = true;
-              break;
+          else if (plateAcq >= 0 && plateAcqCount > 0) {
+            String wellSampleID = retrieve.getWellSampleID(plate, w, wellSample);
+            boolean foundWellSampleRef = false;
+            for (int wsRef=0; wsRef<retrieve.getWellSampleRefCount(plate, plateAcq); wsRef++) {
+              String wellSampleRef = retrieve.getPlateAcquisitionWellSampleRef(
+                plate, plateAcq, wsRef);
+              if (wellSampleID.equals(wellSampleRef)) {
+                foundWellSampleRef = true;
+                break;
+              }
             }
-          }
-          if (!foundWellSampleRef) {
-            result(testName, false, "PlateAcquisition missing WellSampleRef" + failureSuffix);
+            if (!foundWellSampleRef) {
+              result(testName, false, "PlateAcquisition missing WellSampleRef" + failureSuffix);
+            }
           }
         }
       }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1405,7 +1405,25 @@ public class FormatReaderTest {
       }
       else if (plate < 0) {
         if (retrieve.getPlateCount() > 0) {
-          result(testName, false, "Plate index" + failureSuffix);
+          boolean allEmpty = true;
+          for (int p=0; p<retrieve.getPlateCount(); p++) {
+            if (retrieve.getWellCount(p) > 0) {
+              boolean emptyWell = true;
+              for (int w=0; w<retrieve.getWellCount(p); w++) {
+                if (retrieve.getWellSampleCount(p, w) > 0) {
+                  emptyWell = false;
+                  break;
+                }
+              }
+              if (!emptyWell) {
+                allEmpty = false;
+              }
+              break;
+            }
+          }
+          if (!allEmpty) {
+            result(testName, false, "Plate index" + failureSuffix);
+          }
         }
         continue;
       }
@@ -1463,6 +1481,9 @@ public class FormatReaderTest {
               result(testName, false, "PlateAcquisition missing WellSampleRef" + failureSuffix);
             }
           }
+        }
+        if (foundWell) {
+          break;
         }
       }
       if (!foundWell) {

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1462,9 +1462,26 @@ public class FormatReaderTest {
 
           int plateAcq = config.getPlateAcquisition();
           int plateAcqCount = retrieve.getPlateAcquisitionCount(plate);
-          if (plateAcq >= plateAcqCount || (plateAcq < 0 && plateAcqCount > 0))
-          {
+          if (plateAcq >= plateAcqCount) {
             result(testName, false, "PlateAcquisition index" + failureSuffix);
+          }
+          else if (plateAcq < 0 && plateAcqCount > 0) {
+            // special case where this WellSample isn't
+            // linked to a PlateAcquisition,
+            // but multiple PlateAcquisitions exist
+            String wellSampleID =
+              retrieve.getWellSampleID(plate, w, wellSample);
+            for (int pa=0; pa<plateAcqCount; pa++) {
+              int wsCount = retrieve.getWellSampleRefCount(plate, pa);
+              for (int wsRef=0; wsRef<wsCount; wsRef++) {
+                String wellSampleRef =
+                  retrieve.getPlateAcquisitionWellSampleRef(plate, pa, wsRef);
+                if (wellSampleID.equals(wellSampleRef)) {
+                  result(testName, false,
+                    "PlateAcquisition-WellSample link" + failureSuffix);
+                }
+              }
+            }
           }
           else if (plateAcq >= 0 && plateAcqCount > 0) {
             String wellSampleID = retrieve.getWellSampleID(plate, w, wellSample);


### PR DESCRIPTION
See https://trello.com/c/c9PwJFcK/284-add-configuration-keys-for-hcs-metadata

HCS/SPW datasets are now required to have ```Plate```, ```PlateAcquisition``` (if present), ```Well```, ```WellSample```, and ```WellSample``` position (if present) values configured.  ```test-config``` will generate these values as appropriate.

The test should fail if configured values do not match actual values, or if the reader's ```MetadataStore``` has at least one ```Plate``` that has at least one ```Well``` with at least one ```WellSample``` and any ```Image``` is not linked to a ```Plate```.  This seems fine for most readers, but breaks down for:

- ```ome-tiff/ome-schemas/2010-06/one-screen-one-plate-four-wells.ome.tiff```
  * none of the ```WellSample```s have an ```ImageRef```, so no ```Image```s linked to the ```Plate```
- ```ome-tiff/ome-schemas/2010-06/two-screens-two-plates-four-wells.ome.tiff```
  * noe of the ```WellSample```s have an ```ImageRef```, so no ```Image```s linked to the ```Plate```
- ```ome-tiff/ome-schemas/2016-06/BBBC/NIRHTa-001.ome.tiff``` 
  * some ```Image```s not linked to the ```Plate```

Some ideas for how to fix, roughly in order of preference:

- add global ```test_hcs``` key to allow the HCS test to be turned off per file
- pass test if ```OMEXMLReader``` or ```OMETiffReader``` is used, but log where it would have failed
- relax test to allow any ```Image``` to be unlinked to a ```Plate``` (when a ```Plate``` is present, and the unlinking is the same between the ```MetadataStore``` and the configuration)

This test also turned up a couple of issues in ```CellVoyagerReader``` and ```ScanrReader```.  The former was keeping an empty ```Plate``` even for non-HCS data, and the latter had an indexing issue in sparse plates that caused multiple wells to have the same row/column index.

Configuration PRs forthcoming; I have split them into one branch per top-level folder, to keep the diff sizes somewhat manageable.