### PR TITLE
Fake: remove "header" key from original metadata

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -620,7 +620,9 @@ public class FakeReader extends FormatReader {
       table = list.getTable("GlobalMetadata");
       if (table != null) {
         for (Map.Entry<String, String> entry : table.entrySet()) {
-          addGlobalMeta(entry.getKey(), entry.getValue());
+          if (!IniTable.HEADER_KEY.equals(entry.getKey())) {
+            addGlobalMeta(entry.getKey(), entry.getValue());
+          }
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HamamatsuVMSReader.java
@@ -265,7 +265,9 @@ public class HamamatsuVMSReader extends FormatReader {
     Double macroHeight = new Double(slideInfo.get("PhysicalMacroHeight"));
 
     for (String key : slideInfo.keySet()) {
-      addGlobalMeta(key, slideInfo.get(key));
+      if (!IniTable.HEADER_KEY.equals(key)) {
+        addGlobalMeta(key, slideInfo.get(key));
+      }
     }
 
     Location dir = new Location(id).getAbsoluteFile().getParentFile();

--- a/components/formats-gpl/src/loci/formats/in/HitachiReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HitachiReader.java
@@ -205,7 +205,9 @@ public class HitachiReader extends FormatReader {
     }
 
     for (String key : image.keySet()) {
-      addGlobalMeta(key, image.get(key));
+      if (!IniTable.HEADER_KEY.equals(key)) {
+        addGlobalMeta(key, image.get(key));
+      }
     }
 
     String imageName = image.get("SampleName");


### PR DESCRIPTION
See https://trello.com/c/4tlJlMuC/339-fake-ini-handling-leads-to-spurious-header-key

To test, use a simple dataset like this:

```
$ cat test.fake.ini
[GlobalMetadata]
foo = bar
$ touch test.fake
```

Without this PR, ```showinf -nopix test.fake``` should show two key/value pairs in the global metadata table: ```foo: bar``` and ```header: GlobalMetadata```.  With this PR, only ```foo: bar`` should be present.

Should be safe for a patch release if needed, and very low priority.