### PR TITLE
bump perf4j up from 0.9.13 to 0.9.16

### DIFF
--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.perf4j</groupId>
       <artifactId>perf4j</artifactId>
-      <version>0.9.13</version>
+      <version>0.9.16</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.perf4j</groupId>
       <artifactId>perf4j</artifactId>
-      <version>0.9.13</version>
+      <version>0.9.16</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Brings Bio-Formats' perf4j up to the one OMERO needs so as to align them.

Does not address the larger issue that we should be using some other library.