### PR TITLE
Add reader for Ventana .bif files

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -148,6 +148,7 @@ loci.formats.in.LEOReader             # sxm
 loci.formats.in.JPKReader             # jpk
 loci.formats.in.NDPIReader            # ndpi
 loci.formats.in.PCORAWReader          # pcoraw
+loci.formats.in.VentanaReader         # bif
 
 # TIFF-based readers with slow isThisType
 loci.formats.in.OMETiffReader         # tif

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -1215,7 +1215,7 @@ public class TiffParser {
 
     RandomAccessInputStream bb = null;
     try {
-      if (!noDiv8) {
+      if (noDiv8) {
         bb = new RandomAccessInputStream(new ByteArrayHandle(bytes));
       }
       // unpack pixels

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -775,11 +775,23 @@ public class TiffParser {
       Arrays.fill(buf, (byte) 0);
       return buf;
     }
-    byte[] tile = new byte[(int) stripByteCounts[countIndex]];
+    int tileSize = (int) stripByteCounts[countIndex];
+    if (jpegTable != null) {
+      tileSize += jpegTable.length - 2;
+    }
+    byte[] tile = new byte[tileSize];
 
     LOGGER.debug("Reading tile Length {} Offset {}", tile.length, stripOffset);
-    in.seek(stripOffset);
-    in.read(tile);
+
+    if (jpegTable != null) {
+      System.arraycopy(jpegTable, 0, tile, 0, jpegTable.length - 2);
+      in.seek(stripOffset + 2);
+      in.read(tile, jpegTable.length - 2, tile.length - (jpegTable.length - 2));
+    }
+    else {
+      in.seek(stripOffset);
+      in.read(tile);
+    }
 
     // reverse bits in each byte if FillOrder == 2
 
@@ -796,13 +808,7 @@ public class TiffParser {
       ifd.getPhotometricInterpretation() == PhotoInterp.Y_CB_CR &&
       ifd.getIFDIntValue(IFD.Y_CB_CR_SUB_SAMPLING) == 1 && ycbcrCorrection;
 
-    if (jpegTable != null) {
-      byte[] q = new byte[jpegTable.length + tile.length - 4];
-      System.arraycopy(jpegTable, 0, q, 0, jpegTable.length - 2);
-      System.arraycopy(tile, 2, q, jpegTable.length - 2, tile.length - 2);
-      tile = compression.decompress(q, codecOptions);
-    }
-    else tile = compression.decompress(tile, codecOptions);
+    tile = compression.decompress(tile, codecOptions);
     TiffCompression.undifference(tile, ifd);
     unpackBytes(buf, 0, tile, ifd);
 
@@ -1139,23 +1145,17 @@ public class TiffParser {
       sampleCount /= nChannels;
     }
 
-    LOGGER.trace(
-      "unpacking {} samples (startIndex={}; totalBits={}; numBytes={})",
-      new Object[] {sampleCount, startIndex, nChannels * bitsPerSample[0],
-      bytes.length});
-
-    long imageWidth = ifd.getImageWidth();
-    long imageHeight = ifd.getImageLength();
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace(
+        "unpacking {} samples (startIndex={}; totalBits={}; numBytes={})",
+        new Object[] {sampleCount, startIndex, nChannels * bitsPerSample[0],
+        bytes.length});
+    }
 
     int bps0 = bitsPerSample[0];
-    int numBytes = ifd.getBytesPerSample()[0];
-    int nSamples = samples.length / (nChannels * numBytes);
 
-    boolean noDiv8 = bps0 % 8 != 0;
     boolean bps8 = bps0 == 8;
     boolean bps16 = bps0 == 16;
-
-    boolean littleEndian = ifd.isLittleEndian();
 
     // Hyper optimisation that takes any 8-bit or 16-bit data, where there is
     // only one channel, the source byte buffer's size is less than or equal to
@@ -1171,6 +1171,15 @@ public class TiffParser {
       System.arraycopy(bytes, 0, samples, 0, bytes.length);
       return;
     }
+
+    long imageWidth = ifd.getImageWidth();
+    long imageHeight = ifd.getImageLength();
+
+    int numBytes = ifd.getBytesPerSample()[0];
+    int nSamples = samples.length / (nChannels * numBytes);
+
+    boolean noDiv8 = bps0 % 8 != 0;
+    boolean littleEndian = ifd.isLittleEndian();
 
     long maxValue = (long) Math.pow(2, bps0) - 1;
     if (photoInterp == PhotoInterp.CMYK) maxValue = Integer.MAX_VALUE;
@@ -1206,7 +1215,9 @@ public class TiffParser {
 
     RandomAccessInputStream bb = null;
     try {
-      bb = new RandomAccessInputStream(new ByteArrayHandle(bytes));
+      if (!noDiv8) {
+        bb = new RandomAccessInputStream(new ByteArrayHandle(bytes));
+      }
       // unpack pixels
       for (int sample=0; sample<sampleCount; sample++) {
         int ndx = startIndex + sample;
@@ -1240,7 +1251,14 @@ public class TiffParser {
               }
             }
             else {
-              value = DataTools.bytesToLong(bytes, index, numBytes, littleEndian);
+              // DataTools.bytesToLong can handle the numBytes == 1 case,
+              // but direct assignment is faster than potentially thousands of method calls
+              if (numBytes == 1){
+                value = bytes[index] & 0xff;
+              }
+              else {
+                value = DataTools.bytesToLong(bytes, index, numBytes, littleEndian);
+              }
             }
 
             if (photoInterp == PhotoInterp.WHITE_IS_ZERO ||
@@ -1250,8 +1268,15 @@ public class TiffParser {
             }
 
             if (outputIndex + numBytes <= samples.length) {
-              DataTools.unpackBytes(value, samples, outputIndex, numBytes,
-                littleEndian);
+              // DataTools.unpackBytes can handle the numBytes == 1 case,
+              // but direct assignment is faster than potentially thousands of method calls
+              if (numBytes == 1) {
+                samples[outputIndex] = (byte) value;
+              }
+              else {
+                DataTools.unpackBytes(value, samples, outputIndex, numBytes,
+                  littleEndian);
+              }
             }
           }
           else {

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -94,6 +94,7 @@ public class VentanaReader extends BaseTiffReader {
   private int tileWidth, tileHeight;
   private TIFFTile[] tiles;
   private int resolutions = 0;
+  private Double physicalPixelSize = null;
 
   // -- Constructor --
 
@@ -293,6 +294,7 @@ public class VentanaReader extends BaseTiffReader {
       tileHeight = 0;
       tiles = null;
       resolutions = 0;
+      physicalPixelSize = null;
     }
   }
 
@@ -538,6 +540,10 @@ public class VentanaReader extends BaseTiffReader {
       store.setImageInstrumentRef(instrument, i);
       store.setObjectiveSettingsID(objective, i);
 
+      if (physicalPixelSize != null) {
+        store.setPixelsPhysicalSizeX(new Length(physicalPixelSize, UNITS.MICROM), i);
+        store.setPixelsPhysicalSizeY(new Length(physicalPixelSize, UNITS.MICROM), i);
+      }
       if (splitTiles()) {
         for (int p=0; p<getImageCount(); p++) {
           store.setPlanePositionX(new Length(tiles[i].baseX, UNITS.REFERENCEFRAME), i, p);
@@ -567,6 +573,13 @@ public class VentanaReader extends BaseTiffReader {
     catch (ParserConfigurationException | SAXException e) {
       throw new IOException(e);
     }
+
+    Element iScan = (Element) root.getElementsByTagName("iScan").item(0);
+    String physicalSize = iScan.getAttribute("ScanRes");
+    if (physicalSize != null) {
+      physicalPixelSize = DataTools.parseDouble(physicalSize);
+    }
+
     Element slideStitchInfo = (Element) root.getElementsByTagName("SlideStitchInfo").item(0);
     Element aoiOrigins = (Element) root.getElementsByTagName("AoiOrigin").item(0);
 

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -157,7 +157,9 @@ public class VentanaReader extends BaseTiffReader {
         if (ifd == null) {
           return false;
         }
-        return ifd.get(XML_TAG) != null;
+        tiffParser.fillInIFD(ifd);
+        String xml = ifd.getIFDTextValue(XML_TAG);
+        return xml != null && xml.indexOf("iScan") >= 0;
       }
       catch (IOException e) {
         LOGGER.debug("I/O exception during isThisType() evaluation.", e);

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -626,6 +626,21 @@ public class VentanaReader extends BaseTiffReader {
           store.setPlanePositionY(new Length(tiles[i].baseY, UNITS.REFERENCEFRAME), i, p);
         }
       }
+
+      if (!hasFlattenedResolutions() && !splitTiles()) {
+        switch (i) {
+          case 0:
+            store.setImageName("", i);
+            break;
+          case 1:
+            // both label and overview are usually in the same image
+            store.setImageName("overview image", i);
+            break;
+          case 2:
+            store.setImageName("mask image", i);
+            break;
+        }
+      }
     }
     setSeries(0);
   }

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -651,10 +651,14 @@ public class VentanaReader extends BaseTiffReader {
       }
       if (splitTiles()) {
         for (int p=0; p<getImageCount(); p++) {
-          store.setPlanePositionX(
-            new Length(tiles[i].baseX, UNITS.REFERENCEFRAME), i, p);
-          store.setPlanePositionY(
-            new Length(tiles[i].baseY, UNITS.REFERENCEFRAME), i, p);
+          double x = tiles[i].baseX;
+          double y = tiles[i].baseY;
+          if (physicalPixelSize != null) {
+            x *= physicalPixelSize;
+            y *= physicalPixelSize;
+          }
+          store.setPlanePositionX(new Length(x, UNITS.MICROM), i, p);
+          store.setPlanePositionY(new Length(y, UNITS.MICROM), i, p);
         }
       }
 

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -334,6 +334,32 @@ public class VentanaReader extends BaseTiffReader {
     return super.openThumbBytes(no);
   }
 
+  /* @see loci.formats.IFormatReader#getThumbSizeX() */
+  @Override
+  public int getThumbSizeX() {
+    if (getCoreIndex() < core.size(0)) {
+      int currentCore = getCoreIndex();
+      setCoreIndex(core.size(0) - 1);
+      int x = super.getThumbSizeX();
+      setCoreIndex(currentCore);
+      return x;
+    }
+    return super.getThumbSizeX();
+  }
+
+  /* @see loci.formats.IFormatReader#getThumbSizeY() */
+  @Override
+  public int getThumbSizeY() {
+    if (getCoreIndex() < core.size(0)) {
+      int currentCore = getCoreIndex();
+      setCoreIndex(core.size(0) - 1);
+      int y = super.getThumbSizeY();
+      setCoreIndex(currentCore);
+      return y;
+    }
+    return super.getThumbSizeY();
+  }
+
   /* @see loci.formats.IFormatReader#close(boolean) */
   @Override
   public void close(boolean fileOnly) throws IOException {

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -212,7 +212,7 @@ public class VentanaReader extends BaseTiffReader {
       return buf;
     }
 
-    if (getCoreIndex() >= core.size(0)) {
+    if (getCoreIndex() >= core.size(0) || areas.size() == 0) {
       tiffParser.getSamples(ifd, buf, x, y, w, h);
       return buf;
     }
@@ -643,14 +643,16 @@ public class VentanaReader extends BaseTiffReader {
     int newX = maxX - minX;
     int newY = maxY - minY;
 
-    for (int s=1; s<core.size(0); s++) {
-      int scale = getScale(s);
-      core.get(0, s).sizeX = newX / scale;
-      core.get(0, s).sizeY = newY / scale;
+    if (areas.size() > 0) {
+      for (int s=1; s<core.size(0); s++) {
+        int scale = getScale(s);
+        core.get(0, s).sizeX = newX / scale;
+        core.get(0, s).sizeY = newY / scale;
+      }
+      // reset full resolution last so that getScale is not affected
+      core.get(0, 0).sizeX = newX;
+      core.get(0, 0).sizeY = newY;
     }
-    // reset full resolution last so that getScale is not affected
-    core.get(0, 0).sizeX = newX;
-    core.get(0, 0).sizeY = newY;
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -112,6 +112,7 @@ public class VentanaReader extends BaseTiffReader {
     domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
     suffixNecessary = true;
     noSubresolutions = true;
+    canSeparateSeries = false;
   }
 
   // -- VentanaReader API methods --

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -401,7 +401,7 @@ public class VentanaReader extends BaseTiffReader {
           if (v[0].equals("level")) {
             resolutionCount++;
           }
-          else if (v[0].equals("mag")) {
+          else if (magnification == null && v[0].equals("mag")) {
             magnification = DataTools.parseDouble(v[1]);
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,8 @@ import loci.common.Constants;
 import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.RandomAccessInputStream;
+import loci.common.Region;
+import loci.common.xml.XMLTools;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatTools;
@@ -53,6 +56,12 @@ import ome.xml.model.primitives.Timestamp;
 
 import ome.units.quantity.Length;
 import ome.units.UNITS;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 /**
  * VentanaReader is the file format reader for Ventana .bif files.
@@ -78,6 +87,9 @@ public class VentanaReader extends BaseTiffReader {
   // -- Fields --
 
   private Double magnification = null;
+  private List<AreaOfInterest> areas = new ArrayList<AreaOfInterest>();
+  private int tileWidth, tileHeight;
+  private TIFFTile[] tiles;
 
   // -- Constructor --
 
@@ -147,8 +159,66 @@ public class VentanaReader extends BaseTiffReader {
     if (tiffParser == null) {
       initTiffParser();
     }
-    int ifd = getIFDIndex(getCoreIndex(), no);
-    tiffParser.getSamples(ifds.get(ifd), buf, x, y, w, h);
+    Arrays.fill(buf, (byte) 0);
+    IFD ifd = ifds.get(getIFDIndex(getCoreIndex(), no));
+    if (getCoreIndex() >= core.get(0).resolutionCount) {
+      tiffParser.getSamples(ifd, buf, x, y, w, h);
+      return buf;
+    }
+
+    Region imageBox = new Region(x, y, w, h);
+
+    int bpp = FormatTools.getBytesPerPixel(getPixelType());
+    int pixel = bpp * getRGBChannelCount();
+    int outputRowLen = w * bpp;
+    boolean interleaved = isInterleaved();
+    if (interleaved) {
+      outputRowLen *= getRGBChannelCount();
+    }
+    byte[] tilePixels = new byte[tileWidth * tileHeight * pixel];
+    for (TIFFTile tile : tiles) {
+      Region tileBox = new Region(tile.realX, tile.realY, tileWidth, tileHeight);
+
+      if (tileBox.intersects(imageBox)) {
+        tiffParser.getSamples(ifd, tilePixels, tile.baseX, tile.baseY, tileWidth, tileHeight);
+
+        Region intersection = tileBox.intersection(imageBox);
+        int intersectionX = 0;
+
+        if (tileBox.x < imageBox.x) {
+          intersectionX = imageBox.x - tileBox.x;
+        }
+
+        int rowLen = (int) Math.min(intersection.width, tileWidth) * bpp;
+        if (interleaved) {
+          rowLen *= getRGBChannelCount();
+        }
+
+        int count = interleaved ? 1 : getRGBChannelCount();
+        for (int c=0; c<count; c++) {
+          for (int row=0; row<intersection.height; row++) {
+            int realRow = row + intersection.y - tileBox.y;
+            int inputOffset = bpp * (realRow * tileWidth + intersection.x - tileBox.x);
+            if (interleaved) {
+              inputOffset *= getRGBChannelCount();
+            }
+            else {
+              inputOffset += (c * tileWidth * tileHeight * bpp);
+            }
+            int outputOffset = bpp * (intersection.x - x) + outputRowLen * (row + intersection.y - y);
+            if (interleaved) {
+              outputOffset *= getRGBChannelCount();
+            }
+            else {
+              outputOffset += (c * w * h * bpp);
+            }
+            int copy = (int) Math.min(rowLen, buf.length - outputOffset);
+            System.arraycopy(tilePixels, inputOffset, buf, outputOffset, copy);
+          }
+        }
+      }
+    }
+
     return buf;
   }
 
@@ -164,6 +234,10 @@ public class VentanaReader extends BaseTiffReader {
     super.close(fileOnly);
     if (!fileOnly) {
       magnification = null;
+      areas.clear();
+      tileWidth = 0;
+      tileHeight = 0;
+      tiles = null;
     }
   }
 
@@ -237,6 +311,9 @@ public class VentanaReader extends BaseTiffReader {
       }
       String xml = ifds.get(index).getIFDTextValue(XML_TAG);
       LOGGER.debug("XMP tag for series #{} = {}", i, xml);
+      if (xml != null && resolutionCount == 1) {
+        parseXML(xml);
+      }
     }
     setSeries(0);
 
@@ -249,7 +326,8 @@ public class VentanaReader extends BaseTiffReader {
       ms.sizeT = 1;
       ms.imageCount = ms.sizeZ * ms.sizeT;
 
-      IFD ifd = ifds.get(getIFDIndex(s, 0));
+      int ifdIndex = getIFDIndex(s, 0);
+      IFD ifd = ifds.get(ifdIndex);
       PhotoInterp p = ifd.getPhotometricInterpretation();
       int samples = ifd.getSamplesPerPixel();
       ms.rgb = samples > 1 || p == PhotoInterp.RGB;
@@ -266,7 +344,84 @@ public class VentanaReader extends BaseTiffReader {
       ms.falseColor = false;
       ms.dimensionOrder = "XYCZT";
       ms.thumbnail = s != 0;
+
+      if (s == 0) {
+        tileWidth = (int) ifd.getTileWidth();
+        tileHeight = (int) ifd.getTileLength();
+        long[] offsets = ifd.getStripOffsets();
+        int x = 0, y = 0;
+        tiles = new TIFFTile[offsets.length];
+        for (int i=0; i<offsets.length; i++) {
+          tiles[i] = new TIFFTile();
+          tiles[i].offset = offsets[i];
+          tiles[i].ifd = ifdIndex;
+          tiles[i].realX = -1 * tileWidth;
+          tiles[i].realY = -1 * tileHeight;
+          tiles[i].baseX = tileWidth * (x++);
+          tiles[i].baseY = tileHeight * y;
+          if (x * tileWidth >= ms.sizeX) {
+            y++;
+            x = 0;
+          }
+        }
+      }
     }
+
+    // now process TIFF tiles and overlap data to get the real coordinates for each tile
+    int tileCols = core.get(0).sizeX / tileWidth;
+    for (AreaOfInterest area : areas) {
+      int tileRow = area.yOrigin / tileHeight;
+      int tileCol = area.xOrigin / tileWidth;
+
+      for (int row=0; row<area.tileRows; row++) {
+        for (int col=0; col<area.tileColumns; col++) {
+          int index = (tileRow + row) * tileCols + (tileCol + col);
+          tiles[index].realX = tiles[index].baseX;
+          tiles[index].realY = tiles[index].baseY;
+        }
+      }
+
+      // largest tile index is in upper right corner
+      // smallest tile index is in lower left corner (snake ordering)
+
+      for (Overlap overlap : area.overlaps) {
+        int thisRow = getTileRow(overlap.a, area.tileRows, area.tileColumns);
+        int thisCol = getTileColumn(overlap.a, area.tileRows, area.tileColumns);
+        if (overlap.direction.equals("RIGHT")) {
+          for (int col=0; col<=thisCol; col++) {
+            int currentIndex = (tileRow + thisRow) * tileCols + (tileCol + col);
+            tiles[currentIndex].realX += overlap.x;
+          }
+          int currentIndex = (tileRow + thisRow) * tileCols + (tileCol + thisCol);
+          tiles[currentIndex].realY += overlap.y;
+        }
+        else if (overlap.direction.equals("UP")) {
+          for (int row=thisRow; row<area.tileRows; row++) {
+            int currentIndex = (tileRow + row) * tileCols + (tileCol + thisCol);
+            tiles[currentIndex].realY -= overlap.y;
+          }
+        }
+        else {
+          throw new FormatException("Unsupported overlap direction: " + overlap.direction);
+        }
+      }
+    }
+  }
+
+  private int getTileRow(int index, int rows, int cols) {
+    int row = (int) Math.floor((double) index / cols);
+    return rows - row - 1;
+  }
+
+  private int getTileColumn(int index, int rows, int cols) {
+    int row = (int) Math.floor((double) index / cols);
+    // even numbered rows increase from left to right
+    // odd numbered rows decrease from left to right
+    int col = index - (row * cols);
+    if (row % 2 == 1) {
+      return cols - col - 1;
+    }
+    return col;
   }
 
   /* @see loci.formats.BaseTiffReader#initMetadataStore() */
@@ -297,6 +452,113 @@ public class VentanaReader extends BaseTiffReader {
       return extra + (coreIndex * core.get(0).imageCount) + no;
     }
     return coreIndex - (core.size() - extra);
+  }
+
+  private void parseXML(String xml) throws IOException {
+    Element root = null;
+    try {
+      root = XMLTools.parseDOM(xml).getDocumentElement();
+    }
+    catch (ParserConfigurationException | SAXException e) {
+      throw new IOException(e);
+    }
+    Element slideStitchInfo = (Element) root.getElementsByTagName("SlideStitchInfo").item(0);
+    Element aoiOrigins = (Element) root.getElementsByTagName("AoiOrigin").item(0);
+
+    NodeList imageInfos = slideStitchInfo.getElementsByTagName("ImageInfo");
+    for (int i=0; i<imageInfos.getLength(); i++) {
+      Element imageInfo = (Element) imageInfos.item(i);
+
+      if (imageInfo.getAttribute("AOIScanned").equals("0")) {
+        continue;
+      }
+      AreaOfInterest aoi = new AreaOfInterest();
+      aoi.index = Integer.parseInt(imageInfo.getAttribute("AOIIndex"));
+      aoi.tileRows = Integer.parseInt(imageInfo.getAttribute("NumRows"));
+      aoi.tileColumns = Integer.parseInt(imageInfo.getAttribute("NumCols"));
+
+      NodeList joints = imageInfo.getElementsByTagName("TileJointInfo");
+      for (int j=0; j<joints.getLength(); j++) {
+        Element joint = (Element) joints.item(j);
+        if (joint.getAttribute("FlagJoined").equals("1")) {
+          Overlap overlap = new Overlap();
+          overlap.a = Integer.parseInt(joint.getAttribute("Tile1")) - 1;
+          overlap.b = Integer.parseInt(joint.getAttribute("Tile2")) - 1;
+          overlap.x = DataTools.parseDouble(joint.getAttribute("OverlapX")).intValue();
+          overlap.y = DataTools.parseDouble(joint.getAttribute("OverlapY")).intValue();
+          overlap.direction = joint.getAttribute("Direction");
+          aoi.overlaps.add(overlap);
+        }
+      }
+      areas.add(aoi);
+    }
+
+    NodeList aois = aoiOrigins.getChildNodes();
+    for (int i=0; i<aois.getLength(); i++) {
+      String name = aois.item(i).getNodeName();
+      if (!name.startsWith("AOI")) {
+        continue;
+      }
+      Element aoi = (Element) aois.item(i);
+      int thisIndex = Integer.parseInt(name.replace("AOI", ""));
+      for (AreaOfInterest a : areas) {
+        if (a.index == thisIndex) {
+          a.xOrigin = Integer.parseInt(aoi.getAttribute("OriginX"));
+          a.yOrigin = Integer.parseInt(aoi.getAttribute("OriginY"));
+        }
+      }
+    }
+  }
+
+
+  class AreaOfInterest {
+    // origin in pixels
+    public int xOrigin;
+    public int yOrigin;
+    public int index;
+    public int tileRows;
+    public int tileColumns;
+    public List<Overlap> overlaps = new ArrayList<Overlap>();
+
+    @Override
+    public String toString() {
+      return "AOI #" + index + ", X=" + xOrigin + ", Y=" + yOrigin +
+        ", rows=" + tileRows + ", cols=" + tileColumns +
+        ", overlaps=" + overlaps.size();
+    }
+  }
+
+  class Overlap implements Comparable<Overlap> {
+    public int a;
+    public int b;
+    public int x;
+    public int y;
+    public String direction;
+
+    public int compareTo(Overlap o) {
+      if (a != o.a) {
+        return a - o.a;
+      }
+      return b - o.b;
+    }
+
+    @Override
+    public String toString() {
+      return a + " => " + b + ", overlap = {" + x + ", " + y +
+        "}, direction = " + direction;
+    }
+  }
+
+  class TIFFTile {
+    public int ifd;
+    public long offset;
+    // these are the XY coordinates if we were placing the tile
+    // as in standard TIFF, with no overlaps
+    public int baseX;
+    public int baseY;
+    // these are the XY coordinates after overlap calculation
+    public int realX;
+    public int realY;
   }
 
 }

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -1,0 +1,302 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import loci.common.Constants;
+import loci.common.DataTools;
+import loci.common.DateTools;
+import loci.common.RandomAccessInputStream;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.meta.MetadataStore;
+import loci.formats.tiff.IFD;
+import loci.formats.tiff.PhotoInterp;
+import loci.formats.tiff.TiffIFDEntry;
+import loci.formats.tiff.TiffParser;
+import ome.xml.model.primitives.Color;
+import ome.xml.model.primitives.Timestamp;
+
+import ome.units.quantity.Length;
+import ome.units.UNITS;
+
+/**
+ * VentanaReader is the file format reader for Ventana .bif files.
+ */
+public class VentanaReader extends BaseTiffReader {
+
+  // -- Constants --
+
+  /** Logger for this class. */
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(VentanaReader.class);
+
+  // primary metadata, not present on subresolution images
+  private static final int XML_TAG = 700;
+
+  // Photoshop image resources, see
+  // https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577413_pgfId-1039502
+  private static final int EXTRA_TAG_1 = 34377;
+
+  // Microsoft ICM color profile; only expected on full resolution image
+  private static final int EXTRA_TAG_2 = 34677;
+
+  // -- Fields --
+
+  private Double magnification = null;
+
+  // -- Constructor --
+
+  /** Constructs a new Ventana reader. */
+  public VentanaReader() {
+    super("Ventana .bif", new String[] {"bif"});
+    domains = new String[] {FormatTools.HISTOLOGY_DOMAIN};
+    suffixNecessary = true;
+    noSubresolutions = true;
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  @Override
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
+  }
+
+  /* (non-Javadoc)
+   * @see loci.formats.FormatReader#isThisType(java.lang.String, boolean)
+   */
+  @Override
+  public boolean isThisType(String name, boolean open) {
+    boolean isThisType = super.isThisType(name, open);
+    if (!isThisType && open) {
+      RandomAccessInputStream stream = null;
+      try {
+        stream = new RandomAccessInputStream(name);
+        TiffParser tiffParser = new TiffParser(stream);
+        tiffParser.setDoCaching(false);
+        if (!tiffParser.isValidHeader()) {
+          return false;
+        }
+        IFD ifd = tiffParser.getFirstIFD();
+        if (ifd == null) {
+          return false;
+        }
+        return ifd.get(XML_TAG) != null;
+      }
+      catch (IOException e) {
+        LOGGER.debug("I/O exception during isThisType() evaluation.", e);
+        return false;
+      }
+      finally {
+        try {
+          if (stream != null) {
+            stream.close();
+          }
+        }
+        catch (IOException e) {
+          LOGGER.debug("I/O exception during stream closure.", e);
+        }
+      }
+    }
+    return isThisType;
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  @Override
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+    if (tiffParser == null) {
+      initTiffParser();
+    }
+    int ifd = getIFDIndex(getCoreIndex(), no);
+    tiffParser.getSamples(ifds.get(ifd), buf, x, y, w, h);
+    return buf;
+  }
+
+  /* @see loci.formats.IFormatReader#openThumbBytes(int) */
+  @Override
+  public byte[] openThumbBytes(int no) throws FormatException, IOException {
+    return super.openThumbBytes(no);
+  }
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  @Override
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      magnification = null;
+    }
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileWidth() */
+  @Override
+  public int getOptimalTileWidth() {
+    FormatTools.assertId(currentId, true, 1);
+    try {
+      int ifd = getIFDIndex(getCoreIndex(), 0);
+      return (int) ifds.get(ifd).getTileWidth();
+    }
+    catch (FormatException e) {
+      LOGGER.debug("", e);
+    }
+    return super.getOptimalTileWidth();
+  }
+
+  /* @see loci.formats.IFormatReader#getOptimalTileHeight() */
+  @Override
+  public int getOptimalTileHeight() {
+    FormatTools.assertId(currentId, true, 1);
+    try {
+      int ifd = getIFDIndex(getCoreIndex(), 0);
+      return (int) ifds.get(ifd).getTileLength();
+    }
+    catch (FormatException e) {
+      LOGGER.debug("", e);
+    }
+    return super.getOptimalTileHeight();
+  }
+
+  // -- Internal BaseTiffReader API methods --
+
+  /* @see loci.formats.BaseTiffReader#initStandardMetadata() */
+  @Override
+  protected void initStandardMetadata() throws FormatException, IOException {
+    super.initStandardMetadata();
+
+    ifds = tiffParser.getMainIFDs();
+
+    int seriesCount = ifds.size();
+
+    core.clear();
+    for (int i=0; i<seriesCount; i++) {
+      core.add(new CoreMetadata());
+    }
+
+    int resolutionCount = 0;
+    for (int i=0; i<seriesCount; i++) {
+      setSeries(i);
+      int index = getIFDIndex(i, 0);
+      tiffParser.fillInIFD(ifds.get(index));
+
+      String comment = ifds.get(index).getComment();
+      if (comment == null) {
+        continue;
+      }
+      String[] tokens = comment.split(" ");
+      for (String token : tokens) {
+        String[] v = token.split("=");
+        if (v.length == 2) {
+          addSeriesMeta(v[0], v[1]);
+
+          if (v[0].equals("level")) {
+            resolutionCount++;
+          }
+          else if (v[0].equals("mag")) {
+            magnification = DataTools.parseDouble(v[1]);
+          }
+        }
+      }
+      String xml = ifds.get(index).getIFDTextValue(XML_TAG);
+      LOGGER.debug("XMP tag for series #{} = {}", i, xml);
+    }
+    setSeries(0);
+
+    for (int s=0; s<seriesCount; s++) {
+      CoreMetadata ms = core.get(s);
+      if (s == 0) {
+        ms.resolutionCount = resolutionCount;
+      }
+      ms.sizeZ = 1;
+      ms.sizeT = 1;
+      ms.imageCount = ms.sizeZ * ms.sizeT;
+
+      IFD ifd = ifds.get(getIFDIndex(s, 0));
+      PhotoInterp p = ifd.getPhotometricInterpretation();
+      int samples = ifd.getSamplesPerPixel();
+      ms.rgb = samples > 1 || p == PhotoInterp.RGB;
+
+      ms.sizeX = (int) ifd.getImageWidth();
+      ms.sizeY = (int) ifd.getImageLength();
+      ms.sizeC = ms.rgb ? samples : 1;
+      ms.littleEndian = ifd.isLittleEndian();
+      ms.indexed = p == PhotoInterp.RGB_PALETTE &&
+        (get8BitLookupTable() != null || get16BitLookupTable() != null);
+      ms.pixelType = ifd.getPixelType();
+      ms.metadataComplete = true;
+      ms.interleaved = false;
+      ms.falseColor = false;
+      ms.dimensionOrder = "XYCZT";
+      ms.thumbnail = s != 0;
+    }
+  }
+
+  /* @see loci.formats.BaseTiffReader#initMetadataStore() */
+  @Override
+  protected void initMetadataStore() throws FormatException {
+    super.initMetadataStore();
+
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this, getImageCount() > 1);
+
+    String instrument = MetadataTools.createLSID("Instrument", 0);
+    String objective = MetadataTools.createLSID("Objective", 0, 0);
+    store.setInstrumentID(instrument, 0);
+    store.setObjectiveID(objective, 0, 0);
+    store.setObjectiveNominalMagnification(magnification, 0, 0);
+
+    for (int i=0; i<getSeriesCount(); i++) {
+      setSeries(i);
+      store.setImageInstrumentRef(instrument, i);
+      store.setObjectiveSettingsID(objective, i);
+    }
+    setSeries(0);
+  }
+
+  private int getIFDIndex(int coreIndex, int no) {
+    int extra = ifds.size() - (core.get(0).resolutionCount * core.get(0).imageCount);
+    if (coreIndex < core.size() - extra) {
+      return extra + (coreIndex * core.get(0).imageCount) + no;
+    }
+    return coreIndex - (core.size() - extra);
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -826,7 +826,11 @@ public class VentanaReader extends BaseTiffReader {
         continue;
       }
       AreaOfInterest aoi = new AreaOfInterest();
-      aoi.index = Integer.parseInt(imageInfo.getAttribute("AOIIndex"));
+      String aoiIndex = imageInfo.getAttribute("AOIIndex");
+      aoi.index = i;
+      if (aoiIndex != null && !aoiIndex.isEmpty()) {
+        aoi.index = Integer.parseInt(aoiIndex);
+      }
       aoi.tileRows = Integer.parseInt(imageInfo.getAttribute("NumRows"));
       aoi.tileColumns = Integer.parseInt(imageInfo.getAttribute("NumCols"));
 

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -735,7 +735,7 @@ public class VentanaReader extends BaseTiffReader {
 
     Length pixelSize = null;
     if (physicalPixelSize != null) {
-      pixelSize = new Length(physicalPixelSize, UNITS.MICROM);
+      pixelSize = new Length(physicalPixelSize, UNITS.MICROMETER);
     }
 
     for (int i=0; i<getSeriesCount(); i++) {
@@ -755,8 +755,8 @@ public class VentanaReader extends BaseTiffReader {
             x *= physicalPixelSize;
             y *= physicalPixelSize;
           }
-          store.setPlanePositionX(new Length(x, UNITS.MICROM), i, p);
-          store.setPlanePositionY(new Length(y, UNITS.MICROM), i, p);
+          store.setPlanePositionX(new Length(x, UNITS.MICROMETER), i, p);
+          store.setPlanePositionY(new Length(y, UNITS.MICROMETER), i, p);
         }
       }
 
@@ -781,7 +781,7 @@ public class VentanaReader extends BaseTiffReader {
   /**
    * @param coreIndex the series or resolution for which to find an IFD
    * @param no the plane index for which to find an IFD
-   * @return the index into {@link ifds} for the given series and plane
+   * @return the index into {@link #ifds} for the given series and plane
    */
   private int getIFDIndex(int coreIndex, int no) {
     // natural IFD ordering:

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -236,7 +236,9 @@ public class VentanaReader extends BaseTiffReader {
     byte[] tilePixels = new byte[thisTileWidth * thisTileHeight * pixel];
     for (TIFFTile tile : tiles) {
       Region tileBox = new Region(
-        tile.realX / scale, tile.realY / scale, thisTileWidth, thisTileHeight);
+        scaleCoordinate(tile.realX, getCoreIndex()),
+        scaleCoordinate(tile.realY, getCoreIndex()),
+        thisTileWidth, thisTileHeight);
 
       if (tileBox.intersects(imageBox)) {
         if (scale == 1) {
@@ -247,10 +249,10 @@ public class VentanaReader extends BaseTiffReader {
           // load a whole tile from the subresolution IFD for reuse
           // it's less complicated to just call tiffParser.setSamples(...)
           // each time, but also an order of magnitude slower
-          int resX = tile.baseX / scale;
+          int resX = scaleCoordinate(tile.baseX, getCoreIndex());
           int offsetX = resX % tileWidth;
           resX -= offsetX;
-          int resY = tile.baseY / scale;
+          int resY = scaleCoordinate(tile.baseY, getCoreIndex());
           int offsetY = resY % tileHeight;
           resY -= offsetY;
           if (resX != subResX || resY != subResY || subResTile == null) {
@@ -632,6 +634,15 @@ public class VentanaReader extends BaseTiffReader {
   private int getScale(int resolution) {
     return (int) Math.round(
       (double) core.get(0, 0).sizeX / core.get(0, resolution).sizeX);
+  }
+
+  /**
+   * @param v the coordinate in the full resolution
+   * @param resolution the resolution for which to calculate a scale factor
+   * @return the scaled coordinate for the target resolution
+   */
+  private int scaleCoordinate(int v, int resolution) {
+    return (int) Math.ceil((double) v / getScale(resolution));
   }
 
   /**

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -236,6 +236,8 @@ public class VentanaReader extends BaseTiffReader {
     byte[] subResTile = null;
     int subResX = -1, subResY = -1;
 
+    HashMap<Region, byte[]> cachedTiles = new HashMap<Region, byte[]>();
+
     byte[] tilePixels = new byte[thisTileWidth * thisTileHeight * pixel];
     for (TIFFTile tile : tiles) {
       Region tileBox = new Region(
@@ -270,8 +272,15 @@ public class VentanaReader extends BaseTiffReader {
             if (subResTile == null) {
               subResTile = new byte[tileWidth * tileHeight * pixel];
             }
-            tiffParser.getSamples(
-              ifd, subResTile, resX, resY, tileWidth, tileHeight);
+            Region key = new Region(resX, resY, tileWidth, tileHeight);
+            if (!cachedTiles.containsKey(key)) {
+              byte[] b = new byte[subResTile.length];
+              tiffParser.getSamples(
+                ifd, b, resX, resY, tileWidth, tileHeight);
+              cachedTiles.put(key, b);
+            }
+            System.arraycopy(cachedTiles.get(key), 0,
+              subResTile, 0, subResTile.length);
             subResX = resX;
             subResY = resY;
           }

--- a/components/formats-gpl/src/loci/formats/in/VentanaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/VentanaReader.java
@@ -524,6 +524,19 @@ public class VentanaReader extends BaseTiffReader {
           }
         }
       }
+
+      // remove total overlap pixels from image dimensions
+      // otherwise there will be a black band along the bottom and right side
+      int removeX = (int) Math.floor((area.tileColumns - 1) * rightSum);
+      int removeY = (int) Math.floor((area.tileRows - 1) * upSum);
+      for (int s=1; s<core.get(0).resolutionCount; s++) {
+        int scale = getScale(s);
+        core.get(s).sizeX -= (removeX / scale);
+        core.get(s).sizeY -= (removeY / scale);
+      }
+      // reset full resolution last so that getScale is not affected
+      core.get(0).sizeX -= removeX;
+      core.get(0).sizeY -= removeY;
     }
   }
 


### PR DESCRIPTION
Backported from private PRs.  See https://trac.openmicroscopy.org/ome/ticket/12899 and https://trello.com/c/oCH7PbA5/10-ventana-bif.

Files have been uploaded to ```inbox/ventana/``` for copying to ```curated``` - there are 5 files total.  With this PR, ```showinf -noflat``` on each should detect a pyramid with 9 or 10 resolutions plus two label/overview series.

Ventana .bif files are TIFF files where the first two IFDs correspond to label/overview/macro images and the remaining IFDs form a pyramid.  Each IFD in the pyramid stores the image as tiles that are typically at least 1k x 1k.

Not all stored tiles are used; the largest IFD in the pyramid contains XML that defines one or more ```AOI```s (areas of interest) that have been scanned.  Any tiles outside scanned AOIs are discarded.  Within each AOI, the file defines a list of X and Y overlaps for some pairs of tiles within the AOI (```TileJointInfo```).  These are approximate values, and do not represent all of the overlaps that need to be removed.  The ```TileJointInfo``` values are filtered by the ```Confidence``` value and averaged to produce 3 numbers: X overlap, Y overlap, and Y shift.  X and Y overlap is applied to all tiles in the AOI; Y shift moves every other column of tiles in the AOI by the calculated number of pixels.  These 3 numbers are used to calculate absolute positions for each tile.

In the largest pyramid resolution, each TIFF tile corresponds to one acquired tile.  In smaller resolutions, each TIFF tile is n x n acquired tiles with overlaps embedded.  To read smaller resolutions, each TIFF tile must be split apart and reassembled using the absolute positions that were calculated for the largest resolution.

Ventana .tif files are similar to .bif files, but have been processed to remove all overlaps and all scanned area metadata.  The IFD ordering and magnification metadata is the same as in .bif, but the tiles can be treated as normal TIFF tiles.

To my knowledge, there is no freely available software that can be used to get a ground truth, so this is a little difficult to thoroughly validate.  Comparing the pyramid images to the label/thumbnail image is probably the most reliable check.  The pyramid images can also be checked for any really obvious seams between tiles that indicate incorrect overlap calculation.

There is also a ```ventana.split_tiles``` option (turned off by default) which, when enabled, will return each tile in the largest resolution as a separate series.  This is a fall-back option in case the reader's stitching isn't good enough for a particular file. 

This will require a minor release but isn't critical for 6.1.0, so feel free to exclude in favor of other readers.