### PR TITLE
ICSReader: safeguard against unitIndex growing too large

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/ICSReader.java
+++ b/components/formats-bsd/src/loci/formats/in/ICSReader.java
@@ -1500,7 +1500,7 @@ public class ICSReader extends FormatReader {
           ArrayList<String> realUnits = new ArrayList<String>();
           int unitIndex = 0;
           for (int i=0; i<axes.length; i++) {
-            if (axes[i].toLowerCase().equals("ch")) {
+            if (axes[i].toLowerCase().equals("ch") || unitIndex >= units.length) {
               realUnits.add("nm");
             }
             else {


### PR DESCRIPTION
This fixes the issue reading .ics/.ids files written by SVI Huygens, discussed [here on the forum](https://forum.image.sc/t/bio-formats-fails-reading-single-channel-ics-ids-dataset-written-by-svi-huygens/23868?u=imagejan) and on [this trello card](https://trello.com/c/xQW1FyGQ).
