### PR TITLE
TIFF: use fast reading case when image is stored in contiguous strips

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -941,7 +941,9 @@ public class TiffParser {
     boolean contiguousTiles = tileWidth == imageWidth && planarConfig == 1;
     if (contiguousTiles) {
       for (int i=1; i<stripOffsets.length; i++) {
-        if (stripOffsets[i] != stripOffsets[i - 1] + stripByteCounts[i - 1]) {
+        if (stripOffsets[i] != stripOffsets[i - 1] + stripByteCounts[i - 1] ||
+          stripOffsets[i] + stripByteCounts[i] > in.length())
+        {
           contiguousTiles = false;
           break;
         }

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -938,7 +938,7 @@ public class TiffParser {
     // if the image is stored as strips (not tiles) and
     // the strips are stored in order with no gaps then we can
     // treat them as a single strip for faster reading
-    boolean contiguousTiles = tileWidth == imageWidth;
+    boolean contiguousTiles = tileWidth == imageWidth && planarConfig == 1;
     if (contiguousTiles) {
       for (int i=1; i<stripOffsets.length; i++) {
         if (stripOffsets[i] != stripOffsets[i - 1] + stripByteCounts[i - 1]) {

--- a/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffParser.java
@@ -906,6 +906,7 @@ public class TiffParser {
     else codecOptions = compression.getCompressionCodecOptions(ifd);
     codecOptions.interleaved = true;
     codecOptions.littleEndian = ifd.isLittleEndian();
+    long imageWidth = ifd.getImageWidth();
     long imageLength = ifd.getImageLength();
 
     long[] stripOffsets = null;
@@ -934,6 +935,19 @@ public class TiffParser {
 
     long[] stripByteCounts = ifd.getStripByteCounts();
 
+    // if the image is stored as strips (not tiles) and
+    // the strips are stored in order with no gaps then we can
+    // treat them as a single strip for faster reading
+    boolean contiguousTiles = tileWidth == imageWidth;
+    if (contiguousTiles) {
+      for (int i=1; i<stripOffsets.length; i++) {
+        if (stripOffsets[i] != stripOffsets[i - 1] + stripByteCounts[i - 1]) {
+          contiguousTiles = false;
+          break;
+        }
+      }
+    }
+
     // special case: if we only need one tile, and that tile doesn't need
     // any special handling, then we can just read it directly and return
     if ((effectiveChannels == 1 || planarConfig == 1) && (ifd.getBitsPerSample()[0] % 8) == 0 &&
@@ -941,9 +955,16 @@ public class TiffParser {
       photoInterp != PhotoInterp.CMYK && photoInterp != PhotoInterp.Y_CB_CR &&
       compression == TiffCompression.UNCOMPRESSED &&
       ifd.getIFDIntValue(IFD.FILL_ORDER) != 2 &&
-      numTileRows * numTileCols == 1 && stripOffsets != null && stripByteCounts != null &&
-      in.length() >= stripOffsets[0] + stripByteCounts[0])
+      stripOffsets != null && stripByteCounts != null &&
+      in.length() >= stripOffsets[0] + stripByteCounts[0] &&
+      (numTileRows * numTileCols == 1 || contiguousTiles))
     {
+      if (contiguousTiles) {
+        stripByteCounts = new long[] {stripByteCounts[0] * stripByteCounts.length};
+        stripOffsets = new long[] {stripOffsets[0]};
+        tileLength = imageLength;
+      }
+
       long column = x / tileWidth;
       int firstTile = (int) ((y / tileLength) * numTileCols + column);
       int lastTile =


### PR DESCRIPTION
Backported from a private PR.

This adds a special case to ```TiffParser``` to treat uncompressed strips that are stored in order with no gaps as a single strip.  This should somewhat improve read times for some TIFF files, but likely won't have a noticeable effect upon repo test times.  Any TIFF files that use compression or store tiles instead of strips should be unaffected.

The main thing to verify is that all builds remain green; can definitely exclude in the morning if anything is failing.  There are no API or memo changes, so this should be safe to defer to a patch release.