### PR TITLE
OIR: Allow more than 1000 time-points

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OIRReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OIRReader.java
@@ -1419,8 +1419,8 @@ public class OIRReader extends FormatReader {
     if (tIndex < 0) {
       return 0;
     }
-    // assumes 3 digits
-    return Integer.parseInt(uid.substring(tIndex + 1, tIndex + 4)) - 1;
+    String tSubString = uid.substring(tIndex+1);
+    return Integer.parseInt(tSubString.substring(0, tSubString.indexOf("_"))) - 1;
   }
 
   private int getBlock(String uid) {


### PR DESCRIPTION
This has been raised in thread https://forum.image.sc/t/problems-opening-olympus-oir-files-using-bio-formats/24747/2 (which contains a sample file for download) and https://github.com/openmicroscopy/bioformats/issues/3242 

The issue shows up when loading a timepoint from 1000 onwards which would return an empty frame and `[WARN] No pixel blocks for plane #1000`