### PR TITLE
Cellomics: indexing fixes for plates with a single well or missing fields

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellomicsReader.java
@@ -165,6 +165,22 @@ public class CellomicsReader extends FormatReader {
     return seriesFiles.toArray(new String[seriesFiles.size()]);
   }
 
+  /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
+  public String[] getUsedFiles(boolean noPixels) {
+    FormatTools.assertId(currentId, true, 1);
+
+    if (noPixels) {
+      return metadataFiles.toArray(new String[metadataFiles.size()]);
+    }
+
+    ArrayList<String> allFiles = new ArrayList<String>();
+    allFiles.addAll(metadataFiles);
+    for (ChannelFile f : files) {
+      allFiles.add(f.filename);
+    }
+    return allFiles.toArray(new String[allFiles.size()]);
+  }
+
   /* @see loci.formats.IFormatReader#fileGroupOption(String) */
   @Override
   public int fileGroupOption(String id) throws FormatException, IOException {

--- a/tools/mkplate.py
+++ b/tools/mkplate.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from optparse import OptionParser
+import os
+import sys
+import shutil
+
+if __name__ == "__main__":
+
+    parser = OptionParser()
+    parser.add_option("--basefile", action="store", type="string", dest="basefile")
+    parser.add_option("--prefix", action="store", type="string", dest="platePrefix")
+    parser.add_option("--rows", action="store", type="int", dest="plateRows", default=1)
+    parser.add_option("--columns", action="store", type="int", dest="plateColumns", default=1)
+    parser.add_option("--fields", action="store", type="int", dest="fields", default=1)
+    parser.add_option("--channels", action="store", type="int", dest="channels", default=1)
+
+    (options, args) = parser.parse_args(sys.argv)
+
+    suffix = options.basefile[options.basefile.index('.'):]
+
+    for row in (1, options.plateRows):
+        for col in (1, options.plateColumns):
+            for field in (1, options.fields):
+                for channel in (0, options.channels - 1):
+                  destFile = '{:s}_{:c}{:02d}f{:02d}d{:1d}{:s}'.format(options.platePrefix, row + 64, col, field, channel, suffix)
+                  shutil.copyfile(options.basefile, destFile)


### PR DESCRIPTION
First four commits backported from a private PR; last commit added to fix test failures.  Also fixes https://trello.com/c/Liyb44EG/279-cellomics-dib-plate-failure

For single well plates, this should fix the well row and column reported by ```showinf -nopix -omexml``` to match what is in the file name instead of always being 0.  For plates with missing fields, in particular cases when the first field index is greater than 0, this should fix indexing so that ```showinf -nopix -omexml``` does not throw an exception or result in orphaned ```Image```s.

To test, use ```inbox/cellomics/samples/large-field-index``` and ```curated/cellomics/qa-21720```.  The former mimics the test dataset for the original private PR.  The first field index is 29; ```showinf -nopix -omexml``` on one of the ```*d*.C01``` or ```*o*.C01``` files should show 2 channels x 290 series (10 fields x 29 wells), which matches the file count.  ```showinf -nopix -omexml``` on the QA 21720 dataset should result in a single series that is linked to the ```Plate``` as well row 0 and column 13 (```A14```, as in the file name).

I would expect this to impact memo files, so not safe for a patch release.


