### PR TITLE
CellWorX: ignore files that contain "_thumb"

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -784,7 +784,7 @@ public class CellWorxReader extends FormatReader {
       for (String f : directoryList) {
         if (checkSuffix(f, new String [] {"tif", "tiff", "pnl"})) {
           String path = new Location(parent, f).getAbsolutePath();
-          if (path.startsWith(base) && path.indexOf("_thumb_") < 0) {
+          if (path.startsWith(base) && path.indexOf("_thumb") < 0) {
             files[nextFile++] = path;
           }
         }

--- a/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
+++ b/components/formats-gpl/src/loci/formats/in/CellWorxReader.java
@@ -157,6 +157,29 @@ public class CellWorxReader extends FormatReader {
     return files.toArray(new String[files.size()]);
   }
 
+  /* @see loci.formats.IFormatReader#getUsedFiles(boolean) */
+  @Override
+  public String[] getUsedFiles(boolean noPixels) {
+    String[] files = super.getUsedFiles(noPixels);
+
+    List<String> allFiles = new ArrayList<String>();
+    for (String f : files) {
+      allFiles.add(f);
+    }
+    if (directoryList != null) {
+      Location root = new Location(currentId).getParentFile();
+      for (String f : directoryList) {
+        if (f.toLowerCase().indexOf("_thumb") > 0) {
+          String path = new Location(root, f).getAbsolutePath();
+          if (!allFiles.contains(path)) {
+            allFiles.add(path);
+          }
+        }
+      }
+    }
+    return allFiles.toArray(new String[allFiles.size()]);
+  }
+
   /**
    * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
    */
@@ -252,6 +275,11 @@ public class CellWorxReader extends FormatReader {
     }
 
     super.initFile(id);
+    if (directoryList == null) {
+      Location rootDir = new Location(id).getAbsoluteFile().getParentFile();
+      directoryList = rootDir.list(true);
+      Arrays.sort(directoryList);
+    }
 
     try {
       ServiceFactory factory = new ServiceFactory();
@@ -784,7 +812,8 @@ public class CellWorxReader extends FormatReader {
       for (String f : directoryList) {
         if (checkSuffix(f, new String [] {"tif", "tiff", "pnl"})) {
           String path = new Location(parent, f).getAbsolutePath();
-          if (path.startsWith(base) && path.indexOf("_thumb") < 0) {
+          if (path.startsWith(base) && path.toLowerCase().indexOf("_thumb") < 0)
+          {
             files[nextFile++] = path;
           }
         }

--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1928,6 +1928,11 @@ public class FormatReaderTest {
             continue;
           }
 
+          // CellWorx datasets can only be reliably detected with the .HTD file
+          if (reader.getFormat().equals("CellWorx")) {
+            continue;
+          }
+
           // NRRD datasets are allowed to have differing used files.
           // One raw file can have multiple header files associated with
           // it, in which case selecting the raw file will always produce


### PR DESCRIPTION
Backported from a private PR.

Thumbnail files with a UUID in the file name may be of the form
```<plate name>_<dimensions>_thumb<UUID>.tif```, not
```<plate name>_<dimensions>_thumb_<UUID>tif```.  Checking the index of
```_thumb``` in the file name catches both cases.

To test use ```curated/cellworx/samples/thumb-test``` (copied from ```curated/cellworx/public/idr0005```, with TIFF files renamed).  With this PR, ```showinf -nopix 2011-04-19-plate-1.HTD``` should throw an exception:

```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 3
	at loci.formats.in.CellWorxReader.getTiffFiles(CellWorxReader.java:788)
	at loci.formats.in.CellWorxReader.initFile(CellWorxReader.java:346)
	at loci.formats.FormatReader.setId(FormatReader.java:1389)
	at loci.formats.ImageReader.setId(ImageReader.java:842)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1035)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1121)
```

With this PR, the same command should have identical results compared to ```curated/cellworx/public/idr0005```.

I wouldn't expect this to impact tests or memo files, so should be fine for a patch release.