### PR TITLE
Assume that all .rcpnl files have one timepoint

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -487,6 +487,21 @@ public class DeltavisionReader extends FormatReader {
     }
 
     int nStagePositions = xTiles * yTiles;
+
+    // if an *.rcpnl file is encountered, assume all timepoints are positions
+    // the stage position values may not represent a uniform grid,
+    // but should still be separate positions
+    if (checkSuffix(currentId, "rcpnl")) {
+      nStagePositions = getSizeT();
+      if (xTiles * yTiles != nStagePositions) {
+        // if positions are not uniform, we can't reliably determine
+        // the size of the grid or the direction in which the stage moved
+        xTiles = nStagePositions;
+        yTiles = 1;
+        backwardsStage = false;
+      }
+    }
+
     if (nStagePositions > 0 && nStagePositions <= getSizeT()) {
       int t = getSizeT();
       m.sizeT /= nStagePositions;


### PR DESCRIPTION
Backported from a private PR.

.rcpnl files use a format nearly identical to Deltavision, but the timepoint field is assumed to represent the stage position count.  This was handled by existing logic when the stage positions formed a uniform grid, but we are now encountering files where the Y positions in a row or X positions in a column vary slightly.

To test, copy/symlink ```curated/deltavision/samples/lung-lentiCMtriple-4_R3D.dv``` to ```lung-lentiCMtriple-4_R3D.rcpnl```.  ```showinf -nopix lung-lentiCMtriple-4_R3D.rcpnl``` without this PR will be identical to the same command with ```lung-lentiCMtriple-4_R3D.dv```.  With this PR, the results for ```lung-lentiCMtriple-4_R3D.dv``` should be unchanged, but for ```lung-lentiCMtriple-4_R3D.rcpnl``` there should be 6 series each with 1 timepoint instead of 1 series with 6 timepoints.

There is only one other .rcpnl file in the repository and it should only have a single position, so I would not expect tests to be affected.  Memo files should also be unchanged, so this should be safe for a patch release.  Once approved, this might require a note on the Deltavision format doc page.