### PR TITLE
Flex: use plate barcode for grouping, so that truncated files are kept

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -251,8 +251,14 @@ public class FlexReader extends FormatReader {
       new RandomAccessInputStream(getFileHandle(file.file))) {
         IFD ifd;
         if (file.offsets == null) {
-          ifd = file.ifds.get(imageNumber);
-          factor = 1d;
+          if (imageNumber < file.ifds.size()) {
+            ifd = file.ifds.get(imageNumber);
+            factor = 1d;
+          }
+          else {
+            Arrays.fill(buf, (byte) 0);
+            return buf;
+          }
         }
         else {
           // Only the first IFD was read. Hack the IFD to adjust the offset.
@@ -1211,6 +1217,7 @@ public class FlexReader extends FormatReader {
     HashMap<String, ArrayList<String>> v = new HashMap<String, ArrayList<String>>();
     Boolean firstCompressed = null;
     int firstIFDCount = 0;
+    String firstBarcode = null;
     for (String file : fileList) {
       LOGGER.warn("parsing {}", file);
       IFD firstIFD = null;
@@ -1226,7 +1233,23 @@ public class FlexReader extends FormatReader {
         firstCompressed = compressed;
         firstIFDCount = ifdCount;
       }
-      if (compressed == firstCompressed && ifdCount == firstIFDCount) {
+      String xml = XMLTools.sanitizeXML(firstIFD.getIFDStringValue(FLEX));
+      int barcodeIndex = xml.indexOf("Barcode");
+      String barcode = "";
+      if (barcodeIndex >= 0) {
+        int start = xml.indexOf(">", barcodeIndex) + 1;
+        int end = xml.indexOf("<", barcodeIndex);
+        if (start > 0 && end > 0) {
+          barcode = xml.substring(start, end);
+        }
+      }
+      if (firstBarcode == null) {
+        firstBarcode = barcode;
+      }
+
+      if (compressed == firstCompressed && barcode.equals(firstBarcode) &&
+        ifdCount <= firstIFDCount)
+      {
         int[] well = getWell(file);
         int field = getField(file);
         if (well[0] > nRows) nRows = well[0];


### PR DESCRIPTION
Without this change, a truncated file would be rejected from the used file list,
which could completely break plate detection.  With an added barcode
check, plates can include truncated files, and files from different
plates will not be inadvertently grouped together.

To test, use ``` /uod/idr/filesets/idr0056-stojic-lncrnas/20190123-ftp/Stojic_screen B_platesIDR/1982/Meas_01(2014-07-04_14-48-06)/```.  Without this change, ```showinf -nopix``` on any of the files should result in a single series and a single used file.  With this change, all .flex files in the directory should be grouped into a plate.

Tests should continue to pass, and memo files should be unaffected.