### PR TITLE
NetCDF upgrade

### DIFF
--- a/components/formats-gpl/build.xml
+++ b/components/formats-gpl/build.xml
@@ -67,6 +67,9 @@ Type "ant -p" for a list of targets.
         <rsel:not>
           <rsel:name name="netcdf*.jar"/>
         </rsel:not>
+        <rsel:not>
+          <rsel:name name="cdm*.jar"/>
+        </rsel:not>
       </restrict>
     </path>
     <testng failureProperty="failedTest">

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -70,8 +70,8 @@
     </dependency>
     <dependency>
       <groupId>edu.ucar</groupId>
-      <artifactId>netcdf</artifactId>
-      <version>4.3.22</version>
+      <artifactId>netcdf4</artifactId>
+      <version>4.6.10</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>
@@ -279,7 +279,8 @@
                 <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
               </additionalClasspathElements>
               <classpathDependencyExcludes>
-                <classpathDependencyExclude>edu.ucar:netcdf</classpathDependencyExclude>
+                <classpathDependencyExclude>edu.ucar:netcdf4</classpathDependencyExclude>
+                <classpathDependencyExclude>edu.ucar:cdm</classpathDependencyExclude>
               </classpathDependencyExcludes>
               <systemPropertyVariables>
                 <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -70,24 +70,20 @@
     </dependency>
     <dependency>
       <groupId>edu.ucar</groupId>
-      <artifactId>netcdf4</artifactId>
+      <artifactId>cdm</artifactId>
       <version>4.6.10</version>
       <exclusions>
         <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-s3</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.beust</groupId>
+          <artifactId>jcommander</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sleepycat</groupId>
-          <artifactId>je</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jna</groupId>
-          <artifactId>jna</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
         </exclusion>
         <exclusion>
           <groupId>edu.ucar</groupId>
@@ -102,8 +98,8 @@
           <artifactId>jcip-annotations</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>net.sf.ehcache</groupId>
-          <artifactId>ehcache-core</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.jdom</groupId>
@@ -279,7 +275,6 @@
                 <additionalClasspathElement>${basedir}/../../ant/</additionalClasspathElement>
               </additionalClasspathElements>
               <classpathDependencyExcludes>
-                <classpathDependencyExclude>edu.ucar:netcdf4</classpathDependencyExclude>
                 <classpathDependencyExclude>edu.ucar:cdm</classpathDependencyExclude>
               </classpathDependencyExcludes>
               <systemPropertyVariables>

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>cdm</artifactId>
-      <version>4.6.10</version>
+      <version>4.6.13</version>
       <exclusions>
         <exclusion>
           <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Re-opening the effort started in https://github.com/openmicroscopy/bioformats/pull/2938 - see also https://trello.com/c/VrpWk1Fj/119-netcdf-review and discussions in https://github.com/openmicroscopy/bioformats/pull/2928.

At the Bio-Formats level, the primary expectation is that automated tests keep passing especially for all readers using the netcdf service (Minc, Imaris HDF, Veeco). Additionally, this should address known issues with some Imaris IMS files so new files should be included in the testing.

As noted on the previous effort, the biggest known impact might still be at the level of the Bio-Formats/OMERO coupling. Lots of effort are currently put into improving the OMERO 5.5 Java build system and reviewing Java dependencies across the stack (https://github.com/ome/ome-common-java/pull/42, https://github.com/openmicroscopy/bioformats/pull/3335).