### PR TITLE
CZI: update plane positions for many datasets

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -3834,15 +3834,15 @@ public class ZeissCZIReader extends FormatReader {
               if (text != null) {
                 if (tagNode.getNodeName().equals("StageXPosition")) {
                   final Double number = Double.valueOf(text);
-                  stageX = new Length(number, UNITS.REFERENCEFRAME);
+                  stageX = new Length(number, UNITS.MICROM);
                 }
                 else if (tagNode.getNodeName().equals("StageYPosition")) {
                   final Double number = Double.valueOf(text);
-                  stageY = new Length(number, UNITS.REFERENCEFRAME);
+                  stageY = new Length(number, UNITS.MICROM);
                 }
                 else if (tagNode.getNodeName().equals("FocusPosition")) {
                   final Double number = Double.valueOf(text);
-                  stageZ = new Length(number, UNITS.REFERENCEFRAME);
+                  stageZ = new Length(number, UNITS.MICROM);
                 }
                 else if (tagNode.getNodeName().equals("AcquisitionTime")) {
                   Timestamp t = Timestamp.valueOf(text);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1328,25 +1328,25 @@ public class ZeissCZIReader extends FormatReader {
           startTime = p.timestamp;
         }
 
-        if (p.stageX != null) {
-          store.setPlanePositionX(p.stageX, i, plane);
-        }
-        else if (positionsX != null && i < positionsX.length &&
+        if (positionsX != null && i < positionsX.length &&
           positionsX[i] != null)
         {
           store.setPlanePositionX(positionsX[i], i, plane);
+        }
+        else if (p.stageX != null) {
+          store.setPlanePositionX(p.stageX, i, plane);
         }
         else {
           store.setPlanePositionX(new Length(p.col, UNITS.REFERENCEFRAME), i, plane);
         }
 
-        if (p.stageY != null) {
-          store.setPlanePositionY(p.stageY, i, plane);
-        }
-        else if (positionsY != null && i < positionsY.length &&
+        if (positionsY != null && i < positionsY.length &&
           positionsY[i] != null)
         {
           store.setPlanePositionY(positionsY[i], i, plane);
+        }
+        else if (p.stageY != null) {
+          store.setPlanePositionY(p.stageY, i, plane);
         }
         else {
           store.setPlanePositionY(new Length(p.row, UNITS.REFERENCEFRAME), i, plane);
@@ -2039,6 +2039,16 @@ public class ZeissCZIReader extends FormatReader {
               positionsZ[nextPosition] = new Length(DataTools.parseDouble(z), UNITS.MICROMETER);
               nextPosition++;
             }
+          }
+          if (positions.getLength() == 0) {
+            positions = scene.getElementsByTagName("CenterPosition");
+            if (positions.getLength() > 0) {
+              Element position = (Element) positions.item(0);
+              String[] pos = position.getTextContent().split(",");
+              positionsX[nextPosition] = new Length(DataTools.parseDouble(pos[0]), UNITS.MICROM);
+              positionsY[nextPosition] = new Length(DataTools.parseDouble(pos[1]), UNITS.MICROM);
+            }
+            nextPosition++;
           }
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2063,7 +2063,7 @@ public class ZeissCZIReader extends FormatReader {
               nextPosition++;
             }
           }
-          if (positions.getLength() == 0) {
+          if (positions.getLength() == 0 && (mosaics <= 1 || (prestitched != null && prestitched))) {
             positions = scene.getElementsByTagName("CenterPosition");
             if (positions.getLength() > 0) {
               Element position = (Element) positions.item(0);

--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -1328,32 +1328,47 @@ public class ZeissCZIReader extends FormatReader {
           startTime = p.timestamp;
         }
 
+        Length x = null;
         if (positionsX != null && i < positionsX.length &&
           positionsX[i] != null)
         {
-          store.setPlanePositionX(positionsX[i], i, plane);
+          x = positionsX[i];
         }
         else if (p.stageX != null) {
-          store.setPlanePositionX(p.stageX, i, plane);
+          x = p.stageX;
         }
         else {
-          store.setPlanePositionX(new Length(p.col, UNITS.REFERENCEFRAME), i, plane);
+          x = new Length(p.col, UNITS.REFERENCEFRAME);
+        }
+        if (x != null) {
+          store.setPlanePositionX(x, i, plane);
+          if (plane == 0) {
+            store.setStageLabelX(x, i);
+          }
         }
 
+        Length y = null;
         if (positionsY != null && i < positionsY.length &&
           positionsY[i] != null)
         {
-          store.setPlanePositionY(positionsY[i], i, plane);
+          y = positionsY[i];
         }
         else if (p.stageY != null) {
-          store.setPlanePositionY(p.stageY, i, plane);
+          y = p.stageY;
         }
         else {
-          store.setPlanePositionY(new Length(p.row, UNITS.REFERENCEFRAME), i, plane);
+          y = new Length(p.row, UNITS.REFERENCEFRAME);
+        }
+        if (y != null) {
+          store.setPlanePositionY(y, i, plane);
+          if (plane == 0) {
+            store.setStageLabelY(y, i);
+          }
         }
 
+        Length z = null;
         if (p.stageZ != null) {
-          store.setPlanePositionZ(p.stageZ, i, plane);
+          z = p.stageZ;
         }
         else if (positionsZ != null && i < positionsZ.length) {
           int zIndex = getZCTCoords(plane)[0];
@@ -1363,13 +1378,21 @@ public class ZeissCZIReader extends FormatReader {
               if (zStep != null) {
                 value += zIndex * zStep.value().doubleValue();
               }
-              Length pos = new Length(value, zStep.unit());
-              store.setPlanePositionZ(pos, i, plane);
+              z = new Length(value, zStep.unit());
             }
             else {
-              store.setPlanePositionZ(positionsZ[i], i, plane);
+              z = positionsZ[i];
             }
           }
+        }
+        if (z != null) {
+          store.setPlanePositionZ(z, i, plane);
+          if (plane == 0) {
+            store.setStageLabelZ(z, i);
+          }
+        }
+        if (plane == 0 && (x != null || y != null || z != null)) {
+          store.setStageLabelName("Scene position #" + i, i);
         }
 
         if (p.timestamp != null) {


### PR DESCRIPTION
Backported from 3 private PRs.

This is meant to bring XY plane positions closer to what is reported in ZEN.  This primarily impacts datasets with at least one pyramid.  No new sample files have been added, so testing involves comparing the ground truth (screenshots in https://docs.google.com/document/d/1iL9h9yQ3AVmmzHkI2NsUoqCI08Kw4V82C4vdv6WB-44/edit) to the updated configuration.

With the forthcoming configuration PR, I wouldn't expect builds to fail.  Feel free to exclude until there is time to review though.