### PR TITLE
TIFF: don't assume all IFDs have same XY size during non-sequential write

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -476,7 +476,12 @@ public class TiffSaver {
           ifd = parser.getIFD(ifdOffsets[no]);
         }
         else if (no > 0 && no - 1 < ifdOffsets.length) {
-          ifd = parser.getIFD(ifdOffsets[no - 1]);
+          IFD copy = parser.getIFD(ifdOffsets[no - 1]);
+          for (Integer tag : copy.keySet()) {
+            if (!ifd.containsKey(tag)) {
+              ifd.put(tag, copy.get(tag));
+            }
+          }
           long next = parser.getNextOffset(ifdOffsets[no - 1]);
           out.seek(next);
         }


### PR DESCRIPTION
If ```setWritingSequentially(true)``` was not called on the ```TiffSaver```, then writing each
resolution of a pyramid in order caused the previous resolution's
dimensions to be used.  This updates the IFD reuse logic so that only
tags which are not present in the ```ifd``` argument are reused.  Use cases
where ```setWritingSequentially(true)``` is called will not be affected.

This should fix https://github.com/ome/bio-formats-examples/issues/48