### PR TITLE
Make ImageConverter public

### DIFF
--- a/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
+++ b/components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java
@@ -128,7 +128,7 @@ public final class ImageConverter {
 
   // -- Constructor --
 
-  private ImageConverter() { }
+  public ImageConverter() { }
 
   /**
    * Parse the given argument list to determine how to perform file conversion.

--- a/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
+++ b/components/bio-formats-tools/test/loci/formats/tools/ImageConverterTest.java
@@ -137,6 +137,15 @@ public class ImageConverterTest {
     }
   }
 
+  public void testConstructor() throws FormatException, IOException {
+    outFile = tempDir.resolve("test.ome.tiff").toFile();
+    outFile.deleteOnExit();
+    ImageConverter converter = new ImageConverter();
+    boolean status = converter.testConvert(new ImageWriter(), new String[] {"test.fake", outFile.getAbsolutePath()});
+    assertEquals(status, 0);
+    checkImage();
+  }
+
   @Test(dataProvider = "suffixes")
   public void testDefault(String suffix) throws FormatException, IOException {
     outFile = tempDir.resolve("test" + suffix).toFile();


### PR DESCRIPTION
Fixes #3359 

There is no obvious rationale for keeping this constructor private and there are examples of downstream code working around the private scope - see https://github.com/spacetx/spacetx-writer/blob/0.1.1/src/main/java/spacetx/FOVTool.java#L430.

In addition to publicizing the constructor, this PR adds a minimal unit test showing the creation of the `ImageConverter` class