### PR TITLE
Update POM version numbers to 6.1.0

### DIFF
--- a/components/bio-formats-plugins/pom.xml
+++ b/components/bio-formats-plugins/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bio-formats-tools/pom.xml
+++ b/components/bio-formats-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/bundles/bioformats_package/pom.xml
+++ b/components/bundles/bioformats_package/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/bundles/loci_tools/pom.xml
+++ b/components/bundles/loci_tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/forks/turbojpeg/pom.xml
+++ b/components/forks/turbojpeg/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/components/formats-api/pom.xml
+++ b/components/formats-api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-bsd/pom.xml
+++ b/components/formats-bsd/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/formats-bsd/src/loci/formats/UpgradeChecker.java
+++ b/components/formats-bsd/src/loci/formats/UpgradeChecker.java
@@ -64,7 +64,7 @@ public class UpgradeChecker {
   // -- Constants --
 
   /** Version number of the latest stable release. */
-  public static final String STABLE_VERSION = "6.1.0-m2";
+  public static final String STABLE_VERSION = "6.1.0";
 
   /** Location of the OME continuous integration server. */
   public static final String CI_SERVER = "http://ci.openmicroscopy.org";

--- a/components/formats-gpl/pom.xml
+++ b/components/formats-gpl/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/components/test-suite/pom.xml
+++ b/components/test-suite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ome</groupId>
     <artifactId>pom-bio-formats</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>pom-bio-formats</artifactId>
-  <version>6.1.0-SNAPSHOT</version>
+  <version>6.1.0</version>
   <packaging>pom</packaging>
 
   <name>Bio-Formats projects</name>
@@ -35,7 +35,7 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
-    <release.version>6.1.0-SNAPSHOT</release.version>
+    <release.version>6.1.0</release.version>
     <date>${maven.build.timestamp}</date>
     <year>2017</year>
     <project.rootdir>${basedir}</project.rootdir>


### PR DESCRIPTION
Repository: openmicroscopy/bioformats
Already up-to-date.



Generated by build [BIOFORMATS-DEV-latest-version-bump#102](https://ci.openmicroscopy.org/job/BIOFORMATS-DEV-latest-version-bump/102/).

----
--no-rebase