### PR TITLE
LIF: Correctly read scale from polygon regions of interest

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -2361,7 +2361,7 @@ public class LIFReader extends FormatReader {
           for (int i=0; i<x.size(); i++) {
             points.append(x.get(i).doubleValue() * scaleX + roiX);
             points.append(",");
-            points.append(y.get(i).doubleValue() * scaleX + roiY);
+            points.append(y.get(i).doubleValue() * scaleY + roiY);
             if (i < x.size() - 1) points.append(" ");
           }
           store.setPolygonID(shapeID, roi, 1);

--- a/components/formats-gpl/src/loci/formats/in/LIFReader.java
+++ b/components/formats-gpl/src/loci/formats/in/LIFReader.java
@@ -2352,16 +2352,16 @@ public class LIFReader extends FormatReader {
         roiY = transY - 2 * cornerY;
       }
 
-      // TODO : rotation/scaling not populated
+      // TODO : rotation not populated
 
       String shapeID = MetadataTools.createLSID("Shape", roi, 1);
       switch (type) {
         case POLYGON:
           final StringBuilder points = new StringBuilder();
           for (int i=0; i<x.size(); i++) {
-            points.append(x.get(i).doubleValue() + roiX);
+            points.append(x.get(i).doubleValue() * scaleX + roiX);
             points.append(",");
-            points.append(y.get(i).doubleValue() + roiY);
+            points.append(y.get(i).doubleValue() * scaleX + roiY);
             if (i < x.size() - 1) points.append(" ");
           }
           store.setPolygonID(shapeID, roi, 1);

--- a/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/LeicaHandler.java
@@ -1060,16 +1060,16 @@ public class LeicaHandler extends BaseHandler {
         roiY = transY - 2 * cornerY;
       }
 
-      // TODO : rotation/scaling not populated
+      // TODO : rotation not populated
 
       String shapeID = MetadataTools.createLSID("Shape", roi, 1);
       switch (type) {
         case POLYGON:
           final StringBuilder points = new StringBuilder();
           for (int i=0; i<x.size(); i++) {
-            points.append(x.get(i).doubleValue() + roiX);
+            points.append(x.get(i).doubleValue() * scaleX + roiX);
             points.append(",");
-            points.append(y.get(i).doubleValue() + roiY);
+            points.append(y.get(i).doubleValue() * scaleY + roiY);
             if (i < x.size() - 1) points.append(" ");
           }
           store.setPolygonID(shapeID, roi, 1);


### PR DESCRIPTION
Bioformats incorrectly loads elliptical/polygon ROIs from LIF files created in newer versions of LAS X because bioformats does not account for the scale factor (which was unused in previous versions of LAS X). 

This PR uses the ROI scale correctly and so can load ROIs created in both older and newer versions.