### PR TITLE
DeltavisionReader: add lens IDs associated with rcpnl files

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2659,6 +2659,11 @@ public class DeltavisionReader extends FormatReader {
         break;
       case 18107: // API 10X, BH
         lensNA = 0.15;
+
+        if (checkSuffix(currentId, "rcpnl")) {
+          lensNA = 0.30;
+        }
+
         magnification = 10.0;
         workingDistance = 15.00;
         immersion = MetadataTools.getImmersion("Air");

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2662,9 +2662,27 @@ public class DeltavisionReader extends FormatReader {
         magnification = 10.0;
         workingDistance = 15.00;
         immersion = MetadataTools.getImmersion("Air");
+        correction = MetadataTools.getCorrection("PlanFluor");
         break;
       case 18108:
         magnification = 20.0;
+        lensNA = 0.75;
+        correction = MetadataTools.getCorrection("PlanApo");
+        break;
+      case 18109:
+        magnification = 40.0;
+        lensNA = 0.95;
+        correction = MetadataTools.getCorrection("PlanApo");
+        break;
+      case 18110:
+        magnification = 40.0;
+        lensNA = 0.60;
+        correction = MetadataTools.getCorrection("PlanFluor");
+        break;
+      case 18111:
+        magnification = 4.0;
+        lensNA = 0.20;
+        correction = MetadataTools.getCorrection("PlanApo");
         break;
       case 18201: // API 20X, HiRes A, CW
         lensNA = 0.55;

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2663,26 +2663,31 @@ public class DeltavisionReader extends FormatReader {
         workingDistance = 15.00;
         immersion = MetadataTools.getImmersion("Air");
         correction = MetadataTools.getCorrection("PlanFluor");
+        manufacturer = "Nikon";
         break;
       case 18108:
         magnification = 20.0;
         lensNA = 0.75;
         correction = MetadataTools.getCorrection("PlanApo");
+        manufacturer = "Nikon";
         break;
       case 18109:
         magnification = 40.0;
         lensNA = 0.95;
         correction = MetadataTools.getCorrection("PlanApo");
+        manufacturer = "Nikon";
         break;
       case 18110:
         magnification = 40.0;
         lensNA = 0.60;
         correction = MetadataTools.getCorrection("PlanFluor");
+        manufacturer = "Nikon";
         break;
       case 18111:
         magnification = 4.0;
         lensNA = 0.20;
         correction = MetadataTools.getCorrection("PlanApo");
+        manufacturer = "Nikon";
         break;
       case 18201: // API 20X, HiRes A, CW
         lensNA = 0.55;

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2663,6 +2663,9 @@ public class DeltavisionReader extends FormatReader {
         workingDistance = 15.00;
         immersion = MetadataTools.getImmersion("Air");
         break;
+      case 18108:
+        magnification = 20.0;
+        break;
       case 18201: // API 20X, HiRes A, CW
         lensNA = 0.55;
         magnification = 20.;

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -2799,6 +2799,10 @@ public class DeltavisionReader extends FormatReader {
         immersion = MetadataTools.getImmersion("Oil");
         manufacturer = "Nikon";
         break;
+      default:
+        LOGGER.warn(
+          "Unrecognized lens ID {}; objective information may be incorrect",
+          lensID);
     }
 
     String objectiveID = "Objective:" + lensID;


### PR DESCRIPTION
Backported from a private PR.

We received a list of lens definitions for IDs 18107 - 18111, which are primarily associated with the ```rcpnl``` variant of Deltavision files.  Most of these are new IDs, but 18107 was already defined with a different NA.  The original NA (0.15) will still be used if the file extension is not ```rcpnl```, otherwise the new NA (0.30) will be used.

As far as I can see, the only file that we have with a lens ID between 18107 and 18111 is ```curated/deltavision/qa-21574/RC_SevenChannelScan.rcpnl```, which uses 18107.  I would expect ```showinf -nopix -omexml RC_SevenChannelScan.rcpnl``` without this PR to have ```LensNA``` on the ```Objective``` set to 0.15, and with this PR to have it changed to 0.30 (as above).  Renaming the file to ```RC_SevenChannelScan.dv``` should show a ```LensNA``` of 0.15 even with this PR.

This should not affect tests or memo files, and should be safe for a patch release.