### PR TITLE
Columbus: warn and return a blank plane if a file has too few planes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -193,12 +193,16 @@ public class ColumbusReader extends FormatReader {
       }
     }
 
+    Arrays.fill(buf, (byte) 0);
     if (p != null && new Location(p.file).exists()) {
       reader.setId(p.file);
-      reader.openBytes(p.fileIndex, buf, x, y, w, h);
-    }
-    else {
-      Arrays.fill(buf, (byte) 0);
+      if (p.fileIndex < reader.getImageCount()) {
+        reader.openBytes(p.fileIndex, buf, x, y, w, h);
+      }
+      else {
+        LOGGER.warn("Blank plane for series {} plane {}; {} may be truncated",
+          getSeries(), no, p.file);
+      }
     }
     return buf;
   }


### PR DESCRIPTION
See https://github.com/IDR/idr0056-stojic-lncrnas/issues/3

This should prevent an exception from being thrown if a TIFF file is truncated, and instead return a blank plane and log the details at ```WARN```.  This is consistent with what we do for a few other HCS formats.

I wouldn't expect this to have any impact on tests or memo files.