### PR TITLE
Fix FormatReaderTest.isThisType to handle Columbus datasets with flex files

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -2480,7 +2480,8 @@ public class FormatReaderTest {
             // Columbus datasets can consist of OME-TIFF files with
             // extra metadata files
             if (result && r instanceof ColumbusReader &&
-              readers[j] instanceof OMETiffReader)
+              (readers[j] instanceof OMETiffReader ||
+               readers[j] instanceof FlexReader))
             {
               continue;
             }


### PR DESCRIPTION
Most of the datasets we received were composed of TIFF files. Using flex
as the binary container is another variant that needs to be handled
specially to pass the non-regression tests.