### PR TITLE
Zeiss CZI: expand case where tiles are automatically stitched

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -851,6 +851,9 @@ public class ZeissCZIReader extends FormatReader {
       ms0.sizeY = firstY;
       prestitched = true;
     }
+    else if (allowAutostitching() && prestitched == null && mosaics > 1) {
+      prestitched = mosaics == seriesCount && mosaics == calculatedSeries;
+    }
 
     if (ms0.imageCount * seriesCount > planes.size() * scanDim &&
       planes.size() > 0)


### PR DESCRIPTION
Backported from a private PR.

This fixes automatic stitching for 4 existing files in the repository.  Ground truth screenshots are in https://docs.google.com/document/d/139zYc9i5TPQbS_ai3cKnAWNbdix-4G_zUOwpmZcn2Oo/edit.  With the corresponding configuration PR, tests should continue to pass.