### PR TITLE
Operetta: do not attempt to open images that are too small

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -228,7 +228,12 @@ public class OperettaReader extends FormatReader {
           reader = new MinimalTiffReader();
         }
         reader.setId(p.filename);
-        reader.openBytes(0, buf, x, y, w, h);
+        if (reader.getSizeX() >= getSizeX() && reader.getSizeY() >= getSizeY()) {
+          reader.openBytes(0, buf, x, y, w, h);
+        }
+        else {
+          LOGGER.warn("Image dimension mismatch in {}", p.filename);
+        }
         reader.close();
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/OperettaReader.java
+++ b/components/formats-gpl/src/loci/formats/in/OperettaReader.java
@@ -233,6 +233,23 @@ public class OperettaReader extends FormatReader {
         }
         else {
           LOGGER.warn("Image dimension mismatch in {}", p.filename);
+
+          // the XY dimensions of this TIFF are smaller than expected,
+          // so read the stored image into the upper left corner
+          // the bottom and right side will have a black border
+          if (x < reader.getSizeX() && y < reader.getSizeY()) {
+            int realWidth = (int) Math.min(w, reader.getSizeX() - x);
+            int realHeight = (int) Math.min(h, reader.getSizeY() - y);
+            byte[] realPixels =
+              reader.openBytes(0, x, y, realWidth, realHeight);
+
+            int bpp = FormatTools.getBytesPerPixel(getPixelType());
+            int row = realWidth * bpp;
+            int outputRow = w * bpp;
+            for (int yy=0; yy<realHeight; yy++) {
+              System.arraycopy(realPixels, yy * row, buf, yy * outputRow, row);
+            }
+          }
         }
         reader.close();
       }


### PR DESCRIPTION
Backported from a private PR.

Sometimes a TIFF file will have smaller XY dimensions than all other TIFF files, and will not match the dimensions recorded in ```Index.idx.xml```.  Instead of throwing an exception, this commit returns a blank plane and logs the file name at ```WARN```.

So far we have only seen this in one specific plate, with no clear indication of how/why one file has smaller dimensions.  It wouldn't surprise me even a little if IDR encounters this at some point, though.

To test, use ```curated/perkinelmer-operetta/samples/smaller-xy```, which is copied from QA 17826 as noted in the readme.  ```showinf -series 7 Index.idx.xml``` without this PR should throw a ```FormatException```.  With this PR, the same command should display 2 channels without an exception; the first channel contains data and the second is blank.  The name of the smaller file should be logged.

Happy to have this do something other than return a blank plane, either now or in the future.  Pasting the smaller image into the upper-left corner would be possible, as would scaling it to match the expected XY dimensions.