### PR TITLE
Travis: Disabling oraclejdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ addons:
 
 jdk:
   - openjdk11
-  - oraclejdk11
   - openjdk8
-  - oraclejdk8
 
 env:
   - BUILD=maven


### PR DESCRIPTION
Disabling the oraclejdk at least temporarily to fix broken CI