### PR TITLE
Deltavision panel support

### DIFF
--- a/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
+++ b/components/bio-formats-plugins/src/loci/plugins/in/ImportProcess.java
@@ -564,13 +564,20 @@ public class ImportProcess implements StatusReporter {
       String dimOrder = options.getInputOrder(s);
       if (dimOrder != null) dimensionSwapper.swapDimensions(dimOrder);
 
-      // set output order
-      getDimensionSwapper().setOutputOrder(stackOrder);
       try {
         DimensionOrder order = DimensionOrder.fromString(stackOrder);
         getOMEMetadata().setPixelsDimensionOrder(order, s);
       }
       catch (EnumerationException e) { }
+    }
+
+    // if using TileStitcher, getSeriesCount() will be smaller
+    // than the underlying reader's series count
+    // all of the underlying series need to be dimension swapped
+    for (int s=0; s<getDimensionSwapper().getSeriesCount(); s++) {
+      getDimensionSwapper().setSeries(s);
+      // set output order
+      getDimensionSwapper().setOutputOrder(stackOrder);
     }
   }
 

--- a/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
+++ b/components/formats-gpl/src/loci/formats/in/DeltavisionReader.java
@@ -871,6 +871,19 @@ public class DeltavisionReader extends FormatReader {
         }
     }
 
+    if (xTiles * yTiles > getSeriesCount()) {
+      if (xTiles == getSeriesCount()) {
+        yTiles = 1;
+      }
+      else if (yTiles == getSeriesCount()) {
+        xTiles = 1;
+      }
+      else {
+        xTiles = 1;
+        yTiles = 1;
+      }
+    }
+
     if (getSeriesCount() == 1) {
       xTiles = 1;
       yTiles = 1;


### PR DESCRIPTION
Backported from a private PR; #3394 is related.

Adds support for reading the new panel count field, as well as the extended timepoint count, acquisition date,  and a few new enum values.  I have not yet added new test data to the repo, as I'm waiting on confirmation that the files I have can be shared.  If they can't be, I'll make a few dummy datasets next week based upon what's already in the curated repo.

This affects memo files, so will require a minor release.  The acquisition date changes require a configuration update, which is forthcoming.  I would not expect any other existing tests to fail with the date configuration included, but you may wish to one or two older .dv files with multiple series by hand (e.g. things in ```curated/deltavision/dan/```).