### PR TITLE
TIFF: fixes for tag overwriting

### DIFF
--- a/components/formats-bsd/test/loci/formats/utests/tiff/TiffSaverTest.java
+++ b/components/formats-bsd/test/loci/formats/utests/tiff/TiffSaverTest.java
@@ -170,4 +170,16 @@ public class TiffSaverTest {
     assertTrue("new comment".equals(tiffParser.getComment()));
   }
 
+  @Test
+  public void testOverwriteCommentEqualLength() throws FormatException, IOException {
+    out.seek(0);
+    tiffSaver.writeHeader();
+    tiffSaver.writeIFD(ifd, 46);
+    tiffSaver.writeIFD(ifd, 0);
+    tiffSaver.overwriteComment(in, "COMMENT");
+    assertEquals("COMMENT", tiffParser.getComment());
+    assertEquals("comment",
+      tiffParser.getIFDs().get(1).getIFDTextValue(IFD.IMAGE_DESCRIPTION));
+  }
+
 }


### PR DESCRIPTION
Backported from a private PR.

1062297 updates ```TiffSaver.overwriteIFDValue``` to overwrite the original value with 0s before the new value is written.  This means that the original tag value is completely gone, and no longer orphaned but still visible in a hex editor.  This is helpful for anyone using ```overwriteIFDValue``` (or higher-level things like ```tiffcomment```) to de-identify or anonymize TIFFs.

In working on this, it became clear that there was a bug in ```overwriteIFDValue``` when the new value has the same length as the original value (but neither value is inlined).  The bug is exhibited by the unit test in fe4d563, which fails without 1062297 and passes with it.

I would expect all other tests to continue to pass; as this is specific to writing, there should be no memo changes.  It probably makes sense to spot check a few common workflows of ```tiffcomment``` and ```bfconvert``` to be on the safe side, though, particularly for things like (pyramid) OME-TIFF.  I'm inclined to think this is safe for a patch release, but happy to be told otherwise.