### PR TITLE
Install Ant via APT packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: java
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
@@ -12,8 +13,10 @@ cache:
   - downloads
 
 addons:
-  apt_packages:
+  apt:
+    packages:
     - git
+    - ant
 
 jdk:
   - openjdk11


### PR DESCRIPTION
See https://travis-ci.community/t/travis-ci-doesnt-install-ant-while-using-language-java/3856. Travis CI is now failing since Ant is no longer installed by default on `xenial`.

Having Travis CI green should be the main thing to review.