### PR TITLE
TiffSaver: add overwriteIFDValue signature that takes an IFD offset

### DIFF
--- a/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
+++ b/components/formats-bsd/src/loci/formats/tiff/TiffSaver.java
@@ -724,6 +724,11 @@ public class TiffSaver {
    * new data to the end of the file and updates the offset field; if not, or
    * if the old data is already at the end of the file, it overwrites the old
    * data in place.
+   *
+   * @param raf the input stream representing the file to be edited
+   * @param ifd the index into the list of IFDs {@see TiffParser#getIFDOffsets()}
+   * @param tag the tag code
+   * @param value the new value for the tag
    */
   public void overwriteIFDValue(RandomAccessInputStream raf,
     int ifd, int tag, Object value) throws FormatException, IOException
@@ -759,14 +764,52 @@ public class TiffSaver {
       throw new FormatException(
         "No such IFD (" + ifd + " of " + offsets.length + ")");
     }
-    raf.seek(offsets[ifd]);
+    overwriteIFDValue(raf, offsets[ifd], tag, value);
+  }
+
+  /**
+   * Surgically overwrites an existing IFD value with the given one. This
+   * method requires that the IFD directory entry already exist. It
+   * intelligently updates the count field of the entry to match the new
+   * length. If the new length is longer than the old length, it appends the
+   * new data to the end of the file and updates the offset field; if not, or
+   * if the old data is already at the end of the file, it overwrites the old
+   * data in place.
+   *
+   * @param raf the input stream representing the file to be edited
+   * @param ifdOffset the offset to the IFD
+   * @param tag the tag code
+   * @param value the new value for the tag
+   */
+  public void overwriteIFDValue(RandomAccessInputStream raf,
+    long ifdOffset, int tag, Object value) throws FormatException, IOException
+  {
+    raf.seek(0);
+    TiffParser parser = new TiffParser(raf);
+    Boolean valid = parser.checkHeader();
+    if (valid == null) {
+      throw new FormatException("Invalid TIFF header");
+    }
+
+    boolean little = valid.booleanValue();
+    boolean bigTiff = parser.isBigTiff();
+
+    setLittleEndian(little);
+    setBigTiff(bigTiff);
+
+    long offset = bigTiff ? 8 : 4; // offset to the IFD
+
+    int bytesPerEntry = bigTiff ?
+      TiffConstants.BIG_TIFF_BYTES_PER_ENTRY : TiffConstants.BYTES_PER_ENTRY;
+
+    raf.seek(ifdOffset);
 
     // get the number of directory entries
     long num = bigTiff ? raf.readLong() : raf.readUnsignedShort();
 
     // search directory entries for proper tag
     for (int i=0; i<num; i++) {
-      raf.seek(offsets[ifd] + (bigTiff ? 8 : 2) + bytesPerEntry * i);
+      raf.seek(ifdOffset + (bigTiff ? 8 : 2) + bytesPerEntry * i);
 
       TiffIFDEntry entry = parser.readTiffIFDEntry();
       if (entry.getTag() == tag) {
@@ -844,7 +887,7 @@ public class TiffSaver {
         }
 
         // overwrite old entry
-        out.seek(offsets[ifd] + (bigTiff ? 8 : 2) + bytesPerEntry * i + 2);
+        out.seek(ifdOffset + (bigTiff ? 8 : 2) + bytesPerEntry * i + 2);
         out.writeShort(newType);
         writeIntValue(out, newCount);
         writeIntValue(out, newOffset);


### PR DESCRIPTION
This is helpful for modifying thumbnail and sub-IFDs, which aren't
included in the list of offsets returned by ```TiffParser.getIFDOffsets()```.

I wouldn't expect this to have any impact on memo files or existing tests, but it arguably still requires a minor release since it's an API addition.